### PR TITLE
libcusmm: specify GPU version 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,27 @@ LIBNAME      := dbcsr
 LIBRARY      := lib$(LIBNAME)
 default_target: $(LIBRARY)
 
-# Read the configuration ============================================
+# Read the configuration ====================================================
 MODDEPS = "lower"
 include $(INCLUDEMAKE)
+
+# Set the compute version and NVFLAGS =======================================
+ifeq ($(GPUVER),K20X)
+ ARCH_NUMBER = 35
+else ifeq ($(GPUVER),K40)
+ ARCH_NUMBER = 35
+else ifeq ($(GPUVER),K80)
+ ARCH_NUMBER = 37
+else ifeq ($(GPUVER),P100)
+ ARCH_NUMBER = 60 
+else ifeq ($(GPUVER),)
+else
+ $(error GPUVER not recognized)
+endif
+
+ifneq ($(ARCH_NUMBER),)
+ NVFLAGS += -arch sm_$(ARCH_NUMBER)
+endif
 
 # Test programs =========================================================
 include $(TESTSDIR)/Makefile.inc

--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ TOOL_HELP += "doxygen : Generate the doxygen documentation"
 
 # Libcusmm stuff ============================================================
 $(LIBCUSMM_ABS_DIR)/parameters.h: $(LIBCUSMM_ABS_DIR)/generate_parameters.py $(wildcard $(LIBCUSMM_ABS_DIR)/parameters_*.txt)
-	cd $(LIBCUSMM_ABS_DIR); ./generate_parameters.py
+	cd $(LIBCUSMM_ABS_DIR); ./generate_parameters.py --arch=$(ARCH_NUMBER)
 
 $(LIBCUSMM_ABS_DIR)/cusmm_kernels.h: $(LIBCUSMM_ABS_DIR)/generate_kernels.py $(wildcard $(LIBCUSMM_ABS_DIR)/kernels/*.h)
 	cd $(LIBCUSMM_ABS_DIR); ./generate_kernels.py

--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,7 @@ TOOL_HELP += "doxygen : Generate the doxygen documentation"
 
 # Libcusmm stuff ============================================================
 $(LIBCUSMM_ABS_DIR)/parameters.h: $(LIBCUSMM_ABS_DIR)/generate_parameters.py $(wildcard $(LIBCUSMM_ABS_DIR)/parameters_*.txt)
-	cd $(LIBCUSMM_ABS_DIR); ./generate_parameters.py --arch=$(ARCH_NUMBER)
+	cd $(LIBCUSMM_ABS_DIR); ./generate_parameters.py --gpu_version=$(GPUVER)
 
 $(LIBCUSMM_ABS_DIR)/cusmm_kernels.h: $(LIBCUSMM_ABS_DIR)/generate_kernels.py $(wildcard $(LIBCUSMM_ABS_DIR)/kernels/*.h)
 	cd $(LIBCUSMM_ABS_DIR); ./generate_kernels.py

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -17,10 +17,11 @@
 # requires:
 # a) set the NVCC variable, e.g. NVCC = nvcc
 # b) specify -D__DBCSR_ACC in FCFLAGS variable
-# c) set the ARCH_NUMBER variable, e.g. ARCH_NUMBER = 35 for K20 card 
-#    or ARCH_NUMBER = 60 for P100 card
+# c) set the GPUVER variable, e.g. GPUVER = K20 for K20 card 
+#    or GPUVER = P100 for P100 card
 # d) set the NVFLAGS variable, 
-#    e.g. NVFLAGS = -O3 -w -arch sm_$(ARCH_NUMBER) --std=c++11
+#    e.g. NVFLAGS = -O3 -w --std=c++11
+#    in the Makefile, the -arch will be appended with the correct compute version
 # e) specify the CUDA include path in the CXXFLAGS variable, 
 #    e.g. CXXFLAGS += -I$(CUDA_PATH)/include 
 # f) specify the corresponding CUDA libraries in the LIBS variable,

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -102,8 +102,8 @@ LIBS        = -L${LAPACK_PATH}/lib -llapack -lblas
 ifneq ($(GPU),)
 NVCC        = nvcc
 FCFLAGS    += -D__DBCSR_ACC
-ARCH_NUMBER = 35
-NVFLAGS     = -O3 -w -arch sm_$(ARCH_NUMBER) --std=c++11
+GPUVER      = K40
+NVFLAGS     = -O3 -w --std=c++11
 CXXFLAGS   += -I${CUDA_PATH}/include
 LIBS       += -lstdc++ -lcudart -lnvrtc -lcuda
 endif

--- a/src/acc/libsmm_acc/libcusmm/generate_parameters.py
+++ b/src/acc/libsmm_acc/libcusmm/generate_parameters.py
@@ -34,7 +34,7 @@ def main(argv):
     with open(param_fn) as f:
         content = f.read().splitlines()
     print("About to process", len(content), "lines from file", param_fn)
-    parameters = get_parameters_from_file(content, arch_num)
+    parameters = get_parameters_from_file(content)
 
     # Construct output
     out, all_pars = write_parameters_file(parameters)
@@ -48,7 +48,7 @@ def main(argv):
 
 
 #===============================================================================
-def get_parameters_from_file(content, arch_num):
+def get_parameters_from_file(content):
     """
     Get parameters from a parameters file
     :param content: content of a parameter-file:
@@ -64,12 +64,8 @@ def get_parameters_from_file(content, arch_num):
     parameter_line_pattern_l = \
         '\s*Kernel_dnt_(largeDB[12])\(m=(\d+), n=(\d+), k=(\d+), tile_m=(\d+), tile_n=(\d+), w=(\d+), v=(\d+), threads=(\d+), grouping=(\d+), minblocks=(\d+)\)'
     # tiny
-    if arch_num < 60:
-        parameter_line_pattern_t = \
-            '\s*Kernel_dnt_(tiny)\(m=(\d+), n=(\d+), k=(\d+), split_thread=(\d+), threads=(\d+), grouping=(\d+), minblocks=(\d+)\)'
-    else: 
-        parameter_line_pattern_t = \
-            '\s*Kernel_dnt_(tiny)\(m=(\d+), n=(\d+), k=(\d+), threads=(\d+), grouping=(\d+), minblocks=(\d+)\)'
+    parameter_line_pattern_t = \
+        '\s*Kernel_dnt_(tiny)\(m=(\d+), n=(\d+), k=(\d+), threads=(\d+), grouping=(\d+), minblocks=(\d+)\)'
 
     parameters = dict()
     for line in content:

--- a/src/acc/libsmm_acc/libcusmm/generate_parameters.py
+++ b/src/acc/libsmm_acc/libcusmm/generate_parameters.py
@@ -9,28 +9,17 @@ from optparse import OptionParser
 
 
 #===============================================================================
-# Correspondance between CUDA compute versions and parameter_file
-param_files = {
-    35: "parameters_K20X.txt", # "parameters_K40.txt"  
-    37: "parameters_K80.txt",
-    60: "parameters_P100.txt",
-}
-
-#===============================================================================
 def main(argv):
     usage = "Generator of LibCuSMM. The Library for Cuda Small Matrix Multiplications."
     parser = OptionParser(usage)
-    parser.add_option("-a", "--arch", metavar="SM_NUMBER", default="60",
-                      help="CUDA compute version, used to select the appropriate libcusmm parameters file. Default: %default")
+    parser.add_option("-g", "--gpu_version", metavar="GPU_VERSION", default="P100",
+                      help="GPU card version, used to select the appropriate libcusmm parameters file. Default: %default")
     (options, args) = parser.parse_args(argv)
     assert(len(args) == 0)
 
     # Read existing parameters
-    arch_num = int(options.arch)
-    assert arch_num in param_files.keys(), "Cannot find autotuned parameters for compute version " + str(arch_num) + \
-                                           ".\nAvailable compute versions: " + str(param_files.keys()) + \
-                                           ".\nAvailable GPU cards: " + str(param_files.values())
-    param_fn = param_files[arch_num]
+    print("GPU version:\n", options.gpu_version)
+    param_fn = "parameters_" + options.gpu_version + ".txt"
     with open(param_fn) as f:
         content = f.read().splitlines()
     print("About to process", len(content), "lines from file", param_fn)

--- a/src/acc/libsmm_acc/libcusmm/parameters_K20X.txt
+++ b/src/acc/libsmm_acc/libcusmm/parameters_K20X.txt
@@ -52,7 +52,7 @@
   Kernel_dnt_medium(m=4, n=6, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 63.1415 GFlop/s
   Kernel_dnt_tiny(m=4, n=6, k=24, split_thread=32, threads=128, grouping=16, minblocks=1) , # 59.2859 GFlop/s
   Kernel_dnt_medium(m=4, n=6, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 63.6068 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=6, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=96, grouping=16, minblocks=1) , # 66.9879 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=6, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=96, grouping=16, minblocks=1) , # 66.9879 GFlop/s
   Kernel_dnt_tiny(m=4, n=7, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 20.3949 GFlop/s
   Kernel_dnt_tiny(m=4, n=7, k=5, split_thread=32, threads=128, grouping=16, minblocks=1) , # 25.5066 GFlop/s
   Kernel_dnt_tiny(m=4, n=7, k=7, split_thread=32, threads=128, grouping=16, minblocks=1) , # 34.4269 GFlop/s
@@ -73,9 +73,9 @@
   Kernel_dnt_medium(m=4, n=8, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 67.3422 GFlop/s
   Kernel_dnt_medium(m=4, n=8, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 80.9386 GFlop/s
   Kernel_dnt_medium(m=4, n=8, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 83.121 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=8, k=24, tile_m=1, tile_n=1, w=12, v=8, threads=96, grouping=16, minblocks=1) , # 72.6651 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=8, k=24, tile_m=1, tile_n=1, w=12, v=8, threads=96, grouping=16, minblocks=1) , # 72.6651 GFlop/s
   Kernel_dnt_medium(m=4, n=8, k=26, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 74.4863 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=8, k=32, tile_m=1, tile_n=1, w=16, v=8, threads=128, grouping=16, minblocks=1) , # 83.7638 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=8, k=32, tile_m=1, tile_n=1, w=16, v=8, threads=128, grouping=16, minblocks=1) , # 83.7638 GFlop/s
   Kernel_dnt_medium(m=4, n=9, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 24.1362 GFlop/s
   Kernel_dnt_medium(m=4, n=9, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 29.7245 GFlop/s
   Kernel_dnt_medium(m=4, n=9, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 34.6329 GFlop/s
@@ -127,8 +127,8 @@
   Kernel_dnt_medium(m=4, n=16, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 117.51 GFlop/s
   Kernel_dnt_medium(m=4, n=16, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 118.855 GFlop/s
   Kernel_dnt_medium(m=4, n=16, k=24, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 116.045 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=16, k=26, tile_m=1, tile_n=1, w=12, v=16, threads=96, grouping=16, minblocks=8) , # 109.271 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=16, k=32, tile_m=1, tile_n=1, w=16, v=16, threads=128, grouping=16, minblocks=12) , # 119.269 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=16, k=26, tile_m=1, tile_n=1, w=12, v=16, threads=96, grouping=16, minblocks=8) , # 109.271 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=16, k=32, tile_m=1, tile_n=1, w=16, v=16, threads=128, grouping=16, minblocks=12) , # 119.269 GFlop/s
   Kernel_dnt_medium(m=4, n=17, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 44.3641 GFlop/s
   Kernel_dnt_medium(m=4, n=17, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 54.048 GFlop/s
   Kernel_dnt_medium(m=4, n=17, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 56.5091 GFlop/s
@@ -138,10 +138,10 @@
   Kernel_dnt_medium(m=4, n=17, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 109.498 GFlop/s
   Kernel_dnt_medium(m=4, n=17, k=17, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 98.7893 GFlop/s
   Kernel_dnt_medium(m=4, n=17, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 113.492 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=17, k=23, tile_m=1, tile_n=1, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 99.7952 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=17, k=24, tile_m=1, tile_n=1, w=12, v=14, threads=128, grouping=16, minblocks=12) , # 107.141 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=17, k=23, tile_m=1, tile_n=1, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 99.7952 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=17, k=24, tile_m=1, tile_n=1, w=12, v=14, threads=128, grouping=16, minblocks=12) , # 107.141 GFlop/s
   Kernel_dnt_medium(m=4, n=17, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 106.081 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=17, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=128, grouping=16, minblocks=4) , # 113.471 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=17, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=128, grouping=16, minblocks=4) , # 113.471 GFlop/s
   Kernel_dnt_medium(m=4, n=22, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 57.4498 GFlop/s
   Kernel_dnt_medium(m=4, n=22, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 62.5018 GFlop/s
   Kernel_dnt_medium(m=4, n=22, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 72.8839 GFlop/s
@@ -152,9 +152,9 @@
   Kernel_dnt_medium(m=4, n=22, k=17, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 121.506 GFlop/s
   Kernel_dnt_medium(m=4, n=22, k=22, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 120.919 GFlop/s
   Kernel_dnt_medium(m=4, n=22, k=23, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 116.314 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=22, k=24, tile_m=1, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 121.22 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=22, k=24, tile_m=1, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 121.22 GFlop/s
   Kernel_dnt_medium(m=4, n=22, k=26, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=4) , # 117.406 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=22, k=32, tile_m=1, tile_n=1, w=8, v=20, threads=96, grouping=16, minblocks=8) , # 127.401 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=22, k=32, tile_m=1, tile_n=1, w=8, v=20, threads=96, grouping=16, minblocks=8) , # 127.401 GFlop/s
   Kernel_dnt_medium(m=4, n=23, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 59.7783 GFlop/s
   Kernel_dnt_medium(m=4, n=23, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 64.7027 GFlop/s
   Kernel_dnt_medium(m=4, n=23, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 75.5435 GFlop/s
@@ -165,22 +165,22 @@
   Kernel_dnt_medium(m=4, n=23, k=17, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 110.912 GFlop/s
   Kernel_dnt_medium(m=4, n=23, k=22, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 118.425 GFlop/s
   Kernel_dnt_medium(m=4, n=23, k=23, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 119.87 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=23, k=24, tile_m=1, tile_n=1, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 119.172 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=23, k=24, tile_m=1, tile_n=1, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 119.172 GFlop/s
   Kernel_dnt_medium(m=4, n=23, k=26, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 119.54 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=23, k=32, tile_m=1, tile_n=1, w=8, v=20, threads=96, grouping=16, minblocks=4) , # 127.587 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=23, k=32, tile_m=1, tile_n=1, w=8, v=20, threads=96, grouping=16, minblocks=4) , # 127.587 GFlop/s
   Kernel_dnt_tiny(m=4, n=24, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 58.0271 GFlop/s
   Kernel_dnt_medium(m=4, n=24, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 67.3989 GFlop/s
   Kernel_dnt_medium(m=4, n=24, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 78.5843 GFlop/s
   Kernel_dnt_medium(m=4, n=24, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 90.4024 GFlop/s
   Kernel_dnt_medium(m=4, n=24, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 107.128 GFlop/s
   Kernel_dnt_medium(m=4, n=24, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 115.396 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=24, k=16, tile_m=1, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=1) , # 117.543 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=24, k=16, tile_m=1, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=1) , # 117.543 GFlop/s
   Kernel_dnt_medium(m=4, n=24, k=17, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 115.374 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=24, k=22, tile_m=1, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 123.01 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=24, k=23, tile_m=1, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=8) , # 121.888 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=24, k=24, tile_m=1, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=4) , # 126.228 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=24, k=22, tile_m=1, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 123.01 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=24, k=23, tile_m=1, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=8) , # 121.888 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=24, k=24, tile_m=1, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=4) , # 126.228 GFlop/s
   Kernel_dnt_medium(m=4, n=24, k=26, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 124.519 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=24, k=32, tile_m=1, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=4) , # 131.226 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=24, k=32, tile_m=1, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=4) , # 131.226 GFlop/s
   Kernel_dnt_largeDB2(m=4, n=25, k=4, tile_m=2, tile_n=1, w=2, v=24, threads=96, grouping=16, minblocks=4) , # 59.7499 GFlop/s
   Kernel_dnt_small(m=4, n=25, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 65.252 GFlop/s
   Kernel_dnt_medium(m=4, n=25, k=7, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 77.9696 GFlop/s
@@ -222,14 +222,14 @@
   Kernel_dnt_tiny(m=4, n=32, k=5, split_thread=32, threads=128, grouping=16, minblocks=1) , # 74.5054 GFlop/s
   Kernel_dnt_medium(m=4, n=32, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 85.0733 GFlop/s
   Kernel_dnt_medium(m=4, n=32, k=7, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 94.5942 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=32, k=8, tile_m=1, tile_n=1, w=4, v=32, threads=128, grouping=16, minblocks=8) , # 101.579 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=32, k=8, tile_m=1, tile_n=1, w=4, v=32, threads=128, grouping=16, minblocks=8) , # 101.579 GFlop/s
   Kernel_dnt_medium(m=4, n=32, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 114.088 GFlop/s
   Kernel_dnt_medium(m=4, n=32, k=13, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 127.948 GFlop/s
   Kernel_dnt_medium(m=4, n=32, k=16, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 129.951 GFlop/s
   Kernel_dnt_medium(m=4, n=32, k=17, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 129.899 GFlop/s
   Kernel_dnt_medium(m=4, n=32, k=22, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 133.965 GFlop/s
   Kernel_dnt_medium(m=4, n=32, k=23, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=4) , # 135.677 GFlop/s
-  Kernel_dnt_largeDB(m=4, n=32, k=24, tile_m=1, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 137.129 GFlop/s
+  Kernel_dnt_largeDB1(m=4, n=32, k=24, tile_m=1, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 137.129 GFlop/s
   Kernel_dnt_largeDB2(m=4, n=32, k=25, tile_m=1, tile_n=1, w=12, v=32, threads=128, grouping=16, minblocks=12) , # 138.999 GFlop/s
   Kernel_dnt_largeDB2(m=4, n=32, k=26, tile_m=1, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 140.06 GFlop/s
   Kernel_dnt_largeDB2(m=4, n=32, k=28, tile_m=2, tile_n=1, w=14, v=20, threads=96, grouping=16, minblocks=4) , # 142.731 GFlop/s
@@ -312,9 +312,9 @@
   Kernel_dnt_medium(m=5, n=8, k=17, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 63.6387 GFlop/s
   Kernel_dnt_medium(m=5, n=8, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 85.8051 GFlop/s
   Kernel_dnt_medium(m=5, n=8, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 87.9872 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=8, k=24, tile_m=1, tile_n=1, w=12, v=8, threads=128, grouping=16, minblocks=4) , # 84.7498 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=8, k=24, tile_m=1, tile_n=1, w=12, v=8, threads=128, grouping=16, minblocks=4) , # 84.7498 GFlop/s
   Kernel_dnt_medium(m=5, n=8, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 83.6633 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=8, k=32, tile_m=1, tile_n=1, w=16, v=8, threads=128, grouping=16, minblocks=12) , # 94.1701 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=8, k=32, tile_m=1, tile_n=1, w=16, v=8, threads=128, grouping=16, minblocks=12) , # 94.1701 GFlop/s
   Kernel_dnt_medium(m=5, n=9, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 30.6314 GFlop/s
   Kernel_dnt_medium(m=5, n=9, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 37.6561 GFlop/s
   Kernel_dnt_medium(m=5, n=9, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 43.5479 GFlop/s
@@ -322,7 +322,7 @@
   Kernel_dnt_small(m=5, n=9, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 49.4117 GFlop/s
   Kernel_dnt_medium(m=5, n=9, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 61.0651 GFlop/s
   Kernel_dnt_medium(m=5, n=9, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 71.6433 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=9, k=16, tile_m=1, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=1) , # 71.2271 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=9, k=16, tile_m=1, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=1) , # 71.2271 GFlop/s
   Kernel_dnt_medium(m=5, n=9, k=17, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 71.4887 GFlop/s
   Kernel_dnt_medium(m=5, n=9, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 85.9047 GFlop/s
   Kernel_dnt_medium(m=5, n=9, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 88.2854 GFlop/s
@@ -359,9 +359,9 @@
   Kernel_dnt_medium(m=5, n=16, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 121.579 GFlop/s
   Kernel_dnt_medium(m=5, n=16, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 135.569 GFlop/s
   Kernel_dnt_medium(m=5, n=16, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 129.272 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=16, k=24, tile_m=1, tile_n=1, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 131.765 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=16, k=26, tile_m=1, tile_n=1, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 128.942 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=16, k=32, tile_m=1, tile_n=1, w=16, v=16, threads=128, grouping=16, minblocks=12) , # 139.49 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=16, k=24, tile_m=1, tile_n=1, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 131.765 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=16, k=26, tile_m=1, tile_n=1, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 128.942 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=16, k=32, tile_m=1, tile_n=1, w=16, v=16, threads=128, grouping=16, minblocks=12) , # 139.49 GFlop/s
   Kernel_dnt_medium(m=5, n=17, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 54.7705 GFlop/s
   Kernel_dnt_medium(m=5, n=17, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 66.6945 GFlop/s
   Kernel_dnt_small(m=5, n=17, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 67.0057 GFlop/s
@@ -372,13 +372,13 @@
   Kernel_dnt_medium(m=5, n=17, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 119.245 GFlop/s
   Kernel_dnt_medium(m=5, n=17, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 136.959 GFlop/s
   Kernel_dnt_medium(m=5, n=17, k=23, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 123.364 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=17, k=24, tile_m=1, tile_n=1, w=12, v=14, threads=128, grouping=16, minblocks=12) , # 128.46 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=17, k=24, tile_m=1, tile_n=1, w=12, v=14, threads=128, grouping=16, minblocks=12) , # 128.46 GFlop/s
   Kernel_dnt_medium(m=5, n=17, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=4) , # 132.131 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=17, k=32, tile_m=1, tile_n=1, w=14, v=6, threads=128, grouping=16, minblocks=12) , # 135.01 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=17, k=32, tile_m=1, tile_n=1, w=14, v=6, threads=128, grouping=16, minblocks=12) , # 135.01 GFlop/s
   Kernel_dnt_tiny(m=5, n=22, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 64.6247 GFlop/s
   Kernel_dnt_small(m=5, n=22, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 71.6059 GFlop/s
   Kernel_dnt_medium(m=5, n=22, k=6, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 73.2559 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=22, k=8, tile_m=1, tile_n=1, w=4, v=22, threads=128, grouping=16, minblocks=8) , # 92.3688 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=22, k=8, tile_m=1, tile_n=1, w=4, v=22, threads=128, grouping=16, minblocks=8) , # 92.3688 GFlop/s
   Kernel_dnt_medium(m=5, n=22, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 98.0181 GFlop/s
   Kernel_dnt_medium(m=5, n=22, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 119.94 GFlop/s
   Kernel_dnt_medium(m=5, n=22, k=16, tile_m=1, tile_n=4, threads=96, grouping=16, minblocks=12) , # 136.353 GFlop/s
@@ -387,7 +387,7 @@
   Kernel_dnt_medium(m=5, n=22, k=23, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=8) , # 135.879 GFlop/s
   Kernel_dnt_medium(m=5, n=22, k=24, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=8) , # 138.483 GFlop/s
   Kernel_dnt_medium(m=5, n=22, k=26, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=1) , # 145.469 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=22, k=32, tile_m=1, tile_n=1, w=16, v=22, threads=192, grouping=16, minblocks=8) , # 143.787 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=22, k=32, tile_m=1, tile_n=1, w=16, v=22, threads=192, grouping=16, minblocks=8) , # 143.787 GFlop/s
   Kernel_dnt_tiny(m=5, n=23, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 66.9592 GFlop/s
   Kernel_dnt_small(m=5, n=23, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 74.1593 GFlop/s
   Kernel_dnt_medium(m=5, n=23, k=6, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 76.2473 GFlop/s
@@ -399,21 +399,21 @@
   Kernel_dnt_medium(m=5, n=23, k=22, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=8) , # 144.101 GFlop/s
   Kernel_dnt_medium(m=5, n=23, k=23, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=8) , # 141.081 GFlop/s
   Kernel_dnt_medium(m=5, n=23, k=24, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=8) , # 143.882 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=23, k=26, tile_m=1, tile_n=1, w=10, v=22, threads=128, grouping=16, minblocks=12) , # 136.154 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=23, k=32, tile_m=1, tile_n=1, w=16, v=22, threads=192, grouping=16, minblocks=8) , # 145.364 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=23, k=26, tile_m=1, tile_n=1, w=10, v=22, threads=128, grouping=16, minblocks=12) , # 136.154 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=23, k=32, tile_m=1, tile_n=1, w=16, v=22, threads=192, grouping=16, minblocks=8) , # 145.364 GFlop/s
   Kernel_dnt_tiny(m=5, n=24, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 70.2727 GFlop/s
   Kernel_dnt_small(m=5, n=24, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 79.6991 GFlop/s
   Kernel_dnt_medium(m=5, n=24, k=6, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 80.5021 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=24, k=8, tile_m=1, tile_n=1, w=4, v=24, threads=128, grouping=16, minblocks=12) , # 100.583 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=24, k=8, tile_m=1, tile_n=1, w=4, v=24, threads=128, grouping=16, minblocks=12) , # 100.583 GFlop/s
   Kernel_dnt_medium(m=5, n=24, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 107.639 GFlop/s
   Kernel_dnt_medium(m=5, n=24, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 130.403 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=24, k=16, tile_m=1, tile_n=1, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 138.648 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=24, k=17, tile_m=1, tile_n=1, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 128.385 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=24, k=16, tile_m=1, tile_n=1, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 138.648 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=24, k=17, tile_m=1, tile_n=1, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 128.385 GFlop/s
   Kernel_dnt_medium(m=5, n=24, k=22, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=1) , # 147.78 GFlop/s
   Kernel_dnt_medium(m=5, n=24, k=23, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=8) , # 147.238 GFlop/s
   Kernel_dnt_medium(m=5, n=24, k=24, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 149.11 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=24, k=26, tile_m=1, tile_n=1, w=10, v=24, threads=128, grouping=16, minblocks=8) , # 144.829 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=24, k=32, tile_m=1, tile_n=1, w=12, v=24, threads=160, grouping=16, minblocks=12) , # 151.834 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=24, k=26, tile_m=1, tile_n=1, w=10, v=24, threads=128, grouping=16, minblocks=8) , # 144.829 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=24, k=32, tile_m=1, tile_n=1, w=12, v=24, threads=160, grouping=16, minblocks=12) , # 151.834 GFlop/s
   Kernel_dnt_largeDB2(m=5, n=25, k=4, tile_m=1, tile_n=1, w=2, v=24, threads=128, grouping=16, minblocks=1) , # 71.6625 GFlop/s
   Kernel_dnt_small(m=5, n=25, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 80.6391 GFlop/s
   Kernel_dnt_medium(m=5, n=25, k=7, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 92.0275 GFlop/s
@@ -431,11 +431,11 @@
   Kernel_dnt_medium(m=5, n=26, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 97.7841 GFlop/s
   Kernel_dnt_medium(m=5, n=26, k=9, tile_m=5, tile_n=1, threads=96, grouping=16, minblocks=12) , # 106.059 GFlop/s
   Kernel_dnt_medium(m=5, n=26, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 127.925 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=26, k=16, tile_m=1, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=1) , # 124.739 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=26, k=16, tile_m=1, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=1) , # 124.739 GFlop/s
   Kernel_dnt_medium(m=5, n=26, k=17, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 121.911 GFlop/s
   Kernel_dnt_medium(m=5, n=26, k=22, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 138.328 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=26, k=23, tile_m=1, tile_n=2, w=6, v=26, threads=96, grouping=16, minblocks=4) , # 133.003 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=26, k=24, tile_m=1, tile_n=1, w=12, v=26, threads=160, grouping=16, minblocks=12) , # 142.549 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=26, k=23, tile_m=1, tile_n=2, w=6, v=26, threads=96, grouping=16, minblocks=4) , # 133.003 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=26, k=24, tile_m=1, tile_n=1, w=12, v=26, threads=160, grouping=16, minblocks=12) , # 142.549 GFlop/s
   Kernel_dnt_largeDB2(m=5, n=26, k=25, tile_m=6, tile_n=1, w=12, v=26, threads=96, grouping=16, minblocks=12) , # 150.57 GFlop/s
   Kernel_dnt_largeDB2(m=5, n=26, k=26, tile_m=5, tile_n=1, w=12, v=26, threads=96, grouping=16, minblocks=12) , # 152.336 GFlop/s
   Kernel_dnt_largeDB2(m=5, n=26, k=28, tile_m=2, tile_n=3, w=14, v=26, threads=96, grouping=16, minblocks=12) , # 161.207 GFlop/s
@@ -461,8 +461,8 @@
   Kernel_dnt_medium(m=5, n=32, k=16, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=4) , # 148.849 GFlop/s
   Kernel_dnt_medium(m=5, n=32, k=17, tile_m=6, tile_n=1, threads=96, grouping=16, minblocks=8) , # 145.146 GFlop/s
   Kernel_dnt_medium(m=5, n=32, k=22, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=1) , # 152.464 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=32, k=23, tile_m=1, tile_n=2, w=6, v=32, threads=96, grouping=16, minblocks=8) , # 153.738 GFlop/s
-  Kernel_dnt_largeDB(m=5, n=32, k=24, tile_m=1, tile_n=2, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 156.997 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=32, k=23, tile_m=1, tile_n=2, w=6, v=32, threads=96, grouping=16, minblocks=8) , # 153.738 GFlop/s
+  Kernel_dnt_largeDB1(m=5, n=32, k=24, tile_m=1, tile_n=2, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 156.997 GFlop/s
   Kernel_dnt_largeDB2(m=5, n=32, k=25, tile_m=5, tile_n=1, w=12, v=32, threads=96, grouping=16, minblocks=12) , # 165.526 GFlop/s
   Kernel_dnt_largeDB2(m=5, n=32, k=26, tile_m=1, tile_n=2, w=10, v=32, threads=96, grouping=16, minblocks=1) , # 167.342 GFlop/s
   Kernel_dnt_largeDB2(m=5, n=32, k=28, tile_m=2, tile_n=1, w=10, v=32, threads=96, grouping=16, minblocks=4) , # 170.549 GFlop/s
@@ -528,16 +528,16 @@
   Kernel_dnt_medium(m=6, n=8, k=17, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 75.7991 GFlop/s
   Kernel_dnt_medium(m=6, n=8, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 102.189 GFlop/s
   Kernel_dnt_medium(m=6, n=8, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 104.903 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=8, k=24, tile_m=1, tile_n=1, w=12, v=8, threads=128, grouping=16, minblocks=1) , # 99.5961 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=8, k=24, tile_m=1, tile_n=1, w=12, v=8, threads=128, grouping=16, minblocks=1) , # 99.5961 GFlop/s
   Kernel_dnt_medium(m=6, n=8, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 100.125 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=8, k=32, tile_m=1, tile_n=1, w=16, v=8, threads=96, grouping=16, minblocks=8) , # 110.732 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=8, k=32, tile_m=1, tile_n=1, w=16, v=8, threads=96, grouping=16, minblocks=8) , # 110.732 GFlop/s
   Kernel_dnt_medium(m=6, n=9, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 35.8024 GFlop/s
   Kernel_dnt_medium(m=6, n=9, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 43.8484 GFlop/s
   Kernel_dnt_medium(m=6, n=9, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 51.8175 GFlop/s
   Kernel_dnt_small(m=6, n=9, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 58.965 GFlop/s
   Kernel_dnt_medium(m=6, n=9, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 63.9309 GFlop/s
   Kernel_dnt_medium(m=6, n=9, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 78.5539 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=9, k=16, tile_m=1, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 84.561 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=9, k=16, tile_m=1, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 84.561 GFlop/s
   Kernel_dnt_medium(m=6, n=9, k=17, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 84.3988 GFlop/s
   Kernel_dnt_medium(m=6, n=9, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 100.301 GFlop/s
   Kernel_dnt_medium(m=6, n=9, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 103.968 GFlop/s
@@ -550,26 +550,26 @@
   Kernel_dnt_medium(m=6, n=13, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 76.7893 GFlop/s
   Kernel_dnt_medium(m=6, n=13, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 82.6919 GFlop/s
   Kernel_dnt_medium(m=6, n=13, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 103.505 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=13, k=16, tile_m=1, tile_n=1, w=8, v=12, threads=128, grouping=16, minblocks=8) , # 109.832 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=13, k=16, tile_m=1, tile_n=1, w=8, v=12, threads=128, grouping=16, minblocks=8) , # 109.832 GFlop/s
   Kernel_dnt_medium(m=6, n=13, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 107.414 GFlop/s
   Kernel_dnt_medium(m=6, n=13, k=22, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 126.399 GFlop/s
   Kernel_dnt_medium(m=6, n=13, k=23, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 127.16 GFlop/s
   Kernel_dnt_medium(m=6, n=13, k=24, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 129.224 GFlop/s
   Kernel_dnt_medium(m=6, n=13, k=26, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 124.698 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=13, k=32, tile_m=1, tile_n=1, w=16, v=8, threads=128, grouping=16, minblocks=12) , # 134.667 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=13, k=32, tile_m=1, tile_n=1, w=16, v=8, threads=128, grouping=16, minblocks=12) , # 134.667 GFlop/s
   Kernel_dnt_medium(m=6, n=16, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 63.5995 GFlop/s
   Kernel_dnt_medium(m=6, n=16, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 78.998 GFlop/s
   Kernel_dnt_small(m=6, n=16, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 79.6159 GFlop/s
   Kernel_dnt_small(m=6, n=16, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 94.2819 GFlop/s
   Kernel_dnt_medium(m=6, n=16, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 99.4404 GFlop/s
   Kernel_dnt_medium(m=6, n=16, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 121.474 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=16, k=16, tile_m=1, tile_n=1, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 131.447 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=16, k=16, tile_m=1, tile_n=1, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 131.447 GFlop/s
   Kernel_dnt_medium(m=6, n=16, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 130.503 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=16, k=22, tile_m=1, tile_n=1, w=10, v=16, threads=96, grouping=16, minblocks=8) , # 140.994 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=16, k=22, tile_m=1, tile_n=1, w=10, v=16, threads=96, grouping=16, minblocks=8) , # 140.994 GFlop/s
   Kernel_dnt_medium(m=6, n=16, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 143.929 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=16, k=24, tile_m=1, tile_n=1, w=12, v=16, threads=96, grouping=16, minblocks=1) , # 151.414 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=16, k=24, tile_m=1, tile_n=1, w=12, v=16, threads=96, grouping=16, minblocks=1) , # 151.414 GFlop/s
   Kernel_dnt_medium(m=6, n=16, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=1) , # 150.43 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=16, k=32, tile_m=1, tile_n=1, w=16, v=16, threads=128, grouping=16, minblocks=12) , # 162.722 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=16, k=32, tile_m=1, tile_n=1, w=16, v=16, threads=128, grouping=16, minblocks=12) , # 162.722 GFlop/s
   Kernel_dnt_tiny(m=6, n=17, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 60.5441 GFlop/s
   Kernel_dnt_small(m=6, n=17, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 68.6498 GFlop/s
   Kernel_dnt_medium(m=6, n=17, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 75.0572 GFlop/s
@@ -582,72 +582,72 @@
   Kernel_dnt_medium(m=6, n=17, k=23, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 137.919 GFlop/s
   Kernel_dnt_medium(m=6, n=17, k=24, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 141.952 GFlop/s
   Kernel_dnt_medium(m=6, n=17, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=1) , # 145.765 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=17, k=32, tile_m=1, tile_n=1, w=14, v=8, threads=128, grouping=16, minblocks=12) , # 147.119 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=17, k=32, tile_m=1, tile_n=1, w=14, v=8, threads=128, grouping=16, minblocks=12) , # 147.119 GFlop/s
   Kernel_dnt_small(m=6, n=22, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 68.9181 GFlop/s
   Kernel_dnt_medium(m=6, n=22, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 77.9158 GFlop/s
   Kernel_dnt_medium(m=6, n=22, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 85.5436 GFlop/s
   Kernel_dnt_medium(m=6, n=22, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 107.115 GFlop/s
   Kernel_dnt_medium(m=6, n=22, k=9, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 107.717 GFlop/s
   Kernel_dnt_medium(m=6, n=22, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 130.85 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=22, k=16, tile_m=1, tile_n=2, w=8, v=14, threads=96, grouping=16, minblocks=4) , # 143.533 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=22, k=16, tile_m=1, tile_n=2, w=8, v=14, threads=96, grouping=16, minblocks=4) , # 143.533 GFlop/s
   Kernel_dnt_medium(m=6, n=22, k=17, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 147.658 GFlop/s
   Kernel_dnt_medium(m=6, n=22, k=22, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 142.021 GFlop/s
   Kernel_dnt_medium(m=6, n=22, k=23, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 144.504 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=22, k=24, tile_m=2, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=4) , # 150.931 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=22, k=24, tile_m=2, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=4) , # 150.931 GFlop/s
   Kernel_dnt_medium(m=6, n=22, k=26, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 151.978 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=22, k=32, tile_m=2, tile_n=3, w=16, v=16, threads=96, grouping=16, minblocks=12) , # 160.565 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=22, k=32, tile_m=2, tile_n=3, w=16, v=16, threads=96, grouping=16, minblocks=12) , # 160.565 GFlop/s
   Kernel_dnt_small(m=6, n=23, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 70.9369 GFlop/s
   Kernel_dnt_medium(m=6, n=23, k=5, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 80.8594 GFlop/s
   Kernel_dnt_medium(m=6, n=23, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 88.9708 GFlop/s
   Kernel_dnt_medium(m=6, n=23, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 111.224 GFlop/s
   Kernel_dnt_medium(m=6, n=23, k=9, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 111.977 GFlop/s
   Kernel_dnt_medium(m=6, n=23, k=13, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=8) , # 138.705 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=23, k=16, tile_m=2, tile_n=1, w=8, v=16, threads=96, grouping=16, minblocks=4) , # 145.791 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=23, k=17, tile_m=2, tile_n=1, w=8, v=12, threads=96, grouping=16, minblocks=4) , # 130.847 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=23, k=16, tile_m=2, tile_n=1, w=8, v=16, threads=96, grouping=16, minblocks=4) , # 145.791 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=23, k=17, tile_m=2, tile_n=1, w=8, v=12, threads=96, grouping=16, minblocks=4) , # 130.847 GFlop/s
   Kernel_dnt_medium(m=6, n=23, k=22, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 145.676 GFlop/s
   Kernel_dnt_medium(m=6, n=23, k=23, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 147.626 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=23, k=24, tile_m=2, tile_n=1, w=8, v=16, threads=96, grouping=16, minblocks=1) , # 153.564 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=23, k=26, tile_m=2, tile_n=1, w=10, v=16, threads=128, grouping=16, minblocks=12) , # 149.513 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=23, k=32, tile_m=2, tile_n=1, w=8, v=16, threads=96, grouping=16, minblocks=8) , # 163.779 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=23, k=24, tile_m=2, tile_n=1, w=8, v=16, threads=96, grouping=16, minblocks=1) , # 153.564 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=23, k=26, tile_m=2, tile_n=1, w=10, v=16, threads=128, grouping=16, minblocks=12) , # 149.513 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=23, k=32, tile_m=2, tile_n=1, w=8, v=16, threads=96, grouping=16, minblocks=8) , # 163.779 GFlop/s
   Kernel_dnt_small(m=6, n=24, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 77.1222 GFlop/s
   Kernel_dnt_medium(m=6, n=24, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 85.3145 GFlop/s
   Kernel_dnt_medium(m=6, n=24, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 94.4076 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=24, k=8, tile_m=2, tile_n=1, w=4, v=24, threads=96, grouping=16, minblocks=8) , # 110.004 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=24, k=8, tile_m=2, tile_n=1, w=4, v=24, threads=96, grouping=16, minblocks=8) , # 110.004 GFlop/s
   Kernel_dnt_medium(m=6, n=24, k=9, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 118.271 GFlop/s
   Kernel_dnt_medium(m=6, n=24, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 142.641 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=24, k=16, tile_m=1, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 155.64 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=24, k=17, tile_m=1, tile_n=2, w=8, v=24, threads=96, grouping=16, minblocks=4) , # 140.277 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=24, k=16, tile_m=1, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 155.64 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=24, k=17, tile_m=1, tile_n=2, w=8, v=24, threads=96, grouping=16, minblocks=4) , # 140.277 GFlop/s
   Kernel_dnt_medium(m=6, n=24, k=22, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 154.822 GFlop/s
   Kernel_dnt_medium(m=6, n=24, k=23, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 156.783 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=24, k=24, tile_m=2, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=8) , # 163.247 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=24, k=26, tile_m=1, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=4) , # 158.81 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=24, k=32, tile_m=2, tile_n=1, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 171.227 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=24, k=24, tile_m=2, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=8) , # 163.247 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=24, k=26, tile_m=1, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=4) , # 158.81 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=24, k=32, tile_m=2, tile_n=1, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 171.227 GFlop/s
   Kernel_dnt_medium(m=6, n=26, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 72.8888 GFlop/s
   Kernel_dnt_medium(m=6, n=26, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 86.2243 GFlop/s
   Kernel_dnt_medium(m=6, n=26, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 100.321 GFlop/s
   Kernel_dnt_medium(m=6, n=26, k=8, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 114.794 GFlop/s
   Kernel_dnt_medium(m=6, n=26, k=9, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 124.78 GFlop/s
   Kernel_dnt_medium(m=6, n=26, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 150.084 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=26, k=16, tile_m=2, tile_n=1, w=8, v=26, threads=128, grouping=16, minblocks=12) , # 148.541 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=26, k=16, tile_m=2, tile_n=1, w=8, v=26, threads=128, grouping=16, minblocks=12) , # 148.541 GFlop/s
   Kernel_dnt_medium(m=6, n=26, k=17, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 146.817 GFlop/s
   Kernel_dnt_medium(m=6, n=26, k=22, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 164.867 GFlop/s
   Kernel_dnt_medium(m=6, n=26, k=23, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 167.944 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=26, k=24, tile_m=1, tile_n=1, w=12, v=26, threads=160, grouping=16, minblocks=12) , # 167.824 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=26, k=26, tile_m=1, tile_n=2, w=10, v=26, threads=96, grouping=16, minblocks=12) , # 160.058 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=26, k=32, tile_m=1, tile_n=1, w=12, v=26, threads=160, grouping=16, minblocks=12) , # 172.981 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=26, k=24, tile_m=1, tile_n=1, w=12, v=26, threads=160, grouping=16, minblocks=12) , # 167.824 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=26, k=26, tile_m=1, tile_n=2, w=10, v=26, threads=96, grouping=16, minblocks=12) , # 160.058 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=26, k=32, tile_m=1, tile_n=1, w=12, v=26, threads=160, grouping=16, minblocks=12) , # 172.981 GFlop/s
   Kernel_dnt_medium(m=6, n=32, k=4, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 88.5988 GFlop/s
   Kernel_dnt_medium(m=6, n=32, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 107.109 GFlop/s
   Kernel_dnt_small(m=6, n=32, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 112.623 GFlop/s
   Kernel_dnt_medium(m=6, n=32, k=8, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 136.523 GFlop/s
   Kernel_dnt_medium(m=6, n=32, k=9, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 148.067 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=32, k=13, tile_m=1, tile_n=2, w=6, v=16, threads=96, grouping=16, minblocks=8) , # 157.238 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=32, k=16, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 170.847 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=32, k=13, tile_m=1, tile_n=2, w=6, v=16, threads=96, grouping=16, minblocks=8) , # 157.238 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=32, k=16, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 170.847 GFlop/s
   Kernel_dnt_medium(m=6, n=32, k=17, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 172.856 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=32, k=22, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 177.946 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=32, k=23, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 179.578 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=32, k=24, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 184.552 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=32, k=22, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 177.946 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=32, k=23, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 179.578 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=32, k=24, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 184.552 GFlop/s
   Kernel_dnt_medium(m=6, n=32, k=26, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=1) , # 182.386 GFlop/s
-  Kernel_dnt_largeDB(m=6, n=32, k=32, tile_m=2, tile_n=1, w=8, v=18, threads=128, grouping=16, minblocks=12) , # 192.489 GFlop/s
+  Kernel_dnt_largeDB1(m=6, n=32, k=32, tile_m=2, tile_n=1, w=8, v=18, threads=128, grouping=16, minblocks=12) , # 192.489 GFlop/s
   Kernel_dnt_medium(m=6, n=36, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 119.79 GFlop/s
   Kernel_dnt_tiny(m=7, n=4, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 20.321 GFlop/s
   Kernel_dnt_tiny(m=7, n=4, k=5, split_thread=32, threads=128, grouping=16, minblocks=1) , # 25.1685 GFlop/s
@@ -679,7 +679,7 @@
   Kernel_dnt_largeDB2(m=7, n=7, k=28, tile_m=1, tile_n=1, w=14, v=6, threads=128, grouping=16, minblocks=1) , # 119.39 GFlop/s
   Kernel_dnt_largeDB2(m=7, n=7, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=8) , # 126.959 GFlop/s
   Kernel_dnt_largeDB2(m=7, n=7, k=45, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=1) , # 128.604 GFlop/s
-  Kernel_dnt_largeDB(m=7, n=7, k=49, tile_m=1, tile_n=1, w=18, v=4, threads=128, grouping=16, minblocks=12) , # 120.76 GFlop/s
+  Kernel_dnt_largeDB1(m=7, n=7, k=49, tile_m=1, tile_n=1, w=18, v=4, threads=128, grouping=16, minblocks=12) , # 120.76 GFlop/s
   Kernel_dnt_medium(m=7, n=9, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 42.249 GFlop/s
   Kernel_dnt_medium(m=7, n=9, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 50.9731 GFlop/s
   Kernel_dnt_medium(m=7, n=9, k=7, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 68.4855 GFlop/s
@@ -763,7 +763,7 @@
   Kernel_dnt_medium(m=8, n=4, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 83.3154 GFlop/s
   Kernel_dnt_medium(m=8, n=4, k=24, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 78.1446 GFlop/s
   Kernel_dnt_medium(m=8, n=4, k=26, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 72.9839 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=4, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=4) , # 84.7409 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=4, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=4) , # 84.7409 GFlop/s
   Kernel_dnt_medium(m=8, n=5, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 27.0068 GFlop/s
   Kernel_dnt_medium(m=8, n=5, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 33.1999 GFlop/s
   Kernel_dnt_medium(m=8, n=5, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 38.8056 GFlop/s
@@ -787,9 +787,9 @@
   Kernel_dnt_medium(m=8, n=6, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 87.1602 GFlop/s
   Kernel_dnt_medium(m=8, n=6, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 102.308 GFlop/s
   Kernel_dnt_medium(m=8, n=6, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 105.056 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=6, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=1) , # 99.2986 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=6, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=1) , # 99.2986 GFlop/s
   Kernel_dnt_medium(m=8, n=6, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 100.382 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=6, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=128, grouping=16, minblocks=12) , # 112.447 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=6, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=128, grouping=16, minblocks=12) , # 112.447 GFlop/s
   Kernel_dnt_tiny(m=8, n=8, k=4, split_thread=32, threads=96, grouping=16, minblocks=1) , # 52.7483 GFlop/s
   Kernel_dnt_tiny(m=8, n=8, k=5, split_thread=32, threads=96, grouping=16, minblocks=1) , # 62.8469 GFlop/s
   Kernel_dnt_tiny(m=8, n=8, k=6, split_thread=32, threads=128, grouping=16, minblocks=1) , # 72.9942 GFlop/s
@@ -803,7 +803,7 @@
   Kernel_dnt_medium(m=8, n=8, k=24, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 139.574 GFlop/s
   Kernel_dnt_medium(m=8, n=8, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 139.438 GFlop/s
   Kernel_dnt_medium(m=8, n=8, k=32, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 141.729 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=8, k=64, tile_m=1, tile_n=1, w=16, v=8, threads=128, grouping=16, minblocks=12) , # 155.798 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=8, k=64, tile_m=1, tile_n=1, w=16, v=8, threads=128, grouping=16, minblocks=12) , # 155.798 GFlop/s
   Kernel_dnt_medium(m=8, n=9, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 47.6694 GFlop/s
   Kernel_dnt_medium(m=8, n=9, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 57.6518 GFlop/s
   Kernel_dnt_medium(m=8, n=9, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 67.1608 GFlop/s
@@ -814,35 +814,35 @@
   Kernel_dnt_medium(m=8, n=9, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 116.819 GFlop/s
   Kernel_dnt_medium(m=8, n=9, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 122.26 GFlop/s
   Kernel_dnt_medium(m=8, n=9, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 123.944 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=9, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=8) , # 125.923 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=9, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=8) , # 125.923 GFlop/s
   Kernel_dnt_medium(m=8, n=9, k=26, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 128.998 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=9, k=32, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=12) , # 131.311 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=9, k=32, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=12) , # 131.311 GFlop/s
   Kernel_dnt_tiny(m=8, n=13, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 63.3347 GFlop/s
   Kernel_dnt_medium(m=8, n=13, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 75.8181 GFlop/s
   Kernel_dnt_tiny(m=8, n=13, k=6, split_thread=32, threads=128, grouping=16, minblocks=1) , # 86.1038 GFlop/s
   Kernel_dnt_small(m=8, n=13, k=8, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=8) , # 98.14 GFlop/s
   Kernel_dnt_medium(m=8, n=13, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 105.704 GFlop/s
   Kernel_dnt_medium(m=8, n=13, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 123.059 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=13, k=16, tile_m=1, tile_n=1, w=8, v=10, threads=128, grouping=16, minblocks=12) , # 135.239 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=13, k=16, tile_m=1, tile_n=1, w=8, v=10, threads=128, grouping=16, minblocks=12) , # 135.239 GFlop/s
   Kernel_dnt_medium(m=8, n=13, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 137.477 GFlop/s
   Kernel_dnt_medium(m=8, n=13, k=22, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 162.424 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=13, k=23, tile_m=1, tile_n=1, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 145.317 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=13, k=23, tile_m=1, tile_n=1, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 145.317 GFlop/s
   Kernel_dnt_medium(m=8, n=13, k=24, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 151.977 GFlop/s
   Kernel_dnt_medium(m=8, n=13, k=26, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 152.263 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=13, k=32, tile_m=1, tile_n=1, w=16, v=10, threads=128, grouping=16, minblocks=1) , # 160.083 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=13, k=32, tile_m=1, tile_n=1, w=16, v=10, threads=128, grouping=16, minblocks=1) , # 160.083 GFlop/s
   Kernel_dnt_tiny(m=8, n=16, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 77.4084 GFlop/s
   Kernel_dnt_medium(m=8, n=16, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 91.6492 GFlop/s
   Kernel_dnt_tiny(m=8, n=16, k=6, split_thread=32, threads=128, grouping=16, minblocks=1) , # 102.56 GFlop/s
   Kernel_dnt_small(m=8, n=16, k=8, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 121.25 GFlop/s
   Kernel_dnt_medium(m=8, n=16, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 120.932 GFlop/s
   Kernel_dnt_medium(m=8, n=16, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 150.649 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=16, k=16, tile_m=1, tile_n=1, w=8, v=16, threads=128, grouping=16, minblocks=1) , # 165.868 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=16, k=16, tile_m=1, tile_n=1, w=8, v=16, threads=128, grouping=16, minblocks=1) , # 165.868 GFlop/s
   Kernel_dnt_medium(m=8, n=16, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 166.714 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=16, k=22, tile_m=1, tile_n=1, w=8, v=16, threads=128, grouping=16, minblocks=1) , # 174.831 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=16, k=22, tile_m=1, tile_n=1, w=8, v=16, threads=128, grouping=16, minblocks=1) , # 174.831 GFlop/s
   Kernel_dnt_medium(m=8, n=16, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 177.658 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=16, k=24, tile_m=1, tile_n=1, w=12, v=16, threads=128, grouping=16, minblocks=12) , # 183.951 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=16, k=26, tile_m=2, tile_n=1, w=10, v=6, threads=96, grouping=16, minblocks=1) , # 180.88 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=16, k=32, tile_m=1, tile_n=1, w=16, v=16, threads=128, grouping=16, minblocks=4) , # 193.463 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=16, k=24, tile_m=1, tile_n=1, w=12, v=16, threads=128, grouping=16, minblocks=12) , # 183.951 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=16, k=26, tile_m=2, tile_n=1, w=10, v=6, threads=96, grouping=16, minblocks=1) , # 180.88 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=16, k=32, tile_m=1, tile_n=1, w=16, v=16, threads=128, grouping=16, minblocks=4) , # 193.463 GFlop/s
   Kernel_dnt_medium(m=8, n=17, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 77.1216 GFlop/s
   Kernel_dnt_medium(m=8, n=17, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 92.0325 GFlop/s
   Kernel_dnt_small(m=8, n=17, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 91.8413 GFlop/s
@@ -853,61 +853,61 @@
   Kernel_dnt_medium(m=8, n=17, k=17, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 143.132 GFlop/s
   Kernel_dnt_medium(m=8, n=17, k=22, tile_m=1, tile_n=1, threads=224, grouping=16, minblocks=8) , # 150.659 GFlop/s
   Kernel_dnt_medium(m=8, n=17, k=23, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 157.854 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=17, k=24, tile_m=2, tile_n=1, w=12, v=6, threads=96, grouping=16, minblocks=12) , # 164.338 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=17, k=24, tile_m=2, tile_n=1, w=12, v=6, threads=96, grouping=16, minblocks=12) , # 164.338 GFlop/s
   Kernel_dnt_medium(m=8, n=17, k=26, tile_m=1, tile_n=1, threads=224, grouping=16, minblocks=8) , # 155.587 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=17, k=32, tile_m=2, tile_n=3, w=16, v=16, threads=96, grouping=16, minblocks=12) , # 172.147 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=17, k=32, tile_m=2, tile_n=3, w=16, v=16, threads=96, grouping=16, minblocks=12) , # 172.147 GFlop/s
   Kernel_dnt_medium(m=8, n=22, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 98.4831 GFlop/s
   Kernel_dnt_small(m=8, n=22, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 102.251 GFlop/s
   Kernel_dnt_medium(m=8, n=22, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 113.706 GFlop/s
   Kernel_dnt_medium(m=8, n=22, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 142.267 GFlop/s
   Kernel_dnt_medium(m=8, n=22, k=9, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=8) , # 141.743 GFlop/s
   Kernel_dnt_medium(m=8, n=22, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 172.127 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=22, k=16, tile_m=2, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=1) , # 186.548 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=22, k=17, tile_m=2, tile_n=1, w=8, v=10, threads=96, grouping=16, minblocks=4) , # 175.381 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=22, k=22, tile_m=2, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=8) , # 183.582 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=22, k=23, tile_m=2, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=1) , # 185.959 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=22, k=24, tile_m=2, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 195.033 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=22, k=26, tile_m=2, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=4) , # 187.132 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=22, k=32, tile_m=2, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=8) , # 211.83 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=22, k=16, tile_m=2, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=1) , # 186.548 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=22, k=17, tile_m=2, tile_n=1, w=8, v=10, threads=96, grouping=16, minblocks=4) , # 175.381 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=22, k=22, tile_m=2, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=8) , # 183.582 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=22, k=23, tile_m=2, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=1) , # 185.959 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=22, k=24, tile_m=2, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 195.033 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=22, k=26, tile_m=2, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=4) , # 187.132 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=22, k=32, tile_m=2, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=8) , # 211.83 GFlop/s
   Kernel_dnt_medium(m=8, n=23, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 102.42 GFlop/s
   Kernel_dnt_small(m=8, n=23, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=8) , # 105.176 GFlop/s
   Kernel_dnt_medium(m=8, n=23, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 118.044 GFlop/s
   Kernel_dnt_medium(m=8, n=23, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 147.212 GFlop/s
   Kernel_dnt_medium(m=8, n=23, k=9, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 147.697 GFlop/s
   Kernel_dnt_medium(m=8, n=23, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 178.045 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=23, k=16, tile_m=2, tile_n=1, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 188.608 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=23, k=17, tile_m=2, tile_n=1, w=8, v=10, threads=96, grouping=16, minblocks=1) , # 178.959 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=23, k=22, tile_m=2, tile_n=1, w=8, v=12, threads=96, grouping=16, minblocks=8) , # 187.535 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=23, k=23, tile_m=2, tile_n=1, w=8, v=12, threads=96, grouping=16, minblocks=8) , # 189.238 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=23, k=24, tile_m=2, tile_n=1, w=8, v=12, threads=96, grouping=16, minblocks=8) , # 196.5 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=23, k=26, tile_m=2, tile_n=1, w=10, v=22, threads=128, grouping=16, minblocks=12) , # 191.916 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=23, k=32, tile_m=2, tile_n=1, w=8, v=10, threads=96, grouping=16, minblocks=1) , # 214.467 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=23, k=16, tile_m=2, tile_n=1, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 188.608 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=23, k=17, tile_m=2, tile_n=1, w=8, v=10, threads=96, grouping=16, minblocks=1) , # 178.959 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=23, k=22, tile_m=2, tile_n=1, w=8, v=12, threads=96, grouping=16, minblocks=8) , # 187.535 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=23, k=23, tile_m=2, tile_n=1, w=8, v=12, threads=96, grouping=16, minblocks=8) , # 189.238 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=23, k=24, tile_m=2, tile_n=1, w=8, v=12, threads=96, grouping=16, minblocks=8) , # 196.5 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=23, k=26, tile_m=2, tile_n=1, w=10, v=22, threads=128, grouping=16, minblocks=12) , # 191.916 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=23, k=32, tile_m=2, tile_n=1, w=8, v=10, threads=96, grouping=16, minblocks=1) , # 214.467 GFlop/s
   Kernel_dnt_small(m=8, n=24, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 99.7498 GFlop/s
   Kernel_dnt_small(m=8, n=24, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=4) , # 111.391 GFlop/s
   Kernel_dnt_medium(m=8, n=24, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 123.551 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=24, k=8, tile_m=2, tile_n=1, w=4, v=24, threads=96, grouping=16, minblocks=1) , # 143.632 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=24, k=8, tile_m=2, tile_n=1, w=4, v=24, threads=96, grouping=16, minblocks=1) , # 143.632 GFlop/s
   Kernel_dnt_medium(m=8, n=24, k=9, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=8) , # 154.155 GFlop/s
   Kernel_dnt_medium(m=8, n=24, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 185.726 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=24, k=16, tile_m=2, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 198.469 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=24, k=17, tile_m=2, tile_n=1, w=8, v=10, threads=96, grouping=16, minblocks=1) , # 187.951 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=24, k=22, tile_m=2, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 199.801 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=24, k=23, tile_m=2, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=1) , # 199.689 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=24, k=24, tile_m=2, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=4) , # 207.228 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=24, k=26, tile_m=2, tile_n=1, w=8, v=12, threads=96, grouping=16, minblocks=8) , # 204.676 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=24, k=32, tile_m=2, tile_n=1, w=8, v=10, threads=96, grouping=16, minblocks=8) , # 221.005 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=24, k=16, tile_m=2, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 198.469 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=24, k=17, tile_m=2, tile_n=1, w=8, v=10, threads=96, grouping=16, minblocks=1) , # 187.951 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=24, k=22, tile_m=2, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 199.801 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=24, k=23, tile_m=2, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=1) , # 199.689 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=24, k=24, tile_m=2, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=4) , # 207.228 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=24, k=26, tile_m=2, tile_n=1, w=8, v=12, threads=96, grouping=16, minblocks=8) , # 204.676 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=24, k=32, tile_m=2, tile_n=1, w=8, v=10, threads=96, grouping=16, minblocks=8) , # 221.005 GFlop/s
   Kernel_dnt_small(m=8, n=26, k=4, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=4) , # 98.6441 GFlop/s
   Kernel_dnt_small(m=8, n=26, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=8) , # 103.296 GFlop/s
   Kernel_dnt_medium(m=8, n=26, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 117.769 GFlop/s
   Kernel_dnt_medium(m=8, n=26, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 147.311 GFlop/s
   Kernel_dnt_medium(m=8, n=26, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 157.749 GFlop/s
   Kernel_dnt_medium(m=8, n=26, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 183.678 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=26, k=16, tile_m=2, tile_n=1, w=8, v=26, threads=128, grouping=16, minblocks=8) , # 184.93 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=26, k=17, tile_m=2, tile_n=1, w=8, v=26, threads=128, grouping=16, minblocks=12) , # 174.79 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=26, k=22, tile_m=2, tile_n=1, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 190.782 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=26, k=23, tile_m=2, tile_n=1, w=8, v=26, threads=128, grouping=16, minblocks=12) , # 192.48 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=26, k=24, tile_m=2, tile_n=1, w=8, v=26, threads=128, grouping=16, minblocks=12) , # 201.264 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=26, k=26, tile_m=2, tile_n=2, w=8, v=26, threads=128, grouping=16, minblocks=12) , # 200.465 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=26, k=32, tile_m=2, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=12) , # 213.624 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=26, k=16, tile_m=2, tile_n=1, w=8, v=26, threads=128, grouping=16, minblocks=8) , # 184.93 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=26, k=17, tile_m=2, tile_n=1, w=8, v=26, threads=128, grouping=16, minblocks=12) , # 174.79 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=26, k=22, tile_m=2, tile_n=1, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 190.782 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=26, k=23, tile_m=2, tile_n=1, w=8, v=26, threads=128, grouping=16, minblocks=12) , # 192.48 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=26, k=24, tile_m=2, tile_n=1, w=8, v=26, threads=128, grouping=16, minblocks=12) , # 201.264 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=26, k=26, tile_m=2, tile_n=2, w=8, v=26, threads=128, grouping=16, minblocks=12) , # 200.465 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=26, k=32, tile_m=2, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=12) , # 213.624 GFlop/s
   Kernel_dnt_small(m=8, n=32, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=8) , # 120.164 GFlop/s
   Kernel_dnt_small(m=8, n=32, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=4) , # 126.86 GFlop/s
   Kernel_dnt_medium(m=8, n=32, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 143.186 GFlop/s
@@ -916,12 +916,12 @@
   Kernel_dnt_medium(m=8, n=32, k=13, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 193.414 GFlop/s
   Kernel_dnt_medium(m=8, n=32, k=16, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 216.01 GFlop/s
   Kernel_dnt_medium(m=8, n=32, k=17, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 213.609 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=32, k=22, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 222.573 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=32, k=23, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 224.463 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=32, k=24, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 231.134 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=32, k=26, tile_m=2, tile_n=2, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 230.134 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=32, k=32, tile_m=2, tile_n=1, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 238.795 GFlop/s
-  Kernel_dnt_largeDB(m=8, n=64, k=8, tile_m=1, tile_n=4, w=4, v=48, threads=128, grouping=16, minblocks=12) , # 205.107 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=32, k=22, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 222.573 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=32, k=23, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 224.463 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=32, k=24, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 231.134 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=32, k=26, tile_m=2, tile_n=2, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 230.134 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=32, k=32, tile_m=2, tile_n=1, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 238.795 GFlop/s
+  Kernel_dnt_largeDB1(m=8, n=64, k=8, tile_m=1, tile_n=4, w=4, v=48, threads=128, grouping=16, minblocks=12) , # 205.107 GFlop/s
   Kernel_dnt_largeDB2(m=9, n=4, k=4, tile_m=1, tile_n=1, w=2, v=4, threads=96, grouping=16, minblocks=1) , # 25.2097 GFlop/s
   Kernel_dnt_medium(m=9, n=4, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 29.9919 GFlop/s
   Kernel_dnt_medium(m=9, n=4, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 35.1352 GFlop/s
@@ -929,7 +929,7 @@
   Kernel_dnt_small(m=9, n=4, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 40.9728 GFlop/s
   Kernel_dnt_medium(m=9, n=4, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 48.8693 GFlop/s
   Kernel_dnt_small(m=9, n=4, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 57.4295 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=4, k=16, tile_m=1, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 60.1671 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=4, k=16, tile_m=1, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 60.1671 GFlop/s
   Kernel_dnt_medium(m=9, n=4, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 59.5034 GFlop/s
   Kernel_dnt_medium(m=9, n=4, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 80.7153 GFlop/s
   Kernel_dnt_medium(m=9, n=4, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 81.9869 GFlop/s
@@ -946,7 +946,7 @@
   Kernel_dnt_small(m=9, n=5, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 49.3598 GFlop/s
   Kernel_dnt_medium(m=9, n=5, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 60.7052 GFlop/s
   Kernel_dnt_medium(m=9, n=5, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 71.4975 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=5, k=16, tile_m=1, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=12) , # 70.7421 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=5, k=16, tile_m=1, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=12) , # 70.7421 GFlop/s
   Kernel_dnt_medium(m=9, n=5, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 73.9933 GFlop/s
   Kernel_dnt_medium(m=9, n=5, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 86.1888 GFlop/s
   Kernel_dnt_medium(m=9, n=5, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 88.3985 GFlop/s
@@ -962,11 +962,11 @@
   Kernel_dnt_small(m=9, n=6, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 58.9838 GFlop/s
   Kernel_dnt_medium(m=9, n=6, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 63.1913 GFlop/s
   Kernel_dnt_medium(m=9, n=6, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 78.6654 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=6, k=16, tile_m=1, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 87.0012 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=6, k=16, tile_m=1, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 87.0012 GFlop/s
   Kernel_dnt_medium(m=9, n=6, k=17, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 84.4738 GFlop/s
   Kernel_dnt_medium(m=9, n=6, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 101.406 GFlop/s
   Kernel_dnt_medium(m=9, n=6, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 104.769 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=6, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=4) , # 108.241 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=6, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=4) , # 108.241 GFlop/s
   Kernel_dnt_medium(m=9, n=6, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 111.759 GFlop/s
   Kernel_dnt_medium(m=9, n=6, k=32, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 118.358 GFlop/s
   Kernel_dnt_medium(m=9, n=7, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 42.4018 GFlop/s
@@ -985,13 +985,13 @@
   Kernel_dnt_medium(m=9, n=8, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 76.9026 GFlop/s
   Kernel_dnt_medium(m=9, n=8, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 82.1029 GFlop/s
   Kernel_dnt_medium(m=9, n=8, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 99.4363 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=8, k=16, tile_m=1, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=1) , # 106.792 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=8, k=16, tile_m=1, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=1) , # 106.792 GFlop/s
   Kernel_dnt_medium(m=9, n=8, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 103.155 GFlop/s
   Kernel_dnt_medium(m=9, n=8, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 122.251 GFlop/s
   Kernel_dnt_medium(m=9, n=8, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 125.713 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=8, k=24, tile_m=1, tile_n=1, w=12, v=8, threads=128, grouping=16, minblocks=8) , # 127.47 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=8, k=24, tile_m=1, tile_n=1, w=12, v=8, threads=128, grouping=16, minblocks=8) , # 127.47 GFlop/s
   Kernel_dnt_medium(m=9, n=8, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 127.087 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=8, k=32, tile_m=1, tile_n=1, w=12, v=8, threads=128, grouping=16, minblocks=12) , # 132.924 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=8, k=32, tile_m=1, tile_n=1, w=12, v=8, threads=128, grouping=16, minblocks=12) , # 132.924 GFlop/s
   Kernel_dnt_tiny(m=9, n=9, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 62.4312 GFlop/s
   Kernel_dnt_tiny(m=9, n=9, k=5, split_thread=32, threads=96, grouping=16, minblocks=1) , # 74.0588 GFlop/s
   Kernel_dnt_medium(m=9, n=9, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 83.6127 GFlop/s
@@ -1009,8 +1009,8 @@
   Kernel_dnt_medium(m=9, n=9, k=28, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 155.64 GFlop/s
   Kernel_dnt_medium(m=9, n=9, k=32, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 159.535 GFlop/s
   Kernel_dnt_largeDB2(m=9, n=9, k=45, tile_m=1, tile_n=1, w=16, v=8, threads=160, grouping=16, minblocks=1) , # 160.12 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=9, k=64, tile_m=1, tile_n=1, w=14, v=6, threads=128, grouping=16, minblocks=12) , # 160.483 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=9, k=81, tile_m=1, tile_n=1, w=14, v=6, threads=128, grouping=16, minblocks=12) , # 164.81 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=9, k=64, tile_m=1, tile_n=1, w=14, v=6, threads=128, grouping=16, minblocks=12) , # 160.483 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=9, k=81, tile_m=1, tile_n=1, w=14, v=6, threads=128, grouping=16, minblocks=12) , # 164.81 GFlop/s
   Kernel_dnt_largeDB2(m=9, n=13, k=4, tile_m=1, tile_n=1, w=2, v=12, threads=128, grouping=16, minblocks=1) , # 68.546 GFlop/s
   Kernel_dnt_tiny(m=9, n=13, k=5, split_thread=32, threads=128, grouping=16, minblocks=1) , # 81.5548 GFlop/s
   Kernel_dnt_small(m=9, n=13, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 86.6047 GFlop/s
@@ -1018,7 +1018,7 @@
   Kernel_dnt_medium(m=9, n=13, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 110.269 GFlop/s
   Kernel_dnt_medium(m=9, n=13, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 118.614 GFlop/s
   Kernel_dnt_largeDB2(m=9, n=13, k=13, tile_m=1, tile_n=2, w=6, v=10, threads=96, grouping=16, minblocks=8) , # 137.421 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=13, k=16, tile_m=1, tile_n=1, w=8, v=12, threads=128, grouping=16, minblocks=8) , # 148.198 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=13, k=16, tile_m=1, tile_n=1, w=8, v=12, threads=128, grouping=16, minblocks=8) , # 148.198 GFlop/s
   Kernel_dnt_medium(m=9, n=13, k=17, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 144.57 GFlop/s
   Kernel_dnt_medium(m=9, n=13, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 157.619 GFlop/s
   Kernel_dnt_medium(m=9, n=13, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 159.911 GFlop/s
@@ -1034,14 +1034,14 @@
   Kernel_dnt_medium(m=9, n=16, k=8, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=8) , # 114.152 GFlop/s
   Kernel_dnt_medium(m=9, n=16, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 125.152 GFlop/s
   Kernel_dnt_medium(m=9, n=16, k=13, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 138.713 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=16, k=16, tile_m=1, tile_n=2, w=8, v=10, threads=96, grouping=16, minblocks=1) , # 161.565 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=16, k=16, tile_m=1, tile_n=2, w=8, v=10, threads=96, grouping=16, minblocks=1) , # 161.565 GFlop/s
   Kernel_dnt_medium(m=9, n=16, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 162.59 GFlop/s
   Kernel_dnt_medium(m=9, n=16, k=22, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 167.882 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=16, k=23, tile_m=1, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=8) , # 166.582 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=16, k=24, tile_m=1, tile_n=2, w=12, v=14, threads=128, grouping=16, minblocks=12) , # 170.479 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=16, k=26, tile_m=1, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=8) , # 173.529 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=16, k=32, tile_m=1, tile_n=2, w=14, v=16, threads=128, grouping=16, minblocks=12) , # 179.16 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=16, k=64, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 207.542 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=16, k=23, tile_m=1, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=8) , # 166.582 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=16, k=24, tile_m=1, tile_n=2, w=12, v=14, threads=128, grouping=16, minblocks=12) , # 170.479 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=16, k=26, tile_m=1, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=8) , # 173.529 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=16, k=32, tile_m=1, tile_n=2, w=14, v=16, threads=128, grouping=16, minblocks=12) , # 179.16 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=16, k=64, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 207.542 GFlop/s
   Kernel_dnt_medium(m=9, n=17, k=4, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 77.9597 GFlop/s
   Kernel_dnt_medium(m=9, n=17, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 93.47 GFlop/s
   Kernel_dnt_medium(m=9, n=17, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 98.6733 GFlop/s
@@ -1052,9 +1052,9 @@
   Kernel_dnt_medium(m=9, n=17, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 162.657 GFlop/s
   Kernel_dnt_medium(m=9, n=17, k=22, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=8) , # 165.859 GFlop/s
   Kernel_dnt_medium(m=9, n=17, k=23, tile_m=1, tile_n=1, threads=224, grouping=16, minblocks=8) , # 162.634 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=17, k=24, tile_m=2, tile_n=1, w=8, v=10, threads=96, grouping=16, minblocks=1) , # 166.06 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=17, k=26, tile_m=1, tile_n=2, w=10, v=10, threads=96, grouping=16, minblocks=4) , # 167.993 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=17, k=32, tile_m=2, tile_n=1, w=16, v=10, threads=96, grouping=16, minblocks=12) , # 180.16 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=17, k=24, tile_m=2, tile_n=1, w=8, v=10, threads=96, grouping=16, minblocks=1) , # 166.06 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=17, k=26, tile_m=1, tile_n=2, w=10, v=10, threads=96, grouping=16, minblocks=4) , # 167.993 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=17, k=32, tile_m=2, tile_n=1, w=16, v=10, threads=96, grouping=16, minblocks=12) , # 180.16 GFlop/s
   Kernel_dnt_medium(m=9, n=22, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 90.7465 GFlop/s
   Kernel_dnt_medium(m=9, n=22, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 106.972 GFlop/s
   Kernel_dnt_medium(m=9, n=22, k=6, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=12) , # 111.035 GFlop/s
@@ -1063,12 +1063,12 @@
   Kernel_dnt_medium(m=9, n=22, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 172.574 GFlop/s
   Kernel_dnt_medium(m=9, n=22, k=16, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 172.49 GFlop/s
   Kernel_dnt_medium(m=9, n=22, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 170.487 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=22, k=22, tile_m=2, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 183.705 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=22, k=22, tile_m=2, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 183.705 GFlop/s
   Kernel_dnt_medium(m=9, n=22, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 191.689 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=22, k=24, tile_m=2, tile_n=2, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 194.866 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=22, k=26, tile_m=2, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 194.953 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=22, k=32, tile_m=2, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 207.422 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=22, k=64, tile_m=2, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 239.402 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=22, k=24, tile_m=2, tile_n=2, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 194.866 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=22, k=26, tile_m=2, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 194.953 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=22, k=32, tile_m=2, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 207.422 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=22, k=64, tile_m=2, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 239.402 GFlop/s
   Kernel_dnt_medium(m=9, n=23, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 94.256 GFlop/s
   Kernel_dnt_medium(m=9, n=23, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 111.899 GFlop/s
   Kernel_dnt_medium(m=9, n=23, k=6, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 114.731 GFlop/s
@@ -1077,24 +1077,24 @@
   Kernel_dnt_medium(m=9, n=23, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 177.746 GFlop/s
   Kernel_dnt_medium(m=9, n=23, k=16, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 177.57 GFlop/s
   Kernel_dnt_medium(m=9, n=23, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 176.836 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=23, k=22, tile_m=2, tile_n=2, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 194.385 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=23, k=23, tile_m=2, tile_n=2, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 198.019 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=23, k=24, tile_m=2, tile_n=2, w=10, v=12, threads=128, grouping=16, minblocks=12) , # 203.27 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=23, k=26, tile_m=2, tile_n=1, w=10, v=12, threads=128, grouping=16, minblocks=12) , # 199.492 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=23, k=32, tile_m=1, tile_n=2, w=14, v=12, threads=128, grouping=16, minblocks=12) , # 209.275 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=23, k=22, tile_m=2, tile_n=2, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 194.385 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=23, k=23, tile_m=2, tile_n=2, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 198.019 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=23, k=24, tile_m=2, tile_n=2, w=10, v=12, threads=128, grouping=16, minblocks=12) , # 203.27 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=23, k=26, tile_m=2, tile_n=1, w=10, v=12, threads=128, grouping=16, minblocks=12) , # 199.492 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=23, k=32, tile_m=1, tile_n=2, w=14, v=12, threads=128, grouping=16, minblocks=12) , # 209.275 GFlop/s
   Kernel_dnt_medium(m=9, n=24, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 100.426 GFlop/s
   Kernel_dnt_medium(m=9, n=24, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 117.722 GFlop/s
   Kernel_dnt_medium(m=9, n=24, k=6, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=12) , # 122.677 GFlop/s
   Kernel_dnt_medium(m=9, n=24, k=8, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 141.521 GFlop/s
   Kernel_dnt_medium(m=9, n=24, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 165.569 GFlop/s
   Kernel_dnt_medium(m=9, n=24, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 189.324 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=24, k=16, tile_m=1, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=1) , # 191.231 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=24, k=16, tile_m=1, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=1) , # 191.231 GFlop/s
   Kernel_dnt_medium(m=9, n=24, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 187.441 GFlop/s
   Kernel_dnt_medium(m=9, n=24, k=22, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 209.101 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=24, k=23, tile_m=2, tile_n=2, w=10, v=24, threads=128, grouping=16, minblocks=12) , # 207.575 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=24, k=24, tile_m=2, tile_n=2, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 215.864 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=24, k=26, tile_m=1, tile_n=2, w=10, v=24, threads=128, grouping=16, minblocks=12) , # 210.582 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=24, k=32, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 225.901 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=24, k=23, tile_m=2, tile_n=2, w=10, v=24, threads=128, grouping=16, minblocks=12) , # 207.575 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=24, k=24, tile_m=2, tile_n=2, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 215.864 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=24, k=26, tile_m=1, tile_n=2, w=10, v=24, threads=128, grouping=16, minblocks=12) , # 210.582 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=24, k=32, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 225.901 GFlop/s
   Kernel_dnt_largeDB2(m=9, n=25, k=4, tile_m=2, tile_n=1, w=2, v=14, threads=128, grouping=16, minblocks=4) , # 107.355 GFlop/s
   Kernel_dnt_medium(m=9, n=25, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 116.291 GFlop/s
   Kernel_dnt_medium(m=9, n=25, k=7, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 132.632 GFlop/s
@@ -1112,11 +1112,11 @@
   Kernel_dnt_medium(m=9, n=26, k=8, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 148.898 GFlop/s
   Kernel_dnt_medium(m=9, n=26, k=9, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 160.328 GFlop/s
   Kernel_dnt_medium(m=9, n=26, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 200.731 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=26, k=16, tile_m=1, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=1) , # 192.481 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=26, k=16, tile_m=1, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=1) , # 192.481 GFlop/s
   Kernel_dnt_medium(m=9, n=26, k=17, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 191.617 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=26, k=22, tile_m=1, tile_n=2, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 201.724 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=26, k=23, tile_m=1, tile_n=2, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 205.283 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=26, k=24, tile_m=1, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=12) , # 215.418 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=26, k=22, tile_m=1, tile_n=2, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 201.724 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=26, k=23, tile_m=1, tile_n=2, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 205.283 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=26, k=24, tile_m=1, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=12) , # 215.418 GFlop/s
   Kernel_dnt_largeDB2(m=9, n=26, k=25, tile_m=1, tile_n=2, w=12, v=14, threads=128, grouping=16, minblocks=12) , # 224.702 GFlop/s
   Kernel_dnt_largeDB2(m=9, n=26, k=26, tile_m=1, tile_n=2, w=12, v=14, threads=128, grouping=16, minblocks=12) , # 225.99 GFlop/s
   Kernel_dnt_largeDB2(m=9, n=26, k=28, tile_m=1, tile_n=4, w=14, v=16, threads=96, grouping=16, minblocks=12) , # 240.33 GFlop/s
@@ -1139,11 +1139,11 @@
   Kernel_dnt_medium(m=9, n=32, k=8, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 183.327 GFlop/s
   Kernel_dnt_medium(m=9, n=32, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 192.731 GFlop/s
   Kernel_dnt_largeDB2(m=9, n=32, k=13, tile_m=3, tile_n=1, w=6, v=30, threads=96, grouping=16, minblocks=12) , # 209.298 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=32, k=16, tile_m=3, tile_n=1, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 215.364 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=32, k=17, tile_m=2, tile_n=2, w=6, v=32, threads=96, grouping=16, minblocks=12) , # 212.232 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=32, k=22, tile_m=3, tile_n=1, w=8, v=20, threads=128, grouping=16, minblocks=12) , # 230.249 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=32, k=23, tile_m=3, tile_n=1, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 232.646 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=32, k=24, tile_m=3, tile_n=1, w=8, v=20, threads=128, grouping=16, minblocks=12) , # 239.302 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=32, k=16, tile_m=3, tile_n=1, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 215.364 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=32, k=17, tile_m=2, tile_n=2, w=6, v=32, threads=96, grouping=16, minblocks=12) , # 212.232 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=32, k=22, tile_m=3, tile_n=1, w=8, v=20, threads=128, grouping=16, minblocks=12) , # 230.249 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=32, k=23, tile_m=3, tile_n=1, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 232.646 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=32, k=24, tile_m=3, tile_n=1, w=8, v=20, threads=128, grouping=16, minblocks=12) , # 239.302 GFlop/s
   Kernel_dnt_largeDB2(m=9, n=32, k=25, tile_m=2, tile_n=3, w=10, v=32, threads=96, grouping=16, minblocks=12) , # 253.788 GFlop/s
   Kernel_dnt_largeDB2(m=9, n=32, k=26, tile_m=3, tile_n=2, w=10, v=30, threads=96, grouping=16, minblocks=12) , # 254.099 GFlop/s
   Kernel_dnt_largeDB2(m=9, n=32, k=28, tile_m=3, tile_n=2, w=14, v=32, threads=96, grouping=16, minblocks=12) , # 261.58 GFlop/s
@@ -1160,27 +1160,27 @@
   Kernel_dnt_largeDB2(m=9, n=45, k=32, tile_m=2, tile_n=4, w=12, v=24, threads=128, grouping=16, minblocks=8) , # 275.89 GFlop/s
   Kernel_dnt_largeDB2(m=9, n=45, k=45, tile_m=2, tile_n=3, w=8, v=18, threads=96, grouping=16, minblocks=12) , # 284.511 GFlop/s
   Kernel_dnt_medium(m=9, n=64, k=9, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 213.899 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=64, k=16, tile_m=3, tile_n=2, w=6, v=48, threads=96, grouping=16, minblocks=12) , # 262.958 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=64, k=22, tile_m=3, tile_n=2, w=6, v=32, threads=96, grouping=16, minblocks=12) , # 285.617 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=64, k=64, tile_m=3, tile_n=2, w=10, v=64, threads=128, grouping=16, minblocks=8) , # 319.273 GFlop/s
-  Kernel_dnt_largeDB(m=9, n=81, k=9, tile_m=5, tile_n=2, w=2, v=52, threads=96, grouping=16, minblocks=12) , # 202.245 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=64, k=16, tile_m=3, tile_n=2, w=6, v=48, threads=96, grouping=16, minblocks=12) , # 262.958 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=64, k=22, tile_m=3, tile_n=2, w=6, v=32, threads=96, grouping=16, minblocks=12) , # 285.617 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=64, k=64, tile_m=3, tile_n=2, w=10, v=64, threads=128, grouping=16, minblocks=8) , # 319.273 GFlop/s
+  Kernel_dnt_largeDB1(m=9, n=81, k=9, tile_m=5, tile_n=2, w=2, v=52, threads=96, grouping=16, minblocks=12) , # 202.245 GFlop/s
   Kernel_dnt_largeDB2(m=10, n=4, k=4, tile_m=1, tile_n=1, w=2, v=4, threads=96, grouping=16, minblocks=4) , # 28.1008 GFlop/s
   Kernel_dnt_small(m=10, n=4, k=10, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 54.1832 GFlop/s
   Kernel_dnt_medium(m=10, n=4, k=15, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 70.4501 GFlop/s
   Kernel_dnt_tiny(m=10, n=10, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 74.7338 GFlop/s
   Kernel_dnt_medium(m=10, n=10, k=10, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 116.741 GFlop/s
   Kernel_dnt_medium(m=10, n=10, k=15, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 141.061 GFlop/s
-  Kernel_dnt_largeDB(m=10, n=10, k=100, tile_m=2, tile_n=2, w=20, v=10, threads=96, grouping=16, minblocks=12) , # 193.259 GFlop/s
+  Kernel_dnt_largeDB1(m=10, n=10, k=100, tile_m=2, tile_n=2, w=20, v=10, threads=96, grouping=16, minblocks=12) , # 193.259 GFlop/s
   Kernel_dnt_largeDB2(m=10, n=15, k=4, tile_m=1, tile_n=2, w=2, v=8, threads=96, grouping=16, minblocks=4) , # 81.7434 GFlop/s
   Kernel_dnt_largeDB2(m=10, n=15, k=10, tile_m=2, tile_n=1, w=4, v=8, threads=96, grouping=16, minblocks=4) , # 137.343 GFlop/s
   Kernel_dnt_largeDB2(m=10, n=15, k=15, tile_m=2, tile_n=1, w=6, v=8, threads=96, grouping=16, minblocks=1) , # 168.752 GFlop/s
   Kernel_dnt_medium(m=10, n=100, k=10, tile_m=2, tile_n=4, threads=128, grouping=16, minblocks=4) , # 250.611 GFlop/s
   Kernel_dnt_medium(m=11, n=11, k=11, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 148.474 GFlop/s
-  Kernel_dnt_largeDB(m=11, n=11, k=121, tile_m=3, tile_n=2, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 206.461 GFlop/s
+  Kernel_dnt_largeDB1(m=11, n=11, k=121, tile_m=3, tile_n=2, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 206.461 GFlop/s
   Kernel_dnt_medium(m=11, n=121, k=11, tile_m=3, tile_n=2, threads=256, grouping=16, minblocks=4) , # 264.615 GFlop/s
   Kernel_dnt_small(m=12, n=12, k=12, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 154.228 GFlop/s
-  Kernel_dnt_largeDB(m=12, n=12, k=144, tile_m=3, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=12) , # 249.09 GFlop/s
-  Kernel_dnt_largeDB(m=12, n=144, k=12, tile_m=3, tile_n=3, w=6, v=80, threads=256, grouping=16, minblocks=4) , # 273.287 GFlop/s
+  Kernel_dnt_largeDB1(m=12, n=12, k=144, tile_m=3, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=12) , # 249.09 GFlop/s
+  Kernel_dnt_largeDB1(m=12, n=144, k=12, tile_m=3, tile_n=3, w=6, v=80, threads=256, grouping=16, minblocks=4) , # 273.287 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=4, k=4, tile_m=1, tile_n=1, w=2, v=4, threads=96, grouping=16, minblocks=4) , # 35.8537 GFlop/s
   Kernel_dnt_medium(m=13, n=4, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 43.1223 GFlop/s
   Kernel_dnt_medium(m=13, n=4, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 50.5155 GFlop/s
@@ -1188,7 +1188,7 @@
   Kernel_dnt_small(m=13, n=4, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 56.8225 GFlop/s
   Kernel_dnt_small(m=13, n=4, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 62.7402 GFlop/s
   Kernel_dnt_medium(m=13, n=4, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 81.1843 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=4, k=16, tile_m=1, tile_n=1, w=8, v=4, threads=128, grouping=16, minblocks=12) , # 82.3205 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=4, k=16, tile_m=1, tile_n=1, w=8, v=4, threads=128, grouping=16, minblocks=12) , # 82.3205 GFlop/s
   Kernel_dnt_medium(m=13, n=4, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 85.3823 GFlop/s
   Kernel_dnt_medium(m=13, n=4, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 106.3 GFlop/s
   Kernel_dnt_medium(m=13, n=4, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 104.38 GFlop/s
@@ -1221,13 +1221,13 @@
   Kernel_dnt_small(m=13, n=6, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 77.0262 GFlop/s
   Kernel_dnt_medium(m=13, n=6, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 82.5687 GFlop/s
   Kernel_dnt_medium(m=13, n=6, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 102.487 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=6, k=16, tile_m=1, tile_n=1, w=8, v=6, threads=128, grouping=16, minblocks=4) , # 112.36 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=6, k=16, tile_m=1, tile_n=1, w=8, v=6, threads=128, grouping=16, minblocks=4) , # 112.36 GFlop/s
   Kernel_dnt_medium(m=13, n=6, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 105.637 GFlop/s
   Kernel_dnt_medium(m=13, n=6, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 126.591 GFlop/s
   Kernel_dnt_medium(m=13, n=6, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 127.181 GFlop/s
   Kernel_dnt_medium(m=13, n=6, k=24, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 131.17 GFlop/s
   Kernel_dnt_medium(m=13, n=6, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 129.955 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=6, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 138.459 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=6, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 138.459 GFlop/s
   Kernel_dnt_medium(m=13, n=7, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 59.9957 GFlop/s
   Kernel_dnt_medium(m=13, n=7, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 72.1074 GFlop/s
   Kernel_dnt_medium(m=13, n=7, k=7, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 95.9252 GFlop/s
@@ -1244,13 +1244,13 @@
   Kernel_dnt_medium(m=13, n=8, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 99.8992 GFlop/s
   Kernel_dnt_medium(m=13, n=8, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 106.433 GFlop/s
   Kernel_dnt_medium(m=13, n=8, k=13, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 117.265 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=8, k=16, tile_m=1, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=8) , # 138.215 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=8, k=16, tile_m=1, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=8) , # 138.215 GFlop/s
   Kernel_dnt_medium(m=13, n=8, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 139.52 GFlop/s
   Kernel_dnt_medium(m=13, n=8, k=22, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 163.585 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=8, k=23, tile_m=1, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 147.91 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=8, k=24, tile_m=1, tile_n=2, w=12, v=6, threads=96, grouping=16, minblocks=1) , # 151.064 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=8, k=23, tile_m=1, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 147.91 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=8, k=24, tile_m=1, tile_n=2, w=12, v=6, threads=96, grouping=16, minblocks=1) , # 151.064 GFlop/s
   Kernel_dnt_medium(m=13, n=8, k=26, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 151.357 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=8, k=32, tile_m=2, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=12) , # 157.473 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=8, k=32, tile_m=2, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=12) , # 157.473 GFlop/s
   Kernel_dnt_tiny(m=13, n=9, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 68.6834 GFlop/s
   Kernel_dnt_tiny(m=13, n=9, k=5, split_thread=32, threads=128, grouping=16, minblocks=1) , # 82.6413 GFlop/s
   Kernel_dnt_small(m=13, n=9, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 87.8396 GFlop/s
@@ -1258,7 +1258,7 @@
   Kernel_dnt_medium(m=13, n=9, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 109.971 GFlop/s
   Kernel_dnt_medium(m=13, n=9, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 118.002 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=9, k=13, tile_m=2, tile_n=1, w=6, v=6, threads=96, grouping=16, minblocks=8) , # 137.392 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=9, k=16, tile_m=1, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=1) , # 147.281 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=9, k=16, tile_m=1, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=1) , # 147.281 GFlop/s
   Kernel_dnt_medium(m=13, n=9, k=17, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 143.348 GFlop/s
   Kernel_dnt_medium(m=13, n=9, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 158.407 GFlop/s
   Kernel_dnt_medium(m=13, n=9, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 160.165 GFlop/s
@@ -1285,7 +1285,7 @@
   Kernel_dnt_largeDB2(m=13, n=13, k=28, tile_m=2, tile_n=2, w=14, v=12, threads=96, grouping=16, minblocks=12) , # 218.849 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=13, k=32, tile_m=2, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=12) , # 223.821 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=13, k=45, tile_m=2, tile_n=2, w=16, v=12, threads=96, grouping=16, minblocks=12) , # 232.303 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=13, k=169, tile_m=2, tile_n=2, w=18, v=8, threads=96, grouping=16, minblocks=12) , # 258.16 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=13, k=169, tile_m=2, tile_n=2, w=18, v=8, threads=96, grouping=16, minblocks=12) , # 258.16 GFlop/s
   Kernel_dnt_small(m=13, n=16, k=4, tile_m=2, tile_n=2, threads=64, grouping=16, minblocks=4) , # 100.974 GFlop/s
   Kernel_dnt_medium(m=13, n=16, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 114.075 GFlop/s
   Kernel_dnt_medium(m=13, n=16, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 131.042 GFlop/s
@@ -1293,12 +1293,12 @@
   Kernel_dnt_medium(m=13, n=16, k=9, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=12) , # 153.966 GFlop/s
   Kernel_dnt_medium(m=13, n=16, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 175.389 GFlop/s
   Kernel_dnt_medium(m=13, n=16, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 210.814 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=16, k=17, tile_m=2, tile_n=2, w=6, v=16, threads=96, grouping=16, minblocks=1) , # 185.642 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=16, k=17, tile_m=2, tile_n=2, w=6, v=16, threads=96, grouping=16, minblocks=1) , # 185.642 GFlop/s
   Kernel_dnt_medium(m=13, n=16, k=22, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 212.052 GFlop/s
   Kernel_dnt_medium(m=13, n=16, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 217.955 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=16, k=24, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 214.166 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=16, k=26, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 210.017 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=16, k=32, tile_m=2, tile_n=2, w=16, v=16, threads=96, grouping=16, minblocks=12) , # 232.99 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=16, k=24, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 214.166 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=16, k=26, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 210.017 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=16, k=32, tile_m=2, tile_n=2, w=16, v=16, threads=96, grouping=16, minblocks=12) , # 232.99 GFlop/s
   Kernel_dnt_medium(m=13, n=17, k=4, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 99.2194 GFlop/s
   Kernel_dnt_medium(m=13, n=17, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 118.252 GFlop/s
   Kernel_dnt_medium(m=13, n=17, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 135.183 GFlop/s
@@ -1308,49 +1308,49 @@
   Kernel_dnt_medium(m=13, n=17, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 218.026 GFlop/s
   Kernel_dnt_medium(m=13, n=17, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 187.859 GFlop/s
   Kernel_dnt_medium(m=13, n=17, k=22, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 222.018 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=17, k=23, tile_m=2, tile_n=2, w=6, v=16, threads=128, grouping=16, minblocks=12) , # 216.451 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=17, k=24, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 214.46 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=17, k=26, tile_m=2, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 211.202 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=17, k=32, tile_m=2, tile_n=2, w=16, v=12, threads=96, grouping=16, minblocks=12) , # 237.799 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=17, k=23, tile_m=2, tile_n=2, w=6, v=16, threads=128, grouping=16, minblocks=12) , # 216.451 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=17, k=24, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 214.46 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=17, k=26, tile_m=2, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 211.202 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=17, k=32, tile_m=2, tile_n=2, w=16, v=12, threads=96, grouping=16, minblocks=12) , # 237.799 GFlop/s
   Kernel_dnt_medium(m=13, n=22, k=4, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 117.05 GFlop/s
   Kernel_dnt_medium(m=13, n=22, k=5, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 132.674 GFlop/s
   Kernel_dnt_medium(m=13, n=22, k=6, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 147.212 GFlop/s
   Kernel_dnt_medium(m=13, n=22, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 172.205 GFlop/s
   Kernel_dnt_medium(m=13, n=22, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 181.465 GFlop/s
   Kernel_dnt_medium(m=13, n=22, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 207.061 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=22, k=16, tile_m=2, tile_n=2, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 206.302 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=22, k=16, tile_m=2, tile_n=2, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 206.302 GFlop/s
   Kernel_dnt_medium(m=13, n=22, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 204.952 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=22, k=22, tile_m=3, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 225.453 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=22, k=23, tile_m=2, tile_n=2, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 227.833 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=22, k=24, tile_m=3, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 239.227 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=22, k=26, tile_m=3, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 241.066 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=22, k=32, tile_m=3, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 252.527 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=22, k=22, tile_m=3, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 225.453 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=22, k=23, tile_m=2, tile_n=2, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 227.833 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=22, k=24, tile_m=3, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 239.227 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=22, k=26, tile_m=3, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 241.066 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=22, k=32, tile_m=3, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 252.527 GFlop/s
   Kernel_dnt_medium(m=13, n=23, k=4, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 118.375 GFlop/s
   Kernel_dnt_medium(m=13, n=23, k=5, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 136.973 GFlop/s
   Kernel_dnt_medium(m=13, n=23, k=6, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 148.462 GFlop/s
   Kernel_dnt_medium(m=13, n=23, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 174.284 GFlop/s
   Kernel_dnt_medium(m=13, n=23, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 185.07 GFlop/s
   Kernel_dnt_medium(m=13, n=23, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 214.408 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=23, k=16, tile_m=2, tile_n=2, w=8, v=22, threads=128, grouping=16, minblocks=12) , # 215.76 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=23, k=16, tile_m=2, tile_n=2, w=8, v=22, threads=128, grouping=16, minblocks=12) , # 215.76 GFlop/s
   Kernel_dnt_medium(m=13, n=23, k=17, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 217.951 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=23, k=22, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 227.875 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=23, k=23, tile_m=2, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 233.26 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=23, k=24, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 243.006 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=23, k=26, tile_m=2, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 235.319 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=23, k=32, tile_m=3, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 256.302 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=23, k=22, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 227.875 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=23, k=23, tile_m=2, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 233.26 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=23, k=24, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 243.006 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=23, k=26, tile_m=2, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 235.319 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=23, k=32, tile_m=3, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 256.302 GFlop/s
   Kernel_dnt_medium(m=13, n=24, k=4, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 126.462 GFlop/s
   Kernel_dnt_medium(m=13, n=24, k=5, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 145.967 GFlop/s
   Kernel_dnt_medium(m=13, n=24, k=6, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=12) , # 158.896 GFlop/s
   Kernel_dnt_medium(m=13, n=24, k=8, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 182.54 GFlop/s
   Kernel_dnt_medium(m=13, n=24, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 195.482 GFlop/s
   Kernel_dnt_medium(m=13, n=24, k=13, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 203.566 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=24, k=16, tile_m=2, tile_n=2, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 223.93 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=24, k=16, tile_m=2, tile_n=2, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 223.93 GFlop/s
   Kernel_dnt_medium(m=13, n=24, k=17, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 228.962 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=24, k=22, tile_m=2, tile_n=3, w=6, v=12, threads=96, grouping=16, minblocks=12) , # 243.549 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=24, k=23, tile_m=2, tile_n=2, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 244.933 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=24, k=24, tile_m=3, tile_n=2, w=12, v=24, threads=96, grouping=16, minblocks=12) , # 256.27 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=24, k=26, tile_m=3, tile_n=2, w=10, v=24, threads=96, grouping=16, minblocks=12) , # 253.677 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=24, k=32, tile_m=3, tile_n=2, w=12, v=24, threads=96, grouping=16, minblocks=12) , # 272.912 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=24, k=22, tile_m=2, tile_n=3, w=6, v=12, threads=96, grouping=16, minblocks=12) , # 243.549 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=24, k=23, tile_m=2, tile_n=2, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 244.933 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=24, k=24, tile_m=3, tile_n=2, w=12, v=24, threads=96, grouping=16, minblocks=12) , # 256.27 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=24, k=26, tile_m=3, tile_n=2, w=10, v=24, threads=96, grouping=16, minblocks=12) , # 253.677 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=24, k=32, tile_m=3, tile_n=2, w=12, v=24, threads=96, grouping=16, minblocks=12) , # 272.912 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=24, k=45, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 323.835 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=25, k=4, tile_m=2, tile_n=2, w=2, v=18, threads=96, grouping=16, minblocks=4) , # 139.434 GFlop/s
   Kernel_dnt_medium(m=13, n=25, k=5, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 146.157 GFlop/s
@@ -1371,9 +1371,9 @@
   Kernel_dnt_largeDB2(m=13, n=26, k=13, tile_m=2, tile_n=3, w=6, v=22, threads=96, grouping=16, minblocks=12) , # 236.552 GFlop/s
   Kernel_dnt_medium(m=13, n=26, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 225.673 GFlop/s
   Kernel_dnt_medium(m=13, n=26, k=17, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 241.87 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=26, k=22, tile_m=2, tile_n=2, w=6, v=26, threads=96, grouping=16, minblocks=12) , # 251.077 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=26, k=23, tile_m=2, tile_n=2, w=6, v=26, threads=96, grouping=16, minblocks=12) , # 255.001 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=26, k=24, tile_m=2, tile_n=3, w=12, v=14, threads=96, grouping=16, minblocks=12) , # 262.921 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=26, k=22, tile_m=2, tile_n=2, w=6, v=26, threads=96, grouping=16, minblocks=12) , # 251.077 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=26, k=23, tile_m=2, tile_n=2, w=6, v=26, threads=96, grouping=16, minblocks=12) , # 255.001 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=26, k=24, tile_m=2, tile_n=3, w=12, v=14, threads=96, grouping=16, minblocks=12) , # 262.921 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=26, k=25, tile_m=2, tile_n=3, w=12, v=20, threads=96, grouping=16, minblocks=12) , # 290.699 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=26, k=26, tile_m=2, tile_n=3, w=12, v=26, threads=96, grouping=16, minblocks=12) , # 296.294 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=26, k=28, tile_m=2, tile_n=2, w=14, v=22, threads=96, grouping=16, minblocks=12) , # 306.437 GFlop/s
@@ -1393,14 +1393,14 @@
   Kernel_dnt_largeDB2(m=13, n=32, k=5, tile_m=3, tile_n=2, w=2, v=32, threads=96, grouping=16, minblocks=12) , # 156.628 GFlop/s
   Kernel_dnt_medium(m=13, n=32, k=6, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 181.813 GFlop/s
   Kernel_dnt_medium(m=13, n=32, k=7, tile_m=5, tile_n=1, threads=96, grouping=16, minblocks=12) , # 188.684 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=32, k=8, tile_m=2, tile_n=2, w=4, v=32, threads=128, grouping=16, minblocks=12) , # 200.207 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=32, k=8, tile_m=2, tile_n=2, w=4, v=32, threads=128, grouping=16, minblocks=12) , # 200.207 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=32, k=9, tile_m=2, tile_n=2, w=4, v=32, threads=128, grouping=16, minblocks=12) , # 223.308 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=32, k=13, tile_m=4, tile_n=2, w=6, v=26, threads=96, grouping=16, minblocks=12) , # 263.806 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=32, k=16, tile_m=2, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=8) , # 260.668 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=32, k=17, tile_m=2, tile_n=3, w=6, v=14, threads=96, grouping=16, minblocks=12) , # 247.911 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=32, k=22, tile_m=2, tile_n=3, w=6, v=16, threads=96, grouping=16, minblocks=12) , # 271.196 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=32, k=23, tile_m=2, tile_n=3, w=6, v=16, threads=96, grouping=16, minblocks=12) , # 275.98 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=32, k=24, tile_m=2, tile_n=2, w=12, v=24, threads=192, grouping=16, minblocks=8) , # 283.245 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=32, k=16, tile_m=2, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=8) , # 260.668 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=32, k=17, tile_m=2, tile_n=3, w=6, v=14, threads=96, grouping=16, minblocks=12) , # 247.911 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=32, k=22, tile_m=2, tile_n=3, w=6, v=16, threads=96, grouping=16, minblocks=12) , # 271.196 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=32, k=23, tile_m=2, tile_n=3, w=6, v=16, threads=96, grouping=16, minblocks=12) , # 275.98 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=32, k=24, tile_m=2, tile_n=2, w=12, v=24, threads=192, grouping=16, minblocks=8) , # 283.245 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=32, k=25, tile_m=2, tile_n=4, w=6, v=26, threads=96, grouping=16, minblocks=12) , # 302.793 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=32, k=26, tile_m=2, tile_n=4, w=12, v=32, threads=96, grouping=16, minblocks=8) , # 303.713 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=32, k=28, tile_m=2, tile_n=4, w=8, v=26, threads=96, grouping=16, minblocks=12) , # 314.111 GFlop/s
@@ -1417,22 +1417,22 @@
   Kernel_dnt_largeDB2(m=13, n=45, k=28, tile_m=2, tile_n=3, w=14, v=36, threads=128, grouping=16, minblocks=8) , # 338.61 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=45, k=32, tile_m=2, tile_n=5, w=12, v=38, threads=96, grouping=16, minblocks=8) , # 342.906 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=45, k=45, tile_m=2, tile_n=5, w=12, v=44, threads=96, grouping=16, minblocks=8) , # 366.795 GFlop/s
-  Kernel_dnt_largeDB(m=13, n=169, k=13, tile_m=4, tile_n=3, w=6, v=96, threads=256, grouping=16, minblocks=1) , # 241.485 GFlop/s
+  Kernel_dnt_largeDB1(m=13, n=169, k=13, tile_m=4, tile_n=3, w=6, v=96, threads=256, grouping=16, minblocks=1) , # 241.485 GFlop/s
   Kernel_dnt_medium(m=14, n=14, k=14, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 197.885 GFlop/s
   Kernel_dnt_medium(m=14, n=14, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 216.145 GFlop/s
   Kernel_dnt_medium(m=14, n=14, k=29, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=4) , # 218.838 GFlop/s
-  Kernel_dnt_largeDB(m=14, n=14, k=32, tile_m=2, tile_n=2, w=16, v=14, threads=96, grouping=16, minblocks=12) , # 224.281 GFlop/s
-  Kernel_dnt_largeDB(m=14, n=14, k=196, tile_m=2, tile_n=2, w=16, v=12, threads=96, grouping=16, minblocks=12) , # 289.084 GFlop/s
+  Kernel_dnt_largeDB1(m=14, n=14, k=32, tile_m=2, tile_n=2, w=16, v=14, threads=96, grouping=16, minblocks=12) , # 224.281 GFlop/s
+  Kernel_dnt_largeDB1(m=14, n=14, k=196, tile_m=2, tile_n=2, w=16, v=12, threads=96, grouping=16, minblocks=12) , # 289.084 GFlop/s
   Kernel_dnt_medium(m=14, n=16, k=14, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 213.982 GFlop/s
   Kernel_dnt_medium(m=14, n=16, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 230.421 GFlop/s
-  Kernel_dnt_largeDB(m=14, n=16, k=29, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 232.968 GFlop/s
-  Kernel_dnt_largeDB(m=14, n=29, k=14, tile_m=2, tile_n=2, w=4, v=20, threads=128, grouping=16, minblocks=12) , # 231.308 GFlop/s
-  Kernel_dnt_largeDB(m=14, n=29, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 267.108 GFlop/s
-  Kernel_dnt_largeDB(m=14, n=29, k=29, tile_m=2, tile_n=2, w=10, v=20, threads=160, grouping=16, minblocks=8) , # 272.491 GFlop/s
-  Kernel_dnt_largeDB(m=14, n=29, k=32, tile_m=2, tile_n=2, w=16, v=20, threads=160, grouping=16, minblocks=8) , # 292.149 GFlop/s
+  Kernel_dnt_largeDB1(m=14, n=16, k=29, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 232.968 GFlop/s
+  Kernel_dnt_largeDB1(m=14, n=29, k=14, tile_m=2, tile_n=2, w=4, v=20, threads=128, grouping=16, minblocks=12) , # 231.308 GFlop/s
+  Kernel_dnt_largeDB1(m=14, n=29, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 267.108 GFlop/s
+  Kernel_dnt_largeDB1(m=14, n=29, k=29, tile_m=2, tile_n=2, w=10, v=20, threads=160, grouping=16, minblocks=8) , # 272.491 GFlop/s
+  Kernel_dnt_largeDB1(m=14, n=29, k=32, tile_m=2, tile_n=2, w=16, v=20, threads=160, grouping=16, minblocks=8) , # 292.149 GFlop/s
   Kernel_dnt_medium(m=14, n=32, k=14, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 258.209 GFlop/s
-  Kernel_dnt_largeDB(m=14, n=32, k=29, tile_m=2, tile_n=2, w=10, v=32, threads=160, grouping=16, minblocks=8) , # 311.422 GFlop/s
-  Kernel_dnt_largeDB(m=14, n=32, k=32, tile_m=2, tile_n=2, w=16, v=32, threads=128, grouping=16, minblocks=8) , # 326.197 GFlop/s
+  Kernel_dnt_largeDB1(m=14, n=32, k=29, tile_m=2, tile_n=2, w=10, v=32, threads=160, grouping=16, minblocks=8) , # 311.422 GFlop/s
+  Kernel_dnt_largeDB1(m=14, n=32, k=32, tile_m=2, tile_n=2, w=16, v=32, threads=128, grouping=16, minblocks=8) , # 326.197 GFlop/s
   Kernel_dnt_medium(m=14, n=196, k=14, tile_m=2, tile_n=6, threads=256, grouping=16, minblocks=1) , # 278.411 GFlop/s
   Kernel_dnt_largeDB2(m=15, n=4, k=4, tile_m=1, tile_n=1, w=2, v=4, threads=96, grouping=16, minblocks=4) , # 41.0244 GFlop/s
   Kernel_dnt_medium(m=15, n=4, k=10, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 76.5643 GFlop/s
@@ -1443,8 +1443,8 @@
   Kernel_dnt_small(m=15, n=15, k=4, tile_m=2, tile_n=2, threads=64, grouping=16, minblocks=1) , # 119.369 GFlop/s
   Kernel_dnt_medium(m=15, n=15, k=10, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 184.444 GFlop/s
   Kernel_dnt_medium(m=15, n=15, k=15, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 226.439 GFlop/s
-  Kernel_dnt_largeDB(m=15, n=15, k=225, tile_m=2, tile_n=2, w=16, v=10, threads=96, grouping=16, minblocks=12) , # 311.643 GFlop/s
-  Kernel_dnt_largeDB(m=15, n=225, k=15, tile_m=3, tile_n=3, w=4, v=150, threads=384, grouping=16, minblocks=1) , # 258.751 GFlop/s
+  Kernel_dnt_largeDB1(m=15, n=15, k=225, tile_m=2, tile_n=2, w=16, v=10, threads=96, grouping=16, minblocks=12) , # 311.643 GFlop/s
+  Kernel_dnt_largeDB1(m=15, n=225, k=15, tile_m=3, tile_n=3, w=4, v=150, threads=384, grouping=16, minblocks=1) , # 258.751 GFlop/s
   Kernel_dnt_medium(m=16, n=4, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 43.2513 GFlop/s
   Kernel_dnt_medium(m=16, n=4, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 52.8509 GFlop/s
   Kernel_dnt_tiny(m=16, n=4, k=6, split_thread=32, threads=128, grouping=16, minblocks=1) , # 56.0623 GFlop/s
@@ -1457,7 +1457,7 @@
   Kernel_dnt_medium(m=16, n=4, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 118.619 GFlop/s
   Kernel_dnt_medium(m=16, n=4, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 118.972 GFlop/s
   Kernel_dnt_medium(m=16, n=4, k=26, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 116.617 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=4, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=12) , # 119.202 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=4, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=12) , # 119.202 GFlop/s
   Kernel_dnt_medium(m=16, n=5, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 53.2937 GFlop/s
   Kernel_dnt_medium(m=16, n=5, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 64.8851 GFlop/s
   Kernel_dnt_tiny(m=16, n=5, k=6, split_thread=32, threads=128, grouping=16, minblocks=1) , # 68.9342 GFlop/s
@@ -1468,49 +1468,49 @@
   Kernel_dnt_medium(m=16, n=5, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 125.062 GFlop/s
   Kernel_dnt_medium(m=16, n=5, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 134.168 GFlop/s
   Kernel_dnt_medium(m=16, n=5, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 127.673 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=5, k=24, tile_m=1, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=12) , # 129.534 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=5, k=26, tile_m=1, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=1) , # 127.182 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=12) , # 138.029 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=5, k=24, tile_m=1, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=12) , # 129.534 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=5, k=26, tile_m=1, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=1) , # 127.182 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=12) , # 138.029 GFlop/s
   Kernel_dnt_medium(m=16, n=6, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 63.7826 GFlop/s
   Kernel_dnt_medium(m=16, n=6, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 77.3562 GFlop/s
   Kernel_dnt_tiny(m=16, n=6, k=6, split_thread=32, threads=128, grouping=16, minblocks=1) , # 81.9641 GFlop/s
   Kernel_dnt_medium(m=16, n=6, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 99.2729 GFlop/s
   Kernel_dnt_medium(m=16, n=6, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 108.16 GFlop/s
   Kernel_dnt_medium(m=16, n=6, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 128.018 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=6, k=16, tile_m=1, tile_n=1, w=8, v=6, threads=128, grouping=16, minblocks=4) , # 134.069 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=6, k=16, tile_m=1, tile_n=1, w=8, v=6, threads=128, grouping=16, minblocks=4) , # 134.069 GFlop/s
   Kernel_dnt_medium(m=16, n=6, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 141.119 GFlop/s
   Kernel_dnt_medium(m=16, n=6, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 147.402 GFlop/s
   Kernel_dnt_medium(m=16, n=6, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 147.837 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=6, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=96, grouping=16, minblocks=8) , # 151.996 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=6, k=26, tile_m=1, tile_n=1, w=10, v=6, threads=96, grouping=16, minblocks=4) , # 149.231 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=6, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=128, grouping=16, minblocks=12) , # 163.734 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=6, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=96, grouping=16, minblocks=8) , # 151.996 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=6, k=26, tile_m=1, tile_n=1, w=10, v=6, threads=96, grouping=16, minblocks=4) , # 149.231 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=6, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=128, grouping=16, minblocks=12) , # 163.734 GFlop/s
   Kernel_dnt_tiny(m=16, n=8, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 78.0533 GFlop/s
   Kernel_dnt_medium(m=16, n=8, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 91.3267 GFlop/s
   Kernel_dnt_tiny(m=16, n=8, k=6, split_thread=32, threads=128, grouping=16, minblocks=1) , # 105.373 GFlop/s
   Kernel_dnt_small(m=16, n=8, k=8, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 124.195 GFlop/s
   Kernel_dnt_medium(m=16, n=8, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 121.754 GFlop/s
   Kernel_dnt_medium(m=16, n=8, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 150.445 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=8, k=16, tile_m=1, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=4) , # 166.502 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=8, k=16, tile_m=1, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=4) , # 166.502 GFlop/s
   Kernel_dnt_medium(m=16, n=8, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 167.3 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=8, k=22, tile_m=1, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=4) , # 175.569 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=8, k=22, tile_m=1, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=4) , # 175.569 GFlop/s
   Kernel_dnt_medium(m=16, n=8, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 178.527 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=8, k=24, tile_m=2, tile_n=1, w=12, v=8, threads=96, grouping=16, minblocks=4) , # 185.133 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=8, k=26, tile_m=1, tile_n=1, w=12, v=8, threads=128, grouping=16, minblocks=12) , # 178.92 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=8, k=32, tile_m=1, tile_n=1, w=16, v=8, threads=128, grouping=16, minblocks=1) , # 194.196 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=8, k=24, tile_m=2, tile_n=1, w=12, v=8, threads=96, grouping=16, minblocks=4) , # 185.133 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=8, k=26, tile_m=1, tile_n=1, w=12, v=8, threads=128, grouping=16, minblocks=12) , # 178.92 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=8, k=32, tile_m=1, tile_n=1, w=16, v=8, threads=128, grouping=16, minblocks=1) , # 194.196 GFlop/s
   Kernel_dnt_medium(m=16, n=9, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 82.0886 GFlop/s
   Kernel_dnt_medium(m=16, n=9, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 98.1233 GFlop/s
   Kernel_dnt_small(m=16, n=9, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 102.023 GFlop/s
   Kernel_dnt_small(m=16, n=9, k=8, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=4) , # 120.113 GFlop/s
   Kernel_dnt_medium(m=16, n=9, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 128.209 GFlop/s
   Kernel_dnt_medium(m=16, n=9, k=13, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 149.02 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=9, k=16, tile_m=2, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 161.845 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=9, k=16, tile_m=2, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 161.845 GFlop/s
   Kernel_dnt_medium(m=16, n=9, k=17, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 166.142 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=9, k=22, tile_m=2, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 171.029 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=9, k=23, tile_m=2, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=4) , # 173.179 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=9, k=24, tile_m=2, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=8) , # 175.852 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=9, k=26, tile_m=2, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=1) , # 180.319 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=9, k=32, tile_m=2, tile_n=1, w=6, v=6, threads=96, grouping=16, minblocks=12) , # 179.384 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=9, k=64, tile_m=3, tile_n=2, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 213.459 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=9, k=22, tile_m=2, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 171.029 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=9, k=23, tile_m=2, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=4) , # 173.179 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=9, k=24, tile_m=2, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=8) , # 175.852 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=9, k=26, tile_m=2, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=1) , # 180.319 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=9, k=32, tile_m=2, tile_n=1, w=6, v=6, threads=96, grouping=16, minblocks=12) , # 179.384 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=9, k=64, tile_m=3, tile_n=2, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 213.459 GFlop/s
   Kernel_dnt_small(m=16, n=13, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 101.905 GFlop/s
   Kernel_dnt_small(m=16, n=13, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=8) , # 116.398 GFlop/s
   Kernel_dnt_medium(m=16, n=13, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 127.421 GFlop/s
@@ -1519,14 +1519,14 @@
   Kernel_dnt_medium(m=16, n=13, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 189.636 GFlop/s
   Kernel_dnt_medium(m=16, n=13, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 214.841 GFlop/s
   Kernel_dnt_medium(m=16, n=13, k=17, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 191.644 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=13, k=22, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 210.521 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=13, k=23, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 214.991 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=13, k=22, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 210.521 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=13, k=23, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 214.991 GFlop/s
   Kernel_dnt_medium(m=16, n=13, k=24, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 212.921 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=13, k=26, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 210.224 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=13, k=32, tile_m=2, tile_n=2, w=16, v=12, threads=128, grouping=16, minblocks=12) , # 234.974 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=13, k=26, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 210.224 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=13, k=32, tile_m=2, tile_n=2, w=16, v=12, threads=128, grouping=16, minblocks=12) , # 234.974 GFlop/s
   Kernel_dnt_medium(m=16, n=14, k=14, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 215.62 GFlop/s
   Kernel_dnt_medium(m=16, n=14, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 230.5 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=14, k=29, tile_m=2, tile_n=1, w=8, v=14, threads=128, grouping=16, minblocks=12) , # 231.585 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=14, k=29, tile_m=2, tile_n=1, w=8, v=14, threads=128, grouping=16, minblocks=12) , # 231.585 GFlop/s
   Kernel_dnt_small(m=16, n=16, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 142.372 GFlop/s
   Kernel_dnt_small(m=16, n=16, k=5, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 161.476 GFlop/s
   Kernel_dnt_small(m=16, n=16, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=8) , # 180.677 GFlop/s
@@ -1538,40 +1538,40 @@
   Kernel_dnt_medium(m=16, n=16, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=8) , # 247.453 GFlop/s
   Kernel_dnt_medium(m=16, n=16, k=22, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 268.121 GFlop/s
   Kernel_dnt_medium(m=16, n=16, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 272.615 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=16, k=24, tile_m=2, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=12) , # 265.276 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=16, k=26, tile_m=2, tile_n=2, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 263.235 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=16, k=29, tile_m=2, tile_n=2, w=14, v=16, threads=128, grouping=16, minblocks=12) , # 270.638 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=16, k=32, tile_m=2, tile_n=2, w=14, v=14, threads=128, grouping=16, minblocks=12) , # 276.949 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=16, k=55, tile_m=2, tile_n=2, w=14, v=16, threads=128, grouping=16, minblocks=12) , # 303.184 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=16, k=64, tile_m=2, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 312.221 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=16, k=256, tile_m=2, tile_n=2, w=14, v=12, threads=128, grouping=16, minblocks=12) , # 341.89 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=16, k=24, tile_m=2, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=12) , # 265.276 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=16, k=26, tile_m=2, tile_n=2, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 263.235 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=16, k=29, tile_m=2, tile_n=2, w=14, v=16, threads=128, grouping=16, minblocks=12) , # 270.638 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=16, k=32, tile_m=2, tile_n=2, w=14, v=14, threads=128, grouping=16, minblocks=12) , # 276.949 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=16, k=55, tile_m=2, tile_n=2, w=14, v=16, threads=128, grouping=16, minblocks=12) , # 303.184 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=16, k=64, tile_m=2, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 312.221 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=16, k=256, tile_m=2, tile_n=2, w=14, v=12, threads=128, grouping=16, minblocks=12) , # 341.89 GFlop/s
   Kernel_dnt_medium(m=16, n=17, k=4, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=4) , # 113.047 GFlop/s
   Kernel_dnt_medium(m=16, n=17, k=5, tile_m=1, tile_n=3, threads=96, grouping=16, minblocks=12) , # 135.825 GFlop/s
   Kernel_dnt_medium(m=16, n=17, k=6, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 152.914 GFlop/s
   Kernel_dnt_medium(m=16, n=17, k=8, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 165.821 GFlop/s
   Kernel_dnt_medium(m=16, n=17, k=9, tile_m=1, tile_n=3, threads=96, grouping=16, minblocks=12) , # 179.436 GFlop/s
   Kernel_dnt_medium(m=16, n=17, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 215.752 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=17, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 202.68 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=17, k=17, tile_m=3, tile_n=2, w=6, v=16, threads=128, grouping=16, minblocks=12) , # 210.423 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=17, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 202.68 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=17, k=17, tile_m=3, tile_n=2, w=6, v=16, threads=128, grouping=16, minblocks=12) , # 210.423 GFlop/s
   Kernel_dnt_medium(m=16, n=17, k=22, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 234.804 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=17, k=23, tile_m=1, tile_n=3, w=6, v=14, threads=128, grouping=16, minblocks=12) , # 235.716 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=17, k=24, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 241.704 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=17, k=26, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 235.825 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=17, k=32, tile_m=2, tile_n=3, w=12, v=6, threads=96, grouping=16, minblocks=12) , # 255.137 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=17, k=23, tile_m=1, tile_n=3, w=6, v=14, threads=128, grouping=16, minblocks=12) , # 235.716 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=17, k=24, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 241.704 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=17, k=26, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 235.825 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=17, k=32, tile_m=2, tile_n=3, w=12, v=6, threads=96, grouping=16, minblocks=12) , # 255.137 GFlop/s
   Kernel_dnt_medium(m=16, n=22, k=4, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 138.141 GFlop/s
   Kernel_dnt_medium(m=16, n=22, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 161.969 GFlop/s
   Kernel_dnt_medium(m=16, n=22, k=6, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 169.805 GFlop/s
   Kernel_dnt_medium(m=16, n=22, k=8, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 205.457 GFlop/s
   Kernel_dnt_medium(m=16, n=22, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 217.014 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=22, k=13, tile_m=2, tile_n=2, w=4, v=22, threads=96, grouping=16, minblocks=12) , # 223.224 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=22, k=13, tile_m=2, tile_n=2, w=4, v=22, threads=96, grouping=16, minblocks=12) , # 223.224 GFlop/s
   Kernel_dnt_medium(m=16, n=22, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 253.21 GFlop/s
   Kernel_dnt_medium(m=16, n=22, k=17, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 260.436 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=22, k=22, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 273.938 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=22, k=23, tile_m=2, tile_n=3, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 277.81 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=22, k=24, tile_m=2, tile_n=3, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 291.318 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=22, k=26, tile_m=2, tile_n=3, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 289.631 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=22, k=32, tile_m=2, tile_n=3, w=12, v=6, threads=96, grouping=16, minblocks=12) , # 305.311 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=22, k=64, tile_m=2, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 349.601 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=22, k=22, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 273.938 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=22, k=23, tile_m=2, tile_n=3, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 277.81 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=22, k=24, tile_m=2, tile_n=3, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 291.318 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=22, k=26, tile_m=2, tile_n=3, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 289.631 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=22, k=32, tile_m=2, tile_n=3, w=12, v=6, threads=96, grouping=16, minblocks=12) , # 305.311 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=22, k=64, tile_m=2, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 349.601 GFlop/s
   Kernel_dnt_medium(m=16, n=23, k=4, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 143.468 GFlop/s
   Kernel_dnt_medium(m=16, n=23, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 167.762 GFlop/s
   Kernel_dnt_medium(m=16, n=23, k=6, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 176.832 GFlop/s
@@ -1580,62 +1580,62 @@
   Kernel_dnt_medium(m=16, n=23, k=13, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 230.437 GFlop/s
   Kernel_dnt_medium(m=16, n=23, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 263.178 GFlop/s
   Kernel_dnt_medium(m=16, n=23, k=17, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 264.544 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=23, k=22, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 279.549 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=23, k=23, tile_m=2, tile_n=2, w=10, v=16, threads=128, grouping=16, minblocks=12) , # 282.297 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=23, k=24, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 295.553 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=23, k=26, tile_m=2, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 291.977 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=23, k=32, tile_m=2, tile_n=3, w=12, v=6, threads=96, grouping=16, minblocks=12) , # 313.606 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=23, k=22, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 279.549 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=23, k=23, tile_m=2, tile_n=2, w=10, v=16, threads=128, grouping=16, minblocks=12) , # 282.297 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=23, k=24, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 295.553 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=23, k=26, tile_m=2, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 291.977 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=23, k=32, tile_m=2, tile_n=3, w=12, v=6, threads=96, grouping=16, minblocks=12) , # 313.606 GFlop/s
   Kernel_dnt_medium(m=16, n=24, k=4, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 150.444 GFlop/s
   Kernel_dnt_medium(m=16, n=24, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 174.489 GFlop/s
   Kernel_dnt_medium(m=16, n=24, k=6, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 184.054 GFlop/s
   Kernel_dnt_medium(m=16, n=24, k=8, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 207.226 GFlop/s
   Kernel_dnt_medium(m=16, n=24, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 235.336 GFlop/s
   Kernel_dnt_medium(m=16, n=24, k=13, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 239.748 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=24, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 283.218 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=24, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 283.218 GFlop/s
   Kernel_dnt_medium(m=16, n=24, k=17, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 275.019 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=24, k=22, tile_m=2, tile_n=3, w=8, v=18, threads=96, grouping=16, minblocks=12) , # 298.156 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=24, k=23, tile_m=2, tile_n=3, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 302.868 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=24, k=24, tile_m=2, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 313.429 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=24, k=26, tile_m=2, tile_n=3, w=10, v=24, threads=96, grouping=16, minblocks=12) , # 309.598 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=24, k=32, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 328.287 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=24, k=22, tile_m=2, tile_n=3, w=8, v=18, threads=96, grouping=16, minblocks=12) , # 298.156 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=24, k=23, tile_m=2, tile_n=3, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 302.868 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=24, k=24, tile_m=2, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 313.429 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=24, k=26, tile_m=2, tile_n=3, w=10, v=24, threads=96, grouping=16, minblocks=12) , # 309.598 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=24, k=32, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 328.287 GFlop/s
   Kernel_dnt_medium(m=16, n=26, k=4, tile_m=1, tile_n=5, threads=128, grouping=16, minblocks=12) , # 145.64 GFlop/s
   Kernel_dnt_medium(m=16, n=26, k=5, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 161.73 GFlop/s
   Kernel_dnt_medium(m=16, n=26, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 166.297 GFlop/s
   Kernel_dnt_medium(m=16, n=26, k=8, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 203.682 GFlop/s
   Kernel_dnt_medium(m=16, n=26, k=9, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 211.795 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=26, k=13, tile_m=2, tile_n=2, w=6, v=26, threads=128, grouping=16, minblocks=12) , # 235.299 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=26, k=16, tile_m=2, tile_n=2, w=8, v=18, threads=128, grouping=16, minblocks=12) , # 273.171 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=26, k=17, tile_m=2, tile_n=2, w=8, v=18, threads=128, grouping=16, minblocks=12) , # 265.788 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=26, k=22, tile_m=2, tile_n=4, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 285.563 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=26, k=23, tile_m=2, tile_n=2, w=6, v=18, threads=128, grouping=16, minblocks=12) , # 284.848 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=26, k=24, tile_m=2, tile_n=2, w=8, v=18, threads=128, grouping=16, minblocks=12) , # 301.847 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=26, k=26, tile_m=2, tile_n=4, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 298.512 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=26, k=32, tile_m=2, tile_n=4, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 308.645 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=29, k=14, tile_m=2, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 264.624 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=29, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 294.66 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=29, k=29, tile_m=2, tile_n=2, w=6, v=24, threads=128, grouping=16, minblocks=12) , # 312.556 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=29, k=55, tile_m=2, tile_n=4, w=6, v=24, threads=96, grouping=16, minblocks=12) , # 360.672 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=26, k=13, tile_m=2, tile_n=2, w=6, v=26, threads=128, grouping=16, minblocks=12) , # 235.299 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=26, k=16, tile_m=2, tile_n=2, w=8, v=18, threads=128, grouping=16, minblocks=12) , # 273.171 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=26, k=17, tile_m=2, tile_n=2, w=8, v=18, threads=128, grouping=16, minblocks=12) , # 265.788 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=26, k=22, tile_m=2, tile_n=4, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 285.563 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=26, k=23, tile_m=2, tile_n=2, w=6, v=18, threads=128, grouping=16, minblocks=12) , # 284.848 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=26, k=24, tile_m=2, tile_n=2, w=8, v=18, threads=128, grouping=16, minblocks=12) , # 301.847 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=26, k=26, tile_m=2, tile_n=4, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 298.512 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=26, k=32, tile_m=2, tile_n=4, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 308.645 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=29, k=14, tile_m=2, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 264.624 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=29, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 294.66 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=29, k=29, tile_m=2, tile_n=2, w=6, v=24, threads=128, grouping=16, minblocks=12) , # 312.556 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=29, k=55, tile_m=2, tile_n=4, w=6, v=24, threads=96, grouping=16, minblocks=12) , # 360.672 GFlop/s
   Kernel_dnt_small(m=16, n=32, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=4) , # 149.795 GFlop/s
   Kernel_dnt_medium(m=16, n=32, k=5, tile_m=2, tile_n=2, threads=192, grouping=16, minblocks=8) , # 166.138 GFlop/s
   Kernel_dnt_medium(m=16, n=32, k=6, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 189.982 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=32, k=8, tile_m=2, tile_n=2, w=4, v=24, threads=128, grouping=16, minblocks=12) , # 234.188 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=32, k=9, tile_m=2, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 239.327 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=32, k=13, tile_m=2, tile_n=2, w=6, v=24, threads=128, grouping=16, minblocks=12) , # 290.526 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=32, k=16, tile_m=2, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 326.65 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=32, k=17, tile_m=2, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 322.698 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=32, k=22, tile_m=2, tile_n=4, w=6, v=28, threads=96, grouping=16, minblocks=12) , # 328.078 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=32, k=23, tile_m=2, tile_n=2, w=6, v=24, threads=128, grouping=16, minblocks=12) , # 344.677 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=32, k=24, tile_m=2, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 358.185 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=32, k=26, tile_m=2, tile_n=2, w=6, v=24, threads=128, grouping=16, minblocks=12) , # 342.564 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=32, k=32, tile_m=2, tile_n=4, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 360.103 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=55, k=16, tile_m=2, tile_n=4, w=8, v=32, threads=128, grouping=16, minblocks=8) , # 331.33 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=55, k=29, tile_m=2, tile_n=4, w=8, v=40, threads=128, grouping=16, minblocks=8) , # 387.674 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=55, k=55, tile_m=2, tile_n=4, w=8, v=24, threads=128, grouping=16, minblocks=8) , # 430.218 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=64, k=9, tile_m=2, tile_n=4, w=4, v=40, threads=128, grouping=16, minblocks=4) , # 281.238 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=64, k=16, tile_m=2, tile_n=4, w=8, v=40, threads=128, grouping=16, minblocks=8) , # 374.147 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=64, k=22, tile_m=2, tile_n=4, w=8, v=40, threads=128, grouping=16, minblocks=8) , # 409.267 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=64, k=64, tile_m=2, tile_n=4, w=8, v=44, threads=128, grouping=16, minblocks=8) , # 500.346 GFlop/s
-  Kernel_dnt_largeDB(m=16, n=256, k=16, tile_m=2, tile_n=6, w=6, v=168, threads=384, grouping=16, minblocks=1) , # 309.179 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=32, k=8, tile_m=2, tile_n=2, w=4, v=24, threads=128, grouping=16, minblocks=12) , # 234.188 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=32, k=9, tile_m=2, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 239.327 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=32, k=13, tile_m=2, tile_n=2, w=6, v=24, threads=128, grouping=16, minblocks=12) , # 290.526 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=32, k=16, tile_m=2, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 326.65 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=32, k=17, tile_m=2, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 322.698 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=32, k=22, tile_m=2, tile_n=4, w=6, v=28, threads=96, grouping=16, minblocks=12) , # 328.078 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=32, k=23, tile_m=2, tile_n=2, w=6, v=24, threads=128, grouping=16, minblocks=12) , # 344.677 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=32, k=24, tile_m=2, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 358.185 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=32, k=26, tile_m=2, tile_n=2, w=6, v=24, threads=128, grouping=16, minblocks=12) , # 342.564 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=32, k=32, tile_m=2, tile_n=4, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 360.103 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=55, k=16, tile_m=2, tile_n=4, w=8, v=32, threads=128, grouping=16, minblocks=8) , # 331.33 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=55, k=29, tile_m=2, tile_n=4, w=8, v=40, threads=128, grouping=16, minblocks=8) , # 387.674 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=55, k=55, tile_m=2, tile_n=4, w=8, v=24, threads=128, grouping=16, minblocks=8) , # 430.218 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=64, k=9, tile_m=2, tile_n=4, w=4, v=40, threads=128, grouping=16, minblocks=4) , # 281.238 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=64, k=16, tile_m=2, tile_n=4, w=8, v=40, threads=128, grouping=16, minblocks=8) , # 374.147 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=64, k=22, tile_m=2, tile_n=4, w=8, v=40, threads=128, grouping=16, minblocks=8) , # 409.267 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=64, k=64, tile_m=2, tile_n=4, w=8, v=44, threads=128, grouping=16, minblocks=8) , # 500.346 GFlop/s
+  Kernel_dnt_largeDB1(m=16, n=256, k=16, tile_m=2, tile_n=6, w=6, v=168, threads=384, grouping=16, minblocks=1) , # 309.179 GFlop/s
   Kernel_dnt_medium(m=17, n=4, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 44.4021 GFlop/s
   Kernel_dnt_medium(m=17, n=4, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 54.1312 GFlop/s
   Kernel_dnt_small(m=17, n=4, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 55.1151 GFlop/s
@@ -1648,7 +1648,7 @@
   Kernel_dnt_medium(m=17, n=4, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 109.504 GFlop/s
   Kernel_dnt_medium(m=17, n=4, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 109.247 GFlop/s
   Kernel_dnt_medium(m=17, n=4, k=26, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 112.934 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=4, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=1) , # 116.496 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=4, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=1) , # 116.496 GFlop/s
   Kernel_dnt_medium(m=17, n=5, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 55.1226 GFlop/s
   Kernel_dnt_medium(m=17, n=5, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 67.2537 GFlop/s
   Kernel_dnt_small(m=17, n=5, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 67.5261 GFlop/s
@@ -1661,20 +1661,20 @@
   Kernel_dnt_medium(m=17, n=5, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 132.002 GFlop/s
   Kernel_dnt_medium(m=17, n=5, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 135.055 GFlop/s
   Kernel_dnt_medium(m=17, n=5, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=4) , # 131.777 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=4) , # 138.231 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=4) , # 138.231 GFlop/s
   Kernel_dnt_tiny(m=17, n=6, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 60.0659 GFlop/s
   Kernel_dnt_small(m=17, n=6, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 69.3811 GFlop/s
   Kernel_dnt_small(m=17, n=6, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 76.6485 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=6, k=8, tile_m=1, tile_n=1, w=4, v=6, threads=128, grouping=16, minblocks=1) , # 87.7851 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=6, k=8, tile_m=1, tile_n=1, w=4, v=6, threads=128, grouping=16, minblocks=1) , # 87.7851 GFlop/s
   Kernel_dnt_medium(m=17, n=6, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 93.856 GFlop/s
   Kernel_dnt_medium(m=17, n=6, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 121.148 GFlop/s
   Kernel_dnt_medium(m=17, n=6, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 129.192 GFlop/s
   Kernel_dnt_medium(m=17, n=6, k=17, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 129.614 GFlop/s
   Kernel_dnt_medium(m=17, n=6, k=22, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=4) , # 140.116 GFlop/s
   Kernel_dnt_medium(m=17, n=6, k=23, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=4) , # 138.103 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=6, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=12) , # 142.037 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=6, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=12) , # 142.037 GFlop/s
   Kernel_dnt_medium(m=17, n=6, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=4) , # 145.376 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=6, k=32, tile_m=2, tile_n=2, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 150.065 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=6, k=32, tile_m=2, tile_n=2, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 150.065 GFlop/s
   Kernel_dnt_small(m=17, n=8, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 73.5398 GFlop/s
   Kernel_dnt_medium(m=17, n=8, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 84.7969 GFlop/s
   Kernel_dnt_medium(m=17, n=8, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 90.287 GFlop/s
@@ -1685,9 +1685,9 @@
   Kernel_dnt_medium(m=17, n=8, k=17, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 153.384 GFlop/s
   Kernel_dnt_medium(m=17, n=8, k=22, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 157.352 GFlop/s
   Kernel_dnt_medium(m=17, n=8, k=23, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 157.04 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=8, k=24, tile_m=2, tile_n=3, w=12, v=6, threads=96, grouping=16, minblocks=12) , # 158.743 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=8, k=26, tile_m=2, tile_n=3, w=12, v=8, threads=96, grouping=16, minblocks=12) , # 158.262 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=8, k=32, tile_m=3, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=12) , # 178.979 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=8, k=24, tile_m=2, tile_n=3, w=12, v=6, threads=96, grouping=16, minblocks=12) , # 158.743 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=8, k=26, tile_m=2, tile_n=3, w=12, v=8, threads=96, grouping=16, minblocks=12) , # 158.262 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=8, k=32, tile_m=3, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=12) , # 178.979 GFlop/s
   Kernel_dnt_small(m=17, n=9, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 77.9497 GFlop/s
   Kernel_dnt_medium(m=17, n=9, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 93.1439 GFlop/s
   Kernel_dnt_medium(m=17, n=9, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 98.5145 GFlop/s
@@ -1700,7 +1700,7 @@
   Kernel_dnt_medium(m=17, n=9, k=23, tile_m=1, tile_n=1, threads=224, grouping=16, minblocks=8) , # 166.022 GFlop/s
   Kernel_dnt_medium(m=17, n=9, k=24, tile_m=1, tile_n=1, threads=224, grouping=16, minblocks=8) , # 168.798 GFlop/s
   Kernel_dnt_medium(m=17, n=9, k=26, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 168.829 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=9, k=32, tile_m=2, tile_n=3, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 184.866 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=9, k=32, tile_m=2, tile_n=3, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 184.866 GFlop/s
   Kernel_dnt_medium(m=17, n=13, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 100.145 GFlop/s
   Kernel_dnt_medium(m=17, n=13, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 118.278 GFlop/s
   Kernel_dnt_medium(m=17, n=13, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 131.89 GFlop/s
@@ -1712,21 +1712,21 @@
   Kernel_dnt_medium(m=17, n=13, k=22, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 220.321 GFlop/s
   Kernel_dnt_medium(m=17, n=13, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 220.147 GFlop/s
   Kernel_dnt_medium(m=17, n=13, k=24, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 222.453 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=13, k=26, tile_m=2, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 213.018 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=13, k=32, tile_m=2, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=12) , # 238.862 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=13, k=26, tile_m=2, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 213.018 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=13, k=32, tile_m=2, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=12) , # 238.862 GFlop/s
   Kernel_dnt_medium(m=17, n=16, k=4, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 116.716 GFlop/s
   Kernel_dnt_medium(m=17, n=16, k=5, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 136.165 GFlop/s
   Kernel_dnt_medium(m=17, n=16, k=6, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 154.74 GFlop/s
   Kernel_dnt_medium(m=17, n=16, k=8, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 169.907 GFlop/s
   Kernel_dnt_medium(m=17, n=16, k=9, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=12) , # 177.331 GFlop/s
   Kernel_dnt_medium(m=17, n=16, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 203.746 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=16, k=16, tile_m=3, tile_n=1, w=4, v=10, threads=96, grouping=16, minblocks=4) , # 206.356 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=16, k=16, tile_m=3, tile_n=1, w=4, v=10, threads=96, grouping=16, minblocks=4) , # 206.356 GFlop/s
   Kernel_dnt_medium(m=17, n=16, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 207.944 GFlop/s
   Kernel_dnt_medium(m=17, n=16, k=22, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 235.476 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=16, k=23, tile_m=3, tile_n=1, w=6, v=16, threads=128, grouping=16, minblocks=12) , # 235.699 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=16, k=24, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 245.438 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=16, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 240.279 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=16, k=32, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 257.664 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=16, k=23, tile_m=3, tile_n=1, w=6, v=16, threads=128, grouping=16, minblocks=12) , # 235.699 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=16, k=24, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 245.438 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=16, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 240.279 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=16, k=32, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 257.664 GFlop/s
   Kernel_dnt_small(m=17, n=17, k=4, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=4) , # 123.512 GFlop/s
   Kernel_dnt_small(m=17, n=17, k=5, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=8) , # 144.444 GFlop/s
   Kernel_dnt_medium(m=17, n=17, k=6, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 153.953 GFlop/s
@@ -1735,76 +1735,76 @@
   Kernel_dnt_medium(m=17, n=17, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 227.787 GFlop/s
   Kernel_dnt_medium(m=17, n=17, k=16, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 228.835 GFlop/s
   Kernel_dnt_largeDB2(m=17, n=17, k=17, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 239.722 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=17, k=22, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 235.625 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=17, k=23, tile_m=2, tile_n=2, w=6, v=16, threads=128, grouping=16, minblocks=12) , # 237.176 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=17, k=24, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 240.597 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=17, k=26, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 240.047 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=17, k=32, tile_m=3, tile_n=2, w=14, v=12, threads=96, grouping=16, minblocks=12) , # 260.215 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=17, k=22, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 235.625 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=17, k=23, tile_m=2, tile_n=2, w=6, v=16, threads=128, grouping=16, minblocks=12) , # 237.176 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=17, k=24, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 240.597 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=17, k=26, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 240.047 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=17, k=32, tile_m=3, tile_n=2, w=14, v=12, threads=96, grouping=16, minblocks=12) , # 260.215 GFlop/s
   Kernel_dnt_medium(m=17, n=22, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 138.391 GFlop/s
   Kernel_dnt_medium(m=17, n=22, k=5, tile_m=1, tile_n=5, threads=128, grouping=16, minblocks=12) , # 148.4 GFlop/s
   Kernel_dnt_medium(m=17, n=22, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 150.275 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=22, k=8, tile_m=2, tile_n=2, w=4, v=22, threads=128, grouping=16, minblocks=12) , # 182.307 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=22, k=8, tile_m=2, tile_n=2, w=4, v=22, threads=128, grouping=16, minblocks=12) , # 182.307 GFlop/s
   Kernel_dnt_medium(m=17, n=22, k=9, tile_m=1, tile_n=5, threads=96, grouping=16, minblocks=12) , # 187.291 GFlop/s
   Kernel_dnt_medium(m=17, n=22, k=13, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 214.624 GFlop/s
   Kernel_dnt_medium(m=17, n=22, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 246.559 GFlop/s
   Kernel_dnt_medium(m=17, n=22, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 251.891 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=22, k=22, tile_m=3, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 245.288 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=22, k=23, tile_m=3, tile_n=2, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 245.432 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=22, k=24, tile_m=3, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 262.797 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=22, k=26, tile_m=3, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 257.52 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=22, k=32, tile_m=2, tile_n=2, w=16, v=22, threads=128, grouping=16, minblocks=8) , # 279.426 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=22, k=22, tile_m=3, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 245.288 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=22, k=23, tile_m=3, tile_n=2, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 245.432 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=22, k=24, tile_m=3, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 262.797 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=22, k=26, tile_m=3, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 257.52 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=22, k=32, tile_m=2, tile_n=2, w=16, v=22, threads=128, grouping=16, minblocks=8) , # 279.426 GFlop/s
   Kernel_dnt_medium(m=17, n=23, k=4, tile_m=5, tile_n=1, threads=96, grouping=16, minblocks=12) , # 131.562 GFlop/s
   Kernel_dnt_medium(m=17, n=23, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 153.614 GFlop/s
   Kernel_dnt_medium(m=17, n=23, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 153.311 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=23, k=8, tile_m=2, tile_n=2, w=4, v=22, threads=128, grouping=16, minblocks=12) , # 183.993 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=23, k=8, tile_m=2, tile_n=2, w=4, v=22, threads=128, grouping=16, minblocks=12) , # 183.993 GFlop/s
   Kernel_dnt_medium(m=17, n=23, k=9, tile_m=1, tile_n=5, threads=96, grouping=16, minblocks=12) , # 192.159 GFlop/s
   Kernel_dnt_medium(m=17, n=23, k=13, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 227.532 GFlop/s
   Kernel_dnt_medium(m=17, n=23, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 253.516 GFlop/s
   Kernel_dnt_medium(m=17, n=23, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 253.057 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=23, k=22, tile_m=2, tile_n=2, w=10, v=22, threads=128, grouping=16, minblocks=12) , # 263.902 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=23, k=23, tile_m=3, tile_n=2, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 257.187 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=23, k=24, tile_m=2, tile_n=2, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 274.723 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=23, k=26, tile_m=3, tile_n=2, w=10, v=14, threads=96, grouping=16, minblocks=12) , # 264.933 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=23, k=32, tile_m=2, tile_n=2, w=16, v=16, threads=160, grouping=16, minblocks=8) , # 282.093 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=23, k=22, tile_m=2, tile_n=2, w=10, v=22, threads=128, grouping=16, minblocks=12) , # 263.902 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=23, k=23, tile_m=3, tile_n=2, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 257.187 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=23, k=24, tile_m=2, tile_n=2, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 274.723 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=23, k=26, tile_m=3, tile_n=2, w=10, v=14, threads=96, grouping=16, minblocks=12) , # 264.933 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=23, k=32, tile_m=2, tile_n=2, w=16, v=16, threads=160, grouping=16, minblocks=8) , # 282.093 GFlop/s
   Kernel_dnt_medium(m=17, n=24, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 149.438 GFlop/s
   Kernel_dnt_medium(m=17, n=24, k=5, tile_m=1, tile_n=5, threads=128, grouping=16, minblocks=12) , # 160.205 GFlop/s
   Kernel_dnt_medium(m=17, n=24, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 165.872 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=24, k=8, tile_m=2, tile_n=2, w=4, v=24, threads=128, grouping=16, minblocks=12) , # 196.795 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=24, k=8, tile_m=2, tile_n=2, w=4, v=24, threads=128, grouping=16, minblocks=12) , # 196.795 GFlop/s
   Kernel_dnt_medium(m=17, n=24, k=9, tile_m=1, tile_n=5, threads=96, grouping=16, minblocks=12) , # 203.363 GFlop/s
   Kernel_dnt_medium(m=17, n=24, k=13, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 236.192 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=24, k=16, tile_m=2, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 260.019 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=24, k=16, tile_m=2, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 260.019 GFlop/s
   Kernel_dnt_medium(m=17, n=24, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 260.23 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=24, k=22, tile_m=3, tile_n=2, w=10, v=24, threads=96, grouping=16, minblocks=12) , # 265.399 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=24, k=23, tile_m=3, tile_n=2, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 267.658 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=24, k=24, tile_m=2, tile_n=2, w=12, v=24, threads=128, grouping=16, minblocks=1) , # 276.151 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=24, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 280.206 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=24, k=32, tile_m=2, tile_n=2, w=16, v=24, threads=128, grouping=16, minblocks=8) , # 301.526 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=24, k=22, tile_m=3, tile_n=2, w=10, v=24, threads=96, grouping=16, minblocks=12) , # 265.399 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=24, k=23, tile_m=3, tile_n=2, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 267.658 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=24, k=24, tile_m=2, tile_n=2, w=12, v=24, threads=128, grouping=16, minblocks=1) , # 276.151 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=24, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 280.206 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=24, k=32, tile_m=2, tile_n=2, w=16, v=24, threads=128, grouping=16, minblocks=8) , # 301.526 GFlop/s
   Kernel_dnt_medium(m=17, n=26, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 155.546 GFlop/s
   Kernel_dnt_medium(m=17, n=26, k=5, tile_m=1, tile_n=6, threads=96, grouping=16, minblocks=12) , # 155.547 GFlop/s
   Kernel_dnt_medium(m=17, n=26, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 174.528 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=26, k=8, tile_m=2, tile_n=2, w=4, v=26, threads=128, grouping=16, minblocks=12) , # 205.713 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=26, k=8, tile_m=2, tile_n=2, w=4, v=26, threads=128, grouping=16, minblocks=12) , # 205.713 GFlop/s
   Kernel_dnt_medium(m=17, n=26, k=9, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 205.14 GFlop/s
   Kernel_dnt_medium(m=17, n=26, k=13, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 243.482 GFlop/s
   Kernel_dnt_medium(m=17, n=26, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 272.907 GFlop/s
   Kernel_dnt_medium(m=17, n=26, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 275.819 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=26, k=22, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 277.137 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=26, k=23, tile_m=3, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 285.309 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=26, k=24, tile_m=3, tile_n=2, w=8, v=26, threads=96, grouping=16, minblocks=12) , # 292.828 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=26, k=26, tile_m=3, tile_n=2, w=10, v=14, threads=96, grouping=16, minblocks=12) , # 288.933 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=26, k=32, tile_m=2, tile_n=2, w=16, v=18, threads=160, grouping=16, minblocks=8) , # 317.652 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=32, k=4, tile_m=3, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 148.299 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=26, k=22, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 277.137 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=26, k=23, tile_m=3, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 285.309 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=26, k=24, tile_m=3, tile_n=2, w=8, v=26, threads=96, grouping=16, minblocks=12) , # 292.828 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=26, k=26, tile_m=3, tile_n=2, w=10, v=14, threads=96, grouping=16, minblocks=12) , # 288.933 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=26, k=32, tile_m=2, tile_n=2, w=16, v=18, threads=160, grouping=16, minblocks=8) , # 317.652 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=32, k=4, tile_m=3, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 148.299 GFlop/s
   Kernel_dnt_medium(m=17, n=32, k=5, tile_m=3, tile_n=1, threads=192, grouping=16, minblocks=8) , # 168.196 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=32, k=6, tile_m=3, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 182.522 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=32, k=8, tile_m=3, tile_n=2, w=4, v=28, threads=96, grouping=16, minblocks=12) , # 230.442 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=32, k=6, tile_m=3, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 182.522 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=32, k=8, tile_m=3, tile_n=2, w=4, v=28, threads=96, grouping=16, minblocks=12) , # 230.442 GFlop/s
   Kernel_dnt_medium(m=17, n=32, k=9, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 233.382 GFlop/s
   Kernel_dnt_medium(m=17, n=32, k=13, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 261.656 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=32, k=16, tile_m=3, tile_n=2, w=4, v=26, threads=128, grouping=16, minblocks=12) , # 304.612 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=32, k=17, tile_m=3, tile_n=2, w=8, v=28, threads=96, grouping=16, minblocks=12) , # 292.771 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=32, k=22, tile_m=3, tile_n=2, w=6, v=32, threads=128, grouping=16, minblocks=8) , # 305.08 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=32, k=23, tile_m=3, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 328.197 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=32, k=24, tile_m=3, tile_n=2, w=8, v=28, threads=96, grouping=16, minblocks=12) , # 335.43 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=32, k=26, tile_m=3, tile_n=2, w=8, v=28, threads=96, grouping=16, minblocks=12) , # 337.328 GFlop/s
-  Kernel_dnt_largeDB(m=17, n=32, k=32, tile_m=3, tile_n=2, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 356.942 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=32, k=16, tile_m=3, tile_n=2, w=4, v=26, threads=128, grouping=16, minblocks=12) , # 304.612 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=32, k=17, tile_m=3, tile_n=2, w=8, v=28, threads=96, grouping=16, minblocks=12) , # 292.771 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=32, k=22, tile_m=3, tile_n=2, w=6, v=32, threads=128, grouping=16, minblocks=8) , # 305.08 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=32, k=23, tile_m=3, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 328.197 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=32, k=24, tile_m=3, tile_n=2, w=8, v=28, threads=96, grouping=16, minblocks=12) , # 335.43 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=32, k=26, tile_m=3, tile_n=2, w=8, v=28, threads=96, grouping=16, minblocks=12) , # 337.328 GFlop/s
+  Kernel_dnt_largeDB1(m=17, n=32, k=32, tile_m=3, tile_n=2, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 356.942 GFlop/s
   Kernel_dnt_medium(m=22, n=4, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 57.5751 GFlop/s
   Kernel_dnt_small(m=22, n=4, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 61.4088 GFlop/s
   Kernel_dnt_medium(m=22, n=4, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 66.0702 GFlop/s
@@ -1817,7 +1817,7 @@
   Kernel_dnt_medium(m=22, n=4, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 125.232 GFlop/s
   Kernel_dnt_medium(m=22, n=4, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 126.365 GFlop/s
   Kernel_dnt_medium(m=22, n=4, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 123.866 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=4, k=32, tile_m=1, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 128.16 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=4, k=32, tile_m=1, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 128.16 GFlop/s
   Kernel_dnt_tiny(m=22, n=5, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 64.238 GFlop/s
   Kernel_dnt_small(m=22, n=5, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 73.3009 GFlop/s
   Kernel_dnt_medium(m=22, n=5, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 74.4677 GFlop/s
@@ -1830,20 +1830,20 @@
   Kernel_dnt_medium(m=22, n=5, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 147.827 GFlop/s
   Kernel_dnt_medium(m=22, n=5, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 141.609 GFlop/s
   Kernel_dnt_medium(m=22, n=5, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 144.189 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=12) , # 146.023 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=12) , # 146.023 GFlop/s
   Kernel_dnt_small(m=22, n=6, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 69.8662 GFlop/s
   Kernel_dnt_medium(m=22, n=6, k=5, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 77.9372 GFlop/s
   Kernel_dnt_medium(m=22, n=6, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 84.6147 GFlop/s
   Kernel_dnt_medium(m=22, n=6, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 106.018 GFlop/s
   Kernel_dnt_medium(m=22, n=6, k=9, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=8) , # 109.232 GFlop/s
   Kernel_dnt_medium(m=22, n=6, k=13, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 137.639 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=6, k=16, tile_m=2, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=1) , # 143.963 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=6, k=16, tile_m=2, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=1) , # 143.963 GFlop/s
   Kernel_dnt_medium(m=22, n=6, k=17, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 147.12 GFlop/s
   Kernel_dnt_medium(m=22, n=6, k=22, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=8) , # 147.34 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=6, k=23, tile_m=2, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 144.445 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=6, k=24, tile_m=2, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=1) , # 152.082 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=6, k=23, tile_m=2, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 144.445 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=6, k=24, tile_m=2, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=1) , # 152.082 GFlop/s
   Kernel_dnt_medium(m=22, n=6, k=26, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 150.145 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=6, k=32, tile_m=3, tile_n=2, w=16, v=4, threads=96, grouping=16, minblocks=12) , # 163.029 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=6, k=32, tile_m=3, tile_n=2, w=16, v=4, threads=96, grouping=16, minblocks=12) , # 163.029 GFlop/s
   Kernel_dnt_small(m=22, n=8, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 94.6278 GFlop/s
   Kernel_dnt_medium(m=22, n=8, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 101.742 GFlop/s
   Kernel_dnt_medium(m=22, n=8, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 113.174 GFlop/s
@@ -1852,11 +1852,11 @@
   Kernel_dnt_medium(m=22, n=8, k=13, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 172.352 GFlop/s
   Kernel_dnt_medium(m=22, n=8, k=16, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 187.276 GFlop/s
   Kernel_dnt_medium(m=22, n=8, k=17, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=4) , # 184.837 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=8, k=22, tile_m=2, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 185.428 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=8, k=23, tile_m=1, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 187.194 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=8, k=24, tile_m=2, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=8) , # 197.07 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=8, k=26, tile_m=1, tile_n=2, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 190.52 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=8, k=32, tile_m=3, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=12) , # 205.185 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=8, k=22, tile_m=2, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 185.428 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=8, k=23, tile_m=1, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 187.194 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=8, k=24, tile_m=2, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=8) , # 197.07 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=8, k=26, tile_m=1, tile_n=2, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 190.52 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=8, k=32, tile_m=3, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=12) , # 205.185 GFlop/s
   Kernel_dnt_medium(m=22, n=9, k=4, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 89.3747 GFlop/s
   Kernel_dnt_medium(m=22, n=9, k=5, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 106.787 GFlop/s
   Kernel_dnt_medium(m=22, n=9, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 112.692 GFlop/s
@@ -1867,50 +1867,50 @@
   Kernel_dnt_medium(m=22, n=9, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=1) , # 179.675 GFlop/s
   Kernel_dnt_medium(m=22, n=9, k=22, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 198.116 GFlop/s
   Kernel_dnt_medium(m=22, n=9, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 201.354 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=9, k=24, tile_m=2, tile_n=2, w=12, v=6, threads=128, grouping=16, minblocks=12) , # 200.245 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=9, k=26, tile_m=2, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 197.52 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=9, k=32, tile_m=2, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 207.544 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=9, k=64, tile_m=2, tile_n=2, w=12, v=8, threads=96, grouping=16, minblocks=12) , # 239.452 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=9, k=24, tile_m=2, tile_n=2, w=12, v=6, threads=128, grouping=16, minblocks=12) , # 200.245 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=9, k=26, tile_m=2, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 197.52 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=9, k=32, tile_m=2, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 207.544 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=9, k=64, tile_m=2, tile_n=2, w=12, v=8, threads=96, grouping=16, minblocks=12) , # 239.452 GFlop/s
   Kernel_dnt_medium(m=22, n=13, k=4, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 116.442 GFlop/s
   Kernel_dnt_medium(m=22, n=13, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 133.637 GFlop/s
   Kernel_dnt_medium(m=22, n=13, k=6, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 146.616 GFlop/s
   Kernel_dnt_medium(m=22, n=13, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 171.063 GFlop/s
   Kernel_dnt_medium(m=22, n=13, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 183.073 GFlop/s
   Kernel_dnt_medium(m=22, n=13, k=13, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 223.261 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=13, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 214.711 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=13, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 214.711 GFlop/s
   Kernel_dnt_medium(m=22, n=13, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=4) , # 224.809 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=13, k=22, tile_m=3, tile_n=2, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 221.172 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=13, k=22, tile_m=3, tile_n=2, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 221.172 GFlop/s
   Kernel_dnt_medium(m=22, n=13, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=1) , # 228.978 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=13, k=24, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 233.378 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=13, k=26, tile_m=3, tile_n=2, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 236.465 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=13, k=32, tile_m=2, tile_n=3, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 250.128 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=13, k=24, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 233.378 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=13, k=26, tile_m=3, tile_n=2, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 236.465 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=13, k=32, tile_m=2, tile_n=3, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 250.128 GFlop/s
   Kernel_dnt_medium(m=22, n=16, k=4, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 141.362 GFlop/s
   Kernel_dnt_medium(m=22, n=16, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 165.072 GFlop/s
   Kernel_dnt_medium(m=22, n=16, k=6, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 168.045 GFlop/s
   Kernel_dnt_medium(m=22, n=16, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 208.282 GFlop/s
   Kernel_dnt_medium(m=22, n=16, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 221.618 GFlop/s
   Kernel_dnt_medium(m=22, n=16, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=8) , # 242.184 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=16, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 254.265 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=16, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 254.265 GFlop/s
   Kernel_dnt_medium(m=22, n=16, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 270.21 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=16, k=22, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 275.664 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=16, k=23, tile_m=2, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 279.173 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=16, k=24, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 292.083 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=16, k=26, tile_m=2, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 290.449 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=16, k=32, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 308.173 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=16, k=64, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 357.117 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=16, k=22, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 275.664 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=16, k=23, tile_m=2, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 279.173 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=16, k=24, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 292.083 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=16, k=26, tile_m=2, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 290.449 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=16, k=32, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 308.173 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=16, k=64, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 357.117 GFlop/s
   Kernel_dnt_medium(m=22, n=17, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 139.051 GFlop/s
   Kernel_dnt_medium(m=22, n=17, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 159.925 GFlop/s
   Kernel_dnt_medium(m=22, n=17, k=6, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 158.152 GFlop/s
   Kernel_dnt_medium(m=22, n=17, k=8, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 188.223 GFlop/s
   Kernel_dnt_medium(m=22, n=17, k=9, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 202.404 GFlop/s
   Kernel_dnt_medium(m=22, n=17, k=13, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 224.16 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=17, k=16, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 245.41 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=17, k=16, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 245.41 GFlop/s
   Kernel_dnt_medium(m=22, n=17, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 257.375 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=17, k=22, tile_m=2, tile_n=4, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 256.316 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=17, k=22, tile_m=2, tile_n=4, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 256.316 GFlop/s
   Kernel_dnt_medium(m=22, n=17, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=1) , # 255.027 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=17, k=24, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 259.941 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=17, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 256.136 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=17, k=32, tile_m=2, tile_n=2, w=16, v=16, threads=128, grouping=16, minblocks=8) , # 275.263 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=17, k=24, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 259.941 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=17, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 256.136 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=17, k=32, tile_m=2, tile_n=2, w=16, v=16, threads=128, grouping=16, minblocks=8) , # 275.263 GFlop/s
   Kernel_dnt_small(m=22, n=22, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=4) , # 163.707 GFlop/s
   Kernel_dnt_small(m=22, n=22, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=4) , # 187.588 GFlop/s
   Kernel_dnt_medium(m=22, n=22, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 192.65 GFlop/s
@@ -1921,66 +1921,66 @@
   Kernel_dnt_medium(m=22, n=22, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=1) , # 317.077 GFlop/s
   Kernel_dnt_largeDB2(m=22, n=22, k=22, tile_m=3, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 330.052 GFlop/s
   Kernel_dnt_medium(m=22, n=22, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=1) , # 308.901 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=22, k=24, tile_m=2, tile_n=2, w=8, v=22, threads=192, grouping=16, minblocks=8) , # 310.483 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=22, k=26, tile_m=2, tile_n=2, w=8, v=14, threads=192, grouping=16, minblocks=8) , # 317.329 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=22, k=32, tile_m=2, tile_n=2, w=16, v=22, threads=128, grouping=16, minblocks=4) , # 345.889 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=22, k=64, tile_m=3, tile_n=3, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 397.616 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=22, k=24, tile_m=2, tile_n=2, w=8, v=22, threads=192, grouping=16, minblocks=8) , # 310.483 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=22, k=26, tile_m=2, tile_n=2, w=8, v=14, threads=192, grouping=16, minblocks=8) , # 317.329 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=22, k=32, tile_m=2, tile_n=2, w=16, v=22, threads=128, grouping=16, minblocks=4) , # 345.889 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=22, k=64, tile_m=3, tile_n=3, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 397.616 GFlop/s
   Kernel_dnt_medium(m=22, n=23, k=4, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=4) , # 147.314 GFlop/s
   Kernel_dnt_medium(m=22, n=23, k=5, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 165.555 GFlop/s
   Kernel_dnt_medium(m=22, n=23, k=6, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 177.922 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=23, k=8, tile_m=3, tile_n=2, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 217.558 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=23, k=9, tile_m=3, tile_n=2, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 220.434 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=23, k=8, tile_m=3, tile_n=2, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 217.558 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=23, k=9, tile_m=3, tile_n=2, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 220.434 GFlop/s
   Kernel_dnt_medium(m=22, n=23, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 270.773 GFlop/s
   Kernel_dnt_medium(m=22, n=23, k=16, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 295.869 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=23, k=17, tile_m=3, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 281.315 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=23, k=22, tile_m=3, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 301.99 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=23, k=23, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 311.315 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=23, k=24, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 311.437 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=23, k=26, tile_m=2, tile_n=3, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 325.286 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=23, k=32, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 332.066 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=23, k=17, tile_m=3, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 281.315 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=23, k=22, tile_m=3, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 301.99 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=23, k=23, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 311.315 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=23, k=24, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 311.437 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=23, k=26, tile_m=2, tile_n=3, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 325.286 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=23, k=32, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 332.066 GFlop/s
   Kernel_dnt_medium(m=22, n=24, k=4, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=8) , # 146.658 GFlop/s
   Kernel_dnt_medium(m=22, n=24, k=5, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 172.584 GFlop/s
   Kernel_dnt_medium(m=22, n=24, k=6, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 190.547 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=24, k=8, tile_m=3, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=12) , # 231.867 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=24, k=9, tile_m=2, tile_n=3, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 230.841 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=24, k=8, tile_m=3, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=12) , # 231.867 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=24, k=9, tile_m=2, tile_n=3, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 230.841 GFlop/s
   Kernel_dnt_medium(m=22, n=24, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 283.717 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=24, k=16, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 305.622 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=24, k=17, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 300.284 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=24, k=22, tile_m=3, tile_n=2, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 321.992 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=24, k=23, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 330.118 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=24, k=24, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 337.228 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=24, k=26, tile_m=2, tile_n=3, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 342.548 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=24, k=32, tile_m=3, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 356.369 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=24, k=16, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 305.622 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=24, k=17, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 300.284 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=24, k=22, tile_m=3, tile_n=2, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 321.992 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=24, k=23, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 330.118 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=24, k=24, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 337.228 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=24, k=26, tile_m=2, tile_n=3, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 342.548 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=24, k=32, tile_m=3, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 356.369 GFlop/s
   Kernel_dnt_medium(m=22, n=26, k=4, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 150.577 GFlop/s
   Kernel_dnt_medium(m=22, n=26, k=5, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 174.989 GFlop/s
   Kernel_dnt_medium(m=22, n=26, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 196.805 GFlop/s
   Kernel_dnt_medium(m=22, n=26, k=8, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 217.596 GFlop/s
   Kernel_dnt_medium(m=22, n=26, k=9, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 231.7 GFlop/s
   Kernel_dnt_medium(m=22, n=26, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 276.614 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=26, k=16, tile_m=3, tile_n=2, w=6, v=26, threads=160, grouping=16, minblocks=8) , # 268.495 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=26, k=17, tile_m=2, tile_n=3, w=6, v=14, threads=160, grouping=16, minblocks=8) , # 274.845 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=26, k=22, tile_m=2, tile_n=3, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 305.508 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=26, k=23, tile_m=2, tile_n=2, w=6, v=26, threads=160, grouping=16, minblocks=8) , # 307.774 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=26, k=24, tile_m=2, tile_n=3, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 312.05 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=26, k=26, tile_m=2, tile_n=3, w=4, v=18, threads=128, grouping=16, minblocks=12) , # 314.535 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=26, k=32, tile_m=2, tile_n=3, w=14, v=16, threads=128, grouping=16, minblocks=8) , # 328.943 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=32, k=4, tile_m=3, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=12) , # 173.713 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=26, k=16, tile_m=3, tile_n=2, w=6, v=26, threads=160, grouping=16, minblocks=8) , # 268.495 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=26, k=17, tile_m=2, tile_n=3, w=6, v=14, threads=160, grouping=16, minblocks=8) , # 274.845 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=26, k=22, tile_m=2, tile_n=3, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 305.508 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=26, k=23, tile_m=2, tile_n=2, w=6, v=26, threads=160, grouping=16, minblocks=8) , # 307.774 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=26, k=24, tile_m=2, tile_n=3, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 312.05 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=26, k=26, tile_m=2, tile_n=3, w=4, v=18, threads=128, grouping=16, minblocks=12) , # 314.535 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=26, k=32, tile_m=2, tile_n=3, w=14, v=16, threads=128, grouping=16, minblocks=8) , # 328.943 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=32, k=4, tile_m=3, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=12) , # 173.713 GFlop/s
   Kernel_dnt_medium(m=22, n=32, k=5, tile_m=2, tile_n=2, threads=192, grouping=16, minblocks=8) , # 199.383 GFlop/s
   Kernel_dnt_medium(m=22, n=32, k=6, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 213.238 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=32, k=8, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 279.051 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=32, k=9, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 280.794 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=32, k=8, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 279.051 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=32, k=9, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 280.794 GFlop/s
   Kernel_dnt_medium(m=22, n=32, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 317.355 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=32, k=16, tile_m=3, tile_n=2, w=8, v=32, threads=128, grouping=16, minblocks=8) , # 321.452 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=32, k=17, tile_m=3, tile_n=3, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 322.465 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=32, k=22, tile_m=2, tile_n=3, w=4, v=20, threads=128, grouping=16, minblocks=12) , # 368.406 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=32, k=23, tile_m=2, tile_n=3, w=6, v=32, threads=160, grouping=16, minblocks=8) , # 359.94 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=32, k=24, tile_m=2, tile_n=3, w=12, v=32, threads=128, grouping=16, minblocks=8) , # 374.035 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=32, k=26, tile_m=2, tile_n=3, w=4, v=20, threads=128, grouping=16, minblocks=12) , # 379.484 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=32, k=32, tile_m=2, tile_n=3, w=12, v=32, threads=128, grouping=16, minblocks=8) , # 392.581 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=64, k=9, tile_m=3, tile_n=4, w=4, v=40, threads=128, grouping=16, minblocks=4) , # 278.224 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=64, k=16, tile_m=3, tile_n=4, w=4, v=40, threads=128, grouping=16, minblocks=4) , # 364.597 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=64, k=22, tile_m=6, tile_n=2, w=4, v=32, threads=128, grouping=16, minblocks=1) , # 383.067 GFlop/s
-  Kernel_dnt_largeDB(m=22, n=64, k=64, tile_m=3, tile_n=4, w=8, v=24, threads=128, grouping=16, minblocks=1) , # 504.56 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=32, k=16, tile_m=3, tile_n=2, w=8, v=32, threads=128, grouping=16, minblocks=8) , # 321.452 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=32, k=17, tile_m=3, tile_n=3, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 322.465 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=32, k=22, tile_m=2, tile_n=3, w=4, v=20, threads=128, grouping=16, minblocks=12) , # 368.406 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=32, k=23, tile_m=2, tile_n=3, w=6, v=32, threads=160, grouping=16, minblocks=8) , # 359.94 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=32, k=24, tile_m=2, tile_n=3, w=12, v=32, threads=128, grouping=16, minblocks=8) , # 374.035 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=32, k=26, tile_m=2, tile_n=3, w=4, v=20, threads=128, grouping=16, minblocks=12) , # 379.484 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=32, k=32, tile_m=2, tile_n=3, w=12, v=32, threads=128, grouping=16, minblocks=8) , # 392.581 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=64, k=9, tile_m=3, tile_n=4, w=4, v=40, threads=128, grouping=16, minblocks=4) , # 278.224 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=64, k=16, tile_m=3, tile_n=4, w=4, v=40, threads=128, grouping=16, minblocks=4) , # 364.597 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=64, k=22, tile_m=6, tile_n=2, w=4, v=32, threads=128, grouping=16, minblocks=1) , # 383.067 GFlop/s
+  Kernel_dnt_largeDB1(m=22, n=64, k=64, tile_m=3, tile_n=4, w=8, v=24, threads=128, grouping=16, minblocks=1) , # 504.56 GFlop/s
   Kernel_dnt_medium(m=23, n=4, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 59.6814 GFlop/s
   Kernel_dnt_small(m=23, n=4, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 63.3487 GFlop/s
   Kernel_dnt_medium(m=23, n=4, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 68.454 GFlop/s
@@ -1993,7 +1993,7 @@
   Kernel_dnt_medium(m=23, n=4, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 125.969 GFlop/s
   Kernel_dnt_medium(m=23, n=4, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 122.921 GFlop/s
   Kernel_dnt_medium(m=23, n=4, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 127.127 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=4, k=32, tile_m=1, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 128.586 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=4, k=32, tile_m=1, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 128.586 GFlop/s
   Kernel_dnt_tiny(m=23, n=5, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 66.3956 GFlop/s
   Kernel_dnt_small(m=23, n=5, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 76.0417 GFlop/s
   Kernel_dnt_medium(m=23, n=5, k=6, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 76.9185 GFlop/s
@@ -2006,7 +2006,7 @@
   Kernel_dnt_medium(m=23, n=5, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 144.145 GFlop/s
   Kernel_dnt_medium(m=23, n=5, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 146.774 GFlop/s
   Kernel_dnt_medium(m=23, n=5, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 149.841 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=8) , # 148.711 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=8) , # 148.711 GFlop/s
   Kernel_dnt_small(m=23, n=6, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 71.0708 GFlop/s
   Kernel_dnt_medium(m=23, n=6, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 79.8984 GFlop/s
   Kernel_dnt_medium(m=23, n=6, k=6, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 88.3131 GFlop/s
@@ -2016,10 +2016,10 @@
   Kernel_dnt_medium(m=23, n=6, k=16, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 149.132 GFlop/s
   Kernel_dnt_medium(m=23, n=6, k=17, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 136.359 GFlop/s
   Kernel_dnt_medium(m=23, n=6, k=22, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=4) , # 153.003 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=6, k=23, tile_m=1, tile_n=2, w=8, v=6, threads=96, grouping=16, minblocks=8) , # 148.475 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=6, k=24, tile_m=1, tile_n=2, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 154.711 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=6, k=26, tile_m=1, tile_n=2, w=8, v=4, threads=96, grouping=16, minblocks=1) , # 151.108 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=6, k=32, tile_m=2, tile_n=3, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 164.982 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=6, k=23, tile_m=1, tile_n=2, w=8, v=6, threads=96, grouping=16, minblocks=8) , # 148.475 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=6, k=24, tile_m=1, tile_n=2, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 154.711 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=6, k=26, tile_m=1, tile_n=2, w=8, v=4, threads=96, grouping=16, minblocks=1) , # 151.108 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=6, k=32, tile_m=2, tile_n=3, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 164.982 GFlop/s
   Kernel_dnt_small(m=23, n=8, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 96.1136 GFlop/s
   Kernel_dnt_medium(m=23, n=8, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 104.824 GFlop/s
   Kernel_dnt_medium(m=23, n=8, k=6, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 117.471 GFlop/s
@@ -2029,10 +2029,10 @@
   Kernel_dnt_medium(m=23, n=8, k=16, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 188.882 GFlop/s
   Kernel_dnt_medium(m=23, n=8, k=17, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 180.998 GFlop/s
   Kernel_dnt_medium(m=23, n=8, k=22, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=4) , # 190.243 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=8, k=23, tile_m=1, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 192.208 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=8, k=24, tile_m=1, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=1) , # 198.683 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=8, k=26, tile_m=1, tile_n=2, w=10, v=8, threads=128, grouping=16, minblocks=12) , # 196.116 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=8, k=32, tile_m=1, tile_n=2, w=12, v=8, threads=96, grouping=16, minblocks=1) , # 208.86 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=8, k=23, tile_m=1, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 192.208 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=8, k=24, tile_m=1, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=1) , # 198.683 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=8, k=26, tile_m=1, tile_n=2, w=10, v=8, threads=128, grouping=16, minblocks=12) , # 196.116 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=8, k=32, tile_m=1, tile_n=2, w=12, v=8, threads=96, grouping=16, minblocks=1) , # 208.86 GFlop/s
   Kernel_dnt_medium(m=23, n=9, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 94.4818 GFlop/s
   Kernel_dnt_medium(m=23, n=9, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 111.971 GFlop/s
   Kernel_dnt_medium(m=23, n=9, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 115.643 GFlop/s
@@ -2043,9 +2043,9 @@
   Kernel_dnt_medium(m=23, n=9, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 180.861 GFlop/s
   Kernel_dnt_medium(m=23, n=9, k=22, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 204.892 GFlop/s
   Kernel_dnt_medium(m=23, n=9, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 205.862 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=9, k=24, tile_m=2, tile_n=2, w=12, v=6, threads=128, grouping=16, minblocks=12) , # 205.963 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=9, k=26, tile_m=2, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 201.066 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=9, k=32, tile_m=2, tile_n=2, w=10, v=6, threads=96, grouping=16, minblocks=12) , # 210.534 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=9, k=24, tile_m=2, tile_n=2, w=12, v=6, threads=128, grouping=16, minblocks=12) , # 205.963 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=9, k=26, tile_m=2, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 201.066 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=9, k=32, tile_m=2, tile_n=2, w=10, v=6, threads=96, grouping=16, minblocks=12) , # 210.534 GFlop/s
   Kernel_dnt_medium(m=23, n=13, k=4, tile_m=4, tile_n=1, threads=96, grouping=16, minblocks=12) , # 116.674 GFlop/s
   Kernel_dnt_medium(m=23, n=13, k=5, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 136.278 GFlop/s
   Kernel_dnt_medium(m=23, n=13, k=6, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 148.585 GFlop/s
@@ -2054,24 +2054,24 @@
   Kernel_dnt_medium(m=23, n=13, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 226.085 GFlop/s
   Kernel_dnt_medium(m=23, n=13, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 216.852 GFlop/s
   Kernel_dnt_medium(m=23, n=13, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 219.365 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=13, k=22, tile_m=2, tile_n=2, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 226.737 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=13, k=23, tile_m=3, tile_n=2, w=6, v=8, threads=96, grouping=16, minblocks=12) , # 232.991 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=13, k=24, tile_m=2, tile_n=3, w=12, v=8, threads=96, grouping=16, minblocks=12) , # 241.459 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=13, k=26, tile_m=3, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 239.493 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=13, k=32, tile_m=3, tile_n=2, w=12, v=8, threads=96, grouping=16, minblocks=12) , # 258.236 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=13, k=22, tile_m=2, tile_n=2, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 226.737 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=13, k=23, tile_m=3, tile_n=2, w=6, v=8, threads=96, grouping=16, minblocks=12) , # 232.991 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=13, k=24, tile_m=2, tile_n=3, w=12, v=8, threads=96, grouping=16, minblocks=12) , # 241.459 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=13, k=26, tile_m=3, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 239.493 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=13, k=32, tile_m=3, tile_n=2, w=12, v=8, threads=96, grouping=16, minblocks=12) , # 258.236 GFlop/s
   Kernel_dnt_medium(m=23, n=16, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 147.182 GFlop/s
   Kernel_dnt_medium(m=23, n=16, k=5, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 165.435 GFlop/s
   Kernel_dnt_medium(m=23, n=16, k=6, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 175.112 GFlop/s
   Kernel_dnt_medium(m=23, n=16, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 216.799 GFlop/s
   Kernel_dnt_medium(m=23, n=16, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 227.299 GFlop/s
   Kernel_dnt_medium(m=23, n=16, k=13, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 234.514 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=16, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 260.11 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=16, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 260.11 GFlop/s
   Kernel_dnt_medium(m=23, n=16, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 266.036 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=16, k=22, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 279.926 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=16, k=23, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 284.497 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=16, k=24, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 297.891 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=16, k=26, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 297.501 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=16, k=32, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 317.92 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=16, k=22, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 279.926 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=16, k=23, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 284.497 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=16, k=24, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 297.891 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=16, k=26, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 297.501 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=16, k=32, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 317.92 GFlop/s
   Kernel_dnt_medium(m=23, n=17, k=4, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=12) , # 133.402 GFlop/s
   Kernel_dnt_medium(m=23, n=17, k=5, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=12) , # 155.289 GFlop/s
   Kernel_dnt_medium(m=23, n=17, k=6, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 160.956 GFlop/s
@@ -2080,76 +2080,76 @@
   Kernel_dnt_medium(m=23, n=17, k=13, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 228.053 GFlop/s
   Kernel_dnt_medium(m=23, n=17, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 253.335 GFlop/s
   Kernel_dnt_medium(m=23, n=17, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 255.563 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=17, k=22, tile_m=2, tile_n=2, w=10, v=10, threads=128, grouping=16, minblocks=12) , # 265.383 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=17, k=23, tile_m=3, tile_n=2, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 252.781 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=17, k=24, tile_m=2, tile_n=2, w=10, v=10, threads=128, grouping=16, minblocks=12) , # 274.855 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=17, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 264.804 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=17, k=32, tile_m=2, tile_n=2, w=16, v=14, threads=192, grouping=16, minblocks=8) , # 281.666 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=17, k=22, tile_m=2, tile_n=2, w=10, v=10, threads=128, grouping=16, minblocks=12) , # 265.383 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=17, k=23, tile_m=3, tile_n=2, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 252.781 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=17, k=24, tile_m=2, tile_n=2, w=10, v=10, threads=128, grouping=16, minblocks=12) , # 274.855 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=17, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 264.804 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=17, k=32, tile_m=2, tile_n=2, w=16, v=14, threads=192, grouping=16, minblocks=8) , # 281.666 GFlop/s
   Kernel_dnt_medium(m=23, n=22, k=4, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=8) , # 146.324 GFlop/s
   Kernel_dnt_medium(m=23, n=22, k=5, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 165.527 GFlop/s
   Kernel_dnt_medium(m=23, n=22, k=6, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 177.939 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=22, k=8, tile_m=3, tile_n=2, w=4, v=20, threads=96, grouping=16, minblocks=12) , # 218.859 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=22, k=9, tile_m=2, tile_n=3, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 222.676 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=22, k=8, tile_m=3, tile_n=2, w=4, v=20, threads=96, grouping=16, minblocks=12) , # 218.859 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=22, k=9, tile_m=2, tile_n=3, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 222.676 GFlop/s
   Kernel_dnt_medium(m=23, n=22, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 270.777 GFlop/s
   Kernel_dnt_medium(m=23, n=22, k=16, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 286.218 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=22, k=17, tile_m=2, tile_n=3, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 282.016 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=22, k=22, tile_m=2, tile_n=3, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 307.973 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=22, k=23, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 314.138 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=22, k=24, tile_m=2, tile_n=3, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 321.113 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=22, k=26, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 323.835 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=22, k=32, tile_m=2, tile_n=3, w=4, v=14, threads=96, grouping=16, minblocks=12) , # 340.251 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=22, k=17, tile_m=2, tile_n=3, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 282.016 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=22, k=22, tile_m=2, tile_n=3, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 307.973 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=22, k=23, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 314.138 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=22, k=24, tile_m=2, tile_n=3, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 321.113 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=22, k=26, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 323.835 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=22, k=32, tile_m=2, tile_n=3, w=4, v=14, threads=96, grouping=16, minblocks=12) , # 340.251 GFlop/s
   Kernel_dnt_medium(m=23, n=23, k=4, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=8) , # 160.698 GFlop/s
   Kernel_dnt_medium(m=23, n=23, k=5, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 179.196 GFlop/s
   Kernel_dnt_medium(m=23, n=23, k=6, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 200.307 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=23, k=8, tile_m=3, tile_n=2, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 225.962 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=23, k=8, tile_m=3, tile_n=2, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 225.962 GFlop/s
   Kernel_dnt_medium(m=23, n=23, k=9, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 239.666 GFlop/s
   Kernel_dnt_medium(m=23, n=23, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 286.552 GFlop/s
   Kernel_dnt_medium(m=23, n=23, k=16, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 319.963 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=23, k=17, tile_m=3, tile_n=2, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 292.211 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=23, k=22, tile_m=2, tile_n=3, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 317.15 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=23, k=17, tile_m=3, tile_n=2, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 292.211 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=23, k=22, tile_m=2, tile_n=3, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 317.15 GFlop/s
   Kernel_dnt_largeDB2(m=23, n=23, k=23, tile_m=3, tile_n=2, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 362.853 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=23, k=24, tile_m=2, tile_n=3, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 331.615 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=23, k=26, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 333.812 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=23, k=32, tile_m=2, tile_n=3, w=4, v=14, threads=96, grouping=16, minblocks=12) , # 352.432 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=23, k=24, tile_m=2, tile_n=3, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 331.615 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=23, k=26, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 333.812 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=23, k=32, tile_m=2, tile_n=3, w=4, v=14, threads=96, grouping=16, minblocks=12) , # 352.432 GFlop/s
   Kernel_dnt_medium(m=23, n=24, k=4, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=4) , # 151.249 GFlop/s
   Kernel_dnt_medium(m=23, n=24, k=5, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 176.59 GFlop/s
   Kernel_dnt_medium(m=23, n=24, k=6, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 196.262 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=24, k=8, tile_m=3, tile_n=2, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 239.385 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=24, k=9, tile_m=2, tile_n=3, w=4, v=20, threads=96, grouping=16, minblocks=12) , # 239.724 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=24, k=8, tile_m=3, tile_n=2, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 239.385 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=24, k=9, tile_m=2, tile_n=3, w=4, v=20, threads=96, grouping=16, minblocks=12) , # 239.724 GFlop/s
   Kernel_dnt_medium(m=23, n=24, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 291.1 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=24, k=16, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 312.142 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=24, k=17, tile_m=3, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 309.544 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=24, k=22, tile_m=2, tile_n=3, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 332.21 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=24, k=23, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 337.924 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=24, k=24, tile_m=3, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 345.783 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=24, k=26, tile_m=2, tile_n=3, w=10, v=20, threads=96, grouping=16, minblocks=12) , # 348.405 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=24, k=32, tile_m=2, tile_n=3, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 366.046 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=24, k=16, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 312.142 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=24, k=17, tile_m=3, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 309.544 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=24, k=22, tile_m=2, tile_n=3, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 332.21 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=24, k=23, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 337.924 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=24, k=24, tile_m=3, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 345.783 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=24, k=26, tile_m=2, tile_n=3, w=10, v=20, threads=96, grouping=16, minblocks=12) , # 348.405 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=24, k=32, tile_m=2, tile_n=3, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 366.046 GFlop/s
   Kernel_dnt_medium(m=23, n=26, k=4, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 153.591 GFlop/s
   Kernel_dnt_medium(m=23, n=26, k=5, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 177.384 GFlop/s
   Kernel_dnt_medium(m=23, n=26, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 202.501 GFlop/s
   Kernel_dnt_medium(m=23, n=26, k=8, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 223.371 GFlop/s
   Kernel_dnt_medium(m=23, n=26, k=9, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 239.736 GFlop/s
   Kernel_dnt_medium(m=23, n=26, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 286.414 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=26, k=16, tile_m=2, tile_n=3, w=6, v=20, threads=160, grouping=16, minblocks=8) , # 278.305 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=26, k=17, tile_m=2, tile_n=3, w=6, v=20, threads=160, grouping=16, minblocks=8) , # 285.804 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=26, k=22, tile_m=2, tile_n=3, w=6, v=20, threads=160, grouping=16, minblocks=8) , # 308.631 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=26, k=23, tile_m=3, tile_n=2, w=6, v=26, threads=160, grouping=16, minblocks=8) , # 313.656 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=26, k=24, tile_m=2, tile_n=3, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 321.263 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=26, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=128, grouping=16, minblocks=8) , # 317.704 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=26, k=32, tile_m=2, tile_n=3, w=14, v=26, threads=128, grouping=16, minblocks=8) , # 340.048 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=32, k=4, tile_m=3, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=12) , # 180.711 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=26, k=16, tile_m=2, tile_n=3, w=6, v=20, threads=160, grouping=16, minblocks=8) , # 278.305 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=26, k=17, tile_m=2, tile_n=3, w=6, v=20, threads=160, grouping=16, minblocks=8) , # 285.804 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=26, k=22, tile_m=2, tile_n=3, w=6, v=20, threads=160, grouping=16, minblocks=8) , # 308.631 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=26, k=23, tile_m=3, tile_n=2, w=6, v=26, threads=160, grouping=16, minblocks=8) , # 313.656 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=26, k=24, tile_m=2, tile_n=3, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 321.263 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=26, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=128, grouping=16, minblocks=8) , # 317.704 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=26, k=32, tile_m=2, tile_n=3, w=14, v=26, threads=128, grouping=16, minblocks=8) , # 340.048 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=32, k=4, tile_m=3, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=12) , # 180.711 GFlop/s
   Kernel_dnt_medium(m=23, n=32, k=5, tile_m=3, tile_n=2, threads=192, grouping=16, minblocks=8) , # 200.317 GFlop/s
   Kernel_dnt_medium(m=23, n=32, k=6, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 221.286 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=32, k=8, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 289.124 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=32, k=9, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 290.689 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=32, k=8, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 289.124 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=32, k=9, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 290.689 GFlop/s
   Kernel_dnt_medium(m=23, n=32, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 327.89 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=32, k=16, tile_m=3, tile_n=2, w=8, v=32, threads=128, grouping=16, minblocks=8) , # 332.643 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=32, k=17, tile_m=3, tile_n=3, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 334.409 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=32, k=22, tile_m=3, tile_n=2, w=10, v=32, threads=128, grouping=16, minblocks=8) , # 360.996 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=32, k=23, tile_m=3, tile_n=2, w=10, v=32, threads=128, grouping=16, minblocks=8) , # 369.126 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=32, k=24, tile_m=3, tile_n=2, w=12, v=32, threads=128, grouping=16, minblocks=8) , # 384.75 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=32, k=26, tile_m=3, tile_n=2, w=10, v=32, threads=128, grouping=16, minblocks=8) , # 381.494 GFlop/s
-  Kernel_dnt_largeDB(m=23, n=32, k=32, tile_m=3, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=8) , # 398.604 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=32, k=16, tile_m=3, tile_n=2, w=8, v=32, threads=128, grouping=16, minblocks=8) , # 332.643 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=32, k=17, tile_m=3, tile_n=3, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 334.409 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=32, k=22, tile_m=3, tile_n=2, w=10, v=32, threads=128, grouping=16, minblocks=8) , # 360.996 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=32, k=23, tile_m=3, tile_n=2, w=10, v=32, threads=128, grouping=16, minblocks=8) , # 369.126 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=32, k=24, tile_m=3, tile_n=2, w=12, v=32, threads=128, grouping=16, minblocks=8) , # 384.75 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=32, k=26, tile_m=3, tile_n=2, w=10, v=32, threads=128, grouping=16, minblocks=8) , # 381.494 GFlop/s
+  Kernel_dnt_largeDB1(m=23, n=32, k=32, tile_m=3, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=8) , # 398.604 GFlop/s
   Kernel_dnt_tiny(m=24, n=4, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 58.8119 GFlop/s
   Kernel_dnt_small(m=24, n=4, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 67.0164 GFlop/s
   Kernel_dnt_medium(m=24, n=4, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 72.194 GFlop/s
@@ -2162,7 +2162,7 @@
   Kernel_dnt_medium(m=24, n=4, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 125.42 GFlop/s
   Kernel_dnt_medium(m=24, n=4, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 128.156 GFlop/s
   Kernel_dnt_medium(m=24, n=4, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 131.844 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=4, k=32, tile_m=1, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 132.646 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=4, k=32, tile_m=1, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 132.646 GFlop/s
   Kernel_dnt_tiny(m=24, n=5, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 70.448 GFlop/s
   Kernel_dnt_small(m=24, n=5, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 80.4972 GFlop/s
   Kernel_dnt_medium(m=24, n=5, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 81.0577 GFlop/s
@@ -2175,124 +2175,124 @@
   Kernel_dnt_medium(m=24, n=5, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 150.001 GFlop/s
   Kernel_dnt_medium(m=24, n=5, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 152.933 GFlop/s
   Kernel_dnt_medium(m=24, n=5, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=1) , # 147.417 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=8) , # 153.309 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=8) , # 153.309 GFlop/s
   Kernel_dnt_small(m=24, n=6, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 76.9814 GFlop/s
   Kernel_dnt_medium(m=24, n=6, k=5, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 85.2808 GFlop/s
   Kernel_dnt_medium(m=24, n=6, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 93.5526 GFlop/s
   Kernel_dnt_medium(m=24, n=6, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 115.359 GFlop/s
   Kernel_dnt_medium(m=24, n=6, k=9, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=4) , # 120.439 GFlop/s
   Kernel_dnt_medium(m=24, n=6, k=13, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 144.87 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=6, k=16, tile_m=1, tile_n=2, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 155.633 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=6, k=16, tile_m=1, tile_n=2, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 155.633 GFlop/s
   Kernel_dnt_medium(m=24, n=6, k=17, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=4) , # 148.725 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=6, k=22, tile_m=1, tile_n=2, w=8, v=6, threads=96, grouping=16, minblocks=4) , # 154.487 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=6, k=23, tile_m=2, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=1) , # 156.025 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=6, k=24, tile_m=2, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 163.99 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=6, k=26, tile_m=2, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=12) , # 159.791 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=6, k=32, tile_m=2, tile_n=1, w=16, v=6, threads=128, grouping=16, minblocks=12) , # 171.985 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=6, k=22, tile_m=1, tile_n=2, w=8, v=6, threads=96, grouping=16, minblocks=4) , # 154.487 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=6, k=23, tile_m=2, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=1) , # 156.025 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=6, k=24, tile_m=2, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 163.99 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=6, k=26, tile_m=2, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=12) , # 159.791 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=6, k=32, tile_m=2, tile_n=1, w=16, v=6, threads=128, grouping=16, minblocks=12) , # 171.985 GFlop/s
   Kernel_dnt_small(m=24, n=8, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 102.382 GFlop/s
   Kernel_dnt_medium(m=24, n=8, k=5, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 110.447 GFlop/s
   Kernel_dnt_medium(m=24, n=8, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 123.269 GFlop/s
   Kernel_dnt_medium(m=24, n=8, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 152.162 GFlop/s
   Kernel_dnt_medium(m=24, n=8, k=9, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=4) , # 157.455 GFlop/s
   Kernel_dnt_medium(m=24, n=8, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 185.221 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=8, k=16, tile_m=1, tile_n=2, w=8, v=6, threads=96, grouping=16, minblocks=4) , # 196.938 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=8, k=16, tile_m=1, tile_n=2, w=8, v=6, threads=96, grouping=16, minblocks=4) , # 196.938 GFlop/s
   Kernel_dnt_medium(m=24, n=8, k=17, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 189.416 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=8, k=22, tile_m=1, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 199.914 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=8, k=23, tile_m=1, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=1) , # 200.887 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=8, k=24, tile_m=2, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 209.127 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=8, k=26, tile_m=2, tile_n=1, w=10, v=8, threads=128, grouping=16, minblocks=12) , # 205.917 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=8, k=32, tile_m=2, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=1) , # 218.41 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=8, k=22, tile_m=1, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 199.914 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=8, k=23, tile_m=1, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=1) , # 200.887 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=8, k=24, tile_m=2, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 209.127 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=8, k=26, tile_m=2, tile_n=1, w=10, v=8, threads=128, grouping=16, minblocks=12) , # 205.917 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=8, k=32, tile_m=2, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=1) , # 218.41 GFlop/s
   Kernel_dnt_medium(m=24, n=9, k=4, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 98.6797 GFlop/s
   Kernel_dnt_medium(m=24, n=9, k=5, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 118.095 GFlop/s
   Kernel_dnt_medium(m=24, n=9, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 123.841 GFlop/s
   Kernel_dnt_medium(m=24, n=9, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 150.841 GFlop/s
   Kernel_dnt_medium(m=24, n=9, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 164.779 GFlop/s
   Kernel_dnt_medium(m=24, n=9, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 192.82 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=9, k=16, tile_m=2, tile_n=2, w=8, v=6, threads=128, grouping=16, minblocks=12) , # 192.434 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=9, k=16, tile_m=2, tile_n=2, w=8, v=6, threads=128, grouping=16, minblocks=12) , # 192.434 GFlop/s
   Kernel_dnt_medium(m=24, n=9, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=1) , # 191.25 GFlop/s
   Kernel_dnt_medium(m=24, n=9, k=22, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 209.088 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=9, k=23, tile_m=2, tile_n=1, w=10, v=6, threads=128, grouping=16, minblocks=12) , # 204.604 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=9, k=24, tile_m=2, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 216.095 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=9, k=26, tile_m=2, tile_n=2, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 211.244 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=9, k=32, tile_m=2, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 227.824 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=9, k=23, tile_m=2, tile_n=1, w=10, v=6, threads=128, grouping=16, minblocks=12) , # 204.604 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=9, k=24, tile_m=2, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 216.095 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=9, k=26, tile_m=2, tile_n=2, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 211.244 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=9, k=32, tile_m=2, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 227.824 GFlop/s
   Kernel_dnt_medium(m=24, n=13, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 125.487 GFlop/s
   Kernel_dnt_medium(m=24, n=13, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 146.004 GFlop/s
   Kernel_dnt_medium(m=24, n=13, k=6, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=12) , # 160.137 GFlop/s
   Kernel_dnt_medium(m=24, n=13, k=8, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 183.429 GFlop/s
   Kernel_dnt_medium(m=24, n=13, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 196.169 GFlop/s
   Kernel_dnt_medium(m=24, n=13, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=1) , # 210.09 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=13, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 243.961 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=13, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 243.961 GFlop/s
   Kernel_dnt_medium(m=24, n=13, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 233.808 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=13, k=22, tile_m=2, tile_n=3, w=6, v=12, threads=96, grouping=16, minblocks=12) , # 244.295 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=13, k=23, tile_m=2, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 245.584 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=13, k=24, tile_m=3, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 253.032 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=13, k=26, tile_m=3, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 252.69 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=13, k=32, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 271.274 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=13, k=22, tile_m=2, tile_n=3, w=6, v=12, threads=96, grouping=16, minblocks=12) , # 244.295 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=13, k=23, tile_m=2, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 245.584 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=13, k=24, tile_m=3, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 253.032 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=13, k=26, tile_m=3, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 252.69 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=13, k=32, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 271.274 GFlop/s
   Kernel_dnt_medium(m=24, n=16, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 151.035 GFlop/s
   Kernel_dnt_medium(m=24, n=16, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 177.041 GFlop/s
   Kernel_dnt_medium(m=24, n=16, k=6, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 183.2 GFlop/s
   Kernel_dnt_medium(m=24, n=16, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 220.011 GFlop/s
   Kernel_dnt_medium(m=24, n=16, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 237.976 GFlop/s
   Kernel_dnt_medium(m=24, n=16, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=8) , # 255.121 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=16, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 283.257 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=16, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 283.257 GFlop/s
   Kernel_dnt_medium(m=24, n=16, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 282.576 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=16, k=22, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 305.434 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=16, k=23, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 305.948 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=16, k=24, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 312.346 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=16, k=26, tile_m=2, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 311.766 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=16, k=32, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 330.08 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=16, k=22, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 305.434 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=16, k=23, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 305.948 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=16, k=24, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 312.346 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=16, k=26, tile_m=2, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 311.766 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=16, k=32, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 330.08 GFlop/s
   Kernel_dnt_medium(m=24, n=17, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 148.753 GFlop/s
   Kernel_dnt_medium(m=24, n=17, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 172.254 GFlop/s
   Kernel_dnt_medium(m=24, n=17, k=6, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 170.444 GFlop/s
   Kernel_dnt_medium(m=24, n=17, k=8, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 202.085 GFlop/s
   Kernel_dnt_medium(m=24, n=17, k=9, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 220.336 GFlop/s
   Kernel_dnt_medium(m=24, n=17, k=13, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 241.006 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=17, k=16, tile_m=2, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=12) , # 267.336 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=17, k=16, tile_m=2, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=12) , # 267.336 GFlop/s
   Kernel_dnt_medium(m=24, n=17, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 269.754 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=17, k=22, tile_m=2, tile_n=4, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 278.395 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=17, k=23, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 270.301 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=17, k=24, tile_m=2, tile_n=2, w=6, v=16, threads=128, grouping=16, minblocks=12) , # 282.786 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=17, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 278.266 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=17, k=32, tile_m=2, tile_n=2, w=16, v=16, threads=128, grouping=16, minblocks=4) , # 299.296 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=22, k=4, tile_m=3, tile_n=2, w=2, v=12, threads=96, grouping=16, minblocks=12) , # 146.407 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=17, k=22, tile_m=2, tile_n=4, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 278.395 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=17, k=23, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 270.301 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=17, k=24, tile_m=2, tile_n=2, w=6, v=16, threads=128, grouping=16, minblocks=12) , # 282.786 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=17, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 278.266 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=17, k=32, tile_m=2, tile_n=2, w=16, v=16, threads=128, grouping=16, minblocks=4) , # 299.296 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=22, k=4, tile_m=3, tile_n=2, w=2, v=12, threads=96, grouping=16, minblocks=12) , # 146.407 GFlop/s
   Kernel_dnt_medium(m=24, n=22, k=5, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 171.925 GFlop/s
   Kernel_dnt_medium(m=24, n=22, k=6, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 190.105 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=22, k=8, tile_m=3, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 231.681 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=22, k=9, tile_m=3, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 233.468 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=22, k=8, tile_m=3, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 231.681 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=22, k=9, tile_m=3, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 233.468 GFlop/s
   Kernel_dnt_medium(m=24, n=22, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 284.038 GFlop/s
   Kernel_dnt_medium(m=24, n=22, k=16, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 308.103 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=22, k=17, tile_m=2, tile_n=3, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 301.954 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=22, k=22, tile_m=2, tile_n=3, w=8, v=18, threads=96, grouping=16, minblocks=12) , # 325.781 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=22, k=23, tile_m=2, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 331.261 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=22, k=24, tile_m=2, tile_n=3, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 338.308 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=22, k=26, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 343.473 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=22, k=32, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 356.001 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=23, k=4, tile_m=3, tile_n=2, w=2, v=12, threads=96, grouping=16, minblocks=12) , # 151.001 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=22, k=17, tile_m=2, tile_n=3, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 301.954 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=22, k=22, tile_m=2, tile_n=3, w=8, v=18, threads=96, grouping=16, minblocks=12) , # 325.781 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=22, k=23, tile_m=2, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 331.261 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=22, k=24, tile_m=2, tile_n=3, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 338.308 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=22, k=26, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 343.473 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=22, k=32, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 356.001 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=23, k=4, tile_m=3, tile_n=2, w=2, v=12, threads=96, grouping=16, minblocks=12) , # 151.001 GFlop/s
   Kernel_dnt_medium(m=24, n=23, k=5, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 176.59 GFlop/s
   Kernel_dnt_medium(m=24, n=23, k=6, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 196.204 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=23, k=8, tile_m=3, tile_n=2, w=4, v=20, threads=96, grouping=16, minblocks=12) , # 239.901 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=23, k=9, tile_m=2, tile_n=3, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 239.093 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=23, k=8, tile_m=3, tile_n=2, w=4, v=20, threads=96, grouping=16, minblocks=12) , # 239.901 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=23, k=9, tile_m=2, tile_n=3, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 239.093 GFlop/s
   Kernel_dnt_medium(m=24, n=23, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 292.274 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=23, k=16, tile_m=2, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 315.493 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=23, k=17, tile_m=2, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 311.324 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=23, k=22, tile_m=2, tile_n=3, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 335.112 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=23, k=23, tile_m=3, tile_n=2, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 341.553 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=23, k=24, tile_m=3, tile_n=2, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 347.719 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=23, k=26, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 351.889 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=23, k=32, tile_m=3, tile_n=2, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 367.949 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=23, k=16, tile_m=2, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 315.493 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=23, k=17, tile_m=2, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 311.324 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=23, k=22, tile_m=2, tile_n=3, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 335.112 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=23, k=23, tile_m=3, tile_n=2, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 341.553 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=23, k=24, tile_m=3, tile_n=2, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 347.719 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=23, k=26, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 351.889 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=23, k=32, tile_m=3, tile_n=2, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 367.949 GFlop/s
   Kernel_dnt_medium(m=24, n=24, k=4, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=8) , # 171.861 GFlop/s
   Kernel_dnt_medium(m=24, n=24, k=5, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 199.591 GFlop/s
   Kernel_dnt_medium(m=24, n=24, k=6, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 223.508 GFlop/s
   Kernel_dnt_medium(m=24, n=24, k=8, tile_m=3, tile_n=3, threads=128, grouping=16, minblocks=8) , # 252.144 GFlop/s
   Kernel_dnt_medium(m=24, n=24, k=9, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 270.155 GFlop/s
   Kernel_dnt_medium(m=24, n=24, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 316.953 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=24, k=16, tile_m=3, tile_n=3, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 346.718 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=24, k=17, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 331.579 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=24, k=22, tile_m=2, tile_n=3, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 362.792 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=24, k=23, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 369.879 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=24, k=16, tile_m=3, tile_n=3, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 346.718 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=24, k=17, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 331.579 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=24, k=22, tile_m=2, tile_n=3, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 362.792 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=24, k=23, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 369.879 GFlop/s
   Kernel_dnt_largeDB2(m=24, n=24, k=24, tile_m=2, tile_n=3, w=12, v=24, threads=96, grouping=16, minblocks=12) , # 411.88 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=24, k=26, tile_m=3, tile_n=2, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 372.117 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=24, k=32, tile_m=3, tile_n=3, w=8, v=10, threads=96, grouping=16, minblocks=12) , # 401.738 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=24, k=26, tile_m=3, tile_n=2, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 372.117 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=24, k=32, tile_m=3, tile_n=3, w=8, v=10, threads=96, grouping=16, minblocks=12) , # 401.738 GFlop/s
   Kernel_dnt_largeDB2(m=24, n=24, k=45, tile_m=3, tile_n=3, w=12, v=24, threads=96, grouping=16, minblocks=8) , # 443.769 GFlop/s
   Kernel_dnt_medium(m=24, n=26, k=4, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 165.895 GFlop/s
   Kernel_dnt_medium(m=24, n=26, k=5, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 192.911 GFlop/s
@@ -2300,26 +2300,26 @@
   Kernel_dnt_medium(m=24, n=26, k=8, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 240.006 GFlop/s
   Kernel_dnt_medium(m=24, n=26, k=9, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 255.794 GFlop/s
   Kernel_dnt_medium(m=24, n=26, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 304.306 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=26, k=16, tile_m=3, tile_n=2, w=8, v=26, threads=128, grouping=16, minblocks=8) , # 296.427 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=26, k=17, tile_m=2, tile_n=3, w=6, v=20, threads=160, grouping=16, minblocks=8) , # 300.411 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=26, k=22, tile_m=2, tile_n=3, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 335.764 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=26, k=23, tile_m=2, tile_n=2, w=6, v=26, threads=160, grouping=16, minblocks=8) , # 332.247 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=26, k=24, tile_m=2, tile_n=3, w=12, v=20, threads=160, grouping=16, minblocks=8) , # 341.77 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=26, k=26, tile_m=2, tile_n=3, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 345.182 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=26, k=32, tile_m=2, tile_n=3, w=14, v=16, threads=128, grouping=16, minblocks=8) , # 358.776 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=32, k=4, tile_m=3, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=12) , # 188.795 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=32, k=5, tile_m=3, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=12) , # 202.909 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=32, k=6, tile_m=4, tile_n=2, w=2, v=20, threads=96, grouping=16, minblocks=12) , # 216.291 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=32, k=8, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 301.015 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=32, k=9, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 301.38 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=32, k=13, tile_m=3, tile_n=2, w=6, v=20, threads=160, grouping=16, minblocks=8) , # 306.849 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=32, k=16, tile_m=3, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 358.411 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=32, k=17, tile_m=3, tile_n=2, w=8, v=22, threads=128, grouping=16, minblocks=8) , # 348.821 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=32, k=22, tile_m=3, tile_n=2, w=8, v=28, threads=128, grouping=16, minblocks=8) , # 382.529 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=32, k=23, tile_m=3, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 388.857 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=32, k=24, tile_m=3, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=8) , # 396.116 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=32, k=26, tile_m=3, tile_n=3, w=6, v=16, threads=96, grouping=16, minblocks=12) , # 397.018 GFlop/s
-  Kernel_dnt_largeDB(m=24, n=32, k=32, tile_m=3, tile_n=2, w=8, v=28, threads=128, grouping=16, minblocks=8) , # 417.571 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=26, k=16, tile_m=3, tile_n=2, w=8, v=26, threads=128, grouping=16, minblocks=8) , # 296.427 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=26, k=17, tile_m=2, tile_n=3, w=6, v=20, threads=160, grouping=16, minblocks=8) , # 300.411 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=26, k=22, tile_m=2, tile_n=3, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 335.764 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=26, k=23, tile_m=2, tile_n=2, w=6, v=26, threads=160, grouping=16, minblocks=8) , # 332.247 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=26, k=24, tile_m=2, tile_n=3, w=12, v=20, threads=160, grouping=16, minblocks=8) , # 341.77 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=26, k=26, tile_m=2, tile_n=3, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 345.182 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=26, k=32, tile_m=2, tile_n=3, w=14, v=16, threads=128, grouping=16, minblocks=8) , # 358.776 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=32, k=4, tile_m=3, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=12) , # 188.795 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=32, k=5, tile_m=3, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=12) , # 202.909 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=32, k=6, tile_m=4, tile_n=2, w=2, v=20, threads=96, grouping=16, minblocks=12) , # 216.291 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=32, k=8, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 301.015 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=32, k=9, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 301.38 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=32, k=13, tile_m=3, tile_n=2, w=6, v=20, threads=160, grouping=16, minblocks=8) , # 306.849 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=32, k=16, tile_m=3, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 358.411 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=32, k=17, tile_m=3, tile_n=2, w=8, v=22, threads=128, grouping=16, minblocks=8) , # 348.821 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=32, k=22, tile_m=3, tile_n=2, w=8, v=28, threads=128, grouping=16, minblocks=8) , # 382.529 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=32, k=23, tile_m=3, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 388.857 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=32, k=24, tile_m=3, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=8) , # 396.116 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=32, k=26, tile_m=3, tile_n=3, w=6, v=16, threads=96, grouping=16, minblocks=12) , # 397.018 GFlop/s
+  Kernel_dnt_largeDB1(m=24, n=32, k=32, tile_m=3, tile_n=2, w=8, v=28, threads=128, grouping=16, minblocks=8) , # 417.571 GFlop/s
   Kernel_dnt_largeDB2(m=24, n=32, k=45, tile_m=2, tile_n=4, w=12, v=30, threads=96, grouping=16, minblocks=8) , # 482.675 GFlop/s
   Kernel_dnt_largeDB2(m=25, n=4, k=4, tile_m=1, tile_n=1, w=2, v=4, threads=128, grouping=16, minblocks=4) , # 61.5545 GFlop/s
   Kernel_dnt_small(m=25, n=4, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 69.6079 GFlop/s
@@ -2375,7 +2375,7 @@
   Kernel_dnt_medium(m=25, n=25, k=5, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 197.231 GFlop/s
   Kernel_dnt_medium(m=25, n=25, k=7, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 226.575 GFlop/s
   Kernel_dnt_medium(m=25, n=25, k=9, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 266.2 GFlop/s
-  Kernel_dnt_largeDB(m=25, n=25, k=13, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 287.179 GFlop/s
+  Kernel_dnt_largeDB1(m=25, n=25, k=13, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 287.179 GFlop/s
   Kernel_dnt_largeDB2(m=25, n=25, k=25, tile_m=3, tile_n=2, w=10, v=20, threads=128, grouping=16, minblocks=8) , # 355.515 GFlop/s
   Kernel_dnt_largeDB2(m=25, n=25, k=26, tile_m=2, tile_n=4, w=10, v=24, threads=128, grouping=16, minblocks=8) , # 353.566 GFlop/s
   Kernel_dnt_largeDB2(m=25, n=25, k=28, tile_m=3, tile_n=2, w=14, v=10, threads=128, grouping=16, minblocks=8) , # 367.79 GFlop/s
@@ -2391,7 +2391,7 @@
   Kernel_dnt_largeDB2(m=25, n=26, k=28, tile_m=3, tile_n=2, w=14, v=10, threads=128, grouping=16, minblocks=8) , # 378.99 GFlop/s
   Kernel_dnt_largeDB2(m=25, n=26, k=32, tile_m=2, tile_n=3, w=14, v=26, threads=128, grouping=16, minblocks=8) , # 387.081 GFlop/s
   Kernel_dnt_largeDB2(m=25, n=26, k=45, tile_m=3, tile_n=2, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 407.931 GFlop/s
-  Kernel_dnt_largeDB(m=25, n=28, k=4, tile_m=3, tile_n=2, w=2, v=14, threads=128, grouping=16, minblocks=12) , # 166.646 GFlop/s
+  Kernel_dnt_largeDB1(m=25, n=28, k=4, tile_m=3, tile_n=2, w=2, v=14, threads=128, grouping=16, minblocks=12) , # 166.646 GFlop/s
   Kernel_dnt_largeDB2(m=25, n=28, k=5, tile_m=3, tile_n=2, w=2, v=14, threads=128, grouping=16, minblocks=12) , # 191.501 GFlop/s
   Kernel_dnt_largeDB2(m=25, n=28, k=7, tile_m=3, tile_n=2, w=2, v=18, threads=128, grouping=16, minblocks=12) , # 235.127 GFlop/s
   Kernel_dnt_largeDB2(m=25, n=28, k=9, tile_m=3, tile_n=2, w=4, v=28, threads=128, grouping=16, minblocks=8) , # 263.105 GFlop/s
@@ -2449,7 +2449,7 @@
   Kernel_dnt_medium(m=26, n=5, k=17, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 135.026 GFlop/s
   Kernel_dnt_medium(m=26, n=5, k=22, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=4) , # 140.428 GFlop/s
   Kernel_dnt_medium(m=26, n=5, k=23, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=8) , # 142.897 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=5, k=24, tile_m=1, tile_n=1, w=12, v=4, threads=160, grouping=16, minblocks=12) , # 141.37 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=5, k=24, tile_m=1, tile_n=1, w=12, v=4, threads=160, grouping=16, minblocks=12) , # 141.37 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=5, k=25, tile_m=3, tile_n=2, w=12, v=4, threads=96, grouping=16, minblocks=12) , # 148.961 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=5, k=26, tile_m=3, tile_n=2, w=12, v=4, threads=96, grouping=16, minblocks=12) , # 150.882 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=5, k=28, tile_m=3, tile_n=2, w=14, v=4, threads=96, grouping=16, minblocks=12) , # 160.591 GFlop/s
@@ -2465,9 +2465,9 @@
   Kernel_dnt_medium(m=26, n=6, k=17, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=4) , # 157.425 GFlop/s
   Kernel_dnt_medium(m=26, n=6, k=22, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 163.987 GFlop/s
   Kernel_dnt_medium(m=26, n=6, k=23, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 166.214 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=6, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=160, grouping=16, minblocks=12) , # 167.712 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=6, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=160, grouping=16, minblocks=12) , # 167.712 GFlop/s
   Kernel_dnt_medium(m=26, n=6, k=26, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=1) , # 165.846 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=6, k=32, tile_m=1, tile_n=1, w=12, v=6, threads=160, grouping=16, minblocks=12) , # 174.271 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=6, k=32, tile_m=1, tile_n=1, w=12, v=6, threads=160, grouping=16, minblocks=12) , # 174.271 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=7, k=4, tile_m=2, tile_n=1, w=2, v=4, threads=96, grouping=16, minblocks=1) , # 93.3904 GFlop/s
   Kernel_dnt_medium(m=26, n=7, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 98.4269 GFlop/s
   Kernel_dnt_medium(m=26, n=7, k=7, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 129.184 GFlop/s
@@ -2484,13 +2484,13 @@
   Kernel_dnt_medium(m=26, n=8, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 147.207 GFlop/s
   Kernel_dnt_medium(m=26, n=8, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 158.986 GFlop/s
   Kernel_dnt_medium(m=26, n=8, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 184.007 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=8, k=16, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 185.8 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=8, k=16, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 185.8 GFlop/s
   Kernel_dnt_medium(m=26, n=8, k=17, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=8) , # 184.285 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=8, k=22, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 191.661 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=8, k=23, tile_m=2, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 194.119 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=8, k=24, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 203.357 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=8, k=26, tile_m=2, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 201.388 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=8, k=32, tile_m=2, tile_n=2, w=14, v=6, threads=128, grouping=16, minblocks=12) , # 214.072 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=8, k=22, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 191.661 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=8, k=23, tile_m=2, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 194.119 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=8, k=24, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 203.357 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=8, k=26, tile_m=2, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 201.388 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=8, k=32, tile_m=2, tile_n=2, w=14, v=6, threads=128, grouping=16, minblocks=12) , # 214.072 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=9, k=4, tile_m=3, tile_n=1, w=2, v=6, threads=96, grouping=16, minblocks=4) , # 109.036 GFlop/s
   Kernel_dnt_medium(m=26, n=9, k=5, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 114.163 GFlop/s
   Kernel_dnt_medium(m=26, n=9, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 131.35 GFlop/s
@@ -2502,7 +2502,7 @@
   Kernel_dnt_medium(m=26, n=9, k=17, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=8) , # 202.974 GFlop/s
   Kernel_dnt_medium(m=26, n=9, k=22, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 205.221 GFlop/s
   Kernel_dnt_medium(m=26, n=9, k=23, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 209.048 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=9, k=24, tile_m=2, tile_n=1, w=12, v=4, threads=128, grouping=16, minblocks=12) , # 218.442 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=9, k=24, tile_m=2, tile_n=1, w=12, v=4, threads=128, grouping=16, minblocks=12) , # 218.442 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=9, k=25, tile_m=2, tile_n=1, w=12, v=4, threads=128, grouping=16, minblocks=12) , # 224.446 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=9, k=26, tile_m=2, tile_n=1, w=12, v=4, threads=128, grouping=16, minblocks=12) , # 226.888 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=9, k=28, tile_m=2, tile_n=1, w=14, v=8, threads=128, grouping=16, minblocks=1) , # 238.998 GFlop/s
@@ -2515,11 +2515,11 @@
   Kernel_dnt_medium(m=26, n=13, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 189.61 GFlop/s
   Kernel_dnt_medium(m=26, n=13, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 206.587 GFlop/s
   Kernel_dnt_medium(m=26, n=13, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 243.394 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=13, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 244.889 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=13, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 244.889 GFlop/s
   Kernel_dnt_medium(m=26, n=13, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 248.672 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=13, k=22, tile_m=2, tile_n=2, w=6, v=10, threads=96, grouping=16, minblocks=12) , # 250.837 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=13, k=23, tile_m=3, tile_n=2, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 251.925 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=13, k=24, tile_m=2, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 262.097 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=13, k=22, tile_m=2, tile_n=2, w=6, v=10, threads=96, grouping=16, minblocks=12) , # 250.837 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=13, k=23, tile_m=3, tile_n=2, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 251.925 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=13, k=24, tile_m=2, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 262.097 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=13, k=25, tile_m=3, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 287.926 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=13, k=26, tile_m=2, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 292.748 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=13, k=28, tile_m=2, tile_n=2, w=14, v=10, threads=96, grouping=16, minblocks=12) , # 305.399 GFlop/s
@@ -2531,65 +2531,65 @@
   Kernel_dnt_small(m=26, n=16, k=8, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 201.911 GFlop/s
   Kernel_dnt_medium(m=26, n=16, k=9, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 223.126 GFlop/s
   Kernel_dnt_medium(m=26, n=16, k=13, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 248.219 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=16, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 272.563 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=16, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 272.563 GFlop/s
   Kernel_dnt_medium(m=26, n=16, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 278.933 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=16, k=22, tile_m=2, tile_n=4, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 283.175 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=16, k=22, tile_m=2, tile_n=4, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 283.175 GFlop/s
   Kernel_dnt_medium(m=26, n=16, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=4) , # 283.731 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=16, k=24, tile_m=2, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=1) , # 283.395 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=16, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 289.704 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=16, k=32, tile_m=2, tile_n=2, w=16, v=16, threads=128, grouping=16, minblocks=1) , # 312.21 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=16, k=24, tile_m=2, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=1) , # 283.395 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=16, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 289.704 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=16, k=32, tile_m=2, tile_n=2, w=16, v=16, threads=128, grouping=16, minblocks=1) , # 312.21 GFlop/s
   Kernel_dnt_medium(m=26, n=17, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 155.536 GFlop/s
   Kernel_dnt_medium(m=26, n=17, k=5, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 152.251 GFlop/s
   Kernel_dnt_medium(m=26, n=17, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 174.981 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=17, k=8, tile_m=2, tile_n=2, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 203.653 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=17, k=8, tile_m=2, tile_n=2, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 203.653 GFlop/s
   Kernel_dnt_medium(m=26, n=17, k=9, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 229.052 GFlop/s
   Kernel_dnt_medium(m=26, n=17, k=13, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 254.23 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=17, k=16, tile_m=2, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=12) , # 281.091 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=17, k=16, tile_m=2, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=12) , # 281.091 GFlop/s
   Kernel_dnt_medium(m=26, n=17, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 285.713 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=17, k=22, tile_m=3, tile_n=2, w=8, v=14, threads=96, grouping=16, minblocks=12) , # 275.4 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=17, k=22, tile_m=3, tile_n=2, w=8, v=14, threads=96, grouping=16, minblocks=12) , # 275.4 GFlop/s
   Kernel_dnt_medium(m=26, n=17, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=4) , # 284.987 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=17, k=24, tile_m=2, tile_n=2, w=6, v=14, threads=128, grouping=16, minblocks=12) , # 298.462 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=17, k=26, tile_m=2, tile_n=2, w=6, v=8, threads=128, grouping=16, minblocks=12) , # 287.445 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=17, k=32, tile_m=2, tile_n=2, w=16, v=12, threads=160, grouping=16, minblocks=8) , # 314.433 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=17, k=24, tile_m=2, tile_n=2, w=6, v=14, threads=128, grouping=16, minblocks=12) , # 298.462 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=17, k=26, tile_m=2, tile_n=2, w=6, v=8, threads=128, grouping=16, minblocks=12) , # 287.445 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=17, k=32, tile_m=2, tile_n=2, w=16, v=12, threads=160, grouping=16, minblocks=8) , # 314.433 GFlop/s
   Kernel_dnt_medium(m=26, n=22, k=4, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 149.972 GFlop/s
   Kernel_dnt_medium(m=26, n=22, k=5, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 176.08 GFlop/s
   Kernel_dnt_medium(m=26, n=22, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 196.809 GFlop/s
   Kernel_dnt_medium(m=26, n=22, k=8, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 217.745 GFlop/s
   Kernel_dnt_medium(m=26, n=22, k=9, tile_m=4, tile_n=2, threads=128, grouping=16, minblocks=8) , # 220.047 GFlop/s
   Kernel_dnt_medium(m=26, n=22, k=13, tile_m=2, tile_n=4, threads=96, grouping=16, minblocks=8) , # 262.523 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=22, k=16, tile_m=3, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=12) , # 289.65 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=22, k=17, tile_m=2, tile_n=3, w=6, v=12, threads=160, grouping=16, minblocks=8) , # 275.462 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=22, k=22, tile_m=2, tile_n=3, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 306.524 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=22, k=23, tile_m=2, tile_n=2, w=6, v=22, threads=160, grouping=16, minblocks=8) , # 306.629 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=22, k=24, tile_m=2, tile_n=3, w=12, v=22, threads=128, grouping=16, minblocks=8) , # 312.951 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=22, k=26, tile_m=2, tile_n=3, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 316.347 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=22, k=32, tile_m=3, tile_n=2, w=14, v=22, threads=128, grouping=16, minblocks=8) , # 331.192 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=22, k=16, tile_m=3, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=12) , # 289.65 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=22, k=17, tile_m=2, tile_n=3, w=6, v=12, threads=160, grouping=16, minblocks=8) , # 275.462 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=22, k=22, tile_m=2, tile_n=3, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 306.524 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=22, k=23, tile_m=2, tile_n=2, w=6, v=22, threads=160, grouping=16, minblocks=8) , # 306.629 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=22, k=24, tile_m=2, tile_n=3, w=12, v=22, threads=128, grouping=16, minblocks=8) , # 312.951 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=22, k=26, tile_m=2, tile_n=3, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 316.347 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=22, k=32, tile_m=3, tile_n=2, w=14, v=22, threads=128, grouping=16, minblocks=8) , # 331.192 GFlop/s
   Kernel_dnt_medium(m=26, n=23, k=4, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 154.026 GFlop/s
   Kernel_dnt_medium(m=26, n=23, k=5, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 179.309 GFlop/s
   Kernel_dnt_medium(m=26, n=23, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 202.375 GFlop/s
   Kernel_dnt_medium(m=26, n=23, k=8, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 222.858 GFlop/s
   Kernel_dnt_medium(m=26, n=23, k=9, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 221.968 GFlop/s
   Kernel_dnt_medium(m=26, n=23, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 273.966 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=23, k=16, tile_m=3, tile_n=2, w=6, v=12, threads=160, grouping=16, minblocks=8) , # 276.664 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=23, k=17, tile_m=2, tile_n=3, w=6, v=12, threads=160, grouping=16, minblocks=8) , # 285.445 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=23, k=22, tile_m=2, tile_n=3, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 317.821 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=23, k=23, tile_m=2, tile_n=2, w=6, v=12, threads=160, grouping=16, minblocks=8) , # 307.93 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=23, k=24, tile_m=2, tile_n=3, w=12, v=12, threads=160, grouping=16, minblocks=8) , # 320.822 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=23, k=26, tile_m=2, tile_n=3, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 327.373 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=23, k=32, tile_m=2, tile_n=3, w=14, v=14, threads=128, grouping=16, minblocks=8) , # 341.076 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=23, k=16, tile_m=3, tile_n=2, w=6, v=12, threads=160, grouping=16, minblocks=8) , # 276.664 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=23, k=17, tile_m=2, tile_n=3, w=6, v=12, threads=160, grouping=16, minblocks=8) , # 285.445 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=23, k=22, tile_m=2, tile_n=3, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 317.821 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=23, k=23, tile_m=2, tile_n=2, w=6, v=12, threads=160, grouping=16, minblocks=8) , # 307.93 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=23, k=24, tile_m=2, tile_n=3, w=12, v=12, threads=160, grouping=16, minblocks=8) , # 320.822 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=23, k=26, tile_m=2, tile_n=3, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 327.373 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=23, k=32, tile_m=2, tile_n=3, w=14, v=14, threads=128, grouping=16, minblocks=8) , # 341.076 GFlop/s
   Kernel_dnt_medium(m=26, n=24, k=4, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 166.334 GFlop/s
   Kernel_dnt_medium(m=26, n=24, k=5, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 194.858 GFlop/s
   Kernel_dnt_medium(m=26, n=24, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 217.359 GFlop/s
   Kernel_dnt_medium(m=26, n=24, k=8, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 240.36 GFlop/s
   Kernel_dnt_medium(m=26, n=24, k=9, tile_m=4, tile_n=2, threads=128, grouping=16, minblocks=8) , # 240.63 GFlop/s
   Kernel_dnt_medium(m=26, n=24, k=13, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 284.219 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=24, k=16, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 317.599 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=24, k=17, tile_m=3, tile_n=2, w=6, v=24, threads=160, grouping=16, minblocks=8) , # 300.196 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=24, k=22, tile_m=2, tile_n=3, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 333.184 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=24, k=23, tile_m=2, tile_n=2, w=6, v=24, threads=160, grouping=16, minblocks=8) , # 332.175 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=24, k=24, tile_m=2, tile_n=3, w=12, v=24, threads=128, grouping=16, minblocks=8) , # 342.541 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=24, k=26, tile_m=2, tile_n=3, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 342.458 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=24, k=32, tile_m=3, tile_n=2, w=14, v=24, threads=128, grouping=16, minblocks=8) , # 360.604 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=24, k=16, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 317.599 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=24, k=17, tile_m=3, tile_n=2, w=6, v=24, threads=160, grouping=16, minblocks=8) , # 300.196 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=24, k=22, tile_m=2, tile_n=3, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 333.184 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=24, k=23, tile_m=2, tile_n=2, w=6, v=24, threads=160, grouping=16, minblocks=8) , # 332.175 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=24, k=24, tile_m=2, tile_n=3, w=12, v=24, threads=128, grouping=16, minblocks=8) , # 342.541 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=24, k=26, tile_m=2, tile_n=3, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 342.458 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=24, k=32, tile_m=3, tile_n=2, w=14, v=24, threads=128, grouping=16, minblocks=8) , # 360.604 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=25, k=4, tile_m=4, tile_n=2, w=2, v=18, threads=96, grouping=16, minblocks=12) , # 167.244 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=25, k=5, tile_m=3, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=12) , # 188.512 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=25, k=7, tile_m=3, tile_n=2, w=2, v=14, threads=128, grouping=16, minblocks=12) , # 217.789 GFlop/s
@@ -2607,11 +2607,11 @@
   Kernel_dnt_medium(m=26, n=26, k=8, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 260.398 GFlop/s
   Kernel_dnt_medium(m=26, n=26, k=9, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 281.056 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=26, k=13, tile_m=2, tile_n=4, w=6, v=18, threads=96, grouping=16, minblocks=12) , # 317.738 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=26, k=16, tile_m=3, tile_n=2, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 332.873 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=26, k=17, tile_m=2, tile_n=3, w=6, v=16, threads=160, grouping=16, minblocks=8) , # 315.978 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=26, k=22, tile_m=2, tile_n=3, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 350.804 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=26, k=23, tile_m=2, tile_n=3, w=6, v=26, threads=160, grouping=16, minblocks=8) , # 348.123 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=26, k=24, tile_m=2, tile_n=3, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 356.594 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=26, k=16, tile_m=3, tile_n=2, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 332.873 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=26, k=17, tile_m=2, tile_n=3, w=6, v=16, threads=160, grouping=16, minblocks=8) , # 315.978 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=26, k=22, tile_m=2, tile_n=3, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 350.804 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=26, k=23, tile_m=2, tile_n=3, w=6, v=26, threads=160, grouping=16, minblocks=8) , # 348.123 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=26, k=24, tile_m=2, tile_n=3, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 356.594 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=26, k=25, tile_m=2, tile_n=4, w=12, v=24, threads=96, grouping=16, minblocks=8) , # 375.765 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=26, k=26, tile_m=2, tile_n=3, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 381.742 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=26, k=28, tile_m=2, tile_n=4, w=14, v=26, threads=128, grouping=16, minblocks=8) , # 396.724 GFlop/s
@@ -2629,16 +2629,16 @@
   Kernel_dnt_largeDB2(m=26, n=28, k=45, tile_m=2, tile_n=4, w=12, v=28, threads=96, grouping=16, minblocks=8) , # 457.514 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=32, k=4, tile_m=5, tile_n=2, w=2, v=14, threads=96, grouping=16, minblocks=12) , # 176.504 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=32, k=5, tile_m=5, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 212.767 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=32, k=6, tile_m=5, tile_n=2, w=2, v=18, threads=96, grouping=16, minblocks=12) , # 222.341 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=32, k=6, tile_m=5, tile_n=2, w=2, v=18, threads=96, grouping=16, minblocks=12) , # 222.341 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=32, k=7, tile_m=5, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 247.293 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=32, k=8, tile_m=3, tile_n=3, w=4, v=28, threads=128, grouping=16, minblocks=8) , # 245.658 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=32, k=8, tile_m=3, tile_n=3, w=4, v=28, threads=128, grouping=16, minblocks=8) , # 245.658 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=32, k=9, tile_m=2, tile_n=4, w=4, v=28, threads=128, grouping=16, minblocks=8) , # 280.034 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=32, k=13, tile_m=2, tile_n=4, w=6, v=16, threads=128, grouping=16, minblocks=8) , # 316.971 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=32, k=16, tile_m=2, tile_n=4, w=8, v=28, threads=128, grouping=16, minblocks=8) , # 335.651 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=32, k=17, tile_m=2, tile_n=4, w=8, v=24, threads=128, grouping=16, minblocks=8) , # 325.543 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=32, k=22, tile_m=2, tile_n=4, w=8, v=28, threads=128, grouping=16, minblocks=8) , # 358.85 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=32, k=23, tile_m=2, tile_n=4, w=8, v=28, threads=128, grouping=16, minblocks=8) , # 365.224 GFlop/s
-  Kernel_dnt_largeDB(m=26, n=32, k=24, tile_m=2, tile_n=4, w=12, v=14, threads=128, grouping=16, minblocks=8) , # 382.529 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=32, k=16, tile_m=2, tile_n=4, w=8, v=28, threads=128, grouping=16, minblocks=8) , # 335.651 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=32, k=17, tile_m=2, tile_n=4, w=8, v=24, threads=128, grouping=16, minblocks=8) , # 325.543 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=32, k=22, tile_m=2, tile_n=4, w=8, v=28, threads=128, grouping=16, minblocks=8) , # 358.85 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=32, k=23, tile_m=2, tile_n=4, w=8, v=28, threads=128, grouping=16, minblocks=8) , # 365.224 GFlop/s
+  Kernel_dnt_largeDB1(m=26, n=32, k=24, tile_m=2, tile_n=4, w=12, v=14, threads=128, grouping=16, minblocks=8) , # 382.529 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=32, k=25, tile_m=2, tile_n=4, w=12, v=32, threads=128, grouping=16, minblocks=1) , # 399.183 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=32, k=26, tile_m=2, tile_n=4, w=12, v=32, threads=128, grouping=16, minblocks=8) , # 404.75 GFlop/s
   Kernel_dnt_largeDB2(m=26, n=32, k=28, tile_m=2, tile_n=4, w=10, v=32, threads=128, grouping=16, minblocks=8) , # 409.577 GFlop/s
@@ -2756,25 +2756,25 @@
   Kernel_dnt_largeDB2(m=28, n=45, k=45, tile_m=2, tile_n=5, w=16, v=40, threads=192, grouping=16, minblocks=4) , # 490.812 GFlop/s
   Kernel_dnt_medium(m=29, n=14, k=14, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 242.078 GFlop/s
   Kernel_dnt_medium(m=29, n=14, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 258.248 GFlop/s
-  Kernel_dnt_largeDB(m=29, n=14, k=29, tile_m=2, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=8) , # 274.397 GFlop/s
-  Kernel_dnt_largeDB(m=29, n=14, k=32, tile_m=2, tile_n=2, w=16, v=10, threads=160, grouping=16, minblocks=8) , # 293.429 GFlop/s
+  Kernel_dnt_largeDB1(m=29, n=14, k=29, tile_m=2, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=8) , # 274.397 GFlop/s
+  Kernel_dnt_largeDB1(m=29, n=14, k=32, tile_m=2, tile_n=2, w=16, v=10, threads=160, grouping=16, minblocks=8) , # 293.429 GFlop/s
   Kernel_dnt_medium(m=29, n=16, k=14, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 277.48 GFlop/s
-  Kernel_dnt_largeDB(m=29, n=16, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 295.779 GFlop/s
-  Kernel_dnt_largeDB(m=29, n=16, k=29, tile_m=2, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=8) , # 310.193 GFlop/s
-  Kernel_dnt_largeDB(m=29, n=16, k=55, tile_m=2, tile_n=4, w=6, v=6, threads=96, grouping=16, minblocks=12) , # 360.532 GFlop/s
-  Kernel_dnt_largeDB(m=29, n=29, k=14, tile_m=2, tile_n=4, w=4, v=16, threads=128, grouping=16, minblocks=8) , # 309.036 GFlop/s
-  Kernel_dnt_largeDB(m=29, n=29, k=16, tile_m=4, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 321.264 GFlop/s
+  Kernel_dnt_largeDB1(m=29, n=16, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 295.779 GFlop/s
+  Kernel_dnt_largeDB1(m=29, n=16, k=29, tile_m=2, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=8) , # 310.193 GFlop/s
+  Kernel_dnt_largeDB1(m=29, n=16, k=55, tile_m=2, tile_n=4, w=6, v=6, threads=96, grouping=16, minblocks=12) , # 360.532 GFlop/s
+  Kernel_dnt_largeDB1(m=29, n=29, k=14, tile_m=2, tile_n=4, w=4, v=16, threads=128, grouping=16, minblocks=8) , # 309.036 GFlop/s
+  Kernel_dnt_largeDB1(m=29, n=29, k=16, tile_m=4, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 321.264 GFlop/s
   Kernel_dnt_largeDB2(m=29, n=29, k=29, tile_m=2, tile_n=5, w=10, v=22, threads=96, grouping=16, minblocks=8) , # 397.654 GFlop/s
-  Kernel_dnt_largeDB(m=29, n=29, k=32, tile_m=2, tile_n=4, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 395.307 GFlop/s
-  Kernel_dnt_largeDB(m=29, n=29, k=55, tile_m=2, tile_n=4, w=8, v=22, threads=128, grouping=16, minblocks=8) , # 431.556 GFlop/s
-  Kernel_dnt_largeDB(m=29, n=32, k=14, tile_m=3, tile_n=3, w=4, v=24, threads=128, grouping=16, minblocks=8) , # 331.383 GFlop/s
-  Kernel_dnt_largeDB(m=29, n=32, k=29, tile_m=4, tile_n=2, w=10, v=24, threads=128, grouping=16, minblocks=8) , # 423.499 GFlop/s
-  Kernel_dnt_largeDB(m=29, n=32, k=32, tile_m=2, tile_n=4, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 433.652 GFlop/s
-  Kernel_dnt_largeDB(m=29, n=32, k=55, tile_m=2, tile_n=4, w=8, v=14, threads=128, grouping=16, minblocks=8) , # 478.124 GFlop/s
-  Kernel_dnt_largeDB(m=29, n=55, k=16, tile_m=4, tile_n=4, w=8, v=38, threads=128, grouping=16, minblocks=4) , # 326.811 GFlop/s
-  Kernel_dnt_largeDB(m=29, n=55, k=29, tile_m=5, tile_n=3, w=10, v=44, threads=160, grouping=16, minblocks=4) , # 384.341 GFlop/s
-  Kernel_dnt_largeDB(m=29, n=55, k=32, tile_m=4, tile_n=4, w=8, v=34, threads=128, grouping=16, minblocks=1) , # 424.502 GFlop/s
-  Kernel_dnt_largeDB(m=29, n=55, k=55, tile_m=3, tile_n=5, w=6, v=30, threads=128, grouping=16, minblocks=1) , # 465.271 GFlop/s
+  Kernel_dnt_largeDB1(m=29, n=29, k=32, tile_m=2, tile_n=4, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 395.307 GFlop/s
+  Kernel_dnt_largeDB1(m=29, n=29, k=55, tile_m=2, tile_n=4, w=8, v=22, threads=128, grouping=16, minblocks=8) , # 431.556 GFlop/s
+  Kernel_dnt_largeDB1(m=29, n=32, k=14, tile_m=3, tile_n=3, w=4, v=24, threads=128, grouping=16, minblocks=8) , # 331.383 GFlop/s
+  Kernel_dnt_largeDB1(m=29, n=32, k=29, tile_m=4, tile_n=2, w=10, v=24, threads=128, grouping=16, minblocks=8) , # 423.499 GFlop/s
+  Kernel_dnt_largeDB1(m=29, n=32, k=32, tile_m=2, tile_n=4, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 433.652 GFlop/s
+  Kernel_dnt_largeDB1(m=29, n=32, k=55, tile_m=2, tile_n=4, w=8, v=14, threads=128, grouping=16, minblocks=8) , # 478.124 GFlop/s
+  Kernel_dnt_largeDB1(m=29, n=55, k=16, tile_m=4, tile_n=4, w=8, v=38, threads=128, grouping=16, minblocks=4) , # 326.811 GFlop/s
+  Kernel_dnt_largeDB1(m=29, n=55, k=29, tile_m=5, tile_n=3, w=10, v=44, threads=160, grouping=16, minblocks=4) , # 384.341 GFlop/s
+  Kernel_dnt_largeDB1(m=29, n=55, k=32, tile_m=4, tile_n=4, w=8, v=34, threads=128, grouping=16, minblocks=1) , # 424.502 GFlop/s
+  Kernel_dnt_largeDB1(m=29, n=55, k=55, tile_m=3, tile_n=5, w=6, v=30, threads=128, grouping=16, minblocks=1) , # 465.271 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=4, k=4, tile_m=1, tile_n=1, w=2, v=4, threads=128, grouping=16, minblocks=1) , # 78.1605 GFlop/s
   Kernel_dnt_tiny(m=32, n=4, k=5, split_thread=32, threads=128, grouping=16, minblocks=1) , # 75.2026 GFlop/s
   Kernel_dnt_medium(m=32, n=4, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 84.3077 GFlop/s
@@ -2786,7 +2786,7 @@
   Kernel_dnt_medium(m=32, n=4, k=17, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 132.452 GFlop/s
   Kernel_dnt_medium(m=32, n=4, k=22, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=4) , # 135.963 GFlop/s
   Kernel_dnt_medium(m=32, n=4, k=23, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=1) , # 136.381 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=4, k=24, tile_m=1, tile_n=1, w=8, v=4, threads=128, grouping=16, minblocks=12) , # 137.282 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=4, k=24, tile_m=1, tile_n=1, w=8, v=4, threads=128, grouping=16, minblocks=12) , # 137.282 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=4, k=25, tile_m=1, tile_n=1, w=8, v=4, threads=128, grouping=16, minblocks=12) , # 139.087 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=4, k=26, tile_m=1, tile_n=1, w=12, v=4, threads=128, grouping=16, minblocks=12) , # 140.533 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=4, k=28, tile_m=2, tile_n=1, w=14, v=4, threads=128, grouping=16, minblocks=12) , # 143.079 GFlop/s
@@ -2802,8 +2802,8 @@
   Kernel_dnt_medium(m=32, n=5, k=16, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=4) , # 153.149 GFlop/s
   Kernel_dnt_medium(m=32, n=5, k=17, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=4) , # 156.458 GFlop/s
   Kernel_dnt_medium(m=32, n=5, k=22, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=1) , # 158.723 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=5, k=23, tile_m=2, tile_n=1, w=6, v=2, threads=96, grouping=16, minblocks=4) , # 154.957 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=5, k=24, tile_m=2, tile_n=1, w=8, v=4, threads=128, grouping=16, minblocks=12) , # 157.474 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=5, k=23, tile_m=2, tile_n=1, w=6, v=2, threads=96, grouping=16, minblocks=4) , # 154.957 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=5, k=24, tile_m=2, tile_n=1, w=8, v=4, threads=128, grouping=16, minblocks=12) , # 157.474 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=5, k=25, tile_m=2, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=12) , # 164.898 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=5, k=26, tile_m=2, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=4) , # 166.861 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=5, k=28, tile_m=2, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=1) , # 169.47 GFlop/s
@@ -2817,11 +2817,11 @@
   Kernel_dnt_medium(m=32, n=6, k=13, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 172.995 GFlop/s
   Kernel_dnt_medium(m=32, n=6, k=16, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=8) , # 179.544 GFlop/s
   Kernel_dnt_medium(m=32, n=6, k=17, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 177.212 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=6, k=22, tile_m=2, tile_n=1, w=8, v=6, threads=128, grouping=16, minblocks=12) , # 177.592 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=6, k=23, tile_m=2, tile_n=1, w=8, v=6, threads=128, grouping=16, minblocks=12) , # 179.563 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=6, k=24, tile_m=2, tile_n=1, w=8, v=6, threads=128, grouping=16, minblocks=12) , # 184.834 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=6, k=26, tile_m=2, tile_n=1, w=6, v=6, threads=96, grouping=16, minblocks=1) , # 181.915 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=6, k=32, tile_m=2, tile_n=1, w=8, v=4, threads=128, grouping=16, minblocks=12) , # 191.164 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=6, k=22, tile_m=2, tile_n=1, w=8, v=6, threads=128, grouping=16, minblocks=12) , # 177.592 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=6, k=23, tile_m=2, tile_n=1, w=8, v=6, threads=128, grouping=16, minblocks=12) , # 179.563 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=6, k=24, tile_m=2, tile_n=1, w=8, v=6, threads=128, grouping=16, minblocks=12) , # 184.834 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=6, k=26, tile_m=2, tile_n=1, w=6, v=6, threads=96, grouping=16, minblocks=1) , # 181.915 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=6, k=32, tile_m=2, tile_n=1, w=8, v=4, threads=128, grouping=16, minblocks=12) , # 191.164 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=7, k=4, tile_m=2, tile_n=2, w=2, v=4, threads=96, grouping=16, minblocks=12) , # 113.424 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=7, k=5, tile_m=2, tile_n=2, w=2, v=4, threads=96, grouping=16, minblocks=4) , # 112.889 GFlop/s
   Kernel_dnt_medium(m=32, n=7, k=7, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 139.831 GFlop/s
@@ -2840,11 +2840,11 @@
   Kernel_dnt_medium(m=32, n=8, k=13, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=8) , # 206.098 GFlop/s
   Kernel_dnt_medium(m=32, n=8, k=16, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 214.735 GFlop/s
   Kernel_dnt_medium(m=32, n=8, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 213.369 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=8, k=22, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 222.523 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=8, k=23, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 223.88 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=8, k=24, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 231.024 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=8, k=26, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 229.882 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=8, k=32, tile_m=2, tile_n=2, w=12, v=8, threads=96, grouping=16, minblocks=12) , # 239.979 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=8, k=22, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 222.523 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=8, k=23, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 223.88 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=8, k=24, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 231.024 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=8, k=26, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 229.882 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=8, k=32, tile_m=2, tile_n=2, w=12, v=8, threads=96, grouping=16, minblocks=12) , # 239.979 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=9, k=4, tile_m=2, tile_n=2, w=2, v=6, threads=96, grouping=16, minblocks=12) , # 132.73 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=9, k=5, tile_m=2, tile_n=2, w=2, v=6, threads=96, grouping=16, minblocks=8) , # 135.487 GFlop/s
   Kernel_dnt_medium(m=32, n=9, k=6, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 145.86 GFlop/s
@@ -2852,11 +2852,11 @@
   Kernel_dnt_medium(m=32, n=9, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 182.062 GFlop/s
   Kernel_dnt_medium(m=32, n=9, k=9, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 189.732 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=9, k=13, tile_m=1, tile_n=3, w=6, v=6, threads=96, grouping=16, minblocks=12) , # 213.509 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=9, k=16, tile_m=2, tile_n=2, w=8, v=6, threads=128, grouping=16, minblocks=12) , # 219.794 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=9, k=16, tile_m=2, tile_n=2, w=8, v=6, threads=128, grouping=16, minblocks=12) , # 219.794 GFlop/s
   Kernel_dnt_medium(m=32, n=9, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 215.226 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=9, k=22, tile_m=1, tile_n=3, w=6, v=6, threads=128, grouping=16, minblocks=12) , # 226.772 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=9, k=23, tile_m=2, tile_n=3, w=6, v=6, threads=96, grouping=16, minblocks=12) , # 230.82 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=9, k=24, tile_m=1, tile_n=3, w=8, v=6, threads=128, grouping=16, minblocks=12) , # 239.49 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=9, k=22, tile_m=1, tile_n=3, w=6, v=6, threads=128, grouping=16, minblocks=12) , # 226.772 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=9, k=23, tile_m=2, tile_n=3, w=6, v=6, threads=96, grouping=16, minblocks=12) , # 230.82 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=9, k=24, tile_m=1, tile_n=3, w=8, v=6, threads=128, grouping=16, minblocks=12) , # 239.49 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=9, k=25, tile_m=2, tile_n=2, w=10, v=6, threads=96, grouping=16, minblocks=12) , # 252.716 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=9, k=26, tile_m=2, tile_n=3, w=10, v=6, threads=96, grouping=16, minblocks=12) , # 257.379 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=9, k=28, tile_m=1, tile_n=3, w=14, v=6, threads=128, grouping=16, minblocks=12) , # 260.597 GFlop/s
@@ -2869,84 +2869,84 @@
   Kernel_dnt_medium(m=32, n=13, k=8, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 218.093 GFlop/s
   Kernel_dnt_medium(m=32, n=13, k=9, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 222.138 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=13, k=13, tile_m=2, tile_n=4, w=6, v=8, threads=96, grouping=16, minblocks=12) , # 265.867 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=13, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 281.835 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=13, k=17, tile_m=2, tile_n=4, w=6, v=8, threads=96, grouping=16, minblocks=12) , # 263.517 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=13, k=22, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=8) , # 273.854 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=13, k=23, tile_m=2, tile_n=2, w=6, v=10, threads=128, grouping=16, minblocks=12) , # 288.889 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=13, k=24, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 292.866 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=13, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 281.835 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=13, k=17, tile_m=2, tile_n=4, w=6, v=8, threads=96, grouping=16, minblocks=12) , # 263.517 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=13, k=22, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=8) , # 273.854 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=13, k=23, tile_m=2, tile_n=2, w=6, v=10, threads=128, grouping=16, minblocks=12) , # 288.889 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=13, k=24, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 292.866 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=13, k=25, tile_m=4, tile_n=2, w=12, v=6, threads=96, grouping=16, minblocks=8) , # 299.633 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=13, k=26, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 305.955 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=13, k=26, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 305.955 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=13, k=28, tile_m=2, tile_n=4, w=14, v=12, threads=128, grouping=16, minblocks=8) , # 315.29 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=13, k=32, tile_m=4, tile_n=2, w=16, v=10, threads=128, grouping=16, minblocks=8) , # 339.092 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=13, k=45, tile_m=2, tile_n=4, w=16, v=12, threads=128, grouping=16, minblocks=8) , # 341.117 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=14, k=14, tile_m=2, tile_n=2, w=6, v=14, threads=128, grouping=16, minblocks=12) , # 271.737 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=14, k=29, tile_m=2, tile_n=2, w=6, v=14, threads=128, grouping=16, minblocks=12) , # 313.057 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=14, k=32, tile_m=2, tile_n=2, w=8, v=10, threads=128, grouping=16, minblocks=12) , # 340.64 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=14, k=14, tile_m=2, tile_n=2, w=6, v=14, threads=128, grouping=16, minblocks=12) , # 271.737 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=14, k=29, tile_m=2, tile_n=2, w=6, v=14, threads=128, grouping=16, minblocks=12) , # 313.057 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=14, k=32, tile_m=2, tile_n=2, w=8, v=10, threads=128, grouping=16, minblocks=12) , # 340.64 GFlop/s
   Kernel_dnt_small(m=32, n=16, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=1) , # 151.321 GFlop/s
   Kernel_dnt_medium(m=32, n=16, k=5, tile_m=2, tile_n=2, threads=192, grouping=16, minblocks=8) , # 166.987 GFlop/s
   Kernel_dnt_medium(m=32, n=16, k=6, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=1) , # 189.814 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=16, k=8, tile_m=2, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=12) , # 237.248 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=16, k=9, tile_m=2, tile_n=2, w=4, v=8, threads=128, grouping=16, minblocks=12) , # 241.881 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=16, k=13, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 292.252 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=16, k=16, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 329.973 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=16, k=17, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 324.51 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=16, k=22, tile_m=2, tile_n=4, w=6, v=10, threads=96, grouping=16, minblocks=12) , # 333.461 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=16, k=23, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 344.66 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=16, k=24, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 358.655 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=16, k=26, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 347.137 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=16, k=32, tile_m=2, tile_n=4, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 362.722 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=16, k=8, tile_m=2, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=12) , # 237.248 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=16, k=9, tile_m=2, tile_n=2, w=4, v=8, threads=128, grouping=16, minblocks=12) , # 241.881 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=16, k=13, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 292.252 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=16, k=16, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 329.973 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=16, k=17, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 324.51 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=16, k=22, tile_m=2, tile_n=4, w=6, v=10, threads=96, grouping=16, minblocks=12) , # 333.461 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=16, k=23, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 344.66 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=16, k=24, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 358.655 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=16, k=26, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 347.137 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=16, k=32, tile_m=2, tile_n=4, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 362.722 GFlop/s
   Kernel_dnt_medium(m=32, n=17, k=4, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 144.864 GFlop/s
   Kernel_dnt_medium(m=32, n=17, k=5, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=1) , # 169.7 GFlop/s
   Kernel_dnt_medium(m=32, n=17, k=6, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 186.207 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=17, k=8, tile_m=2, tile_n=3, w=4, v=14, threads=96, grouping=16, minblocks=12) , # 231.895 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=17, k=8, tile_m=2, tile_n=3, w=4, v=14, threads=96, grouping=16, minblocks=12) , # 231.895 GFlop/s
   Kernel_dnt_medium(m=32, n=17, k=9, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 237.103 GFlop/s
   Kernel_dnt_medium(m=32, n=17, k=13, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 285.362 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=17, k=16, tile_m=2, tile_n=3, w=4, v=14, threads=96, grouping=16, minblocks=12) , # 298.281 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=17, k=17, tile_m=2, tile_n=3, w=8, v=14, threads=96, grouping=16, minblocks=12) , # 294.427 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=17, k=22, tile_m=2, tile_n=3, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 321.363 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=17, k=23, tile_m=2, tile_n=3, w=4, v=14, threads=96, grouping=16, minblocks=12) , # 314.354 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=17, k=24, tile_m=2, tile_n=3, w=6, v=14, threads=96, grouping=16, minblocks=12) , # 333.041 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=17, k=26, tile_m=2, tile_n=3, w=6, v=6, threads=96, grouping=16, minblocks=12) , # 323.24 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=17, k=32, tile_m=2, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 351.318 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=22, k=4, tile_m=3, tile_n=2, w=2, v=12, threads=128, grouping=16, minblocks=12) , # 174.057 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=17, k=16, tile_m=2, tile_n=3, w=4, v=14, threads=96, grouping=16, minblocks=12) , # 298.281 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=17, k=17, tile_m=2, tile_n=3, w=8, v=14, threads=96, grouping=16, minblocks=12) , # 294.427 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=17, k=22, tile_m=2, tile_n=3, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 321.363 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=17, k=23, tile_m=2, tile_n=3, w=4, v=14, threads=96, grouping=16, minblocks=12) , # 314.354 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=17, k=24, tile_m=2, tile_n=3, w=6, v=14, threads=96, grouping=16, minblocks=12) , # 333.041 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=17, k=26, tile_m=2, tile_n=3, w=6, v=6, threads=96, grouping=16, minblocks=12) , # 323.24 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=17, k=32, tile_m=2, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 351.318 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=22, k=4, tile_m=3, tile_n=2, w=2, v=12, threads=128, grouping=16, minblocks=12) , # 174.057 GFlop/s
   Kernel_dnt_medium(m=32, n=22, k=5, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 195.309 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=22, k=6, tile_m=3, tile_n=2, w=2, v=12, threads=128, grouping=16, minblocks=12) , # 213.72 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=22, k=8, tile_m=4, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 264.277 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=22, k=6, tile_m=3, tile_n=2, w=2, v=12, threads=128, grouping=16, minblocks=12) , # 213.72 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=22, k=8, tile_m=4, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 264.277 GFlop/s
   Kernel_dnt_medium(m=32, n=22, k=9, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 280.289 GFlop/s
   Kernel_dnt_medium(m=32, n=22, k=13, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 325.002 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=22, k=16, tile_m=3, tile_n=2, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 348.283 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=22, k=17, tile_m=2, tile_n=4, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 337.15 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=22, k=22, tile_m=3, tile_n=2, w=10, v=20, threads=128, grouping=16, minblocks=8) , # 351.551 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=22, k=23, tile_m=4, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 363.288 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=22, k=24, tile_m=2, tile_n=4, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 385.833 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=22, k=26, tile_m=2, tile_n=4, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 378.454 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=22, k=32, tile_m=2, tile_n=4, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 407.594 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=22, k=16, tile_m=3, tile_n=2, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 348.283 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=22, k=17, tile_m=2, tile_n=4, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 337.15 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=22, k=22, tile_m=3, tile_n=2, w=10, v=20, threads=128, grouping=16, minblocks=8) , # 351.551 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=22, k=23, tile_m=4, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 363.288 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=22, k=24, tile_m=2, tile_n=4, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 385.833 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=22, k=26, tile_m=2, tile_n=4, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 378.454 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=22, k=32, tile_m=2, tile_n=4, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 407.594 GFlop/s
   Kernel_dnt_medium(m=32, n=23, k=4, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 170.118 GFlop/s
   Kernel_dnt_medium(m=32, n=23, k=5, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 202.087 GFlop/s
   Kernel_dnt_medium(m=32, n=23, k=6, tile_m=2, tile_n=3, threads=160, grouping=16, minblocks=8) , # 219.29 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=23, k=8, tile_m=4, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 272.379 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=23, k=8, tile_m=4, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 272.379 GFlop/s
   Kernel_dnt_medium(m=32, n=23, k=9, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 291.61 GFlop/s
   Kernel_dnt_medium(m=32, n=23, k=13, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 337.911 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=23, k=16, tile_m=2, tile_n=4, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 358.681 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=23, k=17, tile_m=2, tile_n=4, w=8, v=10, threads=96, grouping=16, minblocks=12) , # 349.834 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=23, k=22, tile_m=2, tile_n=3, w=10, v=12, threads=128, grouping=16, minblocks=8) , # 361.851 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=23, k=23, tile_m=4, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 374.412 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=23, k=24, tile_m=2, tile_n=4, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 395.474 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=23, k=26, tile_m=2, tile_n=4, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 392.455 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=23, k=32, tile_m=2, tile_n=4, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 419.821 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=24, k=4, tile_m=4, tile_n=2, w=2, v=12, threads=96, grouping=16, minblocks=12) , # 168.649 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=23, k=16, tile_m=2, tile_n=4, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 358.681 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=23, k=17, tile_m=2, tile_n=4, w=8, v=10, threads=96, grouping=16, minblocks=12) , # 349.834 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=23, k=22, tile_m=2, tile_n=3, w=10, v=12, threads=128, grouping=16, minblocks=8) , # 361.851 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=23, k=23, tile_m=4, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 374.412 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=23, k=24, tile_m=2, tile_n=4, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 395.474 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=23, k=26, tile_m=2, tile_n=4, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 392.455 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=23, k=32, tile_m=2, tile_n=4, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 419.821 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=24, k=4, tile_m=4, tile_n=2, w=2, v=12, threads=96, grouping=16, minblocks=12) , # 168.649 GFlop/s
   Kernel_dnt_medium(m=32, n=24, k=5, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=1) , # 192.606 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=24, k=6, tile_m=4, tile_n=2, w=2, v=12, threads=96, grouping=16, minblocks=4) , # 218.903 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=24, k=8, tile_m=2, tile_n=4, w=4, v=14, threads=96, grouping=16, minblocks=12) , # 279.775 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=24, k=9, tile_m=3, tile_n=3, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 275.596 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=24, k=13, tile_m=2, tile_n=4, w=6, v=12, threads=96, grouping=16, minblocks=12) , # 328.765 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=24, k=16, tile_m=2, tile_n=4, w=8, v=14, threads=96, grouping=16, minblocks=12) , # 373.707 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=24, k=17, tile_m=2, tile_n=4, w=8, v=10, threads=96, grouping=16, minblocks=12) , # 364.783 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=24, k=22, tile_m=2, tile_n=3, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 383.032 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=24, k=23, tile_m=2, tile_n=3, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 390.4 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=24, k=24, tile_m=2, tile_n=4, w=8, v=10, threads=96, grouping=16, minblocks=12) , # 411.108 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=24, k=26, tile_m=2, tile_n=4, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 409.018 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=24, k=32, tile_m=2, tile_n=4, w=8, v=10, threads=96, grouping=16, minblocks=12) , # 438.697 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=24, k=6, tile_m=4, tile_n=2, w=2, v=12, threads=96, grouping=16, minblocks=4) , # 218.903 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=24, k=8, tile_m=2, tile_n=4, w=4, v=14, threads=96, grouping=16, minblocks=12) , # 279.775 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=24, k=9, tile_m=3, tile_n=3, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 275.596 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=24, k=13, tile_m=2, tile_n=4, w=6, v=12, threads=96, grouping=16, minblocks=12) , # 328.765 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=24, k=16, tile_m=2, tile_n=4, w=8, v=14, threads=96, grouping=16, minblocks=12) , # 373.707 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=24, k=17, tile_m=2, tile_n=4, w=8, v=10, threads=96, grouping=16, minblocks=12) , # 364.783 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=24, k=22, tile_m=2, tile_n=3, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 383.032 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=24, k=23, tile_m=2, tile_n=3, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 390.4 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=24, k=24, tile_m=2, tile_n=4, w=8, v=10, threads=96, grouping=16, minblocks=12) , # 411.108 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=24, k=26, tile_m=2, tile_n=4, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 409.018 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=24, k=32, tile_m=2, tile_n=4, w=8, v=10, threads=96, grouping=16, minblocks=12) , # 438.697 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=24, k=45, tile_m=2, tile_n=4, w=12, v=18, threads=96, grouping=16, minblocks=8) , # 478.687 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=25, k=4, tile_m=4, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=8) , # 184.135 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=25, k=5, tile_m=5, tile_n=2, w=2, v=14, threads=96, grouping=16, minblocks=12) , # 204.72 GFlop/s
@@ -2960,16 +2960,16 @@
   Kernel_dnt_largeDB2(m=32, n=25, k=45, tile_m=2, tile_n=5, w=12, v=10, threads=96, grouping=16, minblocks=8) , # 426.761 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=26, k=4, tile_m=4, tile_n=2, w=2, v=18, threads=128, grouping=16, minblocks=8) , # 190.663 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=26, k=5, tile_m=5, tile_n=2, w=2, v=14, threads=96, grouping=16, minblocks=12) , # 211.617 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=26, k=6, tile_m=5, tile_n=2, w=2, v=14, threads=96, grouping=16, minblocks=12) , # 220.557 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=26, k=6, tile_m=5, tile_n=2, w=2, v=14, threads=96, grouping=16, minblocks=12) , # 220.557 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=26, k=7, tile_m=5, tile_n=2, w=2, v=14, threads=96, grouping=16, minblocks=12) , # 246.023 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=26, k=8, tile_m=3, tile_n=3, w=4, v=22, threads=128, grouping=16, minblocks=8) , # 246.38 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=26, k=8, tile_m=3, tile_n=3, w=4, v=22, threads=128, grouping=16, minblocks=8) , # 246.38 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=26, k=9, tile_m=2, tile_n=4, w=4, v=14, threads=128, grouping=16, minblocks=8) , # 280.415 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=26, k=13, tile_m=2, tile_n=4, w=4, v=22, threads=128, grouping=16, minblocks=8) , # 323.047 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=26, k=16, tile_m=2, tile_n=4, w=8, v=22, threads=128, grouping=16, minblocks=8) , # 336.964 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=26, k=17, tile_m=4, tile_n=2, w=6, v=22, threads=160, grouping=16, minblocks=8) , # 335.578 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=26, k=22, tile_m=2, tile_n=4, w=8, v=22, threads=128, grouping=16, minblocks=8) , # 363.449 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=26, k=23, tile_m=2, tile_n=4, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 370.605 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=26, k=24, tile_m=4, tile_n=2, w=12, v=14, threads=128, grouping=16, minblocks=8) , # 386.132 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=26, k=16, tile_m=2, tile_n=4, w=8, v=22, threads=128, grouping=16, minblocks=8) , # 336.964 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=26, k=17, tile_m=4, tile_n=2, w=6, v=22, threads=160, grouping=16, minblocks=8) , # 335.578 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=26, k=22, tile_m=2, tile_n=4, w=8, v=22, threads=128, grouping=16, minblocks=8) , # 363.449 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=26, k=23, tile_m=2, tile_n=4, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 370.605 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=26, k=24, tile_m=4, tile_n=2, w=12, v=14, threads=128, grouping=16, minblocks=8) , # 386.132 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=26, k=25, tile_m=2, tile_n=4, w=12, v=18, threads=128, grouping=16, minblocks=8) , # 398.053 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=26, k=26, tile_m=4, tile_n=2, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 399.369 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=26, k=28, tile_m=4, tile_n=2, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 407.816 GFlop/s
@@ -2985,30 +2985,30 @@
   Kernel_dnt_largeDB2(m=32, n=28, k=28, tile_m=4, tile_n=2, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 434.061 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=28, k=32, tile_m=4, tile_n=2, w=16, v=28, threads=128, grouping=16, minblocks=1) , # 453.918 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=28, k=45, tile_m=2, tile_n=5, w=12, v=12, threads=96, grouping=16, minblocks=8) , # 474.442 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=29, k=14, tile_m=2, tile_n=4, w=4, v=16, threads=128, grouping=16, minblocks=8) , # 343.714 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=29, k=29, tile_m=2, tile_n=4, w=10, v=18, threads=128, grouping=16, minblocks=8) , # 425.393 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=29, k=32, tile_m=2, tile_n=4, w=12, v=14, threads=128, grouping=16, minblocks=8) , # 439.946 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=29, k=55, tile_m=2, tile_n=4, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 487.985 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=29, k=14, tile_m=2, tile_n=4, w=4, v=16, threads=128, grouping=16, minblocks=8) , # 343.714 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=29, k=29, tile_m=2, tile_n=4, w=10, v=18, threads=128, grouping=16, minblocks=8) , # 425.393 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=29, k=32, tile_m=2, tile_n=4, w=12, v=14, threads=128, grouping=16, minblocks=8) , # 439.946 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=29, k=55, tile_m=2, tile_n=4, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 487.985 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=32, k=4, tile_m=4, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=8) , # 220.256 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=32, k=5, tile_m=4, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=8) , # 233.012 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=32, k=6, tile_m=4, tile_n=2, w=2, v=20, threads=128, grouping=16, minblocks=8) , # 233.277 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=32, k=6, tile_m=4, tile_n=2, w=2, v=20, threads=128, grouping=16, minblocks=8) , # 233.277 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=32, k=7, tile_m=4, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=8) , # 269.642 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=32, k=8, tile_m=3, tile_n=3, w=4, v=16, threads=128, grouping=16, minblocks=1) , # 288.605 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=32, k=8, tile_m=3, tile_n=3, w=4, v=16, threads=128, grouping=16, minblocks=1) , # 288.605 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=32, k=9, tile_m=2, tile_n=4, w=4, v=16, threads=128, grouping=16, minblocks=4) , # 330.576 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=32, k=13, tile_m=2, tile_n=4, w=4, v=16, threads=128, grouping=16, minblocks=4) , # 378.511 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=32, k=14, tile_m=2, tile_n=4, w=6, v=20, threads=128, grouping=16, minblocks=8) , # 370.201 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=32, k=16, tile_m=2, tile_n=4, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 415.932 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=32, k=17, tile_m=2, tile_n=4, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 408.083 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=32, k=22, tile_m=2, tile_n=4, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 439.077 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=32, k=23, tile_m=2, tile_n=4, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 450.644 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=32, k=24, tile_m=2, tile_n=4, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 457.257 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=32, k=14, tile_m=2, tile_n=4, w=6, v=20, threads=128, grouping=16, minblocks=8) , # 370.201 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=32, k=16, tile_m=2, tile_n=4, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 415.932 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=32, k=17, tile_m=2, tile_n=4, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 408.083 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=32, k=22, tile_m=2, tile_n=4, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 439.077 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=32, k=23, tile_m=2, tile_n=4, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 450.644 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=32, k=24, tile_m=2, tile_n=4, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 457.257 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=32, k=25, tile_m=4, tile_n=2, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 471.97 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=32, k=26, tile_m=2, tile_n=4, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 482.604 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=32, k=28, tile_m=2, tile_n=4, w=10, v=12, threads=128, grouping=16, minblocks=8) , # 485.43 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=32, k=29, tile_m=2, tile_n=4, w=10, v=20, threads=128, grouping=16, minblocks=8) , # 470.358 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=32, k=29, tile_m=2, tile_n=4, w=10, v=20, threads=128, grouping=16, minblocks=8) , # 470.358 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=32, k=32, tile_m=2, tile_n=4, w=12, v=20, threads=128, grouping=16, minblocks=8) , # 509.322 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=32, k=45, tile_m=2, tile_n=4, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 526.52 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=32, k=55, tile_m=2, tile_n=4, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 531.47 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=32, k=55, tile_m=2, tile_n=4, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 531.47 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=45, k=4, tile_m=4, tile_n=2, w=2, v=34, threads=192, grouping=16, minblocks=1) , # 193.676 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=45, k=5, tile_m=4, tile_n=2, w=2, v=24, threads=192, grouping=16, minblocks=1) , # 201.497 GFlop/s
   Kernel_dnt_medium(m=32, n=45, k=7, tile_m=2, tile_n=3, threads=256, grouping=16, minblocks=4) , # 238.295 GFlop/s
@@ -3019,9 +3019,9 @@
   Kernel_dnt_largeDB2(m=32, n=45, k=28, tile_m=4, tile_n=3, w=14, v=28, threads=128, grouping=16, minblocks=1) , # 503.765 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=45, k=32, tile_m=4, tile_n=3, w=8, v=28, threads=128, grouping=16, minblocks=1) , # 523.025 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=45, k=45, tile_m=4, tile_n=3, w=12, v=32, threads=128, grouping=16, minblocks=1) , # 536.898 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=55, k=29, tile_m=4, tile_n=4, w=8, v=36, threads=128, grouping=16, minblocks=4) , # 447.064 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=55, k=32, tile_m=4, tile_n=4, w=4, v=26, threads=128, grouping=16, minblocks=1) , # 477.495 GFlop/s
-  Kernel_dnt_largeDB(m=32, n=55, k=55, tile_m=3, tile_n=5, w=6, v=24, threads=128, grouping=16, minblocks=1) , # 518.157 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=55, k=29, tile_m=4, tile_n=4, w=8, v=36, threads=128, grouping=16, minblocks=4) , # 447.064 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=55, k=32, tile_m=4, tile_n=4, w=4, v=26, threads=128, grouping=16, minblocks=1) , # 477.495 GFlop/s
+  Kernel_dnt_largeDB1(m=32, n=55, k=55, tile_m=3, tile_n=5, w=6, v=24, threads=128, grouping=16, minblocks=1) , # 518.157 GFlop/s
   Kernel_dnt_medium(m=36, n=6, k=6, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 113.312 GFlop/s
   Kernel_dnt_largeDB2(m=45, n=4, k=4, tile_m=1, tile_n=2, w=2, v=4, threads=96, grouping=16, minblocks=1) , # 90.7503 GFlop/s
   Kernel_dnt_largeDB2(m=45, n=4, k=5, tile_m=1, tile_n=2, w=2, v=4, threads=96, grouping=16, minblocks=12) , # 88.8845 GFlop/s
@@ -3131,47 +3131,47 @@
   Kernel_dnt_largeDB2(m=45, n=45, k=32, tile_m=3, tile_n=6, w=16, v=28, threads=128, grouping=16, minblocks=1) , # 511.25 GFlop/s
   Kernel_dnt_largeDB2(m=45, n=45, k=45, tile_m=3, tile_n=6, w=16, v=28, threads=128, grouping=16, minblocks=1) , # 534.417 GFlop/s
   Kernel_dnt_medium(m=49, n=7, k=7, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=8) , # 145.44 GFlop/s
-  Kernel_dnt_largeDB(m=55, n=16, k=16, tile_m=3, tile_n=3, w=8, v=12, threads=128, grouping=16, minblocks=8) , # 322.352 GFlop/s
-  Kernel_dnt_largeDB(m=55, n=16, k=29, tile_m=3, tile_n=3, w=6, v=8, threads=128, grouping=16, minblocks=8) , # 369.726 GFlop/s
-  Kernel_dnt_largeDB(m=55, n=16, k=55, tile_m=5, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=8) , # 426.451 GFlop/s
-  Kernel_dnt_largeDB(m=55, n=29, k=16, tile_m=3, tile_n=5, w=8, v=20, threads=128, grouping=16, minblocks=1) , # 339.155 GFlop/s
-  Kernel_dnt_largeDB(m=55, n=29, k=29, tile_m=3, tile_n=5, w=10, v=26, threads=160, grouping=16, minblocks=4) , # 383.513 GFlop/s
-  Kernel_dnt_largeDB(m=55, n=29, k=32, tile_m=3, tile_n=5, w=8, v=20, threads=128, grouping=16, minblocks=1) , # 427.971 GFlop/s
-  Kernel_dnt_largeDB(m=55, n=29, k=55, tile_m=3, tile_n=5, w=6, v=20, threads=128, grouping=16, minblocks=4) , # 466.603 GFlop/s
-  Kernel_dnt_largeDB(m=55, n=32, k=29, tile_m=5, tile_n=3, w=4, v=16, threads=128, grouping=16, minblocks=1) , # 421.352 GFlop/s
-  Kernel_dnt_largeDB(m=55, n=32, k=32, tile_m=5, tile_n=3, w=8, v=16, threads=128, grouping=16, minblocks=1) , # 461.927 GFlop/s
-  Kernel_dnt_largeDB(m=55, n=32, k=55, tile_m=5, tile_n=3, w=6, v=20, threads=128, grouping=16, minblocks=4) , # 500.36 GFlop/s
-  Kernel_dnt_largeDB(m=55, n=55, k=16, tile_m=5, tile_n=5, w=6, v=26, threads=128, grouping=16, minblocks=1) , # 361.626 GFlop/s
-  Kernel_dnt_largeDB(m=55, n=55, k=29, tile_m=5, tile_n=5, w=10, v=30, threads=128, grouping=16, minblocks=1) , # 408.729 GFlop/s
-  Kernel_dnt_largeDB(m=55, n=55, k=32, tile_m=5, tile_n=5, w=6, v=26, threads=128, grouping=16, minblocks=1) , # 501.123 GFlop/s
-  Kernel_dnt_largeDB(m=55, n=55, k=55, tile_m=5, tile_n=5, w=6, v=26, threads=128, grouping=16, minblocks=1) , # 588.05 GFlop/s
+  Kernel_dnt_largeDB1(m=55, n=16, k=16, tile_m=3, tile_n=3, w=8, v=12, threads=128, grouping=16, minblocks=8) , # 322.352 GFlop/s
+  Kernel_dnt_largeDB1(m=55, n=16, k=29, tile_m=3, tile_n=3, w=6, v=8, threads=128, grouping=16, minblocks=8) , # 369.726 GFlop/s
+  Kernel_dnt_largeDB1(m=55, n=16, k=55, tile_m=5, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=8) , # 426.451 GFlop/s
+  Kernel_dnt_largeDB1(m=55, n=29, k=16, tile_m=3, tile_n=5, w=8, v=20, threads=128, grouping=16, minblocks=1) , # 339.155 GFlop/s
+  Kernel_dnt_largeDB1(m=55, n=29, k=29, tile_m=3, tile_n=5, w=10, v=26, threads=160, grouping=16, minblocks=4) , # 383.513 GFlop/s
+  Kernel_dnt_largeDB1(m=55, n=29, k=32, tile_m=3, tile_n=5, w=8, v=20, threads=128, grouping=16, minblocks=1) , # 427.971 GFlop/s
+  Kernel_dnt_largeDB1(m=55, n=29, k=55, tile_m=3, tile_n=5, w=6, v=20, threads=128, grouping=16, minblocks=4) , # 466.603 GFlop/s
+  Kernel_dnt_largeDB1(m=55, n=32, k=29, tile_m=5, tile_n=3, w=4, v=16, threads=128, grouping=16, minblocks=1) , # 421.352 GFlop/s
+  Kernel_dnt_largeDB1(m=55, n=32, k=32, tile_m=5, tile_n=3, w=8, v=16, threads=128, grouping=16, minblocks=1) , # 461.927 GFlop/s
+  Kernel_dnt_largeDB1(m=55, n=32, k=55, tile_m=5, tile_n=3, w=6, v=20, threads=128, grouping=16, minblocks=4) , # 500.36 GFlop/s
+  Kernel_dnt_largeDB1(m=55, n=55, k=16, tile_m=5, tile_n=5, w=6, v=26, threads=128, grouping=16, minblocks=1) , # 361.626 GFlop/s
+  Kernel_dnt_largeDB1(m=55, n=55, k=29, tile_m=5, tile_n=5, w=10, v=30, threads=128, grouping=16, minblocks=1) , # 408.729 GFlop/s
+  Kernel_dnt_largeDB1(m=55, n=55, k=32, tile_m=5, tile_n=5, w=6, v=26, threads=128, grouping=16, minblocks=1) , # 501.123 GFlop/s
+  Kernel_dnt_largeDB1(m=55, n=55, k=55, tile_m=5, tile_n=5, w=6, v=26, threads=128, grouping=16, minblocks=1) , # 588.05 GFlop/s
   Kernel_dnt_medium(m=64, n=8, k=8, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 213.145 GFlop/s
   Kernel_dnt_medium(m=64, n=9, k=9, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 240.201 GFlop/s
-  Kernel_dnt_largeDB(m=64, n=9, k=16, tile_m=2, tile_n=3, w=4, v=6, threads=96, grouping=16, minblocks=12) , # 263.151 GFlop/s
-  Kernel_dnt_largeDB(m=64, n=9, k=22, tile_m=2, tile_n=3, w=6, v=4, threads=96, grouping=16, minblocks=12) , # 286.988 GFlop/s
-  Kernel_dnt_largeDB(m=64, n=9, k=64, tile_m=2, tile_n=3, w=10, v=8, threads=128, grouping=16, minblocks=8) , # 319.492 GFlop/s
-  Kernel_dnt_largeDB(m=64, n=16, k=9, tile_m=2, tile_n=4, w=4, v=10, threads=128, grouping=16, minblocks=8) , # 283.571 GFlop/s
-  Kernel_dnt_largeDB(m=64, n=16, k=16, tile_m=2, tile_n=4, w=8, v=10, threads=128, grouping=16, minblocks=8) , # 379.404 GFlop/s
-  Kernel_dnt_largeDB(m=64, n=16, k=22, tile_m=2, tile_n=4, w=8, v=8, threads=128, grouping=16, minblocks=8) , # 408.89 GFlop/s
-  Kernel_dnt_largeDB(m=64, n=16, k=64, tile_m=2, tile_n=4, w=8, v=10, threads=128, grouping=16, minblocks=8) , # 501.245 GFlop/s
-  Kernel_dnt_largeDB(m=64, n=22, k=9, tile_m=6, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=1) , # 271.107 GFlop/s
-  Kernel_dnt_largeDB(m=64, n=22, k=16, tile_m=2, tile_n=6, w=8, v=14, threads=128, grouping=16, minblocks=1) , # 369.789 GFlop/s
-  Kernel_dnt_largeDB(m=64, n=22, k=22, tile_m=6, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=4) , # 383.088 GFlop/s
-  Kernel_dnt_largeDB(m=64, n=22, k=64, tile_m=2, tile_n=6, w=8, v=2, threads=128, grouping=16, minblocks=4) , # 507.361 GFlop/s
-  Kernel_dnt_largeDB(m=64, n=64, k=9, tile_m=4, tile_n=4, w=4, v=16, threads=256, grouping=16, minblocks=1) , # 271.502 GFlop/s
-  Kernel_dnt_largeDB(m=64, n=64, k=16, tile_m=4, tile_n=4, w=6, v=16, threads=256, grouping=16, minblocks=1) , # 363.539 GFlop/s
-  Kernel_dnt_largeDB(m=64, n=64, k=22, tile_m=4, tile_n=4, w=8, v=16, threads=256, grouping=16, minblocks=1) , # 410.791 GFlop/s
-  Kernel_dnt_largeDB(m=64, n=64, k=64, tile_m=3, tile_n=6, w=16, v=32, threads=256, grouping=16, minblocks=1) , # 563.614 GFlop/s
-  Kernel_dnt_largeDB(m=78, n=78, k=78, tile_m=5, tile_n=5, w=8, v=26, threads=256, grouping=16, minblocks=1) , # 589.26 GFlop/s
-  Kernel_dnt_largeDB(m=81, n=9, k=9, tile_m=3, tile_n=3, w=4, v=6, threads=128, grouping=16, minblocks=8) , # 189.642 GFlop/s
-  Kernel_dnt_largeDB(m=96, n=96, k=96, tile_m=6, tile_n=3, w=14, v=48, threads=512, grouping=16, minblocks=1) , # 614.588 GFlop/s
+  Kernel_dnt_largeDB1(m=64, n=9, k=16, tile_m=2, tile_n=3, w=4, v=6, threads=96, grouping=16, minblocks=12) , # 263.151 GFlop/s
+  Kernel_dnt_largeDB1(m=64, n=9, k=22, tile_m=2, tile_n=3, w=6, v=4, threads=96, grouping=16, minblocks=12) , # 286.988 GFlop/s
+  Kernel_dnt_largeDB1(m=64, n=9, k=64, tile_m=2, tile_n=3, w=10, v=8, threads=128, grouping=16, minblocks=8) , # 319.492 GFlop/s
+  Kernel_dnt_largeDB1(m=64, n=16, k=9, tile_m=2, tile_n=4, w=4, v=10, threads=128, grouping=16, minblocks=8) , # 283.571 GFlop/s
+  Kernel_dnt_largeDB1(m=64, n=16, k=16, tile_m=2, tile_n=4, w=8, v=10, threads=128, grouping=16, minblocks=8) , # 379.404 GFlop/s
+  Kernel_dnt_largeDB1(m=64, n=16, k=22, tile_m=2, tile_n=4, w=8, v=8, threads=128, grouping=16, minblocks=8) , # 408.89 GFlop/s
+  Kernel_dnt_largeDB1(m=64, n=16, k=64, tile_m=2, tile_n=4, w=8, v=10, threads=128, grouping=16, minblocks=8) , # 501.245 GFlop/s
+  Kernel_dnt_largeDB1(m=64, n=22, k=9, tile_m=6, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=1) , # 271.107 GFlop/s
+  Kernel_dnt_largeDB1(m=64, n=22, k=16, tile_m=2, tile_n=6, w=8, v=14, threads=128, grouping=16, minblocks=1) , # 369.789 GFlop/s
+  Kernel_dnt_largeDB1(m=64, n=22, k=22, tile_m=6, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=4) , # 383.088 GFlop/s
+  Kernel_dnt_largeDB1(m=64, n=22, k=64, tile_m=2, tile_n=6, w=8, v=2, threads=128, grouping=16, minblocks=4) , # 507.361 GFlop/s
+  Kernel_dnt_largeDB1(m=64, n=64, k=9, tile_m=4, tile_n=4, w=4, v=16, threads=256, grouping=16, minblocks=1) , # 271.502 GFlop/s
+  Kernel_dnt_largeDB1(m=64, n=64, k=16, tile_m=4, tile_n=4, w=6, v=16, threads=256, grouping=16, minblocks=1) , # 363.539 GFlop/s
+  Kernel_dnt_largeDB1(m=64, n=64, k=22, tile_m=4, tile_n=4, w=8, v=16, threads=256, grouping=16, minblocks=1) , # 410.791 GFlop/s
+  Kernel_dnt_largeDB1(m=64, n=64, k=64, tile_m=3, tile_n=6, w=16, v=32, threads=256, grouping=16, minblocks=1) , # 563.614 GFlop/s
+  Kernel_dnt_largeDB1(m=78, n=78, k=78, tile_m=5, tile_n=5, w=8, v=26, threads=256, grouping=16, minblocks=1) , # 589.26 GFlop/s
+  Kernel_dnt_largeDB1(m=81, n=9, k=9, tile_m=3, tile_n=3, w=4, v=6, threads=128, grouping=16, minblocks=8) , # 189.642 GFlop/s
+  Kernel_dnt_largeDB1(m=96, n=96, k=96, tile_m=6, tile_n=3, w=14, v=48, threads=512, grouping=16, minblocks=1) , # 614.588 GFlop/s
   Kernel_dnt_medium(m=100, n=10, k=10, tile_m=2, tile_n=2, threads=256, grouping=16, minblocks=4) , # 226.917 GFlop/s
   Kernel_dnt_medium(m=121, n=11, k=11, tile_m=5, tile_n=3, threads=128, grouping=16, minblocks=1) , # 233.211 GFlop/s
-  Kernel_dnt_largeDB(m=144, n=12, k=12, tile_m=2, tile_n=4, w=6, v=8, threads=288, grouping=16, minblocks=4) , # 268.209 GFlop/s
-  Kernel_dnt_largeDB(m=169, n=13, k=13, tile_m=3, tile_n=4, w=6, v=10, threads=256, grouping=16, minblocks=1) , # 221.427 GFlop/s
+  Kernel_dnt_largeDB1(m=144, n=12, k=12, tile_m=2, tile_n=4, w=6, v=8, threads=288, grouping=16, minblocks=4) , # 268.209 GFlop/s
+  Kernel_dnt_largeDB1(m=169, n=13, k=13, tile_m=3, tile_n=4, w=6, v=10, threads=256, grouping=16, minblocks=1) , # 221.427 GFlop/s
   Kernel_dnt_medium(m=196, n=14, k=14, tile_m=6, tile_n=2, threads=256, grouping=16, minblocks=1) , # 243.838 GFlop/s
-  Kernel_dnt_largeDB(m=225, n=15, k=15, tile_m=3, tile_n=3, w=4, v=12, threads=384, grouping=16, minblocks=1) , # 248.307 GFlop/s
-  Kernel_dnt_largeDB(m=256, n=16, k=16, tile_m=2, tile_n=6, w=6, v=10, threads=384, grouping=16, minblocks=1) , # 309.19 GFlop/s
+  Kernel_dnt_largeDB1(m=225, n=15, k=15, tile_m=3, tile_n=3, w=4, v=12, threads=384, grouping=16, minblocks=1) , # 248.307 GFlop/s
+  Kernel_dnt_largeDB1(m=256, n=16, k=16, tile_m=2, tile_n=6, w=6, v=10, threads=384, grouping=16, minblocks=1) , # 309.19 GFlop/s
 ]
 
 #EOF

--- a/src/acc/libsmm_acc/libcusmm/parameters_K20X.txt
+++ b/src/acc/libsmm_acc/libcusmm/parameters_K20X.txt
@@ -4,71 +4,71 @@
 # *****************************************************************************
 
 [
-  Kernel_dnt_tiny(m=4, n=4, k=4, split_thread=32, threads=64, grouping=16, minblocks=1) , # 16.5663 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=5, split_thread=32, threads=64, grouping=16, minblocks=1) , # 20.1639 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=6, split_thread=32, threads=64, grouping=16, minblocks=1) , # 23.5514 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=7, split_thread=32, threads=64, grouping=16, minblocks=1) , # 27.508 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=8, split_thread=32, threads=128, grouping=16, minblocks=1) , # 31.7227 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=9, split_thread=32, threads=128, grouping=16, minblocks=1) , # 34.2669 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=10, split_thread=32, threads=128, grouping=16, minblocks=1) , # 37.6563 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=13, split_thread=32, threads=128, grouping=16, minblocks=1) , # 45.9102 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=15, split_thread=32, threads=128, grouping=16, minblocks=1) , # 51.3947 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=16, split_thread=32, threads=128, grouping=16, minblocks=1) , # 54.8645 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=17, split_thread=32, threads=128, grouping=16, minblocks=1) , # 54.3192 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=22, split_thread=32, threads=128, grouping=16, minblocks=1) , # 62.9255 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=23, split_thread=32, threads=128, grouping=16, minblocks=1) , # 60.6683 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=24, split_thread=32, threads=128, grouping=16, minblocks=1) , # 62.8983 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=25, split_thread=32, threads=96, grouping=16, minblocks=1) , # 50.8246 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=26, split_thread=32, threads=96, grouping=16, minblocks=1) , # 53.309 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=28, split_thread=32, threads=96, grouping=16, minblocks=1) , # 54.7759 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=32, split_thread=32, threads=128, grouping=16, minblocks=1) , # 58.5147 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=45, split_thread=32, threads=128, grouping=16, minblocks=1) , # 55.094 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 14.9148 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=5, split_thread=32, threads=128, grouping=16, minblocks=1) , # 18.1077 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=6, split_thread=32, threads=96, grouping=16, minblocks=1) , # 21.2783 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=7, split_thread=32, threads=128, grouping=16, minblocks=1) , # 25.2832 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=8, split_thread=32, threads=96, grouping=16, minblocks=1) , # 29.5849 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=9, split_thread=32, threads=128, grouping=16, minblocks=1) , # 30.8254 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=13, split_thread=32, threads=128, grouping=16, minblocks=1) , # 42.687 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=16, split_thread=32, threads=128, grouping=16, minblocks=1) , # 52.9062 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=17, split_thread=32, threads=128, grouping=16, minblocks=1) , # 51.922 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=22, split_thread=32, threads=128, grouping=16, minblocks=1) , # 48.5357 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=23, split_thread=32, threads=128, grouping=16, minblocks=1) , # 50.2012 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=24, split_thread=32, threads=128, grouping=16, minblocks=1) , # 50.9804 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=25, split_thread=32, threads=128, grouping=16, minblocks=1) , # 45.0794 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=26, split_thread=32, threads=128, grouping=16, minblocks=1) , # 46.9644 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=28, split_thread=32, threads=128, grouping=16, minblocks=1) , # 44.74 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=32, split_thread=32, threads=128, grouping=16, minblocks=1) , # 47.0079 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=45, split_thread=32, threads=128, grouping=16, minblocks=1) , # 39.578 GFlop/s
-  Kernel_dnt_tiny(m=4, n=6, k=4, split_thread=32, threads=96, grouping=16, minblocks=1) , # 17.7217 GFlop/s
-  Kernel_dnt_tiny(m=4, n=6, k=5, split_thread=32, threads=96, grouping=16, minblocks=1) , # 21.2885 GFlop/s
-  Kernel_dnt_tiny(m=4, n=6, k=6, split_thread=32, threads=96, grouping=16, minblocks=1) , # 26.0691 GFlop/s
-  Kernel_dnt_tiny(m=4, n=6, k=8, split_thread=32, threads=96, grouping=16, minblocks=1) , # 35.3897 GFlop/s
-  Kernel_dnt_tiny(m=4, n=6, k=9, split_thread=32, threads=128, grouping=16, minblocks=1) , # 36.1752 GFlop/s
-  Kernel_dnt_tiny(m=4, n=6, k=13, split_thread=32, threads=128, grouping=16, minblocks=1) , # 50.7414 GFlop/s
-  Kernel_dnt_tiny(m=4, n=6, k=16, split_thread=32, threads=128, grouping=16, minblocks=1) , # 62.3605 GFlop/s
-  Kernel_dnt_tiny(m=4, n=6, k=17, split_thread=32, threads=128, grouping=16, minblocks=1) , # 52.168 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=4, threads=64, grouping=16, minblocks=1) , # 16.5663 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=5, threads=64, grouping=16, minblocks=1) , # 20.1639 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=6, threads=64, grouping=16, minblocks=1) , # 23.5514 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=7, threads=64, grouping=16, minblocks=1) , # 27.508 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=8, threads=128, grouping=16, minblocks=1) , # 31.7227 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=9, threads=128, grouping=16, minblocks=1) , # 34.2669 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=10, threads=128, grouping=16, minblocks=1) , # 37.6563 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=13, threads=128, grouping=16, minblocks=1) , # 45.9102 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=15, threads=128, grouping=16, minblocks=1) , # 51.3947 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=16, threads=128, grouping=16, minblocks=1) , # 54.8645 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=17, threads=128, grouping=16, minblocks=1) , # 54.3192 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=22, threads=128, grouping=16, minblocks=1) , # 62.9255 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=23, threads=128, grouping=16, minblocks=1) , # 60.6683 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=24, threads=128, grouping=16, minblocks=1) , # 62.8983 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=25, threads=96, grouping=16, minblocks=1) , # 50.8246 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=26, threads=96, grouping=16, minblocks=1) , # 53.309 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=28, threads=96, grouping=16, minblocks=1) , # 54.7759 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=32, threads=128, grouping=16, minblocks=1) , # 58.5147 GFlop/s
+  Kernel_dnt_tiny(m=4, n=4, k=45, threads=128, grouping=16, minblocks=1) , # 55.094 GFlop/s
+  Kernel_dnt_tiny(m=4, n=5, k=4, threads=128, grouping=16, minblocks=1) , # 14.9148 GFlop/s
+  Kernel_dnt_tiny(m=4, n=5, k=5, threads=128, grouping=16, minblocks=1) , # 18.1077 GFlop/s
+  Kernel_dnt_tiny(m=4, n=5, k=6, threads=96, grouping=16, minblocks=1) , # 21.2783 GFlop/s
+  Kernel_dnt_tiny(m=4, n=5, k=7, threads=128, grouping=16, minblocks=1) , # 25.2832 GFlop/s
+  Kernel_dnt_tiny(m=4, n=5, k=8, threads=96, grouping=16, minblocks=1) , # 29.5849 GFlop/s
+  Kernel_dnt_tiny(m=4, n=5, k=9, threads=128, grouping=16, minblocks=1) , # 30.8254 GFlop/s
+  Kernel_dnt_tiny(m=4, n=5, k=13, threads=128, grouping=16, minblocks=1) , # 42.687 GFlop/s
+  Kernel_dnt_tiny(m=4, n=5, k=16, threads=128, grouping=16, minblocks=1) , # 52.9062 GFlop/s
+  Kernel_dnt_tiny(m=4, n=5, k=17, threads=128, grouping=16, minblocks=1) , # 51.922 GFlop/s
+  Kernel_dnt_tiny(m=4, n=5, k=22, threads=128, grouping=16, minblocks=1) , # 48.5357 GFlop/s
+  Kernel_dnt_tiny(m=4, n=5, k=23, threads=128, grouping=16, minblocks=1) , # 50.2012 GFlop/s
+  Kernel_dnt_tiny(m=4, n=5, k=24, threads=128, grouping=16, minblocks=1) , # 50.9804 GFlop/s
+  Kernel_dnt_tiny(m=4, n=5, k=25, threads=128, grouping=16, minblocks=1) , # 45.0794 GFlop/s
+  Kernel_dnt_tiny(m=4, n=5, k=26, threads=128, grouping=16, minblocks=1) , # 46.9644 GFlop/s
+  Kernel_dnt_tiny(m=4, n=5, k=28, threads=128, grouping=16, minblocks=1) , # 44.74 GFlop/s
+  Kernel_dnt_tiny(m=4, n=5, k=32, threads=128, grouping=16, minblocks=1) , # 47.0079 GFlop/s
+  Kernel_dnt_tiny(m=4, n=5, k=45, threads=128, grouping=16, minblocks=1) , # 39.578 GFlop/s
+  Kernel_dnt_tiny(m=4, n=6, k=4, threads=96, grouping=16, minblocks=1) , # 17.7217 GFlop/s
+  Kernel_dnt_tiny(m=4, n=6, k=5, threads=96, grouping=16, minblocks=1) , # 21.2885 GFlop/s
+  Kernel_dnt_tiny(m=4, n=6, k=6, threads=96, grouping=16, minblocks=1) , # 26.0691 GFlop/s
+  Kernel_dnt_tiny(m=4, n=6, k=8, threads=96, grouping=16, minblocks=1) , # 35.3897 GFlop/s
+  Kernel_dnt_tiny(m=4, n=6, k=9, threads=128, grouping=16, minblocks=1) , # 36.1752 GFlop/s
+  Kernel_dnt_tiny(m=4, n=6, k=13, threads=128, grouping=16, minblocks=1) , # 50.7414 GFlop/s
+  Kernel_dnt_tiny(m=4, n=6, k=16, threads=128, grouping=16, minblocks=1) , # 62.3605 GFlop/s
+  Kernel_dnt_tiny(m=4, n=6, k=17, threads=128, grouping=16, minblocks=1) , # 52.168 GFlop/s
   Kernel_dnt_medium(m=4, n=6, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 61.4407 GFlop/s
   Kernel_dnt_medium(m=4, n=6, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 63.1415 GFlop/s
-  Kernel_dnt_tiny(m=4, n=6, k=24, split_thread=32, threads=128, grouping=16, minblocks=1) , # 59.2859 GFlop/s
+  Kernel_dnt_tiny(m=4, n=6, k=24, threads=128, grouping=16, minblocks=1) , # 59.2859 GFlop/s
   Kernel_dnt_medium(m=4, n=6, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 63.6068 GFlop/s
   Kernel_dnt_largeDB1(m=4, n=6, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=96, grouping=16, minblocks=1) , # 66.9879 GFlop/s
-  Kernel_dnt_tiny(m=4, n=7, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 20.3949 GFlop/s
-  Kernel_dnt_tiny(m=4, n=7, k=5, split_thread=32, threads=128, grouping=16, minblocks=1) , # 25.5066 GFlop/s
-  Kernel_dnt_tiny(m=4, n=7, k=7, split_thread=32, threads=128, grouping=16, minblocks=1) , # 34.4269 GFlop/s
-  Kernel_dnt_tiny(m=4, n=7, k=9, split_thread=32, threads=128, grouping=16, minblocks=1) , # 41.6453 GFlop/s
-  Kernel_dnt_tiny(m=4, n=7, k=13, split_thread=32, threads=128, grouping=16, minblocks=1) , # 57.6433 GFlop/s
+  Kernel_dnt_tiny(m=4, n=7, k=4, threads=128, grouping=16, minblocks=1) , # 20.3949 GFlop/s
+  Kernel_dnt_tiny(m=4, n=7, k=5, threads=128, grouping=16, minblocks=1) , # 25.5066 GFlop/s
+  Kernel_dnt_tiny(m=4, n=7, k=7, threads=128, grouping=16, minblocks=1) , # 34.4269 GFlop/s
+  Kernel_dnt_tiny(m=4, n=7, k=9, threads=128, grouping=16, minblocks=1) , # 41.6453 GFlop/s
+  Kernel_dnt_tiny(m=4, n=7, k=13, threads=128, grouping=16, minblocks=1) , # 57.6433 GFlop/s
   Kernel_dnt_largeDB2(m=4, n=7, k=25, tile_m=1, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=8) , # 70.7435 GFlop/s
   Kernel_dnt_largeDB2(m=4, n=7, k=26, tile_m=1, tile_n=1, w=12, v=6, threads=96, grouping=16, minblocks=4) , # 72.8932 GFlop/s
   Kernel_dnt_largeDB2(m=4, n=7, k=28, tile_m=1, tile_n=1, w=14, v=4, threads=96, grouping=16, minblocks=4) , # 81.1008 GFlop/s
   Kernel_dnt_largeDB2(m=4, n=7, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=4) , # 87.9914 GFlop/s
   Kernel_dnt_largeDB2(m=4, n=7, k=45, tile_m=1, tile_n=1, w=18, v=4, threads=96, grouping=16, minblocks=1) , # 89.4636 GFlop/s
-  Kernel_dnt_tiny(m=4, n=8, k=4, split_thread=32, threads=96, grouping=16, minblocks=1) , # 24.016 GFlop/s
-  Kernel_dnt_tiny(m=4, n=8, k=5, split_thread=32, threads=96, grouping=16, minblocks=1) , # 28.6828 GFlop/s
-  Kernel_dnt_tiny(m=4, n=8, k=6, split_thread=32, threads=96, grouping=16, minblocks=1) , # 34.4605 GFlop/s
-  Kernel_dnt_tiny(m=4, n=8, k=8, split_thread=32, threads=96, grouping=16, minblocks=1) , # 45.9955 GFlop/s
-  Kernel_dnt_tiny(m=4, n=8, k=9, split_thread=32, threads=128, grouping=16, minblocks=1) , # 48.4776 GFlop/s
-  Kernel_dnt_tiny(m=4, n=8, k=13, split_thread=32, threads=128, grouping=16, minblocks=1) , # 54.9661 GFlop/s
+  Kernel_dnt_tiny(m=4, n=8, k=4, threads=96, grouping=16, minblocks=1) , # 24.016 GFlop/s
+  Kernel_dnt_tiny(m=4, n=8, k=5, threads=96, grouping=16, minblocks=1) , # 28.6828 GFlop/s
+  Kernel_dnt_tiny(m=4, n=8, k=6, threads=96, grouping=16, minblocks=1) , # 34.4605 GFlop/s
+  Kernel_dnt_tiny(m=4, n=8, k=8, threads=96, grouping=16, minblocks=1) , # 45.9955 GFlop/s
+  Kernel_dnt_tiny(m=4, n=8, k=9, threads=128, grouping=16, minblocks=1) , # 48.4776 GFlop/s
+  Kernel_dnt_tiny(m=4, n=8, k=13, threads=128, grouping=16, minblocks=1) , # 54.9661 GFlop/s
   Kernel_dnt_medium(m=4, n=8, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 64.3579 GFlop/s
   Kernel_dnt_medium(m=4, n=8, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 67.3422 GFlop/s
   Kernel_dnt_medium(m=4, n=8, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 80.9386 GFlop/s
@@ -118,7 +118,7 @@
   Kernel_dnt_medium(m=4, n=15, k=15, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 100.748 GFlop/s
   Kernel_dnt_medium(m=4, n=16, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 43.4494 GFlop/s
   Kernel_dnt_medium(m=4, n=16, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 53.0611 GFlop/s
-  Kernel_dnt_tiny(m=4, n=16, k=6, split_thread=32, threads=128, grouping=16, minblocks=1) , # 56.7665 GFlop/s
+  Kernel_dnt_tiny(m=4, n=16, k=6, threads=128, grouping=16, minblocks=1) , # 56.7665 GFlop/s
   Kernel_dnt_medium(m=4, n=16, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 71.163 GFlop/s
   Kernel_dnt_medium(m=4, n=16, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 75.903 GFlop/s
   Kernel_dnt_medium(m=4, n=16, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 101.297 GFlop/s
@@ -168,7 +168,7 @@
   Kernel_dnt_largeDB1(m=4, n=23, k=24, tile_m=1, tile_n=1, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 119.172 GFlop/s
   Kernel_dnt_medium(m=4, n=23, k=26, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 119.54 GFlop/s
   Kernel_dnt_largeDB1(m=4, n=23, k=32, tile_m=1, tile_n=1, w=8, v=20, threads=96, grouping=16, minblocks=4) , # 127.587 GFlop/s
-  Kernel_dnt_tiny(m=4, n=24, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 58.0271 GFlop/s
+  Kernel_dnt_tiny(m=4, n=24, k=4, threads=128, grouping=16, minblocks=1) , # 58.0271 GFlop/s
   Kernel_dnt_medium(m=4, n=24, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 67.3989 GFlop/s
   Kernel_dnt_medium(m=4, n=24, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 78.5843 GFlop/s
   Kernel_dnt_medium(m=4, n=24, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 90.4024 GFlop/s
@@ -192,7 +192,7 @@
   Kernel_dnt_largeDB2(m=4, n=25, k=32, tile_m=2, tile_n=1, w=16, v=24, threads=96, grouping=16, minblocks=1) , # 139.761 GFlop/s
   Kernel_dnt_largeDB2(m=4, n=25, k=45, tile_m=2, tile_n=1, w=16, v=24, threads=96, grouping=16, minblocks=8) , # 140.077 GFlop/s
   Kernel_dnt_largeDB2(m=4, n=26, k=4, tile_m=1, tile_n=1, w=2, v=26, threads=128, grouping=16, minblocks=1) , # 63.4377 GFlop/s
-  Kernel_dnt_tiny(m=4, n=26, k=5, split_thread=32, threads=128, grouping=16, minblocks=1) , # 61.4438 GFlop/s
+  Kernel_dnt_tiny(m=4, n=26, k=5, threads=128, grouping=16, minblocks=1) , # 61.4438 GFlop/s
   Kernel_dnt_medium(m=4, n=26, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 71.391 GFlop/s
   Kernel_dnt_medium(m=4, n=26, k=7, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 81.5028 GFlop/s
   Kernel_dnt_medium(m=4, n=26, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 87.1416 GFlop/s
@@ -209,7 +209,7 @@
   Kernel_dnt_largeDB2(m=4, n=26, k=32, tile_m=2, tile_n=1, w=16, v=24, threads=96, grouping=16, minblocks=8) , # 141.257 GFlop/s
   Kernel_dnt_largeDB2(m=4, n=26, k=45, tile_m=2, tile_n=1, w=16, v=14, threads=96, grouping=16, minblocks=8) , # 140.164 GFlop/s
   Kernel_dnt_largeDB2(m=4, n=28, k=4, tile_m=1, tile_n=1, w=2, v=28, threads=128, grouping=16, minblocks=4) , # 68.2828 GFlop/s
-  Kernel_dnt_tiny(m=4, n=28, k=5, split_thread=32, threads=128, grouping=16, minblocks=1) , # 65.6686 GFlop/s
+  Kernel_dnt_tiny(m=4, n=28, k=5, threads=128, grouping=16, minblocks=1) , # 65.6686 GFlop/s
   Kernel_dnt_medium(m=4, n=28, k=7, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 83.3092 GFlop/s
   Kernel_dnt_medium(m=4, n=28, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 100.922 GFlop/s
   Kernel_dnt_medium(m=4, n=28, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 123.15 GFlop/s
@@ -219,7 +219,7 @@
   Kernel_dnt_largeDB2(m=4, n=28, k=32, tile_m=1, tile_n=1, w=16, v=28, threads=128, grouping=16, minblocks=12) , # 141.483 GFlop/s
   Kernel_dnt_largeDB2(m=4, n=28, k=45, tile_m=1, tile_n=1, w=12, v=24, threads=128, grouping=16, minblocks=12) , # 142.643 GFlop/s
   Kernel_dnt_largeDB2(m=4, n=32, k=4, tile_m=1, tile_n=1, w=2, v=32, threads=128, grouping=16, minblocks=4) , # 78.1248 GFlop/s
-  Kernel_dnt_tiny(m=4, n=32, k=5, split_thread=32, threads=128, grouping=16, minblocks=1) , # 74.5054 GFlop/s
+  Kernel_dnt_tiny(m=4, n=32, k=5, threads=128, grouping=16, minblocks=1) , # 74.5054 GFlop/s
   Kernel_dnt_medium(m=4, n=32, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 85.0733 GFlop/s
   Kernel_dnt_medium(m=4, n=32, k=7, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 94.5942 GFlop/s
   Kernel_dnt_largeDB1(m=4, n=32, k=8, tile_m=1, tile_n=1, w=4, v=32, threads=128, grouping=16, minblocks=8) , # 101.579 GFlop/s
@@ -245,30 +245,30 @@
   Kernel_dnt_largeDB2(m=4, n=45, k=28, tile_m=2, tile_n=1, w=14, v=32, threads=128, grouping=16, minblocks=1) , # 147.358 GFlop/s
   Kernel_dnt_largeDB2(m=4, n=45, k=32, tile_m=2, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 150.112 GFlop/s
   Kernel_dnt_largeDB2(m=4, n=45, k=45, tile_m=1, tile_n=1, w=12, v=26, threads=192, grouping=16, minblocks=8) , # 150.749 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 14.8425 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=5, split_thread=32, threads=128, grouping=16, minblocks=1) , # 17.8923 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=6, split_thread=32, threads=96, grouping=16, minblocks=1) , # 20.6833 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=7, split_thread=32, threads=128, grouping=16, minblocks=1) , # 25.0033 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=8, split_thread=32, threads=96, grouping=16, minblocks=1) , # 28.7395 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=9, split_thread=32, threads=96, grouping=16, minblocks=1) , # 30.3363 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=13, split_thread=32, threads=96, grouping=16, minblocks=1) , # 35.8017 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=16, split_thread=32, threads=96, grouping=16, minblocks=1) , # 35.9461 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=17, split_thread=32, threads=128, grouping=16, minblocks=1) , # 34.9185 GFlop/s
+  Kernel_dnt_tiny(m=5, n=4, k=4, threads=128, grouping=16, minblocks=1) , # 14.8425 GFlop/s
+  Kernel_dnt_tiny(m=5, n=4, k=5, threads=128, grouping=16, minblocks=1) , # 17.8923 GFlop/s
+  Kernel_dnt_tiny(m=5, n=4, k=6, threads=96, grouping=16, minblocks=1) , # 20.6833 GFlop/s
+  Kernel_dnt_tiny(m=5, n=4, k=7, threads=128, grouping=16, minblocks=1) , # 25.0033 GFlop/s
+  Kernel_dnt_tiny(m=5, n=4, k=8, threads=96, grouping=16, minblocks=1) , # 28.7395 GFlop/s
+  Kernel_dnt_tiny(m=5, n=4, k=9, threads=96, grouping=16, minblocks=1) , # 30.3363 GFlop/s
+  Kernel_dnt_tiny(m=5, n=4, k=13, threads=96, grouping=16, minblocks=1) , # 35.8017 GFlop/s
+  Kernel_dnt_tiny(m=5, n=4, k=16, threads=96, grouping=16, minblocks=1) , # 35.9461 GFlop/s
+  Kernel_dnt_tiny(m=5, n=4, k=17, threads=128, grouping=16, minblocks=1) , # 34.9185 GFlop/s
   Kernel_dnt_small(m=5, n=4, k=22, tile_m=1, tile_n=1, threads=64, grouping=16, minblocks=1) , # 37.0424 GFlop/s
   Kernel_dnt_small(m=5, n=4, k=23, tile_m=1, tile_n=1, threads=64, grouping=16, minblocks=4) , # 37.32 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=24, split_thread=32, threads=128, grouping=16, minblocks=1) , # 50.5776 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=25, split_thread=32, threads=96, grouping=16, minblocks=1) , # 42.9798 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=26, split_thread=32, threads=128, grouping=16, minblocks=1) , # 46.6834 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=28, split_thread=32, threads=128, grouping=16, minblocks=1) , # 44.9266 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=32, split_thread=32, threads=128, grouping=16, minblocks=1) , # 46.7652 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=45, split_thread=32, threads=128, grouping=16, minblocks=1) , # 39.2713 GFlop/s
-  Kernel_dnt_tiny(m=5, n=5, k=4, split_thread=32, threads=64, grouping=16, minblocks=1) , # 23.8033 GFlop/s
-  Kernel_dnt_tiny(m=5, n=5, k=5, split_thread=32, threads=64, grouping=16, minblocks=1) , # 29.5496 GFlop/s
-  Kernel_dnt_tiny(m=5, n=5, k=6, split_thread=32, threads=64, grouping=16, minblocks=1) , # 33.673 GFlop/s
-  Kernel_dnt_tiny(m=5, n=5, k=7, split_thread=32, threads=96, grouping=16, minblocks=1) , # 39.8149 GFlop/s
-  Kernel_dnt_tiny(m=5, n=5, k=8, split_thread=32, threads=96, grouping=16, minblocks=1) , # 37.8978 GFlop/s
-  Kernel_dnt_tiny(m=5, n=5, k=9, split_thread=32, threads=96, grouping=16, minblocks=1) , # 48.7651 GFlop/s
-  Kernel_dnt_tiny(m=5, n=5, k=13, split_thread=32, threads=128, grouping=16, minblocks=1) , # 55.6173 GFlop/s
+  Kernel_dnt_tiny(m=5, n=4, k=24, threads=128, grouping=16, minblocks=1) , # 50.5776 GFlop/s
+  Kernel_dnt_tiny(m=5, n=4, k=25, threads=96, grouping=16, minblocks=1) , # 42.9798 GFlop/s
+  Kernel_dnt_tiny(m=5, n=4, k=26, threads=128, grouping=16, minblocks=1) , # 46.6834 GFlop/s
+  Kernel_dnt_tiny(m=5, n=4, k=28, threads=128, grouping=16, minblocks=1) , # 44.9266 GFlop/s
+  Kernel_dnt_tiny(m=5, n=4, k=32, threads=128, grouping=16, minblocks=1) , # 46.7652 GFlop/s
+  Kernel_dnt_tiny(m=5, n=4, k=45, threads=128, grouping=16, minblocks=1) , # 39.2713 GFlop/s
+  Kernel_dnt_tiny(m=5, n=5, k=4, threads=64, grouping=16, minblocks=1) , # 23.8033 GFlop/s
+  Kernel_dnt_tiny(m=5, n=5, k=5, threads=64, grouping=16, minblocks=1) , # 29.5496 GFlop/s
+  Kernel_dnt_tiny(m=5, n=5, k=6, threads=64, grouping=16, minblocks=1) , # 33.673 GFlop/s
+  Kernel_dnt_tiny(m=5, n=5, k=7, threads=96, grouping=16, minblocks=1) , # 39.8149 GFlop/s
+  Kernel_dnt_tiny(m=5, n=5, k=8, threads=96, grouping=16, minblocks=1) , # 37.8978 GFlop/s
+  Kernel_dnt_tiny(m=5, n=5, k=9, threads=96, grouping=16, minblocks=1) , # 48.7651 GFlop/s
+  Kernel_dnt_tiny(m=5, n=5, k=13, threads=128, grouping=16, minblocks=1) , # 55.6173 GFlop/s
   Kernel_dnt_small(m=5, n=5, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 58.79 GFlop/s
   Kernel_dnt_small(m=5, n=5, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 60.0103 GFlop/s
   Kernel_dnt_medium(m=5, n=5, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 64.9733 GFlop/s
@@ -279,10 +279,10 @@
   Kernel_dnt_largeDB2(m=5, n=5, k=28, tile_m=1, tile_n=1, w=14, v=4, threads=96, grouping=16, minblocks=4) , # 78.9513 GFlop/s
   Kernel_dnt_largeDB2(m=5, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=1) , # 85.3813 GFlop/s
   Kernel_dnt_largeDB2(m=5, n=5, k=45, tile_m=1, tile_n=1, w=18, v=4, threads=96, grouping=16, minblocks=1) , # 85.4611 GFlop/s
-  Kernel_dnt_tiny(m=5, n=6, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 20.9988 GFlop/s
-  Kernel_dnt_tiny(m=5, n=6, k=5, split_thread=32, threads=96, grouping=16, minblocks=1) , # 25.4954 GFlop/s
-  Kernel_dnt_tiny(m=5, n=6, k=6, split_thread=32, threads=96, grouping=16, minblocks=1) , # 31.0513 GFlop/s
-  Kernel_dnt_tiny(m=5, n=6, k=8, split_thread=32, threads=96, grouping=16, minblocks=1) , # 39.6543 GFlop/s
+  Kernel_dnt_tiny(m=5, n=6, k=4, threads=128, grouping=16, minblocks=1) , # 20.9988 GFlop/s
+  Kernel_dnt_tiny(m=5, n=6, k=5, threads=96, grouping=16, minblocks=1) , # 25.4954 GFlop/s
+  Kernel_dnt_tiny(m=5, n=6, k=6, threads=96, grouping=16, minblocks=1) , # 31.0513 GFlop/s
+  Kernel_dnt_tiny(m=5, n=6, k=8, threads=96, grouping=16, minblocks=1) , # 39.6543 GFlop/s
   Kernel_dnt_small(m=5, n=6, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 37.5652 GFlop/s
   Kernel_dnt_medium(m=5, n=6, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 49.3659 GFlop/s
   Kernel_dnt_small(m=5, n=6, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 58.1624 GFlop/s
@@ -305,7 +305,7 @@
   Kernel_dnt_medium(m=5, n=8, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 27.2512 GFlop/s
   Kernel_dnt_medium(m=5, n=8, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 32.9231 GFlop/s
   Kernel_dnt_medium(m=5, n=8, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 39.1691 GFlop/s
-  Kernel_dnt_tiny(m=5, n=8, k=8, split_thread=32, threads=96, grouping=16, minblocks=1) , # 47.0366 GFlop/s
+  Kernel_dnt_tiny(m=5, n=8, k=8, threads=96, grouping=16, minblocks=1) , # 47.0366 GFlop/s
   Kernel_dnt_small(m=5, n=8, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 48.3135 GFlop/s
   Kernel_dnt_small(m=5, n=8, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 59.2125 GFlop/s
   Kernel_dnt_small(m=5, n=8, k=16, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 67.8873 GFlop/s
@@ -375,7 +375,7 @@
   Kernel_dnt_largeDB1(m=5, n=17, k=24, tile_m=1, tile_n=1, w=12, v=14, threads=128, grouping=16, minblocks=12) , # 128.46 GFlop/s
   Kernel_dnt_medium(m=5, n=17, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=4) , # 132.131 GFlop/s
   Kernel_dnt_largeDB1(m=5, n=17, k=32, tile_m=1, tile_n=1, w=14, v=6, threads=128, grouping=16, minblocks=12) , # 135.01 GFlop/s
-  Kernel_dnt_tiny(m=5, n=22, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 64.6247 GFlop/s
+  Kernel_dnt_tiny(m=5, n=22, k=4, threads=128, grouping=16, minblocks=1) , # 64.6247 GFlop/s
   Kernel_dnt_small(m=5, n=22, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 71.6059 GFlop/s
   Kernel_dnt_medium(m=5, n=22, k=6, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 73.2559 GFlop/s
   Kernel_dnt_largeDB1(m=5, n=22, k=8, tile_m=1, tile_n=1, w=4, v=22, threads=128, grouping=16, minblocks=8) , # 92.3688 GFlop/s
@@ -388,7 +388,7 @@
   Kernel_dnt_medium(m=5, n=22, k=24, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=8) , # 138.483 GFlop/s
   Kernel_dnt_medium(m=5, n=22, k=26, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=1) , # 145.469 GFlop/s
   Kernel_dnt_largeDB1(m=5, n=22, k=32, tile_m=1, tile_n=1, w=16, v=22, threads=192, grouping=16, minblocks=8) , # 143.787 GFlop/s
-  Kernel_dnt_tiny(m=5, n=23, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 66.9592 GFlop/s
+  Kernel_dnt_tiny(m=5, n=23, k=4, threads=128, grouping=16, minblocks=1) , # 66.9592 GFlop/s
   Kernel_dnt_small(m=5, n=23, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 74.1593 GFlop/s
   Kernel_dnt_medium(m=5, n=23, k=6, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 76.2473 GFlop/s
   Kernel_dnt_medium(m=5, n=23, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 94.6116 GFlop/s
@@ -401,7 +401,7 @@
   Kernel_dnt_medium(m=5, n=23, k=24, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=8) , # 143.882 GFlop/s
   Kernel_dnt_largeDB1(m=5, n=23, k=26, tile_m=1, tile_n=1, w=10, v=22, threads=128, grouping=16, minblocks=12) , # 136.154 GFlop/s
   Kernel_dnt_largeDB1(m=5, n=23, k=32, tile_m=1, tile_n=1, w=16, v=22, threads=192, grouping=16, minblocks=8) , # 145.364 GFlop/s
-  Kernel_dnt_tiny(m=5, n=24, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 70.2727 GFlop/s
+  Kernel_dnt_tiny(m=5, n=24, k=4, threads=128, grouping=16, minblocks=1) , # 70.2727 GFlop/s
   Kernel_dnt_small(m=5, n=24, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 79.6991 GFlop/s
   Kernel_dnt_medium(m=5, n=24, k=6, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 80.5021 GFlop/s
   Kernel_dnt_largeDB1(m=5, n=24, k=8, tile_m=1, tile_n=1, w=4, v=24, threads=128, grouping=16, minblocks=12) , # 100.583 GFlop/s
@@ -478,11 +478,11 @@
   Kernel_dnt_largeDB2(m=5, n=45, k=28, tile_m=1, tile_n=2, w=14, v=26, threads=160, grouping=16, minblocks=8) , # 177.397 GFlop/s
   Kernel_dnt_largeDB2(m=5, n=45, k=32, tile_m=1, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 181.043 GFlop/s
   Kernel_dnt_largeDB2(m=5, n=45, k=45, tile_m=1, tile_n=2, w=12, v=42, threads=128, grouping=16, minblocks=8) , # 183.404 GFlop/s
-  Kernel_dnt_tiny(m=6, n=4, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 17.3648 GFlop/s
-  Kernel_dnt_tiny(m=6, n=4, k=5, split_thread=32, threads=96, grouping=16, minblocks=1) , # 20.891 GFlop/s
-  Kernel_dnt_tiny(m=6, n=4, k=6, split_thread=32, threads=96, grouping=16, minblocks=1) , # 25.3088 GFlop/s
-  Kernel_dnt_tiny(m=6, n=4, k=8, split_thread=32, threads=96, grouping=16, minblocks=1) , # 34.4029 GFlop/s
-  Kernel_dnt_tiny(m=6, n=4, k=9, split_thread=32, threads=96, grouping=16, minblocks=1) , # 30.9154 GFlop/s
+  Kernel_dnt_tiny(m=6, n=4, k=4, threads=128, grouping=16, minblocks=1) , # 17.3648 GFlop/s
+  Kernel_dnt_tiny(m=6, n=4, k=5, threads=96, grouping=16, minblocks=1) , # 20.891 GFlop/s
+  Kernel_dnt_tiny(m=6, n=4, k=6, threads=96, grouping=16, minblocks=1) , # 25.3088 GFlop/s
+  Kernel_dnt_tiny(m=6, n=4, k=8, threads=96, grouping=16, minblocks=1) , # 34.4029 GFlop/s
+  Kernel_dnt_tiny(m=6, n=4, k=9, threads=96, grouping=16, minblocks=1) , # 30.9154 GFlop/s
   Kernel_dnt_small(m=6, n=4, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 40.7212 GFlop/s
   Kernel_dnt_small(m=6, n=4, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 48.547 GFlop/s
   Kernel_dnt_small(m=6, n=4, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 42.7597 GFlop/s
@@ -491,11 +491,11 @@
   Kernel_dnt_medium(m=6, n=4, k=24, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 59.3286 GFlop/s
   Kernel_dnt_medium(m=6, n=4, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 63.2716 GFlop/s
   Kernel_dnt_medium(m=6, n=4, k=32, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 71.0281 GFlop/s
-  Kernel_dnt_tiny(m=6, n=5, k=4, split_thread=32, threads=96, grouping=16, minblocks=1) , # 21.0382 GFlop/s
-  Kernel_dnt_tiny(m=6, n=5, k=5, split_thread=32, threads=96, grouping=16, minblocks=1) , # 25.6146 GFlop/s
-  Kernel_dnt_tiny(m=6, n=5, k=6, split_thread=32, threads=96, grouping=16, minblocks=1) , # 30.7386 GFlop/s
-  Kernel_dnt_tiny(m=6, n=5, k=8, split_thread=32, threads=96, grouping=16, minblocks=1) , # 39.7844 GFlop/s
-  Kernel_dnt_tiny(m=6, n=5, k=9, split_thread=32, threads=96, grouping=16, minblocks=1) , # 37.5717 GFlop/s
+  Kernel_dnt_tiny(m=6, n=5, k=4, threads=96, grouping=16, minblocks=1) , # 21.0382 GFlop/s
+  Kernel_dnt_tiny(m=6, n=5, k=5, threads=96, grouping=16, minblocks=1) , # 25.6146 GFlop/s
+  Kernel_dnt_tiny(m=6, n=5, k=6, threads=96, grouping=16, minblocks=1) , # 30.7386 GFlop/s
+  Kernel_dnt_tiny(m=6, n=5, k=8, threads=96, grouping=16, minblocks=1) , # 39.7844 GFlop/s
+  Kernel_dnt_tiny(m=6, n=5, k=9, threads=96, grouping=16, minblocks=1) , # 37.5717 GFlop/s
   Kernel_dnt_small(m=6, n=5, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 49.4221 GFlop/s
   Kernel_dnt_small(m=6, n=5, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 58.085 GFlop/s
   Kernel_dnt_small(m=6, n=5, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 52.5703 GFlop/s
@@ -505,8 +505,8 @@
   Kernel_dnt_medium(m=6, n=5, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 78.7409 GFlop/s
   Kernel_dnt_medium(m=6, n=5, k=32, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 87.6399 GFlop/s
   Kernel_dnt_small(m=6, n=6, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 29.0092 GFlop/s
-  Kernel_dnt_tiny(m=6, n=6, k=5, split_thread=32, threads=64, grouping=16, minblocks=1) , # 34.7398 GFlop/s
-  Kernel_dnt_tiny(m=6, n=6, k=6, split_thread=32, threads=96, grouping=16, minblocks=1) , # 41.3431 GFlop/s
+  Kernel_dnt_tiny(m=6, n=6, k=5, threads=64, grouping=16, minblocks=1) , # 34.7398 GFlop/s
+  Kernel_dnt_tiny(m=6, n=6, k=6, threads=96, grouping=16, minblocks=1) , # 41.3431 GFlop/s
   Kernel_dnt_small(m=6, n=6, k=8, tile_m=1, tile_n=1, threads=64, grouping=16, minblocks=12) , # 51.4584 GFlop/s
   Kernel_dnt_small(m=6, n=6, k=9, tile_m=1, tile_n=1, threads=64, grouping=16, minblocks=4) , # 54.7869 GFlop/s
   Kernel_dnt_small(m=6, n=6, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 65.899 GFlop/s
@@ -521,7 +521,7 @@
   Kernel_dnt_medium(m=6, n=8, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 32.8542 GFlop/s
   Kernel_dnt_medium(m=6, n=8, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 39.5654 GFlop/s
   Kernel_dnt_medium(m=6, n=8, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 46.7754 GFlop/s
-  Kernel_dnt_tiny(m=6, n=8, k=8, split_thread=32, threads=96, grouping=16, minblocks=1) , # 56.4219 GFlop/s
+  Kernel_dnt_tiny(m=6, n=8, k=8, threads=96, grouping=16, minblocks=1) , # 56.4219 GFlop/s
   Kernel_dnt_small(m=6, n=8, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 57.8262 GFlop/s
   Kernel_dnt_small(m=6, n=8, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 70.6689 GFlop/s
   Kernel_dnt_small(m=6, n=8, k=16, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 81.6668 GFlop/s
@@ -570,7 +570,7 @@
   Kernel_dnt_largeDB1(m=6, n=16, k=24, tile_m=1, tile_n=1, w=12, v=16, threads=96, grouping=16, minblocks=1) , # 151.414 GFlop/s
   Kernel_dnt_medium(m=6, n=16, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=1) , # 150.43 GFlop/s
   Kernel_dnt_largeDB1(m=6, n=16, k=32, tile_m=1, tile_n=1, w=16, v=16, threads=128, grouping=16, minblocks=12) , # 162.722 GFlop/s
-  Kernel_dnt_tiny(m=6, n=17, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 60.5441 GFlop/s
+  Kernel_dnt_tiny(m=6, n=17, k=4, threads=128, grouping=16, minblocks=1) , # 60.5441 GFlop/s
   Kernel_dnt_small(m=6, n=17, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 68.6498 GFlop/s
   Kernel_dnt_medium(m=6, n=17, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 75.0572 GFlop/s
   Kernel_dnt_medium(m=6, n=17, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 88.8231 GFlop/s
@@ -649,10 +649,10 @@
   Kernel_dnt_medium(m=6, n=32, k=26, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=1) , # 182.386 GFlop/s
   Kernel_dnt_largeDB1(m=6, n=32, k=32, tile_m=2, tile_n=1, w=8, v=18, threads=128, grouping=16, minblocks=12) , # 192.489 GFlop/s
   Kernel_dnt_medium(m=6, n=36, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 119.79 GFlop/s
-  Kernel_dnt_tiny(m=7, n=4, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 20.321 GFlop/s
-  Kernel_dnt_tiny(m=7, n=4, k=5, split_thread=32, threads=128, grouping=16, minblocks=1) , # 25.1685 GFlop/s
-  Kernel_dnt_tiny(m=7, n=4, k=7, split_thread=32, threads=96, grouping=16, minblocks=1) , # 33.8708 GFlop/s
-  Kernel_dnt_tiny(m=7, n=4, k=9, split_thread=32, threads=96, grouping=16, minblocks=1) , # 41.5372 GFlop/s
+  Kernel_dnt_tiny(m=7, n=4, k=4, threads=128, grouping=16, minblocks=1) , # 20.321 GFlop/s
+  Kernel_dnt_tiny(m=7, n=4, k=5, threads=128, grouping=16, minblocks=1) , # 25.1685 GFlop/s
+  Kernel_dnt_tiny(m=7, n=4, k=7, threads=96, grouping=16, minblocks=1) , # 33.8708 GFlop/s
+  Kernel_dnt_tiny(m=7, n=4, k=9, threads=96, grouping=16, minblocks=1) , # 41.5372 GFlop/s
   Kernel_dnt_medium(m=7, n=4, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 53.8869 GFlop/s
   Kernel_dnt_largeDB2(m=7, n=4, k=25, tile_m=1, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=4) , # 73.2421 GFlop/s
   Kernel_dnt_largeDB2(m=7, n=4, k=26, tile_m=1, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=1) , # 75.2431 GFlop/s
@@ -669,10 +669,10 @@
   Kernel_dnt_largeDB2(m=7, n=5, k=28, tile_m=1, tile_n=1, w=14, v=4, threads=96, grouping=16, minblocks=1) , # 88.1174 GFlop/s
   Kernel_dnt_largeDB2(m=7, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=1) , # 93.4222 GFlop/s
   Kernel_dnt_largeDB2(m=7, n=5, k=45, tile_m=1, tile_n=1, w=18, v=4, threads=128, grouping=16, minblocks=4) , # 98.0637 GFlop/s
-  Kernel_dnt_tiny(m=7, n=7, k=4, split_thread=32, threads=64, grouping=16, minblocks=1) , # 40.7019 GFlop/s
-  Kernel_dnt_tiny(m=7, n=7, k=5, split_thread=32, threads=128, grouping=16, minblocks=1) , # 49.7395 GFlop/s
-  Kernel_dnt_tiny(m=7, n=7, k=7, split_thread=32, threads=96, grouping=16, minblocks=1) , # 64.2082 GFlop/s
-  Kernel_dnt_tiny(m=7, n=7, k=9, split_thread=32, threads=96, grouping=16, minblocks=1) , # 74.9724 GFlop/s
+  Kernel_dnt_tiny(m=7, n=7, k=4, threads=64, grouping=16, minblocks=1) , # 40.7019 GFlop/s
+  Kernel_dnt_tiny(m=7, n=7, k=5, threads=128, grouping=16, minblocks=1) , # 49.7395 GFlop/s
+  Kernel_dnt_tiny(m=7, n=7, k=7, threads=96, grouping=16, minblocks=1) , # 64.2082 GFlop/s
+  Kernel_dnt_tiny(m=7, n=7, k=9, threads=96, grouping=16, minblocks=1) , # 74.9724 GFlop/s
   Kernel_dnt_medium(m=7, n=7, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 92.3343 GFlop/s
   Kernel_dnt_medium(m=7, n=7, k=25, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 116.952 GFlop/s
   Kernel_dnt_medium(m=7, n=7, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 111.036 GFlop/s
@@ -751,12 +751,12 @@
   Kernel_dnt_largeDB2(m=7, n=45, k=32, tile_m=2, tile_n=3, w=8, v=38, threads=96, grouping=16, minblocks=12) , # 236.673 GFlop/s
   Kernel_dnt_largeDB2(m=7, n=45, k=45, tile_m=2, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=8) , # 241.311 GFlop/s
   Kernel_dnt_medium(m=7, n=49, k=7, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 147.937 GFlop/s
-  Kernel_dnt_tiny(m=8, n=4, k=4, split_thread=32, threads=96, grouping=16, minblocks=1) , # 23.9735 GFlop/s
-  Kernel_dnt_tiny(m=8, n=4, k=5, split_thread=32, threads=96, grouping=16, minblocks=1) , # 28.4815 GFlop/s
-  Kernel_dnt_tiny(m=8, n=4, k=6, split_thread=32, threads=96, grouping=16, minblocks=1) , # 34.2353 GFlop/s
-  Kernel_dnt_tiny(m=8, n=4, k=8, split_thread=32, threads=96, grouping=16, minblocks=1) , # 45.8575 GFlop/s
-  Kernel_dnt_tiny(m=8, n=4, k=9, split_thread=32, threads=128, grouping=16, minblocks=1) , # 48.5061 GFlop/s
-  Kernel_dnt_tiny(m=8, n=4, k=13, split_thread=32, threads=128, grouping=16, minblocks=1) , # 55.0971 GFlop/s
+  Kernel_dnt_tiny(m=8, n=4, k=4, threads=96, grouping=16, minblocks=1) , # 23.9735 GFlop/s
+  Kernel_dnt_tiny(m=8, n=4, k=5, threads=96, grouping=16, minblocks=1) , # 28.4815 GFlop/s
+  Kernel_dnt_tiny(m=8, n=4, k=6, threads=96, grouping=16, minblocks=1) , # 34.2353 GFlop/s
+  Kernel_dnt_tiny(m=8, n=4, k=8, threads=96, grouping=16, minblocks=1) , # 45.8575 GFlop/s
+  Kernel_dnt_tiny(m=8, n=4, k=9, threads=128, grouping=16, minblocks=1) , # 48.5061 GFlop/s
+  Kernel_dnt_tiny(m=8, n=4, k=13, threads=128, grouping=16, minblocks=1) , # 55.0971 GFlop/s
   Kernel_dnt_medium(m=8, n=4, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 64.3498 GFlop/s
   Kernel_dnt_medium(m=8, n=4, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 66.887 GFlop/s
   Kernel_dnt_medium(m=8, n=4, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 80.5774 GFlop/s
@@ -790,10 +790,10 @@
   Kernel_dnt_largeDB1(m=8, n=6, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=1) , # 99.2986 GFlop/s
   Kernel_dnt_medium(m=8, n=6, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 100.382 GFlop/s
   Kernel_dnt_largeDB1(m=8, n=6, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=128, grouping=16, minblocks=12) , # 112.447 GFlop/s
-  Kernel_dnt_tiny(m=8, n=8, k=4, split_thread=32, threads=96, grouping=16, minblocks=1) , # 52.7483 GFlop/s
-  Kernel_dnt_tiny(m=8, n=8, k=5, split_thread=32, threads=96, grouping=16, minblocks=1) , # 62.8469 GFlop/s
-  Kernel_dnt_tiny(m=8, n=8, k=6, split_thread=32, threads=128, grouping=16, minblocks=1) , # 72.9942 GFlop/s
-  Kernel_dnt_tiny(m=8, n=8, k=8, split_thread=32, threads=128, grouping=16, minblocks=1) , # 90.7763 GFlop/s
+  Kernel_dnt_tiny(m=8, n=8, k=4, threads=96, grouping=16, minblocks=1) , # 52.7483 GFlop/s
+  Kernel_dnt_tiny(m=8, n=8, k=5, threads=96, grouping=16, minblocks=1) , # 62.8469 GFlop/s
+  Kernel_dnt_tiny(m=8, n=8, k=6, threads=128, grouping=16, minblocks=1) , # 72.9942 GFlop/s
+  Kernel_dnt_tiny(m=8, n=8, k=8, threads=128, grouping=16, minblocks=1) , # 90.7763 GFlop/s
   Kernel_dnt_medium(m=8, n=8, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 96.8478 GFlop/s
   Kernel_dnt_small(m=8, n=8, k=13, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 110.805 GFlop/s
   Kernel_dnt_medium(m=8, n=8, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 122.011 GFlop/s
@@ -817,9 +817,9 @@
   Kernel_dnt_largeDB1(m=8, n=9, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=8) , # 125.923 GFlop/s
   Kernel_dnt_medium(m=8, n=9, k=26, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 128.998 GFlop/s
   Kernel_dnt_largeDB1(m=8, n=9, k=32, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=12) , # 131.311 GFlop/s
-  Kernel_dnt_tiny(m=8, n=13, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 63.3347 GFlop/s
+  Kernel_dnt_tiny(m=8, n=13, k=4, threads=128, grouping=16, minblocks=1) , # 63.3347 GFlop/s
   Kernel_dnt_medium(m=8, n=13, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 75.8181 GFlop/s
-  Kernel_dnt_tiny(m=8, n=13, k=6, split_thread=32, threads=128, grouping=16, minblocks=1) , # 86.1038 GFlop/s
+  Kernel_dnt_tiny(m=8, n=13, k=6, threads=128, grouping=16, minblocks=1) , # 86.1038 GFlop/s
   Kernel_dnt_small(m=8, n=13, k=8, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=8) , # 98.14 GFlop/s
   Kernel_dnt_medium(m=8, n=13, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 105.704 GFlop/s
   Kernel_dnt_medium(m=8, n=13, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 123.059 GFlop/s
@@ -830,9 +830,9 @@
   Kernel_dnt_medium(m=8, n=13, k=24, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 151.977 GFlop/s
   Kernel_dnt_medium(m=8, n=13, k=26, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 152.263 GFlop/s
   Kernel_dnt_largeDB1(m=8, n=13, k=32, tile_m=1, tile_n=1, w=16, v=10, threads=128, grouping=16, minblocks=1) , # 160.083 GFlop/s
-  Kernel_dnt_tiny(m=8, n=16, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 77.4084 GFlop/s
+  Kernel_dnt_tiny(m=8, n=16, k=4, threads=128, grouping=16, minblocks=1) , # 77.4084 GFlop/s
   Kernel_dnt_medium(m=8, n=16, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 91.6492 GFlop/s
-  Kernel_dnt_tiny(m=8, n=16, k=6, split_thread=32, threads=128, grouping=16, minblocks=1) , # 102.56 GFlop/s
+  Kernel_dnt_tiny(m=8, n=16, k=6, threads=128, grouping=16, minblocks=1) , # 102.56 GFlop/s
   Kernel_dnt_small(m=8, n=16, k=8, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 121.25 GFlop/s
   Kernel_dnt_medium(m=8, n=16, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 120.932 GFlop/s
   Kernel_dnt_medium(m=8, n=16, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 150.649 GFlop/s
@@ -992,8 +992,8 @@
   Kernel_dnt_largeDB1(m=9, n=8, k=24, tile_m=1, tile_n=1, w=12, v=8, threads=128, grouping=16, minblocks=8) , # 127.47 GFlop/s
   Kernel_dnt_medium(m=9, n=8, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 127.087 GFlop/s
   Kernel_dnt_largeDB1(m=9, n=8, k=32, tile_m=1, tile_n=1, w=12, v=8, threads=128, grouping=16, minblocks=12) , # 132.924 GFlop/s
-  Kernel_dnt_tiny(m=9, n=9, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 62.4312 GFlop/s
-  Kernel_dnt_tiny(m=9, n=9, k=5, split_thread=32, threads=96, grouping=16, minblocks=1) , # 74.0588 GFlop/s
+  Kernel_dnt_tiny(m=9, n=9, k=4, threads=128, grouping=16, minblocks=1) , # 62.4312 GFlop/s
+  Kernel_dnt_tiny(m=9, n=9, k=5, threads=96, grouping=16, minblocks=1) , # 74.0588 GFlop/s
   Kernel_dnt_medium(m=9, n=9, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 83.6127 GFlop/s
   Kernel_dnt_medium(m=9, n=9, k=7, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 92.4293 GFlop/s
   Kernel_dnt_small(m=9, n=9, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 97.3911 GFlop/s
@@ -1012,9 +1012,9 @@
   Kernel_dnt_largeDB1(m=9, n=9, k=64, tile_m=1, tile_n=1, w=14, v=6, threads=128, grouping=16, minblocks=12) , # 160.483 GFlop/s
   Kernel_dnt_largeDB1(m=9, n=9, k=81, tile_m=1, tile_n=1, w=14, v=6, threads=128, grouping=16, minblocks=12) , # 164.81 GFlop/s
   Kernel_dnt_largeDB2(m=9, n=13, k=4, tile_m=1, tile_n=1, w=2, v=12, threads=128, grouping=16, minblocks=1) , # 68.546 GFlop/s
-  Kernel_dnt_tiny(m=9, n=13, k=5, split_thread=32, threads=128, grouping=16, minblocks=1) , # 81.5548 GFlop/s
+  Kernel_dnt_tiny(m=9, n=13, k=5, threads=128, grouping=16, minblocks=1) , # 81.5548 GFlop/s
   Kernel_dnt_small(m=9, n=13, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 86.6047 GFlop/s
-  Kernel_dnt_tiny(m=9, n=13, k=7, split_thread=32, threads=128, grouping=16, minblocks=1) , # 104.773 GFlop/s
+  Kernel_dnt_tiny(m=9, n=13, k=7, threads=128, grouping=16, minblocks=1) , # 104.773 GFlop/s
   Kernel_dnt_medium(m=9, n=13, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 110.269 GFlop/s
   Kernel_dnt_medium(m=9, n=13, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 118.614 GFlop/s
   Kernel_dnt_largeDB2(m=9, n=13, k=13, tile_m=1, tile_n=2, w=6, v=10, threads=96, grouping=16, minblocks=8) , # 137.421 GFlop/s
@@ -1167,7 +1167,7 @@
   Kernel_dnt_largeDB2(m=10, n=4, k=4, tile_m=1, tile_n=1, w=2, v=4, threads=96, grouping=16, minblocks=4) , # 28.1008 GFlop/s
   Kernel_dnt_small(m=10, n=4, k=10, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 54.1832 GFlop/s
   Kernel_dnt_medium(m=10, n=4, k=15, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 70.4501 GFlop/s
-  Kernel_dnt_tiny(m=10, n=10, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 74.7338 GFlop/s
+  Kernel_dnt_tiny(m=10, n=10, k=4, threads=128, grouping=16, minblocks=1) , # 74.7338 GFlop/s
   Kernel_dnt_medium(m=10, n=10, k=10, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 116.741 GFlop/s
   Kernel_dnt_medium(m=10, n=10, k=15, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 141.061 GFlop/s
   Kernel_dnt_largeDB1(m=10, n=10, k=100, tile_m=2, tile_n=2, w=20, v=10, threads=96, grouping=16, minblocks=12) , # 193.259 GFlop/s
@@ -1238,7 +1238,7 @@
   Kernel_dnt_largeDB2(m=13, n=7, k=28, tile_m=1, tile_n=1, w=14, v=6, threads=128, grouping=16, minblocks=4) , # 160.527 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=7, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=128, grouping=16, minblocks=4) , # 168.672 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=7, k=45, tile_m=1, tile_n=1, w=18, v=6, threads=128, grouping=16, minblocks=4) , # 170.503 GFlop/s
-  Kernel_dnt_tiny(m=13, n=8, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 64.3202 GFlop/s
+  Kernel_dnt_tiny(m=13, n=8, k=4, threads=128, grouping=16, minblocks=1) , # 64.3202 GFlop/s
   Kernel_dnt_small(m=13, n=8, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 71.3921 GFlop/s
   Kernel_dnt_small(m=13, n=8, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 81.3107 GFlop/s
   Kernel_dnt_medium(m=13, n=8, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 99.8992 GFlop/s
@@ -1251,10 +1251,10 @@
   Kernel_dnt_largeDB1(m=13, n=8, k=24, tile_m=1, tile_n=2, w=12, v=6, threads=96, grouping=16, minblocks=1) , # 151.064 GFlop/s
   Kernel_dnt_medium(m=13, n=8, k=26, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 151.357 GFlop/s
   Kernel_dnt_largeDB1(m=13, n=8, k=32, tile_m=2, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=12) , # 157.473 GFlop/s
-  Kernel_dnt_tiny(m=13, n=9, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 68.6834 GFlop/s
-  Kernel_dnt_tiny(m=13, n=9, k=5, split_thread=32, threads=128, grouping=16, minblocks=1) , # 82.6413 GFlop/s
+  Kernel_dnt_tiny(m=13, n=9, k=4, threads=128, grouping=16, minblocks=1) , # 68.6834 GFlop/s
+  Kernel_dnt_tiny(m=13, n=9, k=5, threads=128, grouping=16, minblocks=1) , # 82.6413 GFlop/s
   Kernel_dnt_small(m=13, n=9, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 87.8396 GFlop/s
-  Kernel_dnt_tiny(m=13, n=9, k=7, split_thread=32, threads=128, grouping=16, minblocks=1) , # 105.779 GFlop/s
+  Kernel_dnt_tiny(m=13, n=9, k=7, threads=128, grouping=16, minblocks=1) , # 105.779 GFlop/s
   Kernel_dnt_medium(m=13, n=9, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 109.971 GFlop/s
   Kernel_dnt_medium(m=13, n=9, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 118.002 GFlop/s
   Kernel_dnt_largeDB2(m=13, n=9, k=13, tile_m=2, tile_n=1, w=6, v=6, threads=96, grouping=16, minblocks=8) , # 137.392 GFlop/s
@@ -1447,7 +1447,7 @@
   Kernel_dnt_largeDB1(m=15, n=225, k=15, tile_m=3, tile_n=3, w=4, v=150, threads=384, grouping=16, minblocks=1) , # 258.751 GFlop/s
   Kernel_dnt_medium(m=16, n=4, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 43.2513 GFlop/s
   Kernel_dnt_medium(m=16, n=4, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 52.8509 GFlop/s
-  Kernel_dnt_tiny(m=16, n=4, k=6, split_thread=32, threads=128, grouping=16, minblocks=1) , # 56.0623 GFlop/s
+  Kernel_dnt_tiny(m=16, n=4, k=6, threads=128, grouping=16, minblocks=1) , # 56.0623 GFlop/s
   Kernel_dnt_medium(m=16, n=4, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 70.6265 GFlop/s
   Kernel_dnt_medium(m=16, n=4, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 76.3591 GFlop/s
   Kernel_dnt_medium(m=16, n=4, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 90.3877 GFlop/s
@@ -1460,7 +1460,7 @@
   Kernel_dnt_largeDB1(m=16, n=4, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=12) , # 119.202 GFlop/s
   Kernel_dnt_medium(m=16, n=5, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 53.2937 GFlop/s
   Kernel_dnt_medium(m=16, n=5, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 64.8851 GFlop/s
-  Kernel_dnt_tiny(m=16, n=5, k=6, split_thread=32, threads=128, grouping=16, minblocks=1) , # 68.9342 GFlop/s
+  Kernel_dnt_tiny(m=16, n=5, k=6, threads=128, grouping=16, minblocks=1) , # 68.9342 GFlop/s
   Kernel_dnt_medium(m=16, n=5, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 84.6639 GFlop/s
   Kernel_dnt_medium(m=16, n=5, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 91.9906 GFlop/s
   Kernel_dnt_medium(m=16, n=5, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 107.42 GFlop/s
@@ -1473,7 +1473,7 @@
   Kernel_dnt_largeDB1(m=16, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=12) , # 138.029 GFlop/s
   Kernel_dnt_medium(m=16, n=6, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 63.7826 GFlop/s
   Kernel_dnt_medium(m=16, n=6, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 77.3562 GFlop/s
-  Kernel_dnt_tiny(m=16, n=6, k=6, split_thread=32, threads=128, grouping=16, minblocks=1) , # 81.9641 GFlop/s
+  Kernel_dnt_tiny(m=16, n=6, k=6, threads=128, grouping=16, minblocks=1) , # 81.9641 GFlop/s
   Kernel_dnt_medium(m=16, n=6, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 99.2729 GFlop/s
   Kernel_dnt_medium(m=16, n=6, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 108.16 GFlop/s
   Kernel_dnt_medium(m=16, n=6, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 128.018 GFlop/s
@@ -1484,9 +1484,9 @@
   Kernel_dnt_largeDB1(m=16, n=6, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=96, grouping=16, minblocks=8) , # 151.996 GFlop/s
   Kernel_dnt_largeDB1(m=16, n=6, k=26, tile_m=1, tile_n=1, w=10, v=6, threads=96, grouping=16, minblocks=4) , # 149.231 GFlop/s
   Kernel_dnt_largeDB1(m=16, n=6, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=128, grouping=16, minblocks=12) , # 163.734 GFlop/s
-  Kernel_dnt_tiny(m=16, n=8, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 78.0533 GFlop/s
+  Kernel_dnt_tiny(m=16, n=8, k=4, threads=128, grouping=16, minblocks=1) , # 78.0533 GFlop/s
   Kernel_dnt_medium(m=16, n=8, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 91.3267 GFlop/s
-  Kernel_dnt_tiny(m=16, n=8, k=6, split_thread=32, threads=128, grouping=16, minblocks=1) , # 105.373 GFlop/s
+  Kernel_dnt_tiny(m=16, n=8, k=6, threads=128, grouping=16, minblocks=1) , # 105.373 GFlop/s
   Kernel_dnt_small(m=16, n=8, k=8, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 124.195 GFlop/s
   Kernel_dnt_medium(m=16, n=8, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 121.754 GFlop/s
   Kernel_dnt_medium(m=16, n=8, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 150.445 GFlop/s
@@ -1662,7 +1662,7 @@
   Kernel_dnt_medium(m=17, n=5, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 135.055 GFlop/s
   Kernel_dnt_medium(m=17, n=5, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=4) , # 131.777 GFlop/s
   Kernel_dnt_largeDB1(m=17, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=4) , # 138.231 GFlop/s
-  Kernel_dnt_tiny(m=17, n=6, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 60.0659 GFlop/s
+  Kernel_dnt_tiny(m=17, n=6, k=4, threads=128, grouping=16, minblocks=1) , # 60.0659 GFlop/s
   Kernel_dnt_small(m=17, n=6, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 69.3811 GFlop/s
   Kernel_dnt_small(m=17, n=6, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 76.6485 GFlop/s
   Kernel_dnt_largeDB1(m=17, n=6, k=8, tile_m=1, tile_n=1, w=4, v=6, threads=128, grouping=16, minblocks=1) , # 87.7851 GFlop/s
@@ -1818,7 +1818,7 @@
   Kernel_dnt_medium(m=22, n=4, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 126.365 GFlop/s
   Kernel_dnt_medium(m=22, n=4, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 123.866 GFlop/s
   Kernel_dnt_largeDB1(m=22, n=4, k=32, tile_m=1, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 128.16 GFlop/s
-  Kernel_dnt_tiny(m=22, n=5, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 64.238 GFlop/s
+  Kernel_dnt_tiny(m=22, n=5, k=4, threads=128, grouping=16, minblocks=1) , # 64.238 GFlop/s
   Kernel_dnt_small(m=22, n=5, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 73.3009 GFlop/s
   Kernel_dnt_medium(m=22, n=5, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 74.4677 GFlop/s
   Kernel_dnt_medium(m=22, n=5, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 93.8793 GFlop/s
@@ -1994,7 +1994,7 @@
   Kernel_dnt_medium(m=23, n=4, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 122.921 GFlop/s
   Kernel_dnt_medium(m=23, n=4, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 127.127 GFlop/s
   Kernel_dnt_largeDB1(m=23, n=4, k=32, tile_m=1, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 128.586 GFlop/s
-  Kernel_dnt_tiny(m=23, n=5, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 66.3956 GFlop/s
+  Kernel_dnt_tiny(m=23, n=5, k=4, threads=128, grouping=16, minblocks=1) , # 66.3956 GFlop/s
   Kernel_dnt_small(m=23, n=5, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 76.0417 GFlop/s
   Kernel_dnt_medium(m=23, n=5, k=6, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 76.9185 GFlop/s
   Kernel_dnt_medium(m=23, n=5, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 94.7903 GFlop/s
@@ -2150,7 +2150,7 @@
   Kernel_dnt_largeDB1(m=23, n=32, k=24, tile_m=3, tile_n=2, w=12, v=32, threads=128, grouping=16, minblocks=8) , # 384.75 GFlop/s
   Kernel_dnt_largeDB1(m=23, n=32, k=26, tile_m=3, tile_n=2, w=10, v=32, threads=128, grouping=16, minblocks=8) , # 381.494 GFlop/s
   Kernel_dnt_largeDB1(m=23, n=32, k=32, tile_m=3, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=8) , # 398.604 GFlop/s
-  Kernel_dnt_tiny(m=24, n=4, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 58.8119 GFlop/s
+  Kernel_dnt_tiny(m=24, n=4, k=4, threads=128, grouping=16, minblocks=1) , # 58.8119 GFlop/s
   Kernel_dnt_small(m=24, n=4, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 67.0164 GFlop/s
   Kernel_dnt_medium(m=24, n=4, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 72.194 GFlop/s
   Kernel_dnt_medium(m=24, n=4, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 89.6464 GFlop/s
@@ -2163,7 +2163,7 @@
   Kernel_dnt_medium(m=24, n=4, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 128.156 GFlop/s
   Kernel_dnt_medium(m=24, n=4, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 131.844 GFlop/s
   Kernel_dnt_largeDB1(m=24, n=4, k=32, tile_m=1, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 132.646 GFlop/s
-  Kernel_dnt_tiny(m=24, n=5, k=4, split_thread=32, threads=128, grouping=16, minblocks=1) , # 70.448 GFlop/s
+  Kernel_dnt_tiny(m=24, n=5, k=4, threads=128, grouping=16, minblocks=1) , # 70.448 GFlop/s
   Kernel_dnt_small(m=24, n=5, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 80.4972 GFlop/s
   Kernel_dnt_medium(m=24, n=5, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 81.0577 GFlop/s
   Kernel_dnt_medium(m=24, n=5, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 101.258 GFlop/s
@@ -2776,7 +2776,7 @@
   Kernel_dnt_largeDB1(m=29, n=55, k=32, tile_m=4, tile_n=4, w=8, v=34, threads=128, grouping=16, minblocks=1) , # 424.502 GFlop/s
   Kernel_dnt_largeDB1(m=29, n=55, k=55, tile_m=3, tile_n=5, w=6, v=30, threads=128, grouping=16, minblocks=1) , # 465.271 GFlop/s
   Kernel_dnt_largeDB2(m=32, n=4, k=4, tile_m=1, tile_n=1, w=2, v=4, threads=128, grouping=16, minblocks=1) , # 78.1605 GFlop/s
-  Kernel_dnt_tiny(m=32, n=4, k=5, split_thread=32, threads=128, grouping=16, minblocks=1) , # 75.2026 GFlop/s
+  Kernel_dnt_tiny(m=32, n=4, k=5, threads=128, grouping=16, minblocks=1) , # 75.2026 GFlop/s
   Kernel_dnt_medium(m=32, n=4, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 84.3077 GFlop/s
   Kernel_dnt_medium(m=32, n=4, k=7, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 95.6134 GFlop/s
   Kernel_dnt_medium(m=32, n=4, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 107.39 GFlop/s

--- a/src/acc/libsmm_acc/libcusmm/parameters_K40.txt
+++ b/src/acc/libsmm_acc/libcusmm/parameters_K40.txt
@@ -20,9 +20,9 @@
   Kernel_dnt_small(m=13, n=13, k=13, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 184.195 GFlop/s
   Kernel_dnt_small(m=8, n=8, k=8, tile_m=1, tile_n=1, threads=64, grouping=16, minblocks=4) , # 95.1028 GFlop/s
   Kernel_dnt_small(m=9, n=9, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 111.384 GFlop/s
-  Kernel_dnt_tiny(m=5, n=5, k=5, split_thread=32, threads=64, grouping=16, minblocks=1) , # 30.4899 GFlop/s
-  Kernel_dnt_tiny(m=6, n=6, k=6, split_thread=32, threads=128, grouping=16, minblocks=1) , # 44.1711 GFlop/s
-  Kernel_dnt_tiny(m=7, n=7, k=7, split_thread=32, threads=96, grouping=16, minblocks=1) , # 64.2483 GFlop/s
+  Kernel_dnt_tiny(m=5, n=5, k=5, threads=64, grouping=16, minblocks=1) , # 30.4899 GFlop/s
+  Kernel_dnt_tiny(m=6, n=6, k=6, threads=128, grouping=16, minblocks=1) , # 44.1711 GFlop/s
+  Kernel_dnt_tiny(m=7, n=7, k=7, threads=96, grouping=16, minblocks=1) , # 64.2483 GFlop/s
 ]
 
 #EOF

--- a/src/acc/libsmm_acc/libcusmm/parameters_K80.txt
+++ b/src/acc/libsmm_acc/libcusmm/parameters_K80.txt
@@ -19,10 +19,10 @@
   Kernel_dnt_medium(m=15, n=15, k=15, tile_m=4, tile_n=2, threads=96, grouping=16, minblocks=8) , # 275.724 GFlop/s
   Kernel_dnt_small(m=11, n=11, k=11, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 168.009 GFlop/s
   Kernel_dnt_small(m=9, n=9, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 117.001 GFlop/s
-  Kernel_dnt_tiny(m=5, n=5, k=5, split_thread=32, threads=64, grouping=16, minblocks=1) , # 33.4544 GFlop/s
-  Kernel_dnt_tiny(m=6, n=6, k=6, split_thread=32, threads=96, grouping=16, minblocks=1) , # 47.3645 GFlop/s
-  Kernel_dnt_tiny(m=7, n=7, k=7, split_thread=32, threads=96, grouping=16, minblocks=1) , # 70.7194 GFlop/s
-  Kernel_dnt_tiny(m=8, n=8, k=8, split_thread=32, threads=96, grouping=16, minblocks=1) , # 103.662 GFlop/s
+  Kernel_dnt_tiny(m=5, n=5, k=5, threads=64, grouping=16, minblocks=1) , # 33.4544 GFlop/s
+  Kernel_dnt_tiny(m=6, n=6, k=6, threads=96, grouping=16, minblocks=1) , # 47.3645 GFlop/s
+  Kernel_dnt_tiny(m=7, n=7, k=7, threads=96, grouping=16, minblocks=1) , # 70.7194 GFlop/s
+  Kernel_dnt_tiny(m=8, n=8, k=8, threads=96, grouping=16, minblocks=1) , # 103.662 GFlop/s
 ]
 
 #EOF

--- a/src/acc/libsmm_acc/libcusmm/tune.py
+++ b/src/acc/libsmm_acc/libcusmm/tune.py
@@ -206,13 +206,8 @@ def gen_makefile(outdir, arch):
     output += "do_nothing:\n\n"
     output += "build_all: " +  " ".join(build_targets) + "\n\n"
 
-    output += "EXP = 10\n"
-    output += "EXP_DOUBLE = $$(( 2*$(EXP)  ))\n"
-    output += "HASH_LIMIT = $$(( 2**$(EXP)-1 ))\n"
-    output += "HASHDEFS   = -DEXP=$(EXP) -DEXP_DOUBLE=$(EXP_DOUBLE) -DHASH_LIMIT=$(HASH_LIMIT)\n\n"
-
     output += "libcusmm_benchmark.o : libcusmm_benchmark.cu\n"
-    output += "\tnvcc -O3 -arch=sm_" + str(arch) + " -w $(HASHDEFS) -c -std=c++11 $<\n\n"
+    output += "\tnvcc -O3 -arch=sm_" + str(arch) + " -w -c -std=c++11 $<\n\n"
 
     headers = " ".join( ["."+fn for fn in glob("./kernels/*.h")] )
     output += "%.o : %.cu "+headers+"\n"

--- a/src/acc/libsmm_acc/libcusmm/tune.py
+++ b/src/acc/libsmm_acc/libcusmm/tune.py
@@ -35,7 +35,7 @@ def main():
     all_kernels = eval(open(param_fn).read())
     print("Libcusmm: Found %d existing parameter sets."%len(all_kernels))
 
-    blocksizes = [int(i) for i in sys.argv[1:]]
+    blocksizes = [int(i) for i in args[1:]]
     assert(len(set(blocksizes)) == len(blocksizes))
     blocksizes.sort()
 


### PR DESCRIPTION
- Specify GPU version (i.e. K20, P100, ...) instead of ARCH_NUMBER in Makefile.inc
- Determine ARCH_NUMBER from GPUVER
- libcusmm/generate_parameters.py: read the correct parameter file depending on ARCH_NUMBER
- libcusmm/tune.py: choose compilation options (-arch sm_xx) depending on ARCH_NUMBER and cleanup macros rendered obsolete by new hash