### PR TITLE
Feature/fypp by submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/build_utils/fypp"]
+	path = tools/build_utils/fypp
+	url = https://github.com/aradi/fypp.git

--- a/Makefile
+++ b/Makefile
@@ -367,7 +367,7 @@ vpath %.cpp   $(ALL_SRC_DIRS)
 FYPPFLAGS ?= -n
 
 define compile_file
-	$(TOOLSRC)/build_utils/fypp $(FYPPFLAGS) $(1) $(2)
+	$(TOOLSRC)/build_utils/fypp/bin/fypp $(FYPPFLAGS) $(1) $(2)
 	$(FC) -c $(FCFLAGS) -D__SHORT_FILE__="\"$(notdir $(1))\"" -I'$(dir $(1))' -I'$(SRCDIR)' $(2) $(FCLOGPIPE)
 endef
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ To build with CUDA support you further need:
 
 ## Getting started
 
+Download either a release tarball or clone the latest version from Git using:
+
+    git clone --recursive https://github.com/cp2k/dbcsr.git
+
 Run
 
     make help


### PR DESCRIPTION
The advantage is that it is obvious which version of Fypp we use and it
can be easily updated. The disadvantage is that the release process gets
more complicated since we have to create a tarball which includes a
clone of the Fypp submodule, see:

  https://help.github.com/articles/creating-releases/
  https://stackoverflow.com/questions/34719785/how-to-add-submodule-files-to-a-github-release

On the other hand, this can possibly be automated using some CI system
whenever a new tag gets added.