### PR TITLE
Libcusmm unittest: extend to transpose

### DIFF
--- a/src/acc/libsmm_acc/libcusmm/kernels/cusmm_transpose.h
+++ b/src/acc/libsmm_acc/libcusmm/kernels/cusmm_transpose.h
@@ -11,7 +11,7 @@
 #include "cusmm_common.h"
 
 template < int m, int n>
-__global__ void transpose_d(int *trs_stack, int nblks, double* mat){
+__global__ void transpose_d(int *trs_stack, double* mat){
  __shared__ double buf[m*n];
  int offset = trs_stack[blockIdx.x];
  for(int i=threadIdx.x; i < m*n; i+=blockDim.x){

--- a/src/acc/libsmm_acc/libcusmm/libcusmm.cpp
+++ b/src/acc/libsmm_acc/libcusmm/libcusmm.cpp
@@ -21,7 +21,6 @@
 #define dbcsr_type_real_8     3
 #define dbcsr_type_complex_4  5
 #define dbcsr_type_complex_8  7
-#define MAX_BLOCK_DIM         80
 
 
 //===========================================================================

--- a/src/acc/libsmm_acc/libcusmm/libcusmm.cpp
+++ b/src/acc/libsmm_acc/libcusmm/libcusmm.cpp
@@ -298,7 +298,7 @@ int libcusmm_transpose_d(int *trs_stack, int offset, int nblks,
     
     // Construct argument pointer list and lauch function
     int* trs_stack_ = trs_stack + offset; 
-    void *args[] = { &trs_stack_, &nblks, &buffer};
+    void *args[] = { &trs_stack_, &buffer};
     int res = launch_kernel_from_handle(kern_func, nblks, 128, stream, args); 
 
     return(cudaGetLastError());

--- a/src/acc/libsmm_acc/libcusmm/libcusmm.h
+++ b/src/acc/libsmm_acc/libcusmm/libcusmm.h
@@ -59,7 +59,7 @@ int libcusmm_process_d(int *param_stack, int stack_size,
 static std::unordered_map<Triplet, CUfunction> transpose_handles;
 
 int libcusmm_transpose_d(int *trs_stack, int offset, int nblks, double *buffer,
-                         int m, int n, cudaStream_t * stream);
+                         int m, int n, CUstream stream);
 
 #endif
 //EOF

--- a/src/acc/libsmm_acc/libcusmm/libcusmm_benchmark.cu
+++ b/src/acc/libsmm_acc/libcusmm/libcusmm_benchmark.cu
@@ -442,16 +442,16 @@ int libcusmm_benchmark_transpose_(int n_stack, int* stack, int* d_stack,
  clean_string(kernel_descr[0], descr);
  cudaError = cudaGetLastError();
  if (cudaError != cudaSuccess){
-   printf("%s[TR] ERROR %s cuda_error: %s\n", msg_prefix, descr, cudaGetErrorString(cudaError));
+   printf("%sERROR %s cuda_error: %s\n", msg_prefix, descr, cudaGetErrorString(cudaError));
    error_counter++;
  }
 
  sumGPU = checkSumTransp(mat_trs, n, mat_m, mat_n);
  if(sumGPU != sumCPU){
-     printf("%s[TR] ERROR %s checksum_diff: %g\n", msg_prefix, descr, sumGPU-sumCPU);
+     printf("%sERROR %s checksum_diff: %g\n", msg_prefix, descr, sumGPU-sumCPU);
      error_counter++;
  } else {
-     printf("%s[TR] OK %s\n", msg_prefix, descr);
+     printf("%sOK %s\n", msg_prefix, descr);
  }
 
  return error_counter;
@@ -461,10 +461,10 @@ int libcusmm_benchmark_transpose_(int n_stack, int* stack, int* d_stack,
 
 //===========================================================================
 int libcusmm_benchmark_transpose(libcusmm_benchmark_t* handle,
-                                 int mat_m, int mat_n, int mat_k,
+                                 int mat_m, int mat_n,
                                  TransposeLauncher* launcher, char** kernel_descr){
 
- if(mat_m > handle->max_m || mat_n > handle->max_n || mat_k > handle->max_k){
+ if(mat_m > handle->max_m || mat_n > handle->max_n){
      printf("libcusmm_benchmark_transpose: got handle with too few resources\n");
      exit(1);
  }
@@ -476,15 +476,8 @@ int libcusmm_benchmark_transpose(libcusmm_benchmark_t* handle,
  int errors;
  errors += libcusmm_benchmark_transpose_(handle->n_stack_trs_a, handle->stack_trs_a, handle->d_stack_trs_a,
                                          handle->mat_a, handle->mat_trs_a, handle->d_mat_a,
-                                         handle->n_a, mat_m, mat_k,
+                                         handle->n_a, mat_m, mat_n,
                                          handle->t_start, handle->t_stop, kernel_descr, launcher);
- if(mat_m == mat_k && mat_k == mat_n){
-     // Test transpose of matrix 'b' if its dimensions differ from matrix 'a'
-     errors += libcusmm_benchmark_transpose_(handle->n_stack_trs_b, handle->stack_trs_b, handle->d_stack_trs_b,
-                                             handle->mat_b, handle->mat_trs_b, handle->d_mat_b,
-                                             handle->n_b, mat_k, mat_n,
-                                             handle->t_start, handle->t_stop, kernel_descr, launcher);
- }
  return errors;
 
 }

--- a/src/acc/libsmm_acc/libcusmm/libcusmm_benchmark.cu
+++ b/src/acc/libsmm_acc/libcusmm/libcusmm_benchmark.cu
@@ -210,7 +210,7 @@ double checkSum(double* mat_c, int n_c, int mat_m, int mat_n){
 
 
 //===========================================================================
-double checkSumTransp(double* mat, int n, int mat_m, int mat_n){
+double checkSumTransp(double* mat, int n, int n_stack, int mat_m, int mat_n){
     // for transposition, a regular checkSum does not inform about the 
     // transpose's correctness. Instead, we perform a checkSum on a 
     // sample of elements.
@@ -393,7 +393,7 @@ int libcusmm_benchmark_transpose_(int n_stack, int* stack, int* d_stack,
 
  // Reference result on CPU
  stackTransp(stack, n_stack, mat, mat_trs, mat_m, mat_n);
- sumCPU = checkSumTransp(mat_trs, n, mat_m, mat_n);
+ sumCPU = checkSumTransp(mat_trs, n, n_stack, mat_m, mat_n);
 
  // Compute on GPU
  cudaMemcpy(d_mat, mat, n * mat_m * mat_n * sizeof(double), cudaMemcpyHostToDevice);
@@ -429,7 +429,7 @@ int libcusmm_benchmark_transpose_(int n_stack, int* stack, int* d_stack,
    error_counter++;
  }
 
- sumGPU = checkSumTransp(mat_trs, n, mat_m, mat_n);
+ sumGPU = checkSumTransp(mat_trs, n, n_stack, mat_m, mat_n);
  if(sumGPU != sumCPU){
      printf("%sERROR %s checksum_diff: %g\n", msg_prefix, descr, sumGPU-sumCPU);
      error_counter++;

--- a/src/acc/libsmm_acc/libcusmm/libcusmm_benchmark.h
+++ b/src/acc/libsmm_acc/libcusmm/libcusmm_benchmark.h
@@ -59,7 +59,7 @@ void libcusmm_benchmark_finalize(libcusmm_benchmark_t*);
 int libcusmm_benchmark(libcusmm_benchmark_t* handle,
               int mat_m, int mat_n, int mat_k, int nkernel,
               KernelLauncher* launchers, char** kernel_descr);
-int libcusmm_benchmark_transpose(libcusmm_benchmark_t* handle, int mat_m, int mat_n, int mat_k, 
+int libcusmm_benchmark_transpose(libcusmm_benchmark_t* handle, int mat_m, int mat_n, 
                                  TransposeLauncher* launcher, char** kernel_descr);
 int libcusmm_benchmark_transpose_(int n_stack, int* stack, int* d_stack,
                                   double* mat, double* mat_trs, double* d_mat,

--- a/src/acc/libsmm_acc/libcusmm/libcusmm_benchmark.h
+++ b/src/acc/libsmm_acc/libcusmm/libcusmm_benchmark.h
@@ -40,8 +40,7 @@ void matInit(double* mat, int mat_n, int x, int y, int seed);
 void stackInit(int *stack, int n_stack, int n_c, double* mat_c,
                int n_a, double * mat_a, int n_b, double* mat_b,
                int mat_m, int mat_n, int mat_k);
-void stackInitTransp(int *stack, int n_stack, int n_a, double * mat_a,
-                     int mat_m, int mat_n);
+void stackInitTransp(int *stack, int n_stack, int mat_m, int mat_n);
 
 void stackCalc(int* stack, int n_stack, double* mat_c, double *mat_a, double* mat_b,
                int mat_m, int mat_n, int mat_k);

--- a/src/acc/libsmm_acc/libcusmm/libcusmm_benchmark.h
+++ b/src/acc/libsmm_acc/libcusmm/libcusmm_benchmark.h
@@ -48,7 +48,7 @@ void stackTransp(int* stack, int n_stack, double *mat_a, double* mat_atrs,
                  int mat_m, int mat_n);
 
 double checkSum(double* mat_c, int n_c, int mat_m, int mat_n);
-double checkSumTransp(double* mat, int n_a, int mat_m, int mat_n);
+double checkSumTransp(double* mat, int n, int n_stack, int mat_m, int mat_n);
 
 void libcusmm_benchmark_init(libcusmm_benchmark_t** handle, bool tune_mode,
                              int max_m, int max_n, int max_k);

--- a/src/acc/libsmm_acc/libcusmm/libcusmm_benchmark.h
+++ b/src/acc/libsmm_acc/libcusmm/libcusmm_benchmark.h
@@ -7,6 +7,8 @@
 
 #include <cuda.h>
 
+#define MAX_BLOCK_DIM 80
+
 typedef int (*KernelLauncher)(int *param_stack, int stack_size, CUstream stream,
                               int m_max, int n_max, int k_max,
                               double *a_data, double *b_data, double *c_data);

--- a/src/acc/libsmm_acc/libcusmm/libcusmm_benchmark.h
+++ b/src/acc/libsmm_acc/libcusmm/libcusmm_benchmark.h
@@ -13,24 +13,24 @@ typedef int (*KernelLauncher)(int *param_stack, int stack_size, CUstream stream,
                               int m_max, int n_max, int k_max,
                               double *a_data, double *b_data, double *c_data);
 
+typedef int (*TransposeLauncher)(int *param_stack, int offset, int nblks, 
+                                 double *buffer, int m, int n, CUstream stream);
+
 typedef struct {
     bool tune_mode;
     // max block-sizes to expect
     int max_m, max_n, max_k;
     // number of blocks to allocate in each panel
     int n_a, n_b, n_c;
-    // length of stack
-    int n_stack;
+    // length of stack (multiplication, transpose a, transpose b) 
+    int n_stack, n_stack_trs_a, n_stack_trs_b;
     // host-buffers
-    double* mat_a;
-    double* mat_b;
-    double* mat_c;
-    int*    stack;
+    double *mat_a, *mat_b, *mat_c;
+    double *mat_trs_a, *mat_trs_b;
+    int    *stack, *stack_trs_a, *stack_trs_b;
     // device-buffers
-    double* d_mat_a;
-    double* d_mat_b;
-    double* d_mat_c;
-    int*    d_stack;
+    double *d_mat_a, *d_mat_b, *d_mat_c;
+    int    *d_stack, *d_stack_trs_a, *d_stack_trs_b; 
     // events for measuring the runtime
     CUevent t_start, t_stop;
 } libcusmm_benchmark_t;
@@ -40,11 +40,16 @@ void matInit(double* mat, int mat_n, int x, int y, int seed);
 void stackInit(int *stack, int n_stack, int n_c, double* mat_c,
                int n_a, double * mat_a, int n_b, double* mat_b,
                int mat_m, int mat_n, int mat_k);
+void stackInitTransp(int *stack, int n_stack, int n_a, double * mat_a,
+                     int mat_m, int mat_n);
 
 void stackCalc(int* stack, int n_stack, double* mat_c, double *mat_a, double* mat_b,
                int mat_m, int mat_n, int mat_k);
+void stackTransp(int* stack, int n_stack, double *mat_a, double* mat_atrs,
+                 int mat_m, int mat_n);
 
 double checkSum(double* mat_c, int n_c, int mat_m, int mat_n);
+double checkSumTransp(double* mat, int n_a, int mat_m, int mat_n);
 
 void libcusmm_benchmark_init(libcusmm_benchmark_t** handle, bool tune_mode,
                              int max_m, int max_n, int max_k);
@@ -54,6 +59,12 @@ void libcusmm_benchmark_finalize(libcusmm_benchmark_t*);
 int libcusmm_benchmark(libcusmm_benchmark_t* handle,
               int mat_m, int mat_n, int mat_k, int nkernel,
               KernelLauncher* launchers, char** kernel_descr);
-
+int libcusmm_benchmark_transpose(libcusmm_benchmark_t* handle, int mat_m, int mat_n, int mat_k, 
+                                 TransposeLauncher* launcher, char** kernel_descr);
+int libcusmm_benchmark_transpose_(int n_stack, int* stack, int* d_stack,
+                                  double* mat, double* mat_trs, double* d_mat,
+                                  int n, int mat_m, int mat_n,
+                                  CUevent start, CUevent stop, char** kernel_descr,
+                                  TransposeLauncher* launcher);
 #endif
 //EOF

--- a/tests/Makefile.inc
+++ b/tests/Makefile.inc
@@ -17,6 +17,9 @@ SRC_TESTS += dbcsr_tensor_unittest.F
 dbcsr_tensor_unittest: BIN_DEPS = 
 
 ifneq ($(NVCC),)
-SRC_TESTS += libcusmm_unittest.cu
-libcusmm_unittest: BIN_DEPS =
+SRC_TESTS += libcusmm_unittest_multiply.cu
+libcusmm_unittest_multiply.cu: BIN_DEPS =
+
+SRC_TESTS += libcusmm_unittest_transpose.cu
+libcusmm_unittest_transpose.cu: BIN_DEPS =
 endif

--- a/tests/libcusmm_unittest.cu
+++ b/tests/libcusmm_unittest.cu
@@ -19,11 +19,13 @@
 
 int main(int argc, char** argv){
 
-    KernelLauncher launcher = libcusmm_process_d;
+    KernelLauncher launcher_mm = libcusmm_process_d;
+    TransposeLauncher launcher_tr = libcusmm_transpose_d;
 
     char buffer[1000];
     char * kernel_descr[1] = {buffer};
 
+    // Get all blocksizes available in libcusmm
     std::vector<Triplet> libcusmm_triplets;
     get_libcusmm_triplets(libcusmm_triplets, ht);
     int n_triplets = libcusmm_triplets.size();
@@ -39,18 +41,21 @@ int main(int argc, char** argv){
     libcusmm_benchmark_t* handle;
     libcusmm_benchmark_init(&handle, false, max_m, max_n, max_k);
 
-    int errors = 0;
+    int errors_mm = 0;
+    int errors_tr = 0;
     for(int i=0; i<n_triplets; i++){
         int m = libcusmm_triplets[i][0];
         int n = libcusmm_triplets[i][1];
         int k = libcusmm_triplets[i][2];
         sprintf(buffer, "%d x %d x %d", m, n, k);
-        errors += libcusmm_benchmark(handle, m, n, k, 1, &launcher, kernel_descr);
+        errors_mm += libcusmm_benchmark(handle, m, n, k, 1, &launcher_mm, kernel_descr);
+        errors_tr += libcusmm_benchmark_transpose(handle, m, n, k, &launcher_tr, kernel_descr);
     }
     libcusmm_benchmark_finalize(handle);
 
-    printf("# Done, found %d errors.\n", errors);
-    return(errors);
+    printf("# Done, found %d matrix-matrix multiplication errors.\n", errors_mm);
+    printf("# Done, found %d transpose errors.\n", errors_tr);
+    return errors_mm + errors_tr;
 }
 
 //EOF

--- a/tests/libcusmm_unittest_multiply.cu
+++ b/tests/libcusmm_unittest_multiply.cu
@@ -14,13 +14,12 @@
 
 
 /****************************************************************************\
- \brief Checks correctness of every libcusmm kernel and measures its performance.
+ \brief Checks correctness of every libcusmm multiplication kernel and measures its performance.
 \****************************************************************************/
 
 int main(int argc, char** argv){
 
     KernelLauncher launcher_mm = libcusmm_process_d;
-    TransposeLauncher launcher_tr = libcusmm_transpose_d;
 
     char buffer[1000];
     char * kernel_descr[1] = {buffer};
@@ -41,21 +40,18 @@ int main(int argc, char** argv){
     libcusmm_benchmark_t* handle;
     libcusmm_benchmark_init(&handle, false, max_m, max_n, max_k);
 
-    int errors_mm = 0;
-    int errors_tr = 0;
+    int errors = 0;
     for(int i=0; i<n_triplets; i++){
         int m = libcusmm_triplets[i][0];
         int n = libcusmm_triplets[i][1];
         int k = libcusmm_triplets[i][2];
         sprintf(buffer, "%d x %d x %d", m, n, k);
-        errors_mm += libcusmm_benchmark(handle, m, n, k, 1, &launcher_mm, kernel_descr);
-        errors_tr += libcusmm_benchmark_transpose(handle, m, n, k, &launcher_tr, kernel_descr);
+        errors += libcusmm_benchmark(handle, m, n, k, 1, &launcher_mm, kernel_descr);
     }
     libcusmm_benchmark_finalize(handle);
 
-    printf("# Done, found %d matrix-matrix multiplication errors.\n", errors_mm);
-    printf("# Done, found %d transpose errors.\n", errors_tr);
-    return errors_mm + errors_tr;
+    printf("# Done, found %d matrix-matrix multiplication errors.\n", errors);
+    return errors;
 }
 
 //EOF

--- a/tests/libcusmm_unittest_multiply.cu
+++ b/tests/libcusmm_unittest_multiply.cu
@@ -28,7 +28,7 @@ int main(int argc, char** argv){
     std::vector<Triplet> libcusmm_triplets;
     get_libcusmm_triplets(libcusmm_triplets, ht);
     int n_triplets = libcusmm_triplets.size();
-    printf("# Libcusmm has %d blocksizes compiled in...\n", n_triplets);
+    printf("# Libcusmm has %d blocksizes for multiplication\n", n_triplets);
 
     int max_m=0, max_n=0, max_k=0;
     for(int i=0; i<n_triplets; i++){

--- a/tests/libcusmm_unittest_transpose.cu
+++ b/tests/libcusmm_unittest_transpose.cu
@@ -1,0 +1,75 @@
+/*****************************************************************************
+ *  CP2K: A general program to perform molecular dynamics simulations        *
+ *  Copyright (C) 2000 - 2018  CP2K developers group                         *
+ *****************************************************************************/
+
+#include <algorithm>
+#include <stdio.h>
+#include <stdlib.h>
+#include <cuda_runtime.h>
+#include <vector>
+#include <array>
+#include <utility>
+#include "acc/libsmm_acc/libcusmm/libcusmm_benchmark.h"
+#include "acc/libsmm_acc/libcusmm/libcusmm.h"
+#include "acc/libsmm_acc/libcusmm/parameters.h"
+
+
+/****************************************************************************\
+ \brief Checks correctness of every libcusmm transpose kernel.
+\****************************************************************************/
+
+int main(int argc, char** argv){
+
+    TransposeLauncher launcher_tr = libcusmm_transpose_d;
+
+    char buffer[1000];
+    char * kernel_descr[1] = {buffer};
+
+    // Get all blocksizes available in libcusmm
+    std::vector<Triplet> libcusmm_triplets;
+    get_libcusmm_triplets(libcusmm_triplets, ht);
+    int n_triplets = libcusmm_triplets.size();
+    printf("# Libcusmm has %d blocksizes compiled in...\n", n_triplets);
+
+    int max_m=0, max_n=0, max_k=0;
+    for(int i=0; i<n_triplets; i++){
+        max_m = max(max_n, libcusmm_triplets[i][0]);
+        max_n = max(max_m, libcusmm_triplets[i][1]);
+        max_k = max(max_k, libcusmm_triplets[i][2]);
+    }
+
+    libcusmm_benchmark_t* handle;
+    libcusmm_benchmark_init(&handle, false, max_m, max_n, max_k);
+
+    // Get (m,n) pairs to test transposition
+    std::vector<std::pair<int,int> > libcusmm_transpose_pairs; 
+    for(int i=0; i<n_triplets; i++){
+        int m = libcusmm_triplets[i][0];
+        int n = libcusmm_triplets[i][1];
+        int k = libcusmm_triplets[i][2];
+        libcusmm_transpose_pairs.push_back(std::make_pair(m, k));
+        libcusmm_transpose_pairs.push_back(std::make_pair(k, n));
+    }
+    std::sort(libcusmm_transpose_pairs.begin(), libcusmm_transpose_pairs.end(), 
+              [](std::pair<int,int> a, std::pair<int,int> b) {
+        return (a.first > b.first) || (a.first == b.first && a.second > b.second) ;   
+    });
+    auto last = std::unique(libcusmm_transpose_pairs.begin(), libcusmm_transpose_pairs.end());
+    libcusmm_transpose_pairs.erase(last, libcusmm_transpose_pairs.end()); 
+    int n_pairs = libcusmm_transpose_pairs.size();
+
+    int errors = 0;
+    for(int i=0; i<n_pairs; i++){
+        int m = libcusmm_transpose_pairs[i].first;
+        int n = libcusmm_transpose_pairs[i].second;
+        sprintf(buffer, "%d x %d", m, n);
+        errors += libcusmm_benchmark_transpose(handle, m, n, &launcher_tr, kernel_descr);
+    }
+    libcusmm_benchmark_finalize(handle);
+
+    printf("# Done, found %d transpose errors.\n", errors);
+    return errors;
+}
+
+//EOF

--- a/tests/libcusmm_unittest_transpose.cu
+++ b/tests/libcusmm_unittest_transpose.cu
@@ -30,7 +30,6 @@ int main(int argc, char** argv){
     std::vector<Triplet> libcusmm_triplets;
     get_libcusmm_triplets(libcusmm_triplets, ht);
     int n_triplets = libcusmm_triplets.size();
-    printf("# Libcusmm has %d blocksizes compiled in...\n", n_triplets);
 
     int max_m=0, max_n=0, max_k=0;
     for(int i=0; i<n_triplets; i++){
@@ -58,6 +57,7 @@ int main(int argc, char** argv){
     auto last = std::unique(libcusmm_transpose_pairs.begin(), libcusmm_transpose_pairs.end());
     libcusmm_transpose_pairs.erase(last, libcusmm_transpose_pairs.end()); 
     int n_pairs = libcusmm_transpose_pairs.size();
+    printf("# Libcusmm has %d blocksizes for transposition\n", n_pairs);
 
     int errors = 0;
     for(int i=0; i<n_pairs; i++){


### PR DESCRIPTION
- Add a unittest in libcusmm to test the transpose kernel as well 
- Rename the previous unittest "unittest_multiply"
- Remove an unused argument in the libcusmm transpose kernel 
- Remove obsolete commented out lines in the benchmarking code (libcusmm_benchmark.cu) 
- Closes #27 