### PR TITLE
Adapt autotuning to hashing macro variables

### DIFF
--- a/src/acc/libsmm_acc/libcusmm/libcusmm_benchmark.cu
+++ b/src/acc/libsmm_acc/libcusmm/libcusmm_benchmark.cu
@@ -214,7 +214,7 @@ int libcusmm_benchmark(libcusmm_benchmark_t* h,
  std::vector<int> blocksizes; 
  get_libcusmm_triplets(blocksizes, ht); 
  auto it = std::find(std::begin(blocksizes), std::end(blocksizes), h_mnk); 
- if(it == std::end(blocksizes)){
+ if(it == std::end(blocksizes) && !h->tune_mode){
      printf("Triplet %i x %i x %i is not defined in libcusmm\n", mat_m, mat_n, mat_k);
      exit(1);
  }

--- a/src/acc/libsmm_acc/libcusmm/tune.py
+++ b/src/acc/libsmm_acc/libcusmm/tune.py
@@ -195,8 +195,13 @@ def gen_makefile(outdir):
     output += "do_nothing:\n\n"
     output += "build_all: " +  " ".join(build_targets) + "\n\n"
 
+    output += "EXP = 10\n"
+    output += "EXP_DOUBLE = $$(( 2*$(EXP)  ))\n"
+    output += "HASH_LIMIT = $$(( 2**$(EXP)-1 ))\n"
+    output += "HASHDEFS   = -DEXP=$(EXP) -DEXP_DOUBLE=$(EXP_DOUBLE) -DHASH_LIMIT=$(HASH_LIMIT)\n\n"
+
     output += "libcusmm_benchmark.o : libcusmm_benchmark.cu\n"
-    output += "\tnvcc -O3 -arch=sm_60 -w -c -std=c++11 $<\n\n"
+    output += "\tnvcc -O3 -arch=sm_60 -w $(HASHDEFS) -c -std=c++11 $<\n\n"
 
     headers = " ".join( ["."+fn for fn in glob("./kernels/*.h")] )
     output += "%.o : %.cu "+headers+"\n"


### PR DESCRIPTION
The addition of macros related to hashing variables (commit 90c053640f49a2b85feadc6aa6ef58d7d53f7659) requires the automatically-generated Makefile in the auto-tuning facilities to define these variables as well 