### PR TITLE
Feature/remove python eval

### DIFF
--- a/src/acc/libsmm_acc/libcusmm/collect.py
+++ b/src/acc/libsmm_acc/libcusmm/collect.py
@@ -9,11 +9,11 @@ import json
 from ast import literal_eval
 from kernels.cusmm_dnt import kernel_algorithm
 
-re_mnk    = re.compile("tune_(\d+)x(\d+)x(\d+)_")
-re_winner = re.compile("\nWINNER: \d+ (.+)\n")
-re_gflops = re.compile("# ([0-9.]+) GFlop/s")
-re_errors = re.compile("Number of errors: (\d+)\n")
-re_kernel_descr = re.compile("Kernel_dnt_(\w+)(\(.*\)) , # (\d+\.\d+) GFlop/s")
+re_mnk    = re.compile(r"tune_(\d+)x(\d+)x(\d+)_")
+re_winner = re.compile(r"\nWINNER: \d+ (.+)\n")
+re_gflops = re.compile(r"# ([0-9.]+) GFlop/s")
+re_errors = re.compile(r"Number of errors: (\d+)\n")
+re_kernel_descr = re.compile(r"Kernel_dnt_(\w+)(\(.*\)) , # (\d+\.\d+) GFlop/s")
 
 def get_kernel(kernel_descr):
     match = re_kernel_descr.search(kernel_descr).groups()

--- a/src/acc/libsmm_acc/libcusmm/collect.py
+++ b/src/acc/libsmm_acc/libcusmm/collect.py
@@ -3,13 +3,8 @@
 
 import sys
 import os
-from os import path
-from os.path import basename
 from glob import glob
-from itertools import product, chain
-from optparse import OptionParser
 import re
-from pprint import pprint
 
 re_mnk    = re.compile("tune_(\d+)x(\d+)x(\d+)_")
 re_winner = re.compile("\nWINNER: \d+ (.+)\n")
@@ -21,13 +16,13 @@ def main():
     winners = dict()
 
     for d in glob("tune_*"):
-        if(not path.isdir(d)):
+        if(not os.path.isdir(d)):
             continue
 
         for exe_fn in glob(d+"/tune_*main.cu"):
             mnk = tuple([int(i) for i in re_mnk.search(exe_fn).groups()])
             log_fn = exe_fn.replace("_main.cu", ".log")
-            if(not path.exists(log_fn)):
+            if(not os.path.exists(log_fn)):
                 winners[mnk] = "log missing: "+log_fn
                 continue
 
@@ -47,14 +42,12 @@ def main():
     f.close()
 
     print("Wrote parameters.txt")
-    ##pprint(winners)
 
 #===============================================================================
 def process_log(log_fn, mnk, winners):
     print("Reading: "+log_fn)
 
     f = open(log_fn)
-    #f.seek(-1000, os.SEEK_END)
     content = f.read()
     f.close()
 

--- a/src/acc/libsmm_acc/libcusmm/collect.py
+++ b/src/acc/libsmm_acc/libcusmm/collect.py
@@ -31,13 +31,13 @@ def main():
     winners = dict()
 
     for d in glob("tune_*"):
-        if(not os.path.isdir(d)):
+        if not os.path.isdir(d):
             continue
 
         for exe_fn in glob(d+"/tune_*main.cu"):
             mnk = tuple([int(i) for i in re_mnk.search(exe_fn).groups()])
             log_fn = exe_fn.replace("_main.cu", ".log")
-            if(not os.path.exists(log_fn)):
+            if not os.path.exists(log_fn):
                 winners[mnk] = "log missing: "+log_fn
                 continue
 
@@ -63,31 +63,31 @@ def process_log(log_fn, mnk, winners):
     f.close()
 
     m = re_errors.search(content)
-    if(not m):
+    if not m:
         winners[mnk] = "log incomplete: "+log_fn
         return
 
     n_errors = int(m.group(1))
-    if(n_errors != 0):
+    if n_errors != 0:
         winners[mnk] = "errors: "+log_fn
         return
 
     old_gflops = 0.0
-    if(mnk in winners.keys()):
+    if mnk in winners.keys():
         m = re_gflops.search(winners[mnk])
-        if(not m):
+        if not m:
             return
         old_gflops = float(m.group(1))
 
     new_winner = re_winner.search(content).group(1).strip().replace("GFlops","GFlop/s")
     new_gflops = float(re_gflops.search(new_winner).group(1))
 
-    if(new_gflops > old_gflops):
+    if new_gflops > old_gflops :
         winners[mnk] = new_winner
 
 
 #===============================================================================
-if(len(sys.argv)==2 and sys.argv[-1]=="--selftest"):
+if len(sys.argv)==2 and sys.argv[-1]=="--selftest":
     pass #TODO implement selftest
 else:
     main()

--- a/src/acc/libsmm_acc/libcusmm/collect.py
+++ b/src/acc/libsmm_acc/libcusmm/collect.py
@@ -73,7 +73,7 @@ def process_log(log_fn, mnk, winners):
         return
 
     old_gflops = 0.0
-    if(winners.has_key(mnk)):
+    if(mnk in winners.keys()):
         m = re_gflops.search(winners[mnk])
         if(not m):
             return

--- a/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt.py
+++ b/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt.py
@@ -3,59 +3,51 @@
 
 class Kernel:
 
-    characteristic_parameters = [
-        'm', 'n', 'k',
-        'tile_m', 'tile_n',
-        'w', 'v',
-        'threads', 'grouping', 'minblocks',
-        'algorithm', 'perf'
-    ]
-
-    naming_parameters = [
-        'm', 'n', 'k',
-        'tile_m', 'tile_n',
-        'w', 'v',
-        'threads', 'grouping', 'minblocks',
-    ]
-
-    def __init__(self, **params):
-        pass
-
     def __repr__(self):
-        return ("<%s>" % self.name)
+        return "<%s>" % self.name
 
     def can_handle(self, m, n, k):
-        return (self.m == m and self.n == n and self.k == k)
+        return self.m == m and self.n == n and self.k == k
 
+    @property
     def include(self):
-        pass
+        return "cusmm_dnt_" + self.algorithm + ".h"
 
-    def to_dict(self):
-        pass
+    @property
+    def name(self):
+        return "cusmm_dnt_" + self.algorithm + "_" + \
+               "_".join([str(self.__dict__[k]) for k in sorted(self.launch_parameters)])
 
-    def compose_launcher_code(self, func_signature):
-        output  = "int launch_"+self.name+"(int *param_stack, int stack_size, "
+    @property
+    def as_dict(self):
+        return {**self.__dict__, **{'algorithm': self.algorithm}}
+
+    @property
+    def launcher_code(self):
+        output  = "int launch_" + self.name + "(int *param_stack, int stack_size, "
         output += "cudaStream_t stream, int m_max, int n_max, int k_max, "
         output += "double *a_data, double *b_data, double *c_data){\n"
         output += "int shared_size = 0;\n"
-        output += "//%s\n"%str(self.__dict__)
+        output += "//%s\n" % str(self.__dict__)
         output += "typedef void (*kernel)(const int*, int, const double*, const double*, double*);\n"
-        output += "static kernel kern_func = " + func_signature
+        output += "static kernel kern_func = " + self.func_signature
         output += "static bool configured = false;\n"
         output += "if(configured == false){\n"
         output += "  cudaError_t err = cudaFuncSetSharedMemConfig(kern_func, cudaSharedMemBankSizeEightByte);\n"
         output += "  if(err != cudaSuccess) return(-1);\n"
         output += "  configured = true;\n"
         output += "}\n"
-        output += "kern_func<<< ((stack_size + %(grouping)d - 1) / %(grouping)d), %(threads)d, shared_size, stream >>>\n"%self.__dict__
+        output += "kern_func<<< ((stack_size + %(grouping)d - 1) / %(grouping)d), %(threads)d, shared_size, stream >>>\n" \
+                  % self.__dict__
         output += "(param_stack, stack_size, \n"
         output += "a_data, b_data, c_data);\n"
         output += "return(0);\n"
         output += "}\n"
-        return(output)
+        return output
 
     @staticmethod
     def promising_parameters(m, n, k):
-        pass
+        raise NotImplementedError()
+
 
 #EOF

--- a/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt.py
+++ b/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+
+class Kernel:
+
+    characteristic_parameters = [
+        'm', 'n', 'k',
+        'tile_m', 'tile_n',
+        'w', 'v',
+        'threads', 'grouping', 'minblocks',
+        'algorithm', 'perf'
+    ]
+
+    naming_parameters = [
+        'm', 'n', 'k',
+        'tile_m', 'tile_n',
+        'w', 'v',
+        'threads', 'grouping', 'minblocks',
+    ]
+
+    def __init__(self, **params):
+        pass
+
+    def __repr__(self):
+        return ("<%s>" % self.name)
+
+    def can_handle(self, m, n, k):
+        return (self.m == m and self.n == n and self.k == k)
+
+    def include(self):
+        pass
+
+    def to_dict(self):
+        pass
+
+    def compose_launcher_code(self, func_signature):
+        output  = "int launch_"+self.name+"(int *param_stack, int stack_size, "
+        output += "cudaStream_t stream, int m_max, int n_max, int k_max, "
+        output += "double *a_data, double *b_data, double *c_data){\n"
+        output += "int shared_size = 0;\n"
+        output += "//%s\n"%str(self.__dict__)
+        output += "typedef void (*kernel)(const int*, int, const double*, const double*, double*);\n"
+        output += "static kernel kern_func = " + func_signature
+        output += "static bool configured = false;\n"
+        output += "if(configured == false){\n"
+        output += "  cudaError_t err = cudaFuncSetSharedMemConfig(kern_func, cudaSharedMemBankSizeEightByte);\n"
+        output += "  if(err != cudaSuccess) return(-1);\n"
+        output += "  configured = true;\n"
+        output += "}\n"
+        output += "kern_func<<< ((stack_size + %(grouping)d - 1) / %(grouping)d), %(threads)d, shared_size, stream >>>\n"%self.__dict__
+        output += "(param_stack, stack_size, \n"
+        output += "a_data, b_data, c_data);\n"
+        output += "return(0);\n"
+        output += "}\n"
+        return(output)
+
+    @staticmethod
+    def promising_parameters(m, n, k):
+        pass
+
+#EOF

--- a/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt.py
+++ b/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt.py
@@ -50,4 +50,18 @@ class Kernel:
         raise NotImplementedError()
 
 
+from kernels.cusmm_dnt_largeDB1 import Kernel_dnt_largeDB1
+from kernels.cusmm_dnt_largeDB2 import Kernel_dnt_largeDB2
+from kernels.cusmm_dnt_medium   import Kernel_dnt_medium
+from kernels.cusmm_dnt_small    import Kernel_dnt_small
+from kernels.cusmm_dnt_tiny     import Kernel_dnt_tiny
+
+kernel_algorithm = {
+    'tiny': Kernel_dnt_tiny,
+    'small': Kernel_dnt_small,
+    'medium': Kernel_dnt_medium,
+    'largeDB1': Kernel_dnt_largeDB1,
+    'largeDB2': Kernel_dnt_largeDB2
+}
+
 #EOF

--- a/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt_largeDB1.py
+++ b/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt_largeDB1.py
@@ -1,47 +1,31 @@
 # -*- coding: utf-8 -*-
+from kernels import cusmm_dnt
 
-from math import ceil
 
-class Kernel_dnt_largeDB1(object):
+class Kernel_dnt_largeDB1(cusmm_dnt.Kernel):
+
+    algorithm = "largeDB1"
+
     def __init__(self, **params):
         self.__dict__.update(params)
         self.name  = "cusmm_dnt_largeDB1_"
-        self.name += "_".join([str(params[k]) for k in sorted(params.keys())])
+        self.name += "_".join([str(params[k]) for k in sorted(super().naming_parameters) if k in params.keys()])
         assert(self.threads * self.minblocks <= 2048)
         min_threads = ((self.m+self.tile_m-1)//self.tile_m) * ((self.n+self.tile_n-1)//self.tile_n)
         assert(min_threads <= self.threads)
         assert(self.tile_m <= self.v)
         assert(self.tile_n <= self.w)
 
-    def __repr__(self):
-        return("<%s>"%self.name)
-
-    def can_handle(self, m, n, k):
-        return(self.m==m and self.n==n and self.k==k)
-
     def include(self):
         return("cusmm_dnt_largeDB1.h")
 
-    def launcher_code(self):
-       output  = "int launch_"+self.name+"(int *param_stack, int stack_size, "
-       output += "cudaStream_t stream, int m_max, int n_max, int k_max, "
-       output += "double *a_data, double *b_data, double *c_data){\n"
-       output += "int shared_size = 0;\n"
-       output += "//%s\n"%str(self.__dict__)
-       output += "typedef void (*kernel)(const int*, int, const double*, const double*, double*);\n"
-       output += "static kernel kern_func = cusmm_dnt_largeDB1<%(m)d,%(n)d,%(k)d,%(tile_m)d,%(tile_n)d,%(w)d,%(v)d,%(threads)d,%(grouping)d,%(minblocks)d>;\n"%self.__dict__
-       output += "static bool configured = false;\n"
-       output += "if(configured == false){\n"
-       output += "  cudaError_t err = cudaFuncSetSharedMemConfig(kern_func, cudaSharedMemBankSizeEightByte);\n"
-       output += "  if(err != cudaSuccess) return(-1);\n"
-       output += "  configured = true;\n"
-       output += "}\n"
-       output += "kern_func<<< ((stack_size + %(grouping)d - 1) / %(grouping)d), %(threads)d, shared_size, stream >>>"%self.__dict__
-       output += "(param_stack, stack_size, a_data, b_data, c_data);\n"
-       output += "return(0);\n"
-       output += "}\n"
-       return(output)
+    def to_dict(self):
+        d = {**self.__dict__, **{'algorithm': self.algorithm}}
+        return dict([(e, d[e]) for e in super().characteristic_parameters if e in d.keys()])
 
+    def launcher_code(self):
+        sign = "cusmm_dnt_largeDB1<%(m)d,%(n)d,%(k)d,%(tile_m)d,%(tile_n)d,%(w)d,%(v)d,%(threads)d,%(grouping)d,%(minblocks)d>;\n" % self.__dict__
+        return super().compose_launcher_code(sign)
 
     @staticmethod
     def promising_parameters(m, n, k):

--- a/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt_largeDB1.py
+++ b/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt_largeDB1.py
@@ -5,27 +5,30 @@ from kernels import cusmm_dnt
 class Kernel_dnt_largeDB1(cusmm_dnt.Kernel):
 
     algorithm = "largeDB1"
+    launch_parameters = ['m', 'n', 'k', 'tile_m', 'tile_n', 'w', 'v', 'threads', 'grouping', 'minblocks']
 
-    def __init__(self, **params):
-        self.__dict__.update(params)
-        self.name  = "cusmm_dnt_largeDB1_"
-        self.name += "_".join([str(params[k]) for k in sorted(super().naming_parameters) if k in params.keys()])
+    def __init__(self, *, m, n, k, threads, tile_m, tile_n, w, v, grouping, minblocks, perf):
+        self.m = m
+        self.n = n
+        self.k = k
+        self.tile_m = tile_m
+        self.tile_n = tile_n
+        self.w = w
+        self.v = v
+        self.threads = threads
+        self.grouping = grouping
+        self.minblocks = minblocks
+        self.perf = perf
         assert(self.threads * self.minblocks <= 2048)
         min_threads = ((self.m+self.tile_m-1)//self.tile_m) * ((self.n+self.tile_n-1)//self.tile_n)
         assert(min_threads <= self.threads)
         assert(self.tile_m <= self.v)
         assert(self.tile_n <= self.w)
 
-    def include(self):
-        return("cusmm_dnt_largeDB1.h")
-
-    def to_dict(self):
-        d = {**self.__dict__, **{'algorithm': self.algorithm}}
-        return dict([(e, d[e]) for e in super().characteristic_parameters if e in d.keys()])
-
-    def launcher_code(self):
-        sign = "cusmm_dnt_largeDB1<%(m)d,%(n)d,%(k)d,%(tile_m)d,%(tile_n)d,%(w)d,%(v)d,%(threads)d,%(grouping)d,%(minblocks)d>;\n" % self.__dict__
-        return super().compose_launcher_code(sign)
+    @property
+    def func_signature(self):
+        return "cusmm_dnt_largeDB1<%(m)d,%(n)d,%(k)d,%(tile_m)d,%(tile_n)d,%(w)d,%(v)d,%(threads)d,%(grouping)d,%(minblocks)d>;\n" \
+               % self.__dict__
 
     @staticmethod
     def promising_parameters(m, n, k):

--- a/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt_largeDB2.py
+++ b/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt_largeDB2.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
+from kernels import cusmm_dnt
 
-from math import ceil
 
-class Kernel_dnt_largeDB2(object):
+class Kernel_dnt_largeDB2(cusmm_dnt.Kernel):
+
+    algorithm = "largeDB2"
+
     def __init__(self, **params):
         self.__dict__.update(params)
         self.name  = "cusmm_dnt_largeDB2_"
@@ -13,35 +16,16 @@ class Kernel_dnt_largeDB2(object):
         assert(self.tile_m <= self.v)
         assert(self.tile_n <= self.w)
 
-    def __repr__(self):
-        return("<%s>"%self.name)
-
-    def can_handle(self, m, n, k):
-        return(self.m==m and self.n==n and self.k==k)
-
     def include(self):
         return("cusmm_dnt_largeDB2.h")
 
-    def launcher_code(self):
-       output  = "int launch_"+self.name+"(int *param_stack, int stack_size, "
-       output += "cudaStream_t stream, int m_max, int n_max, int k_max, "
-       output += "double *a_data, double *b_data, double *c_data){\n"
-       output += "int shared_size = 0;\n"
-       output += "//%s\n"%str(self.__dict__)
-       output += "typedef void (*kernel)(const int*, int, const double*, const double*, double*);\n"
-       output += "static kernel kern_func = cusmm_dnt_largeDB2<%(m)d,%(n)d,%(k)d,%(tile_m)d,%(tile_n)d,%(w)d,%(v)d,%(threads)d,%(grouping)d,%(minblocks)d>;\n"%self.__dict__
-       output += "static bool configured = false;\n"
-       output += "if(configured == false){\n"
-       output += "  cudaError_t err = cudaFuncSetSharedMemConfig(kern_func, cudaSharedMemBankSizeEightByte);\n"
-       output += "  if(err != cudaSuccess) return(-1);\n"
-       output += "  configured = true;\n"
-       output += "}\n"
-       output += "kern_func<<< ((stack_size + %(grouping)d - 1) / %(grouping)d), %(threads)d, shared_size, stream >>>"%self.__dict__
-       output += "(param_stack, stack_size, a_data, b_data, c_data);\n"
-       output += "return(0);\n"
-       output += "}\n"
-       return(output)
+    def to_dict(self):
+        d = {**self.__dict__, **{'algorithm': self.algorithm}}
+        return dict([(e, d[e]) for e in super().characteristic_parameters if e in d.keys()])
 
+    def launcher_code(self):
+        sign = "cusmm_dnt_largeDB2<%(m)d,%(n)d,%(k)d,%(tile_m)d,%(tile_n)d,%(w)d,%(v)d,%(threads)d,%(grouping)d,%(minblocks)d>;\n"%self.__dict__
+        return super().compose_launcher_code(sign)
 
     @staticmethod
     def promising_parameters(m, n, k):

--- a/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt_medium.py
+++ b/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt_medium.py
@@ -5,25 +5,26 @@ from kernels import cusmm_dnt
 class Kernel_dnt_medium(cusmm_dnt.Kernel):
 
     algorithm = 'medium'
+    launch_parameters = ['m', 'n', 'k', 'tile_m', 'tile_n', 'threads', 'grouping', 'minblocks']
 
-    def __init__(self, **params):
-        self.__dict__.update(params)
-        self.name  = "cusmm_dnt_medium_"
-        self.name += "_".join([str(params[k]) for k in sorted(super().naming_parameters) if k in params.keys()])
+    def __init__(self, *, m, n, k, threads, tile_m, tile_n, grouping, minblocks, perf):
+        self.m = m
+        self.n = n
+        self.k = k
+        self.tile_m = tile_m
+        self.tile_n = tile_n
+        self.threads = threads
+        self.grouping = grouping
+        self.minblocks = minblocks
+        self.perf = perf
         assert(self.threads * self.minblocks <= 2048)
         min_threads = ((self.m + self.tile_m - 1) // self.tile_m) * ((self.n + self.tile_n - 1) // self.tile_n)
         assert(min_threads <= self.threads)
 
-    def include(self):
-        return("cusmm_dnt_medium.h")
-
-    def to_dict(self):
-        d = {**self.__dict__, **{'algorithm': self.algorithm}}
-        return dict([(e, d[e]) for e in super().characteristic_parameters if e in d.keys()])
-
-    def launcher_code(self):
-        sign = "cusmm_dnt_medium<%(m)d,%(n)d,%(k)d,%(tile_m)d,%(tile_n)d,%(threads)d,%(grouping)d,%(minblocks)d>;\n" % self.__dict__
-        return super().compose_launcher_code(sign)
+    @property
+    def func_signature(self):
+        return "cusmm_dnt_medium<%(m)d,%(n)d,%(k)d,%(tile_m)d,%(tile_n)d,%(threads)d,%(grouping)d,%(minblocks)d>;\n" \
+               % self.__dict__
 
     @staticmethod
     def promising_parameters(m, n, k):

--- a/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt_medium.py
+++ b/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt_medium.py
@@ -1,45 +1,29 @@
 # -*- coding: utf-8 -*-
+from kernels import cusmm_dnt
 
-from math import ceil
 
-class Kernel_dnt_medium(object):
+class Kernel_dnt_medium(cusmm_dnt.Kernel):
+
+    algorithm = 'medium'
+
     def __init__(self, **params):
         self.__dict__.update(params)
         self.name  = "cusmm_dnt_medium_"
-        self.name += "_".join([str(params[k]) for k in sorted(params.keys())])
+        self.name += "_".join([str(params[k]) for k in sorted(super().naming_parameters) if k in params.keys()])
         assert(self.threads * self.minblocks <= 2048)
         min_threads = ((self.m + self.tile_m - 1) // self.tile_m) * ((self.n + self.tile_n - 1) // self.tile_n)
         assert(min_threads <= self.threads)
 
-    def __repr__(self):
-        return("<%s>"%self.name)
-
-    def can_handle(self, m, n, k):
-        return(self.m==m and self.n==n and self.k==k)
-
     def include(self):
         return("cusmm_dnt_medium.h")
 
+    def to_dict(self):
+        d = {**self.__dict__, **{'algorithm': self.algorithm}}
+        return dict([(e, d[e]) for e in super().characteristic_parameters if e in d.keys()])
+
     def launcher_code(self):
-       output  = "int launch_"+self.name+"(int *param_stack, int stack_size, "
-       output += "cudaStream_t stream, int m_max, int n_max, int k_max, "
-       output += "double *a_data, double *b_data, double *c_data){\n"
-       output += "int shared_size = 0;\n"
-       output += "//%s\n"%str(self.__dict__)
-       output += "typedef void (*kernel)(const int*, int, const double*, const double*, double*);\n"
-       output += "static kernel kern_func = cusmm_dnt_medium<%(m)d,%(n)d,%(k)d,%(tile_m)d,%(tile_n)d,%(threads)d,%(grouping)d,%(minblocks)d>;\n"%self.__dict__
-       output += "static bool configured = false;\n"
-       output += "if(configured == false){\n"
-       output += "  cudaError_t err = cudaFuncSetSharedMemConfig(kern_func, cudaSharedMemBankSizeEightByte);\n"
-       output += "  if(err != cudaSuccess) return(-1);\n"
-       output += "  configured = true;\n"
-       output += "}\n"
-       output += "kern_func<<< ((stack_size + %(grouping)d - 1) / %(grouping)d), %(threads)d, shared_size, stream >>>\n"%self.__dict__
-       output += "(param_stack, stack_size, \n"
-       output += "a_data, b_data, c_data);\n"
-       output += "return(0);\n"
-       output += "}\n"
-       return(output)
+        sign = "cusmm_dnt_medium<%(m)d,%(n)d,%(k)d,%(tile_m)d,%(tile_n)d,%(threads)d,%(grouping)d,%(minblocks)d>;\n" % self.__dict__
+        return super().compose_launcher_code(sign)
 
     @staticmethod
     def promising_parameters(m, n, k):

--- a/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt_small.py
+++ b/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt_small.py
@@ -5,22 +5,23 @@ from kernels import cusmm_dnt
 class Kernel_dnt_small(cusmm_dnt.Kernel):
 
     algorithm = "small"
+    launch_parameters = ['m', 'n', 'k', 'tile_m', 'tile_n', 'threads', 'grouping', 'minblocks']
 
-    def __init__(self, **params):
-        self.__dict__.update(params)
-        self.name  = "cusmm_dnt_small_"
-        self.name += "_".join([str(params[k]) for k in sorted(super().naming_parameters) if k in params.keys()])
+    def __init__(self, *, m, n, k, threads, tile_m, tile_n, grouping, minblocks, perf):
+        self.m = m
+        self.n = n
+        self.k = k
+        self.tile_m = tile_m
+        self.tile_n = tile_n
+        self.threads = threads
+        self.grouping = grouping
+        self.minblocks = minblocks
+        self.perf = perf
 
-    def include(self):
-        return("cusmm_dnt_small.h")
-
-    def to_dict(self):
-        d = {**self.__dict__, **{'algorithm': self.algorithm}}
-        return dict([(e, d[e]) for e in super().characteristic_parameters if e in d.keys()])
-
-    def launcher_code(self):
-        sign = "cusmm_dnt_small<%(m)d,%(n)d,%(k)d,%(tile_m)d,%(tile_n)d,%(threads)d,%(grouping)d,%(minblocks)d>;\n" % self.__dict__
-        return super().compose_launcher_code(sign)
+    @property
+    def func_signature(self):
+        return "cusmm_dnt_small<%(m)d,%(n)d,%(k)d,%(tile_m)d,%(tile_n)d,%(threads)d,%(grouping)d,%(minblocks)d>;\n" \
+               % self.__dict__
 
     @staticmethod
     def promising_parameters(m, n, k):

--- a/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt_small.py
+++ b/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt_small.py
@@ -1,45 +1,26 @@
 # -*- coding: utf-8 -*-
+from kernels import cusmm_dnt
 
-from math import ceil
 
-class Kernel_dnt_small(object):
+class Kernel_dnt_small(cusmm_dnt.Kernel):
+
+    algorithm = "small"
+
     def __init__(self, **params):
         self.__dict__.update(params)
         self.name  = "cusmm_dnt_small_"
-        self.name += "_".join([str(params[k]) for k in sorted(params.keys())])
-#        assert(self.threads * self.minblocks <= 2048)
-#        min_threads = ((self.m+self.tile_m-1)//self.tile_m) * ((self.n+self.tile_n-1)//self.tile_n)
-#        assert(min_threads <= self.threads)
-
-    def __repr__(self):
-        return("<%s>"%self.name)
-
-    def can_handle(self, m, n, k):
-        return(self.m==m and self.n==n and self.k==k)
+        self.name += "_".join([str(params[k]) for k in sorted(super().naming_parameters) if k in params.keys()])
 
     def include(self):
         return("cusmm_dnt_small.h")
 
+    def to_dict(self):
+        d = {**self.__dict__, **{'algorithm': self.algorithm}}
+        return dict([(e, d[e]) for e in super().characteristic_parameters if e in d.keys()])
+
     def launcher_code(self):
-       output  = "int launch_"+self.name+"(int *param_stack, int stack_size, "
-       output += "cudaStream_t stream, int m_max, int n_max, int k_max, "
-       output += "double *a_data, double *b_data, double *c_data){\n"
-       output += "int shared_size = 0;\n"
-       output += "//%s\n"%str(self.__dict__)
-       output += "typedef void (*kernel)(const int*, int, const double*, const double*, double*);\n"
-       output += "static kernel kern_func = cusmm_dnt_small<%(m)d,%(n)d,%(k)d,%(tile_m)d,%(tile_n)d,%(threads)d,%(grouping)d,%(minblocks)d>;\n"%self.__dict__
-       output += "static bool configured = false;\n"
-       output += "if(configured == false){\n"
-       output += "  cudaError_t err = cudaFuncSetSharedMemConfig(kern_func, cudaSharedMemBankSizeEightByte);\n"
-       output += "  if(err != cudaSuccess) return(-1);\n"
-       output += "  configured = true;\n"
-       output += "}\n"
-       output += "kern_func<<< ((stack_size + %(grouping)d - 1) / %(grouping)d), %(threads)d, shared_size, stream >>>\n"%self.__dict__
-       output += "(param_stack, stack_size, \n"
-       output += "a_data, b_data, c_data);\n"
-       output += "return(0);\n"
-       output += "}\n"
-       return(output)
+        sign = "cusmm_dnt_small<%(m)d,%(n)d,%(k)d,%(tile_m)d,%(tile_n)d,%(threads)d,%(grouping)d,%(minblocks)d>;\n" % self.__dict__
+        return super().compose_launcher_code(sign)
 
     @staticmethod
     def promising_parameters(m, n, k):

--- a/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt_tiny.py
+++ b/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt_tiny.py
@@ -5,23 +5,21 @@ from kernels import cusmm_dnt
 class Kernel_dnt_tiny(cusmm_dnt.Kernel):
 
     algorithm = "tiny"
+    launch_parameters = ['m', 'n', 'k', 'threads', 'grouping', 'minblocks']
 
-    def __init__(self, **params):
-        self.__dict__.update(params)
-        self.name = "cusmm_dnt_tiny_"
-        self.name += "_".join([str(params[k]) for k in sorted(super().naming_parameters) if k in params.keys()])
+    def __init__(self, *, m, n, k, threads, grouping, minblocks, perf):
+        self.m = m
+        self.n = n
+        self.k = k
+        self.threads = threads
+        self.grouping = grouping
+        self.minblocks = minblocks
+        self.perf = perf
         assert(self.m * self.n <= self.threads)
 
-    def include(self):
-        return("cusmm_dnt_tiny.h")
-
-    def to_dict(self):
-        d = {**self.__dict__, **{'algorithm': self.algorithm}}
-        return dict([(e, d[e]) for e in super().characteristic_parameters if e in d.keys()])
-
-    def launcher_code(self):
-        sign = "cusmm_dnt_tiny<%(m)d,%(n)d,%(k)d,%(threads)d,%(grouping)d,%(minblocks)d>;\n" % self.__dict__
-        return super().compose_launcher_code(sign)
+    @property
+    def func_signature(self):
+        return "cusmm_dnt_tiny<%(m)d,%(n)d,%(k)d,%(threads)d,%(grouping)d,%(minblocks)d>;\n" % self.__dict__
 
     @staticmethod
     def promising_parameters(m, n, k):
@@ -30,14 +28,14 @@ class Kernel_dnt_tiny(cusmm_dnt.Kernel):
             for grouping in range(1, 33, 1):          # soft: divide stack work in chunks of grouping + the rest
                 for threads in (16, 32, 64):          # heuristic: not more than 2 warps per SM (sm_60)
                     if (m * n > threads):
-                       continue                       # hard: not enough threads to cover result matrix
-                
+                        continue                       # hard: not enough threads to cover result matrix
+
                     buf_sz = k * (m + n)
                     sizeof_int = 4; sizeof_double = 8
                     smem_tot = buf_sz * sizeof_double + 3 * grouping * sizeof_int
                     if (smem_tot * minblocks > 48 * 1024): # hard: see cudaFuncSetCacheConfig() docu
-                       continue                       # hard: uses too much shared memory
-                
+                        continue                       # hard: uses too much shared memory
+
                     params.append({'m':m, 'n':n, 'k':k,
                                    'threads':threads,
                                    'grouping':grouping,

--- a/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt_tiny.py
+++ b/src/acc/libsmm_acc/libcusmm/kernels/cusmm_dnt_tiny.py
@@ -1,41 +1,27 @@
 # -*- coding: utf-8 -*-
+from kernels import cusmm_dnt
 
-class Kernel_dnt_tiny(object):
+
+class Kernel_dnt_tiny(cusmm_dnt.Kernel):
+
+    algorithm = "tiny"
+
     def __init__(self, **params):
         self.__dict__.update(params)
-        self.name  = "cusmm_dnt_tiny_"
-        self.name += "_".join([str(params[k]) for k in sorted(params.keys())])
+        self.name = "cusmm_dnt_tiny_"
+        self.name += "_".join([str(params[k]) for k in sorted(super().naming_parameters) if k in params.keys()])
         assert(self.m * self.n <= self.threads)
-
-    def __repr__(self):
-        return("<%s>"%self.name)
-
-    def can_handle(self, m, n, k):
-        return(self.m==m and self.n==n and self.k==k)
 
     def include(self):
         return("cusmm_dnt_tiny.h")
 
+    def to_dict(self):
+        d = {**self.__dict__, **{'algorithm': self.algorithm}}
+        return dict([(e, d[e]) for e in super().characteristic_parameters if e in d.keys()])
+
     def launcher_code(self):
-       output  = "int launch_"+self.name+"(int *param_stack, int stack_size, "
-       output += "cudaStream_t stream, int m_max, int n_max, int k_max, "
-       output += "double *a_data, double *b_data, double *c_data){\n"
-       output += "int shared_size = 0;\n"
-       output += "//%s\n"%str(self.__dict__)
-       output += "typedef void (*kernel)(const int*, int, const double*, const double*, double*);\n"
-       output += "static kernel kern_func = cusmm_dnt_tiny<%(m)d,%(n)d,%(k)d,%(threads)d,%(grouping)d,%(minblocks)d>;\n"%self.__dict__
-       output += "static bool configured = false;\n"
-       output += "if(configured == false){\n"
-       output += "  cudaError_t err = cudaFuncSetSharedMemConfig(kern_func, cudaSharedMemBankSizeEightByte);\n"
-       output += "  if(err != cudaSuccess) return(-1);\n"
-       output += "  configured = true;\n"
-       output += "}\n"
-       output += "kern_func<<< ((stack_size + %(grouping)d - 1) / %(grouping)d), %(threads)d, shared_size, stream >>>\n"%self.__dict__
-       output += "(param_stack, stack_size, \n"
-       output += "a_data, b_data, c_data);\n"
-       output += "return(0);\n"
-       output += "}\n"
-       return(output)
+        sign = "cusmm_dnt_tiny<%(m)d,%(n)d,%(k)d,%(threads)d,%(grouping)d,%(minblocks)d>;\n" % self.__dict__
+        return super().compose_launcher_code(sign)
 
     @staticmethod
     def promising_parameters(m, n, k):

--- a/src/acc/libsmm_acc/libcusmm/merge.py
+++ b/src/acc/libsmm_acc/libcusmm/merge.py
@@ -79,7 +79,7 @@ def main():
     print("Wrote parameters.new")
 
 #===============================================================================
-if(len(sys.argv)==2 and sys.argv[-1]=="--selftest"):
+if len(sys.argv)==2 and sys.argv[-1]=="--selftest":
     pass #TODO implement selftest
 else:
     main()

--- a/src/acc/libsmm_acc/libcusmm/parameters_K20X.txt
+++ b/src/acc/libsmm_acc/libcusmm/parameters_K20X.txt
@@ -1,3177 +1,3170 @@
-# *****************************************************************************
-# * CP2K: A general program to perform molecular dynamics simulations         *
-# * Copyright (C) 2000 - 2018  CP2K developers group                          *
-# *****************************************************************************
-
 [
-  Kernel_dnt_tiny(m=4, n=4, k=4, threads=64, grouping=16, minblocks=1) , # 16.5663 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=5, threads=64, grouping=16, minblocks=1) , # 20.1639 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=6, threads=64, grouping=16, minblocks=1) , # 23.5514 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=7, threads=64, grouping=16, minblocks=1) , # 27.508 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=8, threads=128, grouping=16, minblocks=1) , # 31.7227 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=9, threads=128, grouping=16, minblocks=1) , # 34.2669 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=10, threads=128, grouping=16, minblocks=1) , # 37.6563 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=13, threads=128, grouping=16, minblocks=1) , # 45.9102 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=15, threads=128, grouping=16, minblocks=1) , # 51.3947 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=16, threads=128, grouping=16, minblocks=1) , # 54.8645 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=17, threads=128, grouping=16, minblocks=1) , # 54.3192 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=22, threads=128, grouping=16, minblocks=1) , # 62.9255 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=23, threads=128, grouping=16, minblocks=1) , # 60.6683 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=24, threads=128, grouping=16, minblocks=1) , # 62.8983 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=25, threads=96, grouping=16, minblocks=1) , # 50.8246 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=26, threads=96, grouping=16, minblocks=1) , # 53.309 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=28, threads=96, grouping=16, minblocks=1) , # 54.7759 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=32, threads=128, grouping=16, minblocks=1) , # 58.5147 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=45, threads=128, grouping=16, minblocks=1) , # 55.094 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=4, threads=128, grouping=16, minblocks=1) , # 14.9148 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=5, threads=128, grouping=16, minblocks=1) , # 18.1077 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=6, threads=96, grouping=16, minblocks=1) , # 21.2783 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=7, threads=128, grouping=16, minblocks=1) , # 25.2832 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=8, threads=96, grouping=16, minblocks=1) , # 29.5849 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=9, threads=128, grouping=16, minblocks=1) , # 30.8254 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=13, threads=128, grouping=16, minblocks=1) , # 42.687 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=16, threads=128, grouping=16, minblocks=1) , # 52.9062 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=17, threads=128, grouping=16, minblocks=1) , # 51.922 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=22, threads=128, grouping=16, minblocks=1) , # 48.5357 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=23, threads=128, grouping=16, minblocks=1) , # 50.2012 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=24, threads=128, grouping=16, minblocks=1) , # 50.9804 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=25, threads=128, grouping=16, minblocks=1) , # 45.0794 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=26, threads=128, grouping=16, minblocks=1) , # 46.9644 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=28, threads=128, grouping=16, minblocks=1) , # 44.74 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=32, threads=128, grouping=16, minblocks=1) , # 47.0079 GFlop/s
-  Kernel_dnt_tiny(m=4, n=5, k=45, threads=128, grouping=16, minblocks=1) , # 39.578 GFlop/s
-  Kernel_dnt_tiny(m=4, n=6, k=4, threads=96, grouping=16, minblocks=1) , # 17.7217 GFlop/s
-  Kernel_dnt_tiny(m=4, n=6, k=5, threads=96, grouping=16, minblocks=1) , # 21.2885 GFlop/s
-  Kernel_dnt_tiny(m=4, n=6, k=6, threads=96, grouping=16, minblocks=1) , # 26.0691 GFlop/s
-  Kernel_dnt_tiny(m=4, n=6, k=8, threads=96, grouping=16, minblocks=1) , # 35.3897 GFlop/s
-  Kernel_dnt_tiny(m=4, n=6, k=9, threads=128, grouping=16, minblocks=1) , # 36.1752 GFlop/s
-  Kernel_dnt_tiny(m=4, n=6, k=13, threads=128, grouping=16, minblocks=1) , # 50.7414 GFlop/s
-  Kernel_dnt_tiny(m=4, n=6, k=16, threads=128, grouping=16, minblocks=1) , # 62.3605 GFlop/s
-  Kernel_dnt_tiny(m=4, n=6, k=17, threads=128, grouping=16, minblocks=1) , # 52.168 GFlop/s
-  Kernel_dnt_medium(m=4, n=6, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 61.4407 GFlop/s
-  Kernel_dnt_medium(m=4, n=6, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 63.1415 GFlop/s
-  Kernel_dnt_tiny(m=4, n=6, k=24, threads=128, grouping=16, minblocks=1) , # 59.2859 GFlop/s
-  Kernel_dnt_medium(m=4, n=6, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 63.6068 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=6, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=96, grouping=16, minblocks=1) , # 66.9879 GFlop/s
-  Kernel_dnt_tiny(m=4, n=7, k=4, threads=128, grouping=16, minblocks=1) , # 20.3949 GFlop/s
-  Kernel_dnt_tiny(m=4, n=7, k=5, threads=128, grouping=16, minblocks=1) , # 25.5066 GFlop/s
-  Kernel_dnt_tiny(m=4, n=7, k=7, threads=128, grouping=16, minblocks=1) , # 34.4269 GFlop/s
-  Kernel_dnt_tiny(m=4, n=7, k=9, threads=128, grouping=16, minblocks=1) , # 41.6453 GFlop/s
-  Kernel_dnt_tiny(m=4, n=7, k=13, threads=128, grouping=16, minblocks=1) , # 57.6433 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=7, k=25, tile_m=1, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=8) , # 70.7435 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=7, k=26, tile_m=1, tile_n=1, w=12, v=6, threads=96, grouping=16, minblocks=4) , # 72.8932 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=7, k=28, tile_m=1, tile_n=1, w=14, v=4, threads=96, grouping=16, minblocks=4) , # 81.1008 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=7, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=4) , # 87.9914 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=7, k=45, tile_m=1, tile_n=1, w=18, v=4, threads=96, grouping=16, minblocks=1) , # 89.4636 GFlop/s
-  Kernel_dnt_tiny(m=4, n=8, k=4, threads=96, grouping=16, minblocks=1) , # 24.016 GFlop/s
-  Kernel_dnt_tiny(m=4, n=8, k=5, threads=96, grouping=16, minblocks=1) , # 28.6828 GFlop/s
-  Kernel_dnt_tiny(m=4, n=8, k=6, threads=96, grouping=16, minblocks=1) , # 34.4605 GFlop/s
-  Kernel_dnt_tiny(m=4, n=8, k=8, threads=96, grouping=16, minblocks=1) , # 45.9955 GFlop/s
-  Kernel_dnt_tiny(m=4, n=8, k=9, threads=128, grouping=16, minblocks=1) , # 48.4776 GFlop/s
-  Kernel_dnt_tiny(m=4, n=8, k=13, threads=128, grouping=16, minblocks=1) , # 54.9661 GFlop/s
-  Kernel_dnt_medium(m=4, n=8, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 64.3579 GFlop/s
-  Kernel_dnt_medium(m=4, n=8, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 67.3422 GFlop/s
-  Kernel_dnt_medium(m=4, n=8, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 80.9386 GFlop/s
-  Kernel_dnt_medium(m=4, n=8, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 83.121 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=8, k=24, tile_m=1, tile_n=1, w=12, v=8, threads=96, grouping=16, minblocks=1) , # 72.6651 GFlop/s
-  Kernel_dnt_medium(m=4, n=8, k=26, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 74.4863 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=8, k=32, tile_m=1, tile_n=1, w=16, v=8, threads=128, grouping=16, minblocks=1) , # 83.7638 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 24.1362 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 29.7245 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 34.6329 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=7, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 39.4845 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 44.6668 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 49.1063 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 58.1283 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 66.7055 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 69.4121 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 81.2228 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 83.4097 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=24, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 79.1819 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=9, k=25, tile_m=1, tile_n=1, w=10, v=8, threads=96, grouping=16, minblocks=1) , # 80.8055 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=9, k=26, tile_m=1, tile_n=1, w=10, v=6, threads=96, grouping=16, minblocks=4) , # 82.8333 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=9, k=28, tile_m=1, tile_n=1, w=14, v=6, threads=128, grouping=16, minblocks=12) , # 91.3053 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=9, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 92.4279 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=9, k=45, tile_m=1, tile_n=1, w=18, v=6, threads=96, grouping=16, minblocks=4) , # 97.8429 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=10, k=4, tile_m=1, tile_n=1, w=2, v=10, threads=96, grouping=16, minblocks=1) , # 27.7177 GFlop/s
-  Kernel_dnt_medium(m=4, n=10, k=10, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 52.2698 GFlop/s
-  Kernel_dnt_medium(m=4, n=10, k=15, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 70.3125 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 34.7964 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 42.8558 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 49.8578 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=7, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 56.807 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 56.9443 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 62.3945 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 82.5655 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 95.0394 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 98.1766 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 106.482 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 99.1141 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 102.229 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=25, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 104.392 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=26, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 107.25 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=13, k=28, tile_m=1, tile_n=1, w=14, v=10, threads=96, grouping=16, minblocks=4) , # 112.358 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=13, k=32, tile_m=1, tile_n=1, w=16, v=10, threads=96, grouping=16, minblocks=8) , # 117.253 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=13, k=45, tile_m=1, tile_n=1, w=20, v=12, threads=96, grouping=16, minblocks=8) , # 117.218 GFlop/s
-  Kernel_dnt_medium(m=4, n=15, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 39.8849 GFlop/s
-  Kernel_dnt_medium(m=4, n=15, k=10, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 76.3306 GFlop/s
-  Kernel_dnt_medium(m=4, n=15, k=15, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 100.748 GFlop/s
-  Kernel_dnt_medium(m=4, n=16, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 43.4494 GFlop/s
-  Kernel_dnt_medium(m=4, n=16, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 53.0611 GFlop/s
-  Kernel_dnt_tiny(m=4, n=16, k=6, threads=128, grouping=16, minblocks=1) , # 56.7665 GFlop/s
-  Kernel_dnt_medium(m=4, n=16, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 71.163 GFlop/s
-  Kernel_dnt_medium(m=4, n=16, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 75.903 GFlop/s
-  Kernel_dnt_medium(m=4, n=16, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 101.297 GFlop/s
-  Kernel_dnt_medium(m=4, n=16, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 112.777 GFlop/s
-  Kernel_dnt_medium(m=4, n=16, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 114.289 GFlop/s
-  Kernel_dnt_medium(m=4, n=16, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 117.51 GFlop/s
-  Kernel_dnt_medium(m=4, n=16, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 118.855 GFlop/s
-  Kernel_dnt_medium(m=4, n=16, k=24, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 116.045 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=16, k=26, tile_m=1, tile_n=1, w=12, v=16, threads=96, grouping=16, minblocks=8) , # 109.271 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=16, k=32, tile_m=1, tile_n=1, w=16, v=16, threads=128, grouping=16, minblocks=12) , # 119.269 GFlop/s
-  Kernel_dnt_medium(m=4, n=17, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 44.3641 GFlop/s
-  Kernel_dnt_medium(m=4, n=17, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 54.048 GFlop/s
-  Kernel_dnt_medium(m=4, n=17, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 56.5091 GFlop/s
-  Kernel_dnt_medium(m=4, n=17, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 71.3946 GFlop/s
-  Kernel_dnt_medium(m=4, n=17, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 76.8119 GFlop/s
-  Kernel_dnt_medium(m=4, n=17, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 99.368 GFlop/s
-  Kernel_dnt_medium(m=4, n=17, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 109.498 GFlop/s
-  Kernel_dnt_medium(m=4, n=17, k=17, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 98.7893 GFlop/s
-  Kernel_dnt_medium(m=4, n=17, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 113.492 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=17, k=23, tile_m=1, tile_n=1, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 99.7952 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=17, k=24, tile_m=1, tile_n=1, w=12, v=14, threads=128, grouping=16, minblocks=12) , # 107.141 GFlop/s
-  Kernel_dnt_medium(m=4, n=17, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 106.081 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=17, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=128, grouping=16, minblocks=4) , # 113.471 GFlop/s
-  Kernel_dnt_medium(m=4, n=22, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 57.4498 GFlop/s
-  Kernel_dnt_medium(m=4, n=22, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 62.5018 GFlop/s
-  Kernel_dnt_medium(m=4, n=22, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 72.8839 GFlop/s
-  Kernel_dnt_medium(m=4, n=22, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 91.5999 GFlop/s
-  Kernel_dnt_medium(m=4, n=22, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 99.159 GFlop/s
-  Kernel_dnt_medium(m=4, n=22, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 118.024 GFlop/s
-  Kernel_dnt_medium(m=4, n=22, k=16, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 120.717 GFlop/s
-  Kernel_dnt_medium(m=4, n=22, k=17, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 121.506 GFlop/s
-  Kernel_dnt_medium(m=4, n=22, k=22, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 120.919 GFlop/s
-  Kernel_dnt_medium(m=4, n=22, k=23, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 116.314 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=22, k=24, tile_m=1, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 121.22 GFlop/s
-  Kernel_dnt_medium(m=4, n=22, k=26, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=4) , # 117.406 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=22, k=32, tile_m=1, tile_n=1, w=8, v=20, threads=96, grouping=16, minblocks=8) , # 127.401 GFlop/s
-  Kernel_dnt_medium(m=4, n=23, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 59.7783 GFlop/s
-  Kernel_dnt_medium(m=4, n=23, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 64.7027 GFlop/s
-  Kernel_dnt_medium(m=4, n=23, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 75.5435 GFlop/s
-  Kernel_dnt_medium(m=4, n=23, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 94.7326 GFlop/s
-  Kernel_dnt_medium(m=4, n=23, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 102.115 GFlop/s
-  Kernel_dnt_medium(m=4, n=23, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 109.914 GFlop/s
-  Kernel_dnt_medium(m=4, n=23, k=16, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 123.335 GFlop/s
-  Kernel_dnt_medium(m=4, n=23, k=17, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 110.912 GFlop/s
-  Kernel_dnt_medium(m=4, n=23, k=22, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 118.425 GFlop/s
-  Kernel_dnt_medium(m=4, n=23, k=23, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 119.87 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=23, k=24, tile_m=1, tile_n=1, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 119.172 GFlop/s
-  Kernel_dnt_medium(m=4, n=23, k=26, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 119.54 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=23, k=32, tile_m=1, tile_n=1, w=8, v=20, threads=96, grouping=16, minblocks=4) , # 127.587 GFlop/s
-  Kernel_dnt_tiny(m=4, n=24, k=4, threads=128, grouping=16, minblocks=1) , # 58.0271 GFlop/s
-  Kernel_dnt_medium(m=4, n=24, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 67.3989 GFlop/s
-  Kernel_dnt_medium(m=4, n=24, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 78.5843 GFlop/s
-  Kernel_dnt_medium(m=4, n=24, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 90.4024 GFlop/s
-  Kernel_dnt_medium(m=4, n=24, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 107.128 GFlop/s
-  Kernel_dnt_medium(m=4, n=24, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 115.396 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=24, k=16, tile_m=1, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=1) , # 117.543 GFlop/s
-  Kernel_dnt_medium(m=4, n=24, k=17, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 115.374 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=24, k=22, tile_m=1, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 123.01 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=24, k=23, tile_m=1, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=8) , # 121.888 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=24, k=24, tile_m=1, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=4) , # 126.228 GFlop/s
-  Kernel_dnt_medium(m=4, n=24, k=26, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 124.519 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=24, k=32, tile_m=1, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=4) , # 131.226 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=25, k=4, tile_m=2, tile_n=1, w=2, v=24, threads=96, grouping=16, minblocks=4) , # 59.7499 GFlop/s
-  Kernel_dnt_small(m=4, n=25, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 65.252 GFlop/s
-  Kernel_dnt_medium(m=4, n=25, k=7, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 77.9696 GFlop/s
-  Kernel_dnt_medium(m=4, n=25, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 89.8186 GFlop/s
-  Kernel_dnt_medium(m=4, n=25, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 112.687 GFlop/s
-  Kernel_dnt_medium(m=4, n=25, k=25, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=8) , # 129.771 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=25, k=26, tile_m=2, tile_n=1, w=12, v=22, threads=96, grouping=16, minblocks=8) , # 127.735 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=25, k=28, tile_m=2, tile_n=1, w=14, v=24, threads=96, grouping=16, minblocks=4) , # 135.101 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=25, k=32, tile_m=2, tile_n=1, w=16, v=24, threads=96, grouping=16, minblocks=1) , # 139.761 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=25, k=45, tile_m=2, tile_n=1, w=16, v=24, threads=96, grouping=16, minblocks=8) , # 140.077 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=26, k=4, tile_m=1, tile_n=1, w=2, v=26, threads=128, grouping=16, minblocks=1) , # 63.4377 GFlop/s
-  Kernel_dnt_tiny(m=4, n=26, k=5, threads=128, grouping=16, minblocks=1) , # 61.4438 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 71.391 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=7, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 81.5028 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 87.1416 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 95.4329 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 117.999 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=16, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 118.965 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=17, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=4) , # 117.606 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=22, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=4) , # 124.959 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=23, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 125.45 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=24, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 128.616 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=26, k=25, tile_m=2, tile_n=1, w=12, v=14, threads=96, grouping=16, minblocks=8) , # 128.125 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=26, k=26, tile_m=2, tile_n=1, w=12, v=22, threads=96, grouping=16, minblocks=8) , # 130.88 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=26, k=28, tile_m=2, tile_n=1, w=14, v=26, threads=96, grouping=16, minblocks=1) , # 137.164 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=26, k=32, tile_m=2, tile_n=1, w=16, v=24, threads=96, grouping=16, minblocks=8) , # 141.257 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=26, k=45, tile_m=2, tile_n=1, w=16, v=14, threads=96, grouping=16, minblocks=8) , # 140.164 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=28, k=4, tile_m=1, tile_n=1, w=2, v=28, threads=128, grouping=16, minblocks=4) , # 68.2828 GFlop/s
-  Kernel_dnt_tiny(m=4, n=28, k=5, threads=128, grouping=16, minblocks=1) , # 65.6686 GFlop/s
-  Kernel_dnt_medium(m=4, n=28, k=7, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 83.3092 GFlop/s
-  Kernel_dnt_medium(m=4, n=28, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 100.922 GFlop/s
-  Kernel_dnt_medium(m=4, n=28, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 123.15 GFlop/s
-  Kernel_dnt_medium(m=4, n=28, k=25, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 133.073 GFlop/s
-  Kernel_dnt_medium(m=4, n=28, k=26, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 134.749 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=28, k=28, tile_m=2, tile_n=1, w=14, v=28, threads=96, grouping=16, minblocks=1) , # 140.056 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=28, k=32, tile_m=1, tile_n=1, w=16, v=28, threads=128, grouping=16, minblocks=12) , # 141.483 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=28, k=45, tile_m=1, tile_n=1, w=12, v=24, threads=128, grouping=16, minblocks=12) , # 142.643 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=32, k=4, tile_m=1, tile_n=1, w=2, v=32, threads=128, grouping=16, minblocks=4) , # 78.1248 GFlop/s
-  Kernel_dnt_tiny(m=4, n=32, k=5, threads=128, grouping=16, minblocks=1) , # 74.5054 GFlop/s
-  Kernel_dnt_medium(m=4, n=32, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 85.0733 GFlop/s
-  Kernel_dnt_medium(m=4, n=32, k=7, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 94.5942 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=32, k=8, tile_m=1, tile_n=1, w=4, v=32, threads=128, grouping=16, minblocks=8) , # 101.579 GFlop/s
-  Kernel_dnt_medium(m=4, n=32, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 114.088 GFlop/s
-  Kernel_dnt_medium(m=4, n=32, k=13, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 127.948 GFlop/s
-  Kernel_dnt_medium(m=4, n=32, k=16, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 129.951 GFlop/s
-  Kernel_dnt_medium(m=4, n=32, k=17, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 129.899 GFlop/s
-  Kernel_dnt_medium(m=4, n=32, k=22, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 133.965 GFlop/s
-  Kernel_dnt_medium(m=4, n=32, k=23, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=4) , # 135.677 GFlop/s
-  Kernel_dnt_largeDB1(m=4, n=32, k=24, tile_m=1, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 137.129 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=32, k=25, tile_m=1, tile_n=1, w=12, v=32, threads=128, grouping=16, minblocks=12) , # 138.999 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=32, k=26, tile_m=1, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 140.06 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=32, k=28, tile_m=2, tile_n=1, w=14, v=20, threads=96, grouping=16, minblocks=4) , # 142.731 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=32, k=32, tile_m=1, tile_n=1, w=12, v=32, threads=128, grouping=16, minblocks=12) , # 146.525 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=32, k=45, tile_m=2, tile_n=1, w=16, v=32, threads=128, grouping=16, minblocks=4) , # 148.422 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=45, k=4, tile_m=2, tile_n=1, w=2, v=24, threads=96, grouping=16, minblocks=4) , # 89.1846 GFlop/s
-  Kernel_dnt_medium(m=4, n=45, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 90.7481 GFlop/s
-  Kernel_dnt_medium(m=4, n=45, k=7, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 112.025 GFlop/s
-  Kernel_dnt_medium(m=4, n=45, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 123.37 GFlop/s
-  Kernel_dnt_medium(m=4, n=45, k=13, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=8) , # 132.048 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=45, k=25, tile_m=2, tile_n=1, w=10, v=24, threads=96, grouping=16, minblocks=12) , # 142.681 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=45, k=26, tile_m=2, tile_n=1, w=10, v=32, threads=128, grouping=16, minblocks=12) , # 144.113 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=45, k=28, tile_m=2, tile_n=1, w=14, v=32, threads=128, grouping=16, minblocks=1) , # 147.358 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=45, k=32, tile_m=2, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 150.112 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=45, k=45, tile_m=1, tile_n=1, w=12, v=26, threads=192, grouping=16, minblocks=8) , # 150.749 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=4, threads=128, grouping=16, minblocks=1) , # 14.8425 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=5, threads=128, grouping=16, minblocks=1) , # 17.8923 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=6, threads=96, grouping=16, minblocks=1) , # 20.6833 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=7, threads=128, grouping=16, minblocks=1) , # 25.0033 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=8, threads=96, grouping=16, minblocks=1) , # 28.7395 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=9, threads=96, grouping=16, minblocks=1) , # 30.3363 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=13, threads=96, grouping=16, minblocks=1) , # 35.8017 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=16, threads=96, grouping=16, minblocks=1) , # 35.9461 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=17, threads=128, grouping=16, minblocks=1) , # 34.9185 GFlop/s
-  Kernel_dnt_small(m=5, n=4, k=22, tile_m=1, tile_n=1, threads=64, grouping=16, minblocks=1) , # 37.0424 GFlop/s
-  Kernel_dnt_small(m=5, n=4, k=23, tile_m=1, tile_n=1, threads=64, grouping=16, minblocks=4) , # 37.32 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=24, threads=128, grouping=16, minblocks=1) , # 50.5776 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=25, threads=96, grouping=16, minblocks=1) , # 42.9798 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=26, threads=128, grouping=16, minblocks=1) , # 46.6834 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=28, threads=128, grouping=16, minblocks=1) , # 44.9266 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=32, threads=128, grouping=16, minblocks=1) , # 46.7652 GFlop/s
-  Kernel_dnt_tiny(m=5, n=4, k=45, threads=128, grouping=16, minblocks=1) , # 39.2713 GFlop/s
-  Kernel_dnt_tiny(m=5, n=5, k=4, threads=64, grouping=16, minblocks=1) , # 23.8033 GFlop/s
-  Kernel_dnt_tiny(m=5, n=5, k=5, threads=64, grouping=16, minblocks=1) , # 29.5496 GFlop/s
-  Kernel_dnt_tiny(m=5, n=5, k=6, threads=64, grouping=16, minblocks=1) , # 33.673 GFlop/s
-  Kernel_dnt_tiny(m=5, n=5, k=7, threads=96, grouping=16, minblocks=1) , # 39.8149 GFlop/s
-  Kernel_dnt_tiny(m=5, n=5, k=8, threads=96, grouping=16, minblocks=1) , # 37.8978 GFlop/s
-  Kernel_dnt_tiny(m=5, n=5, k=9, threads=96, grouping=16, minblocks=1) , # 48.7651 GFlop/s
-  Kernel_dnt_tiny(m=5, n=5, k=13, threads=128, grouping=16, minblocks=1) , # 55.6173 GFlop/s
-  Kernel_dnt_small(m=5, n=5, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 58.79 GFlop/s
-  Kernel_dnt_small(m=5, n=5, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 60.0103 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 64.9733 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 66.7856 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=24, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 68.8446 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=25, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 69.5795 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 73.6718 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=5, k=28, tile_m=1, tile_n=1, w=14, v=4, threads=96, grouping=16, minblocks=4) , # 78.9513 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=1) , # 85.3813 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=5, k=45, tile_m=1, tile_n=1, w=18, v=4, threads=96, grouping=16, minblocks=1) , # 85.4611 GFlop/s
-  Kernel_dnt_tiny(m=5, n=6, k=4, threads=128, grouping=16, minblocks=1) , # 20.9988 GFlop/s
-  Kernel_dnt_tiny(m=5, n=6, k=5, threads=96, grouping=16, minblocks=1) , # 25.4954 GFlop/s
-  Kernel_dnt_tiny(m=5, n=6, k=6, threads=96, grouping=16, minblocks=1) , # 31.0513 GFlop/s
-  Kernel_dnt_tiny(m=5, n=6, k=8, threads=96, grouping=16, minblocks=1) , # 39.6543 GFlop/s
-  Kernel_dnt_small(m=5, n=6, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 37.5652 GFlop/s
-  Kernel_dnt_medium(m=5, n=6, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 49.3659 GFlop/s
-  Kernel_dnt_small(m=5, n=6, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 58.1624 GFlop/s
-  Kernel_dnt_small(m=5, n=6, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 52.8571 GFlop/s
-  Kernel_dnt_medium(m=5, n=6, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 69.8459 GFlop/s
-  Kernel_dnt_medium(m=5, n=6, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 72.2008 GFlop/s
-  Kernel_dnt_medium(m=5, n=6, k=24, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 74.465 GFlop/s
-  Kernel_dnt_medium(m=5, n=6, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 78.7224 GFlop/s
-  Kernel_dnt_medium(m=5, n=6, k=32, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 81.0562 GFlop/s
-  Kernel_dnt_medium(m=5, n=7, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 23.7332 GFlop/s
-  Kernel_dnt_medium(m=5, n=7, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 29.2419 GFlop/s
-  Kernel_dnt_medium(m=5, n=7, k=7, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 38.8739 GFlop/s
-  Kernel_dnt_medium(m=5, n=7, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 47.5812 GFlop/s
-  Kernel_dnt_medium(m=5, n=7, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 63.0682 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=7, k=25, tile_m=1, tile_n=1, w=10, v=6, threads=96, grouping=16, minblocks=1) , # 79.9775 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=7, k=26, tile_m=1, tile_n=1, w=10, v=6, threads=96, grouping=16, minblocks=4) , # 81.302 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=7, k=28, tile_m=1, tile_n=1, w=14, v=4, threads=128, grouping=16, minblocks=4) , # 89.0756 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=7, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=4) , # 93.7976 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=7, k=45, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=1) , # 98.0821 GFlop/s
-  Kernel_dnt_medium(m=5, n=8, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 27.2512 GFlop/s
-  Kernel_dnt_medium(m=5, n=8, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 32.9231 GFlop/s
-  Kernel_dnt_medium(m=5, n=8, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 39.1691 GFlop/s
-  Kernel_dnt_tiny(m=5, n=8, k=8, threads=96, grouping=16, minblocks=1) , # 47.0366 GFlop/s
-  Kernel_dnt_small(m=5, n=8, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 48.3135 GFlop/s
-  Kernel_dnt_small(m=5, n=8, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 59.2125 GFlop/s
-  Kernel_dnt_small(m=5, n=8, k=16, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 67.8873 GFlop/s
-  Kernel_dnt_medium(m=5, n=8, k=17, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 63.6387 GFlop/s
-  Kernel_dnt_medium(m=5, n=8, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 85.8051 GFlop/s
-  Kernel_dnt_medium(m=5, n=8, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 87.9872 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=8, k=24, tile_m=1, tile_n=1, w=12, v=8, threads=128, grouping=16, minblocks=4) , # 84.7498 GFlop/s
-  Kernel_dnt_medium(m=5, n=8, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 83.6633 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=8, k=32, tile_m=1, tile_n=1, w=16, v=8, threads=128, grouping=16, minblocks=12) , # 94.1701 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 30.6314 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 37.6561 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 43.5479 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=7, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 49.7157 GFlop/s
-  Kernel_dnt_small(m=5, n=9, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 49.4117 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 61.0651 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 71.6433 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=9, k=16, tile_m=1, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=1) , # 71.2271 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=17, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 71.4887 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 85.9047 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 88.2854 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 90.6552 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=9, k=25, tile_m=1, tile_n=1, w=10, v=8, threads=96, grouping=16, minblocks=1) , # 98.39 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=9, k=26, tile_m=1, tile_n=1, w=10, v=8, threads=96, grouping=16, minblocks=1) , # 99.7839 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=9, k=28, tile_m=1, tile_n=1, w=14, v=8, threads=128, grouping=16, minblocks=4) , # 110.791 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=9, k=32, tile_m=1, tile_n=1, w=16, v=8, threads=96, grouping=16, minblocks=4) , # 114.978 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=9, k=45, tile_m=1, tile_n=1, w=18, v=6, threads=96, grouping=16, minblocks=4) , # 117.396 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 43.3144 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 52.3204 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 60.4434 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=7, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 69.0831 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 63.9439 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 74.3939 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 93.8869 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 94.5206 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 99.4373 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 110.942 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 110.721 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 113.32 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=25, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 114.526 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=13, k=26, tile_m=1, tile_n=1, w=10, v=12, threads=96, grouping=16, minblocks=8) , # 115.088 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=13, k=28, tile_m=1, tile_n=1, w=14, v=12, threads=96, grouping=16, minblocks=4) , # 124.415 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=13, k=32, tile_m=1, tile_n=1, w=16, v=12, threads=96, grouping=16, minblocks=1) , # 122.982 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=13, k=45, tile_m=1, tile_n=1, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 127.844 GFlop/s
-  Kernel_dnt_medium(m=5, n=16, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 53.1228 GFlop/s
-  Kernel_dnt_medium(m=5, n=16, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 63.7683 GFlop/s
-  Kernel_dnt_small(m=5, n=16, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 68.1547 GFlop/s
-  Kernel_dnt_small(m=5, n=16, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 79.5016 GFlop/s
-  Kernel_dnt_medium(m=5, n=16, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 83.055 GFlop/s
-  Kernel_dnt_medium(m=5, n=16, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 101.84 GFlop/s
-  Kernel_dnt_medium(m=5, n=16, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 116.875 GFlop/s
-  Kernel_dnt_medium(m=5, n=16, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 121.579 GFlop/s
-  Kernel_dnt_medium(m=5, n=16, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 135.569 GFlop/s
-  Kernel_dnt_medium(m=5, n=16, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 129.272 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=16, k=24, tile_m=1, tile_n=1, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 131.765 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=16, k=26, tile_m=1, tile_n=1, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 128.942 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=16, k=32, tile_m=1, tile_n=1, w=16, v=16, threads=128, grouping=16, minblocks=12) , # 139.49 GFlop/s
-  Kernel_dnt_medium(m=5, n=17, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 54.7705 GFlop/s
-  Kernel_dnt_medium(m=5, n=17, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 66.6945 GFlop/s
-  Kernel_dnt_small(m=5, n=17, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 67.0057 GFlop/s
-  Kernel_dnt_medium(m=5, n=17, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 77.7652 GFlop/s
-  Kernel_dnt_medium(m=5, n=17, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 87.0744 GFlop/s
-  Kernel_dnt_medium(m=5, n=17, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 106.256 GFlop/s
-  Kernel_dnt_medium(m=5, n=17, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 121.156 GFlop/s
-  Kernel_dnt_medium(m=5, n=17, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 119.245 GFlop/s
-  Kernel_dnt_medium(m=5, n=17, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 136.959 GFlop/s
-  Kernel_dnt_medium(m=5, n=17, k=23, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 123.364 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=17, k=24, tile_m=1, tile_n=1, w=12, v=14, threads=128, grouping=16, minblocks=12) , # 128.46 GFlop/s
-  Kernel_dnt_medium(m=5, n=17, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=4) , # 132.131 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=17, k=32, tile_m=1, tile_n=1, w=14, v=6, threads=128, grouping=16, minblocks=12) , # 135.01 GFlop/s
-  Kernel_dnt_tiny(m=5, n=22, k=4, threads=128, grouping=16, minblocks=1) , # 64.6247 GFlop/s
-  Kernel_dnt_small(m=5, n=22, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 71.6059 GFlop/s
-  Kernel_dnt_medium(m=5, n=22, k=6, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 73.2559 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=22, k=8, tile_m=1, tile_n=1, w=4, v=22, threads=128, grouping=16, minblocks=8) , # 92.3688 GFlop/s
-  Kernel_dnt_medium(m=5, n=22, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 98.0181 GFlop/s
-  Kernel_dnt_medium(m=5, n=22, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 119.94 GFlop/s
-  Kernel_dnt_medium(m=5, n=22, k=16, tile_m=1, tile_n=4, threads=96, grouping=16, minblocks=12) , # 136.353 GFlop/s
-  Kernel_dnt_medium(m=5, n=22, k=17, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 137.955 GFlop/s
-  Kernel_dnt_medium(m=5, n=22, k=22, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=4) , # 135.568 GFlop/s
-  Kernel_dnt_medium(m=5, n=22, k=23, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=8) , # 135.879 GFlop/s
-  Kernel_dnt_medium(m=5, n=22, k=24, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=8) , # 138.483 GFlop/s
-  Kernel_dnt_medium(m=5, n=22, k=26, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=1) , # 145.469 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=22, k=32, tile_m=1, tile_n=1, w=16, v=22, threads=192, grouping=16, minblocks=8) , # 143.787 GFlop/s
-  Kernel_dnt_tiny(m=5, n=23, k=4, threads=128, grouping=16, minblocks=1) , # 66.9592 GFlop/s
-  Kernel_dnt_small(m=5, n=23, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 74.1593 GFlop/s
-  Kernel_dnt_medium(m=5, n=23, k=6, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 76.2473 GFlop/s
-  Kernel_dnt_medium(m=5, n=23, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 94.6116 GFlop/s
-  Kernel_dnt_medium(m=5, n=23, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 102.375 GFlop/s
-  Kernel_dnt_medium(m=5, n=23, k=13, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 123.606 GFlop/s
-  Kernel_dnt_medium(m=5, n=23, k=16, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 140 GFlop/s
-  Kernel_dnt_medium(m=5, n=23, k=17, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=4) , # 125.344 GFlop/s
-  Kernel_dnt_medium(m=5, n=23, k=22, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=8) , # 144.101 GFlop/s
-  Kernel_dnt_medium(m=5, n=23, k=23, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=8) , # 141.081 GFlop/s
-  Kernel_dnt_medium(m=5, n=23, k=24, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=8) , # 143.882 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=23, k=26, tile_m=1, tile_n=1, w=10, v=22, threads=128, grouping=16, minblocks=12) , # 136.154 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=23, k=32, tile_m=1, tile_n=1, w=16, v=22, threads=192, grouping=16, minblocks=8) , # 145.364 GFlop/s
-  Kernel_dnt_tiny(m=5, n=24, k=4, threads=128, grouping=16, minblocks=1) , # 70.2727 GFlop/s
-  Kernel_dnt_small(m=5, n=24, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 79.6991 GFlop/s
-  Kernel_dnt_medium(m=5, n=24, k=6, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 80.5021 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=24, k=8, tile_m=1, tile_n=1, w=4, v=24, threads=128, grouping=16, minblocks=12) , # 100.583 GFlop/s
-  Kernel_dnt_medium(m=5, n=24, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 107.639 GFlop/s
-  Kernel_dnt_medium(m=5, n=24, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 130.403 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=24, k=16, tile_m=1, tile_n=1, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 138.648 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=24, k=17, tile_m=1, tile_n=1, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 128.385 GFlop/s
-  Kernel_dnt_medium(m=5, n=24, k=22, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=1) , # 147.78 GFlop/s
-  Kernel_dnt_medium(m=5, n=24, k=23, tile_m=1, tile_n=1, threads=192, grouping=16, minblocks=8) , # 147.238 GFlop/s
-  Kernel_dnt_medium(m=5, n=24, k=24, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 149.11 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=24, k=26, tile_m=1, tile_n=1, w=10, v=24, threads=128, grouping=16, minblocks=8) , # 144.829 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=24, k=32, tile_m=1, tile_n=1, w=12, v=24, threads=160, grouping=16, minblocks=12) , # 151.834 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=25, k=4, tile_m=1, tile_n=1, w=2, v=24, threads=128, grouping=16, minblocks=1) , # 71.6625 GFlop/s
-  Kernel_dnt_small(m=5, n=25, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 80.6391 GFlop/s
-  Kernel_dnt_medium(m=5, n=25, k=7, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 92.0275 GFlop/s
-  Kernel_dnt_medium(m=5, n=25, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 111.946 GFlop/s
-  Kernel_dnt_medium(m=5, n=25, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 138.956 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=25, k=25, tile_m=1, tile_n=1, w=10, v=22, threads=128, grouping=16, minblocks=1) , # 151.406 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=25, k=26, tile_m=1, tile_n=1, w=10, v=12, threads=128, grouping=16, minblocks=12) , # 152.399 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=25, k=28, tile_m=1, tile_n=1, w=14, v=12, threads=128, grouping=16, minblocks=12) , # 159.392 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=25, k=32, tile_m=1, tile_n=1, w=16, v=20, threads=128, grouping=16, minblocks=1) , # 164.81 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=25, k=45, tile_m=1, tile_n=1, w=16, v=22, threads=128, grouping=16, minblocks=12) , # 167.254 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=26, k=4, tile_m=1, tile_n=2, w=2, v=26, threads=96, grouping=16, minblocks=1) , # 73.0565 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=5, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 72.8437 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 83.0577 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=7, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 92.7505 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 97.7841 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=9, tile_m=5, tile_n=1, threads=96, grouping=16, minblocks=12) , # 106.059 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 127.925 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=26, k=16, tile_m=1, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=1) , # 124.739 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=17, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 121.911 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=22, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 138.328 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=26, k=23, tile_m=1, tile_n=2, w=6, v=26, threads=96, grouping=16, minblocks=4) , # 133.003 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=26, k=24, tile_m=1, tile_n=1, w=12, v=26, threads=160, grouping=16, minblocks=12) , # 142.549 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=26, k=25, tile_m=6, tile_n=1, w=12, v=26, threads=96, grouping=16, minblocks=12) , # 150.57 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=26, k=26, tile_m=5, tile_n=1, w=12, v=26, threads=96, grouping=16, minblocks=12) , # 152.336 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=26, k=28, tile_m=2, tile_n=3, w=14, v=26, threads=96, grouping=16, minblocks=12) , # 161.207 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=26, k=32, tile_m=2, tile_n=3, w=16, v=26, threads=96, grouping=16, minblocks=12) , # 165.179 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=26, k=45, tile_m=3, tile_n=1, w=16, v=16, threads=96, grouping=16, minblocks=12) , # 163.833 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=28, k=4, tile_m=1, tile_n=2, w=2, v=28, threads=96, grouping=16, minblocks=1) , # 78.7832 GFlop/s
-  Kernel_dnt_medium(m=5, n=28, k=5, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 78.538 GFlop/s
-  Kernel_dnt_medium(m=5, n=28, k=7, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 94.7919 GFlop/s
-  Kernel_dnt_medium(m=5, n=28, k=9, tile_m=5, tile_n=1, threads=96, grouping=16, minblocks=12) , # 114.142 GFlop/s
-  Kernel_dnt_medium(m=5, n=28, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 136.621 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=28, k=25, tile_m=1, tile_n=2, w=10, v=14, threads=96, grouping=16, minblocks=12) , # 155.335 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=28, k=26, tile_m=6, tile_n=1, w=10, v=14, threads=96, grouping=16, minblocks=12) , # 157.636 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=28, k=28, tile_m=3, tile_n=2, w=14, v=28, threads=96, grouping=16, minblocks=12) , # 164.633 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=28, k=32, tile_m=5, tile_n=1, w=12, v=28, threads=96, grouping=16, minblocks=12) , # 167.029 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=28, k=45, tile_m=2, tile_n=1, w=12, v=16, threads=96, grouping=16, minblocks=4) , # 170.753 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=32, k=4, tile_m=1, tile_n=2, w=2, v=32, threads=96, grouping=16, minblocks=4) , # 90.3387 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 90.1318 GFlop/s
-  Kernel_dnt_small(m=5, n=32, k=6, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 95.4478 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=7, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 110.148 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 120.304 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=9, tile_m=5, tile_n=1, threads=96, grouping=16, minblocks=12) , # 128.642 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=13, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 146.704 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=16, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=4) , # 148.849 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=17, tile_m=6, tile_n=1, threads=96, grouping=16, minblocks=8) , # 145.146 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=22, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=1) , # 152.464 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=32, k=23, tile_m=1, tile_n=2, w=6, v=32, threads=96, grouping=16, minblocks=8) , # 153.738 GFlop/s
-  Kernel_dnt_largeDB1(m=5, n=32, k=24, tile_m=1, tile_n=2, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 156.997 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=32, k=25, tile_m=5, tile_n=1, w=12, v=32, threads=96, grouping=16, minblocks=12) , # 165.526 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=32, k=26, tile_m=1, tile_n=2, w=10, v=32, threads=96, grouping=16, minblocks=1) , # 167.342 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=32, k=28, tile_m=2, tile_n=1, w=10, v=32, threads=96, grouping=16, minblocks=4) , # 170.549 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=32, k=32, tile_m=1, tile_n=2, w=12, v=32, threads=96, grouping=16, minblocks=8) , # 175.093 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=32, k=45, tile_m=2, tile_n=1, w=12, v=32, threads=96, grouping=16, minblocks=12) , # 178.419 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=45, k=4, tile_m=1, tile_n=2, w=2, v=44, threads=128, grouping=16, minblocks=1) , # 102.104 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=45, k=5, tile_m=1, tile_n=2, w=2, v=24, threads=128, grouping=16, minblocks=12) , # 103.389 GFlop/s
-  Kernel_dnt_medium(m=5, n=45, k=7, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 131.225 GFlop/s
-  Kernel_dnt_medium(m=5, n=45, k=9, tile_m=1, tile_n=4, threads=96, grouping=16, minblocks=12) , # 142.875 GFlop/s
-  Kernel_dnt_medium(m=5, n=45, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=4) , # 154.231 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=45, k=25, tile_m=1, tile_n=2, w=10, v=44, threads=128, grouping=16, minblocks=12) , # 169.95 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=45, k=26, tile_m=3, tile_n=1, w=8, v=18, threads=96, grouping=16, minblocks=12) , # 170.684 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=45, k=28, tile_m=1, tile_n=2, w=14, v=26, threads=160, grouping=16, minblocks=8) , # 177.397 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=45, k=32, tile_m=1, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 181.043 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=45, k=45, tile_m=1, tile_n=2, w=12, v=42, threads=128, grouping=16, minblocks=8) , # 183.404 GFlop/s
-  Kernel_dnt_tiny(m=6, n=4, k=4, threads=128, grouping=16, minblocks=1) , # 17.3648 GFlop/s
-  Kernel_dnt_tiny(m=6, n=4, k=5, threads=96, grouping=16, minblocks=1) , # 20.891 GFlop/s
-  Kernel_dnt_tiny(m=6, n=4, k=6, threads=96, grouping=16, minblocks=1) , # 25.3088 GFlop/s
-  Kernel_dnt_tiny(m=6, n=4, k=8, threads=96, grouping=16, minblocks=1) , # 34.4029 GFlop/s
-  Kernel_dnt_tiny(m=6, n=4, k=9, threads=96, grouping=16, minblocks=1) , # 30.9154 GFlop/s
-  Kernel_dnt_small(m=6, n=4, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 40.7212 GFlop/s
-  Kernel_dnt_small(m=6, n=4, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 48.547 GFlop/s
-  Kernel_dnt_small(m=6, n=4, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 42.7597 GFlop/s
-  Kernel_dnt_medium(m=6, n=4, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 59.0194 GFlop/s
-  Kernel_dnt_medium(m=6, n=4, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 62.4159 GFlop/s
-  Kernel_dnt_medium(m=6, n=4, k=24, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 59.3286 GFlop/s
-  Kernel_dnt_medium(m=6, n=4, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 63.2716 GFlop/s
-  Kernel_dnt_medium(m=6, n=4, k=32, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 71.0281 GFlop/s
-  Kernel_dnt_tiny(m=6, n=5, k=4, threads=96, grouping=16, minblocks=1) , # 21.0382 GFlop/s
-  Kernel_dnt_tiny(m=6, n=5, k=5, threads=96, grouping=16, minblocks=1) , # 25.6146 GFlop/s
-  Kernel_dnt_tiny(m=6, n=5, k=6, threads=96, grouping=16, minblocks=1) , # 30.7386 GFlop/s
-  Kernel_dnt_tiny(m=6, n=5, k=8, threads=96, grouping=16, minblocks=1) , # 39.7844 GFlop/s
-  Kernel_dnt_tiny(m=6, n=5, k=9, threads=96, grouping=16, minblocks=1) , # 37.5717 GFlop/s
-  Kernel_dnt_small(m=6, n=5, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 49.4221 GFlop/s
-  Kernel_dnt_small(m=6, n=5, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 58.085 GFlop/s
-  Kernel_dnt_small(m=6, n=5, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 52.5703 GFlop/s
-  Kernel_dnt_medium(m=6, n=5, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 69.4004 GFlop/s
-  Kernel_dnt_medium(m=6, n=5, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 71.6165 GFlop/s
-  Kernel_dnt_medium(m=6, n=5, k=24, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 73.8541 GFlop/s
-  Kernel_dnt_medium(m=6, n=5, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 78.7409 GFlop/s
-  Kernel_dnt_medium(m=6, n=5, k=32, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 87.6399 GFlop/s
-  Kernel_dnt_small(m=6, n=6, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 29.0092 GFlop/s
-  Kernel_dnt_tiny(m=6, n=6, k=5, threads=64, grouping=16, minblocks=1) , # 34.7398 GFlop/s
-  Kernel_dnt_tiny(m=6, n=6, k=6, threads=96, grouping=16, minblocks=1) , # 41.3431 GFlop/s
-  Kernel_dnt_small(m=6, n=6, k=8, tile_m=1, tile_n=1, threads=64, grouping=16, minblocks=12) , # 51.4584 GFlop/s
-  Kernel_dnt_small(m=6, n=6, k=9, tile_m=1, tile_n=1, threads=64, grouping=16, minblocks=4) , # 54.7869 GFlop/s
-  Kernel_dnt_small(m=6, n=6, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 65.899 GFlop/s
-  Kernel_dnt_small(m=6, n=6, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 74.696 GFlop/s
-  Kernel_dnt_small(m=6, n=6, k=17, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 73.6249 GFlop/s
-  Kernel_dnt_medium(m=6, n=6, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 83.3214 GFlop/s
-  Kernel_dnt_medium(m=6, n=6, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 85.2118 GFlop/s
-  Kernel_dnt_medium(m=6, n=6, k=24, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 87.2119 GFlop/s
-  Kernel_dnt_medium(m=6, n=6, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 91.5958 GFlop/s
-  Kernel_dnt_medium(m=6, n=6, k=32, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 93.8914 GFlop/s
-  Kernel_dnt_medium(m=6, n=6, k=36, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 90.6049 GFlop/s
-  Kernel_dnt_medium(m=6, n=8, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 32.8542 GFlop/s
-  Kernel_dnt_medium(m=6, n=8, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 39.5654 GFlop/s
-  Kernel_dnt_medium(m=6, n=8, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 46.7754 GFlop/s
-  Kernel_dnt_tiny(m=6, n=8, k=8, threads=96, grouping=16, minblocks=1) , # 56.4219 GFlop/s
-  Kernel_dnt_small(m=6, n=8, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 57.8262 GFlop/s
-  Kernel_dnt_small(m=6, n=8, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 70.6689 GFlop/s
-  Kernel_dnt_small(m=6, n=8, k=16, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 81.6668 GFlop/s
-  Kernel_dnt_medium(m=6, n=8, k=17, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 75.7991 GFlop/s
-  Kernel_dnt_medium(m=6, n=8, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 102.189 GFlop/s
-  Kernel_dnt_medium(m=6, n=8, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 104.903 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=8, k=24, tile_m=1, tile_n=1, w=12, v=8, threads=128, grouping=16, minblocks=1) , # 99.5961 GFlop/s
-  Kernel_dnt_medium(m=6, n=8, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 100.125 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=8, k=32, tile_m=1, tile_n=1, w=16, v=8, threads=96, grouping=16, minblocks=8) , # 110.732 GFlop/s
-  Kernel_dnt_medium(m=6, n=9, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 35.8024 GFlop/s
-  Kernel_dnt_medium(m=6, n=9, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 43.8484 GFlop/s
-  Kernel_dnt_medium(m=6, n=9, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 51.8175 GFlop/s
-  Kernel_dnt_small(m=6, n=9, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 58.965 GFlop/s
-  Kernel_dnt_medium(m=6, n=9, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 63.9309 GFlop/s
-  Kernel_dnt_medium(m=6, n=9, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 78.5539 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=9, k=16, tile_m=1, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 84.561 GFlop/s
-  Kernel_dnt_medium(m=6, n=9, k=17, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 84.3988 GFlop/s
-  Kernel_dnt_medium(m=6, n=9, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 100.301 GFlop/s
-  Kernel_dnt_medium(m=6, n=9, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 103.968 GFlop/s
-  Kernel_dnt_medium(m=6, n=9, k=24, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 106.858 GFlop/s
-  Kernel_dnt_medium(m=6, n=9, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 110.172 GFlop/s
-  Kernel_dnt_medium(m=6, n=9, k=32, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 117.743 GFlop/s
-  Kernel_dnt_medium(m=6, n=13, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 50.793 GFlop/s
-  Kernel_dnt_medium(m=6, n=13, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 61.4172 GFlop/s
-  Kernel_dnt_medium(m=6, n=13, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 72.3602 GFlop/s
-  Kernel_dnt_medium(m=6, n=13, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 76.7893 GFlop/s
-  Kernel_dnt_medium(m=6, n=13, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 82.6919 GFlop/s
-  Kernel_dnt_medium(m=6, n=13, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 103.505 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=13, k=16, tile_m=1, tile_n=1, w=8, v=12, threads=128, grouping=16, minblocks=8) , # 109.832 GFlop/s
-  Kernel_dnt_medium(m=6, n=13, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 107.414 GFlop/s
-  Kernel_dnt_medium(m=6, n=13, k=22, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 126.399 GFlop/s
-  Kernel_dnt_medium(m=6, n=13, k=23, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 127.16 GFlop/s
-  Kernel_dnt_medium(m=6, n=13, k=24, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 129.224 GFlop/s
-  Kernel_dnt_medium(m=6, n=13, k=26, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 124.698 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=13, k=32, tile_m=1, tile_n=1, w=16, v=8, threads=128, grouping=16, minblocks=12) , # 134.667 GFlop/s
-  Kernel_dnt_medium(m=6, n=16, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 63.5995 GFlop/s
-  Kernel_dnt_medium(m=6, n=16, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 78.998 GFlop/s
-  Kernel_dnt_small(m=6, n=16, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 79.6159 GFlop/s
-  Kernel_dnt_small(m=6, n=16, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 94.2819 GFlop/s
-  Kernel_dnt_medium(m=6, n=16, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 99.4404 GFlop/s
-  Kernel_dnt_medium(m=6, n=16, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 121.474 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=16, k=16, tile_m=1, tile_n=1, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 131.447 GFlop/s
-  Kernel_dnt_medium(m=6, n=16, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 130.503 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=16, k=22, tile_m=1, tile_n=1, w=10, v=16, threads=96, grouping=16, minblocks=8) , # 140.994 GFlop/s
-  Kernel_dnt_medium(m=6, n=16, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 143.929 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=16, k=24, tile_m=1, tile_n=1, w=12, v=16, threads=96, grouping=16, minblocks=1) , # 151.414 GFlop/s
-  Kernel_dnt_medium(m=6, n=16, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=1) , # 150.43 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=16, k=32, tile_m=1, tile_n=1, w=16, v=16, threads=128, grouping=16, minblocks=12) , # 162.722 GFlop/s
-  Kernel_dnt_tiny(m=6, n=17, k=4, threads=128, grouping=16, minblocks=1) , # 60.5441 GFlop/s
-  Kernel_dnt_small(m=6, n=17, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 68.6498 GFlop/s
-  Kernel_dnt_medium(m=6, n=17, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 75.0572 GFlop/s
-  Kernel_dnt_medium(m=6, n=17, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 88.8231 GFlop/s
-  Kernel_dnt_medium(m=6, n=17, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 96.638 GFlop/s
-  Kernel_dnt_medium(m=6, n=17, k=13, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 115.635 GFlop/s
-  Kernel_dnt_medium(m=6, n=17, k=16, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 122.699 GFlop/s
-  Kernel_dnt_medium(m=6, n=17, k=17, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 122.369 GFlop/s
-  Kernel_dnt_medium(m=6, n=17, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 138.221 GFlop/s
-  Kernel_dnt_medium(m=6, n=17, k=23, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 137.919 GFlop/s
-  Kernel_dnt_medium(m=6, n=17, k=24, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 141.952 GFlop/s
-  Kernel_dnt_medium(m=6, n=17, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=1) , # 145.765 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=17, k=32, tile_m=1, tile_n=1, w=14, v=8, threads=128, grouping=16, minblocks=12) , # 147.119 GFlop/s
-  Kernel_dnt_small(m=6, n=22, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 68.9181 GFlop/s
-  Kernel_dnt_medium(m=6, n=22, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 77.9158 GFlop/s
-  Kernel_dnt_medium(m=6, n=22, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 85.5436 GFlop/s
-  Kernel_dnt_medium(m=6, n=22, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 107.115 GFlop/s
-  Kernel_dnt_medium(m=6, n=22, k=9, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 107.717 GFlop/s
-  Kernel_dnt_medium(m=6, n=22, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 130.85 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=22, k=16, tile_m=1, tile_n=2, w=8, v=14, threads=96, grouping=16, minblocks=4) , # 143.533 GFlop/s
-  Kernel_dnt_medium(m=6, n=22, k=17, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 147.658 GFlop/s
-  Kernel_dnt_medium(m=6, n=22, k=22, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 142.021 GFlop/s
-  Kernel_dnt_medium(m=6, n=22, k=23, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 144.504 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=22, k=24, tile_m=2, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=4) , # 150.931 GFlop/s
-  Kernel_dnt_medium(m=6, n=22, k=26, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 151.978 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=22, k=32, tile_m=2, tile_n=3, w=16, v=16, threads=96, grouping=16, minblocks=12) , # 160.565 GFlop/s
-  Kernel_dnt_small(m=6, n=23, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 70.9369 GFlop/s
-  Kernel_dnt_medium(m=6, n=23, k=5, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 80.8594 GFlop/s
-  Kernel_dnt_medium(m=6, n=23, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 88.9708 GFlop/s
-  Kernel_dnt_medium(m=6, n=23, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 111.224 GFlop/s
-  Kernel_dnt_medium(m=6, n=23, k=9, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 111.977 GFlop/s
-  Kernel_dnt_medium(m=6, n=23, k=13, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=8) , # 138.705 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=23, k=16, tile_m=2, tile_n=1, w=8, v=16, threads=96, grouping=16, minblocks=4) , # 145.791 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=23, k=17, tile_m=2, tile_n=1, w=8, v=12, threads=96, grouping=16, minblocks=4) , # 130.847 GFlop/s
-  Kernel_dnt_medium(m=6, n=23, k=22, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 145.676 GFlop/s
-  Kernel_dnt_medium(m=6, n=23, k=23, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 147.626 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=23, k=24, tile_m=2, tile_n=1, w=8, v=16, threads=96, grouping=16, minblocks=1) , # 153.564 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=23, k=26, tile_m=2, tile_n=1, w=10, v=16, threads=128, grouping=16, minblocks=12) , # 149.513 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=23, k=32, tile_m=2, tile_n=1, w=8, v=16, threads=96, grouping=16, minblocks=8) , # 163.779 GFlop/s
-  Kernel_dnt_small(m=6, n=24, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 77.1222 GFlop/s
-  Kernel_dnt_medium(m=6, n=24, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 85.3145 GFlop/s
-  Kernel_dnt_medium(m=6, n=24, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 94.4076 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=24, k=8, tile_m=2, tile_n=1, w=4, v=24, threads=96, grouping=16, minblocks=8) , # 110.004 GFlop/s
-  Kernel_dnt_medium(m=6, n=24, k=9, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 118.271 GFlop/s
-  Kernel_dnt_medium(m=6, n=24, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 142.641 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=24, k=16, tile_m=1, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 155.64 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=24, k=17, tile_m=1, tile_n=2, w=8, v=24, threads=96, grouping=16, minblocks=4) , # 140.277 GFlop/s
-  Kernel_dnt_medium(m=6, n=24, k=22, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 154.822 GFlop/s
-  Kernel_dnt_medium(m=6, n=24, k=23, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 156.783 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=24, k=24, tile_m=2, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=8) , # 163.247 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=24, k=26, tile_m=1, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=4) , # 158.81 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=24, k=32, tile_m=2, tile_n=1, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 171.227 GFlop/s
-  Kernel_dnt_medium(m=6, n=26, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 72.8888 GFlop/s
-  Kernel_dnt_medium(m=6, n=26, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 86.2243 GFlop/s
-  Kernel_dnt_medium(m=6, n=26, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 100.321 GFlop/s
-  Kernel_dnt_medium(m=6, n=26, k=8, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 114.794 GFlop/s
-  Kernel_dnt_medium(m=6, n=26, k=9, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 124.78 GFlop/s
-  Kernel_dnt_medium(m=6, n=26, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 150.084 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=26, k=16, tile_m=2, tile_n=1, w=8, v=26, threads=128, grouping=16, minblocks=12) , # 148.541 GFlop/s
-  Kernel_dnt_medium(m=6, n=26, k=17, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 146.817 GFlop/s
-  Kernel_dnt_medium(m=6, n=26, k=22, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 164.867 GFlop/s
-  Kernel_dnt_medium(m=6, n=26, k=23, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 167.944 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=26, k=24, tile_m=1, tile_n=1, w=12, v=26, threads=160, grouping=16, minblocks=12) , # 167.824 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=26, k=26, tile_m=1, tile_n=2, w=10, v=26, threads=96, grouping=16, minblocks=12) , # 160.058 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=26, k=32, tile_m=1, tile_n=1, w=12, v=26, threads=160, grouping=16, minblocks=12) , # 172.981 GFlop/s
-  Kernel_dnt_medium(m=6, n=32, k=4, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 88.5988 GFlop/s
-  Kernel_dnt_medium(m=6, n=32, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 107.109 GFlop/s
-  Kernel_dnt_small(m=6, n=32, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 112.623 GFlop/s
-  Kernel_dnt_medium(m=6, n=32, k=8, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 136.523 GFlop/s
-  Kernel_dnt_medium(m=6, n=32, k=9, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 148.067 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=32, k=13, tile_m=1, tile_n=2, w=6, v=16, threads=96, grouping=16, minblocks=8) , # 157.238 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=32, k=16, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 170.847 GFlop/s
-  Kernel_dnt_medium(m=6, n=32, k=17, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 172.856 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=32, k=22, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 177.946 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=32, k=23, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 179.578 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=32, k=24, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 184.552 GFlop/s
-  Kernel_dnt_medium(m=6, n=32, k=26, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=1) , # 182.386 GFlop/s
-  Kernel_dnt_largeDB1(m=6, n=32, k=32, tile_m=2, tile_n=1, w=8, v=18, threads=128, grouping=16, minblocks=12) , # 192.489 GFlop/s
-  Kernel_dnt_medium(m=6, n=36, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 119.79 GFlop/s
-  Kernel_dnt_tiny(m=7, n=4, k=4, threads=128, grouping=16, minblocks=1) , # 20.321 GFlop/s
-  Kernel_dnt_tiny(m=7, n=4, k=5, threads=128, grouping=16, minblocks=1) , # 25.1685 GFlop/s
-  Kernel_dnt_tiny(m=7, n=4, k=7, threads=96, grouping=16, minblocks=1) , # 33.8708 GFlop/s
-  Kernel_dnt_tiny(m=7, n=4, k=9, threads=96, grouping=16, minblocks=1) , # 41.5372 GFlop/s
-  Kernel_dnt_medium(m=7, n=4, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 53.8869 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=4, k=25, tile_m=1, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=4) , # 73.2421 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=4, k=26, tile_m=1, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=1) , # 75.2431 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=4, k=28, tile_m=1, tile_n=1, w=14, v=4, threads=96, grouping=16, minblocks=1) , # 84.3456 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=4, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=4) , # 90.5669 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=4, k=45, tile_m=1, tile_n=1, w=18, v=4, threads=96, grouping=16, minblocks=4) , # 89.7354 GFlop/s
-  Kernel_dnt_medium(m=7, n=5, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 23.648 GFlop/s
-  Kernel_dnt_medium(m=7, n=5, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 28.8325 GFlop/s
-  Kernel_dnt_medium(m=7, n=5, k=7, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 38.3808 GFlop/s
-  Kernel_dnt_medium(m=7, n=5, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 47.369 GFlop/s
-  Kernel_dnt_medium(m=7, n=5, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 62.9693 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=5, k=25, tile_m=1, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=4) , # 79.6162 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=5, k=26, tile_m=1, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=4) , # 81.9313 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=5, k=28, tile_m=1, tile_n=1, w=14, v=4, threads=96, grouping=16, minblocks=1) , # 88.1174 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=1) , # 93.4222 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=5, k=45, tile_m=1, tile_n=1, w=18, v=4, threads=128, grouping=16, minblocks=4) , # 98.0637 GFlop/s
-  Kernel_dnt_tiny(m=7, n=7, k=4, threads=64, grouping=16, minblocks=1) , # 40.7019 GFlop/s
-  Kernel_dnt_tiny(m=7, n=7, k=5, threads=128, grouping=16, minblocks=1) , # 49.7395 GFlop/s
-  Kernel_dnt_tiny(m=7, n=7, k=7, threads=96, grouping=16, minblocks=1) , # 64.2082 GFlop/s
-  Kernel_dnt_tiny(m=7, n=7, k=9, threads=96, grouping=16, minblocks=1) , # 74.9724 GFlop/s
-  Kernel_dnt_medium(m=7, n=7, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 92.3343 GFlop/s
-  Kernel_dnt_medium(m=7, n=7, k=25, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 116.952 GFlop/s
-  Kernel_dnt_medium(m=7, n=7, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 111.036 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=7, k=28, tile_m=1, tile_n=1, w=14, v=6, threads=128, grouping=16, minblocks=1) , # 119.39 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=7, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=8) , # 126.959 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=7, k=45, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=1) , # 128.604 GFlop/s
-  Kernel_dnt_largeDB1(m=7, n=7, k=49, tile_m=1, tile_n=1, w=18, v=4, threads=128, grouping=16, minblocks=12) , # 120.76 GFlop/s
-  Kernel_dnt_medium(m=7, n=9, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 42.249 GFlop/s
-  Kernel_dnt_medium(m=7, n=9, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 50.9731 GFlop/s
-  Kernel_dnt_medium(m=7, n=9, k=7, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 68.4855 GFlop/s
-  Kernel_dnt_medium(m=7, n=9, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 84.8179 GFlop/s
-  Kernel_dnt_medium(m=7, n=9, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 101.494 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=9, k=25, tile_m=1, tile_n=1, w=10, v=8, threads=128, grouping=16, minblocks=4) , # 127.326 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=9, k=26, tile_m=1, tile_n=1, w=10, v=8, threads=96, grouping=16, minblocks=4) , # 129.924 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=9, k=28, tile_m=1, tile_n=1, w=14, v=8, threads=128, grouping=16, minblocks=1) , # 142.345 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=9, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=1) , # 145.13 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=9, k=45, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=1) , # 145.375 GFlop/s
-  Kernel_dnt_medium(m=7, n=13, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 59.6126 GFlop/s
-  Kernel_dnt_medium(m=7, n=13, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 71.567 GFlop/s
-  Kernel_dnt_medium(m=7, n=13, k=7, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 94.7367 GFlop/s
-  Kernel_dnt_medium(m=7, n=13, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 104.845 GFlop/s
-  Kernel_dnt_medium(m=7, n=13, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 131.471 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=13, k=25, tile_m=1, tile_n=1, w=12, v=10, threads=96, grouping=16, minblocks=1) , # 152.657 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=13, k=26, tile_m=1, tile_n=1, w=12, v=10, threads=96, grouping=16, minblocks=4) , # 154.864 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=13, k=28, tile_m=1, tile_n=1, w=14, v=6, threads=96, grouping=16, minblocks=4) , # 160.679 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=13, k=32, tile_m=1, tile_n=1, w=16, v=12, threads=96, grouping=16, minblocks=8) , # 167.82 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=13, k=45, tile_m=1, tile_n=1, w=16, v=12, threads=96, grouping=16, minblocks=1) , # 170.871 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=25, k=4, tile_m=1, tile_n=2, w=2, v=24, threads=96, grouping=16, minblocks=1) , # 90.6823 GFlop/s
-  Kernel_dnt_medium(m=7, n=25, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 96.0502 GFlop/s
-  Kernel_dnt_medium(m=7, n=25, k=7, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 116.201 GFlop/s
-  Kernel_dnt_medium(m=7, n=25, k=9, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=8) , # 137.027 GFlop/s
-  Kernel_dnt_medium(m=7, n=25, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 165.715 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=25, k=25, tile_m=1, tile_n=2, w=12, v=24, threads=96, grouping=16, minblocks=12) , # 192.888 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=25, k=26, tile_m=1, tile_n=2, w=12, v=24, threads=96, grouping=16, minblocks=12) , # 195.055 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=25, k=28, tile_m=2, tile_n=2, w=14, v=16, threads=128, grouping=16, minblocks=12) , # 204.588 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=25, k=32, tile_m=1, tile_n=2, w=16, v=14, threads=96, grouping=16, minblocks=12) , # 209.44 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=25, k=45, tile_m=1, tile_n=2, w=12, v=24, threads=96, grouping=16, minblocks=8) , # 212.537 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=26, k=4, tile_m=1, tile_n=2, w=2, v=26, threads=96, grouping=16, minblocks=4) , # 98.6714 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=26, k=5, tile_m=1, tile_n=2, w=2, v=26, threads=96, grouping=16, minblocks=4) , # 97.2595 GFlop/s
-  Kernel_dnt_medium(m=7, n=26, k=7, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 120.571 GFlop/s
-  Kernel_dnt_medium(m=7, n=26, k=9, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 142.154 GFlop/s
-  Kernel_dnt_medium(m=7, n=26, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 171.139 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=26, k=25, tile_m=1, tile_n=2, w=12, v=26, threads=96, grouping=16, minblocks=1) , # 197.945 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=26, k=26, tile_m=1, tile_n=2, w=12, v=26, threads=96, grouping=16, minblocks=4) , # 200.252 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=26, k=28, tile_m=1, tile_n=2, w=14, v=26, threads=96, grouping=16, minblocks=8) , # 208.875 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=26, k=32, tile_m=1, tile_n=2, w=16, v=18, threads=128, grouping=16, minblocks=8) , # 213.257 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=26, k=45, tile_m=1, tile_n=2, w=12, v=14, threads=96, grouping=16, minblocks=12) , # 219.31 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=28, k=4, tile_m=2, tile_n=2, w=2, v=28, threads=96, grouping=16, minblocks=12) , # 101.062 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=28, k=5, tile_m=2, tile_n=2, w=2, v=28, threads=96, grouping=16, minblocks=12) , # 99.5538 GFlop/s
-  Kernel_dnt_medium(m=7, n=28, k=7, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 121.608 GFlop/s
-  Kernel_dnt_medium(m=7, n=28, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 147.435 GFlop/s
-  Kernel_dnt_medium(m=7, n=28, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 169.528 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=28, k=25, tile_m=2, tile_n=2, w=12, v=28, threads=128, grouping=16, minblocks=12) , # 201.753 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=28, k=26, tile_m=2, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 204.712 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=28, k=28, tile_m=2, tile_n=2, w=14, v=28, threads=96, grouping=16, minblocks=12) , # 210.808 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=28, k=32, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 216.209 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=28, k=45, tile_m=2, tile_n=2, w=12, v=28, threads=96, grouping=16, minblocks=12) , # 223.329 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=32, k=4, tile_m=2, tile_n=2, w=2, v=32, threads=96, grouping=16, minblocks=12) , # 115.233 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=32, k=5, tile_m=2, tile_n=2, w=2, v=32, threads=96, grouping=16, minblocks=12) , # 114.267 GFlop/s
-  Kernel_dnt_medium(m=7, n=32, k=7, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 140.19 GFlop/s
-  Kernel_dnt_medium(m=7, n=32, k=9, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 162.426 GFlop/s
-  Kernel_dnt_medium(m=7, n=32, k=13, tile_m=1, tile_n=4, threads=96, grouping=16, minblocks=12) , # 185.749 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=32, k=25, tile_m=2, tile_n=2, w=12, v=32, threads=96, grouping=16, minblocks=12) , # 215.554 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=32, k=26, tile_m=2, tile_n=2, w=12, v=32, threads=96, grouping=16, minblocks=12) , # 217.184 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=32, k=28, tile_m=2, tile_n=2, w=10, v=20, threads=96, grouping=16, minblocks=12) , # 220.896 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=32, k=32, tile_m=2, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 226.677 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=32, k=45, tile_m=2, tile_n=2, w=12, v=32, threads=96, grouping=16, minblocks=12) , # 234.276 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=45, k=4, tile_m=2, tile_n=2, w=2, v=32, threads=96, grouping=16, minblocks=8) , # 128.485 GFlop/s
-  Kernel_dnt_medium(m=7, n=45, k=5, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 130.706 GFlop/s
-  Kernel_dnt_medium(m=7, n=45, k=7, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 151.354 GFlop/s
-  Kernel_dnt_medium(m=7, n=45, k=9, tile_m=1, tile_n=4, threads=96, grouping=16, minblocks=12) , # 179.007 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=45, k=13, tile_m=2, tile_n=2, w=6, v=28, threads=128, grouping=16, minblocks=12) , # 193.014 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=45, k=25, tile_m=2, tile_n=2, w=8, v=32, threads=96, grouping=16, minblocks=12) , # 223.056 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=45, k=26, tile_m=2, tile_n=2, w=8, v=36, threads=96, grouping=16, minblocks=12) , # 225.941 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=45, k=28, tile_m=2, tile_n=2, w=14, v=16, threads=128, grouping=16, minblocks=8) , # 232.072 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=45, k=32, tile_m=2, tile_n=3, w=8, v=38, threads=96, grouping=16, minblocks=12) , # 236.673 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=45, k=45, tile_m=2, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=8) , # 241.311 GFlop/s
-  Kernel_dnt_medium(m=7, n=49, k=7, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 147.937 GFlop/s
-  Kernel_dnt_tiny(m=8, n=4, k=4, threads=96, grouping=16, minblocks=1) , # 23.9735 GFlop/s
-  Kernel_dnt_tiny(m=8, n=4, k=5, threads=96, grouping=16, minblocks=1) , # 28.4815 GFlop/s
-  Kernel_dnt_tiny(m=8, n=4, k=6, threads=96, grouping=16, minblocks=1) , # 34.2353 GFlop/s
-  Kernel_dnt_tiny(m=8, n=4, k=8, threads=96, grouping=16, minblocks=1) , # 45.8575 GFlop/s
-  Kernel_dnt_tiny(m=8, n=4, k=9, threads=128, grouping=16, minblocks=1) , # 48.5061 GFlop/s
-  Kernel_dnt_tiny(m=8, n=4, k=13, threads=128, grouping=16, minblocks=1) , # 55.0971 GFlop/s
-  Kernel_dnt_medium(m=8, n=4, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 64.3498 GFlop/s
-  Kernel_dnt_medium(m=8, n=4, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 66.887 GFlop/s
-  Kernel_dnt_medium(m=8, n=4, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 80.5774 GFlop/s
-  Kernel_dnt_medium(m=8, n=4, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 83.3154 GFlop/s
-  Kernel_dnt_medium(m=8, n=4, k=24, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 78.1446 GFlop/s
-  Kernel_dnt_medium(m=8, n=4, k=26, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 72.9839 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=4, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=4) , # 84.7409 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 27.0068 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 33.1999 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 38.8056 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 49.3499 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 54.6039 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 64.6405 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 75.6469 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 78.0896 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 86.0905 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 88.5829 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 80.7721 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 83.5916 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=32, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 94.7041 GFlop/s
-  Kernel_dnt_medium(m=8, n=6, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 32.5636 GFlop/s
-  Kernel_dnt_medium(m=8, n=6, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 39.9008 GFlop/s
-  Kernel_dnt_medium(m=8, n=6, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 46.2498 GFlop/s
-  Kernel_dnt_medium(m=8, n=6, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 59.3358 GFlop/s
-  Kernel_dnt_medium(m=8, n=6, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 65.4188 GFlop/s
-  Kernel_dnt_medium(m=8, n=6, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 77.8557 GFlop/s
-  Kernel_dnt_medium(m=8, n=6, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 85.9489 GFlop/s
-  Kernel_dnt_medium(m=8, n=6, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 87.1602 GFlop/s
-  Kernel_dnt_medium(m=8, n=6, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 102.308 GFlop/s
-  Kernel_dnt_medium(m=8, n=6, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 105.056 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=6, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=1) , # 99.2986 GFlop/s
-  Kernel_dnt_medium(m=8, n=6, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 100.382 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=6, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=128, grouping=16, minblocks=12) , # 112.447 GFlop/s
-  Kernel_dnt_tiny(m=8, n=8, k=4, threads=96, grouping=16, minblocks=1) , # 52.7483 GFlop/s
-  Kernel_dnt_tiny(m=8, n=8, k=5, threads=96, grouping=16, minblocks=1) , # 62.8469 GFlop/s
-  Kernel_dnt_tiny(m=8, n=8, k=6, threads=128, grouping=16, minblocks=1) , # 72.9942 GFlop/s
-  Kernel_dnt_tiny(m=8, n=8, k=8, threads=128, grouping=16, minblocks=1) , # 90.7763 GFlop/s
-  Kernel_dnt_medium(m=8, n=8, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 96.8478 GFlop/s
-  Kernel_dnt_small(m=8, n=8, k=13, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 110.805 GFlop/s
-  Kernel_dnt_medium(m=8, n=8, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 122.011 GFlop/s
-  Kernel_dnt_medium(m=8, n=8, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 123.976 GFlop/s
-  Kernel_dnt_medium(m=8, n=8, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 142.579 GFlop/s
-  Kernel_dnt_medium(m=8, n=8, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 138.92 GFlop/s
-  Kernel_dnt_medium(m=8, n=8, k=24, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 139.574 GFlop/s
-  Kernel_dnt_medium(m=8, n=8, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 139.438 GFlop/s
-  Kernel_dnt_medium(m=8, n=8, k=32, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 141.729 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=8, k=64, tile_m=1, tile_n=1, w=16, v=8, threads=128, grouping=16, minblocks=12) , # 155.798 GFlop/s
-  Kernel_dnt_medium(m=8, n=9, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 47.6694 GFlop/s
-  Kernel_dnt_medium(m=8, n=9, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 57.6518 GFlop/s
-  Kernel_dnt_medium(m=8, n=9, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 67.1608 GFlop/s
-  Kernel_dnt_medium(m=8, n=9, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 84.8613 GFlop/s
-  Kernel_dnt_medium(m=8, n=9, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 92.0394 GFlop/s
-  Kernel_dnt_medium(m=8, n=9, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 100.035 GFlop/s
-  Kernel_dnt_medium(m=8, n=9, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 113.671 GFlop/s
-  Kernel_dnt_medium(m=8, n=9, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 116.819 GFlop/s
-  Kernel_dnt_medium(m=8, n=9, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 122.26 GFlop/s
-  Kernel_dnt_medium(m=8, n=9, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 123.944 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=9, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=8) , # 125.923 GFlop/s
-  Kernel_dnt_medium(m=8, n=9, k=26, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 128.998 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=9, k=32, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=12) , # 131.311 GFlop/s
-  Kernel_dnt_tiny(m=8, n=13, k=4, threads=128, grouping=16, minblocks=1) , # 63.3347 GFlop/s
-  Kernel_dnt_medium(m=8, n=13, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 75.8181 GFlop/s
-  Kernel_dnt_tiny(m=8, n=13, k=6, threads=128, grouping=16, minblocks=1) , # 86.1038 GFlop/s
-  Kernel_dnt_small(m=8, n=13, k=8, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=8) , # 98.14 GFlop/s
-  Kernel_dnt_medium(m=8, n=13, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 105.704 GFlop/s
-  Kernel_dnt_medium(m=8, n=13, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 123.059 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=13, k=16, tile_m=1, tile_n=1, w=8, v=10, threads=128, grouping=16, minblocks=12) , # 135.239 GFlop/s
-  Kernel_dnt_medium(m=8, n=13, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 137.477 GFlop/s
-  Kernel_dnt_medium(m=8, n=13, k=22, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 162.424 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=13, k=23, tile_m=1, tile_n=1, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 145.317 GFlop/s
-  Kernel_dnt_medium(m=8, n=13, k=24, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 151.977 GFlop/s
-  Kernel_dnt_medium(m=8, n=13, k=26, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 152.263 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=13, k=32, tile_m=1, tile_n=1, w=16, v=10, threads=128, grouping=16, minblocks=1) , # 160.083 GFlop/s
-  Kernel_dnt_tiny(m=8, n=16, k=4, threads=128, grouping=16, minblocks=1) , # 77.4084 GFlop/s
-  Kernel_dnt_medium(m=8, n=16, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 91.6492 GFlop/s
-  Kernel_dnt_tiny(m=8, n=16, k=6, threads=128, grouping=16, minblocks=1) , # 102.56 GFlop/s
-  Kernel_dnt_small(m=8, n=16, k=8, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 121.25 GFlop/s
-  Kernel_dnt_medium(m=8, n=16, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 120.932 GFlop/s
-  Kernel_dnt_medium(m=8, n=16, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 150.649 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=16, k=16, tile_m=1, tile_n=1, w=8, v=16, threads=128, grouping=16, minblocks=1) , # 165.868 GFlop/s
-  Kernel_dnt_medium(m=8, n=16, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 166.714 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=16, k=22, tile_m=1, tile_n=1, w=8, v=16, threads=128, grouping=16, minblocks=1) , # 174.831 GFlop/s
-  Kernel_dnt_medium(m=8, n=16, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 177.658 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=16, k=24, tile_m=1, tile_n=1, w=12, v=16, threads=128, grouping=16, minblocks=12) , # 183.951 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=16, k=26, tile_m=2, tile_n=1, w=10, v=6, threads=96, grouping=16, minblocks=1) , # 180.88 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=16, k=32, tile_m=1, tile_n=1, w=16, v=16, threads=128, grouping=16, minblocks=4) , # 193.463 GFlop/s
-  Kernel_dnt_medium(m=8, n=17, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 77.1216 GFlop/s
-  Kernel_dnt_medium(m=8, n=17, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 92.0325 GFlop/s
-  Kernel_dnt_small(m=8, n=17, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 91.8413 GFlop/s
-  Kernel_dnt_medium(m=8, n=17, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 111.233 GFlop/s
-  Kernel_dnt_medium(m=8, n=17, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 121.218 GFlop/s
-  Kernel_dnt_medium(m=8, n=17, k=13, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 139.461 GFlop/s
-  Kernel_dnt_medium(m=8, n=17, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 147.572 GFlop/s
-  Kernel_dnt_medium(m=8, n=17, k=17, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 143.132 GFlop/s
-  Kernel_dnt_medium(m=8, n=17, k=22, tile_m=1, tile_n=1, threads=224, grouping=16, minblocks=8) , # 150.659 GFlop/s
-  Kernel_dnt_medium(m=8, n=17, k=23, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 157.854 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=17, k=24, tile_m=2, tile_n=1, w=12, v=6, threads=96, grouping=16, minblocks=12) , # 164.338 GFlop/s
-  Kernel_dnt_medium(m=8, n=17, k=26, tile_m=1, tile_n=1, threads=224, grouping=16, minblocks=8) , # 155.587 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=17, k=32, tile_m=2, tile_n=3, w=16, v=16, threads=96, grouping=16, minblocks=12) , # 172.147 GFlop/s
-  Kernel_dnt_medium(m=8, n=22, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 98.4831 GFlop/s
-  Kernel_dnt_small(m=8, n=22, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 102.251 GFlop/s
-  Kernel_dnt_medium(m=8, n=22, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 113.706 GFlop/s
-  Kernel_dnt_medium(m=8, n=22, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 142.267 GFlop/s
-  Kernel_dnt_medium(m=8, n=22, k=9, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=8) , # 141.743 GFlop/s
-  Kernel_dnt_medium(m=8, n=22, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 172.127 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=22, k=16, tile_m=2, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=1) , # 186.548 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=22, k=17, tile_m=2, tile_n=1, w=8, v=10, threads=96, grouping=16, minblocks=4) , # 175.381 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=22, k=22, tile_m=2, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=8) , # 183.582 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=22, k=23, tile_m=2, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=1) , # 185.959 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=22, k=24, tile_m=2, tile_n=1, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 195.033 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=22, k=26, tile_m=2, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=4) , # 187.132 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=22, k=32, tile_m=2, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=8) , # 211.83 GFlop/s
-  Kernel_dnt_medium(m=8, n=23, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 102.42 GFlop/s
-  Kernel_dnt_small(m=8, n=23, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=8) , # 105.176 GFlop/s
-  Kernel_dnt_medium(m=8, n=23, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 118.044 GFlop/s
-  Kernel_dnt_medium(m=8, n=23, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 147.212 GFlop/s
-  Kernel_dnt_medium(m=8, n=23, k=9, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 147.697 GFlop/s
-  Kernel_dnt_medium(m=8, n=23, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 178.045 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=23, k=16, tile_m=2, tile_n=1, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 188.608 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=23, k=17, tile_m=2, tile_n=1, w=8, v=10, threads=96, grouping=16, minblocks=1) , # 178.959 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=23, k=22, tile_m=2, tile_n=1, w=8, v=12, threads=96, grouping=16, minblocks=8) , # 187.535 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=23, k=23, tile_m=2, tile_n=1, w=8, v=12, threads=96, grouping=16, minblocks=8) , # 189.238 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=23, k=24, tile_m=2, tile_n=1, w=8, v=12, threads=96, grouping=16, minblocks=8) , # 196.5 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=23, k=26, tile_m=2, tile_n=1, w=10, v=22, threads=128, grouping=16, minblocks=12) , # 191.916 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=23, k=32, tile_m=2, tile_n=1, w=8, v=10, threads=96, grouping=16, minblocks=1) , # 214.467 GFlop/s
-  Kernel_dnt_small(m=8, n=24, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 99.7498 GFlop/s
-  Kernel_dnt_small(m=8, n=24, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=4) , # 111.391 GFlop/s
-  Kernel_dnt_medium(m=8, n=24, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 123.551 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=24, k=8, tile_m=2, tile_n=1, w=4, v=24, threads=96, grouping=16, minblocks=1) , # 143.632 GFlop/s
-  Kernel_dnt_medium(m=8, n=24, k=9, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=8) , # 154.155 GFlop/s
-  Kernel_dnt_medium(m=8, n=24, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 185.726 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=24, k=16, tile_m=2, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 198.469 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=24, k=17, tile_m=2, tile_n=1, w=8, v=10, threads=96, grouping=16, minblocks=1) , # 187.951 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=24, k=22, tile_m=2, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 199.801 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=24, k=23, tile_m=2, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=1) , # 199.689 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=24, k=24, tile_m=2, tile_n=1, w=8, v=24, threads=96, grouping=16, minblocks=4) , # 207.228 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=24, k=26, tile_m=2, tile_n=1, w=8, v=12, threads=96, grouping=16, minblocks=8) , # 204.676 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=24, k=32, tile_m=2, tile_n=1, w=8, v=10, threads=96, grouping=16, minblocks=8) , # 221.005 GFlop/s
-  Kernel_dnt_small(m=8, n=26, k=4, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=4) , # 98.6441 GFlop/s
-  Kernel_dnt_small(m=8, n=26, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=8) , # 103.296 GFlop/s
-  Kernel_dnt_medium(m=8, n=26, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 117.769 GFlop/s
-  Kernel_dnt_medium(m=8, n=26, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 147.311 GFlop/s
-  Kernel_dnt_medium(m=8, n=26, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 157.749 GFlop/s
-  Kernel_dnt_medium(m=8, n=26, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 183.678 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=26, k=16, tile_m=2, tile_n=1, w=8, v=26, threads=128, grouping=16, minblocks=8) , # 184.93 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=26, k=17, tile_m=2, tile_n=1, w=8, v=26, threads=128, grouping=16, minblocks=12) , # 174.79 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=26, k=22, tile_m=2, tile_n=1, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 190.782 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=26, k=23, tile_m=2, tile_n=1, w=8, v=26, threads=128, grouping=16, minblocks=12) , # 192.48 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=26, k=24, tile_m=2, tile_n=1, w=8, v=26, threads=128, grouping=16, minblocks=12) , # 201.264 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=26, k=26, tile_m=2, tile_n=2, w=8, v=26, threads=128, grouping=16, minblocks=12) , # 200.465 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=26, k=32, tile_m=2, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=12) , # 213.624 GFlop/s
-  Kernel_dnt_small(m=8, n=32, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=8) , # 120.164 GFlop/s
-  Kernel_dnt_small(m=8, n=32, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=4) , # 126.86 GFlop/s
-  Kernel_dnt_medium(m=8, n=32, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 143.186 GFlop/s
-  Kernel_dnt_medium(m=8, n=32, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 175.277 GFlop/s
-  Kernel_dnt_medium(m=8, n=32, k=9, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 183.653 GFlop/s
-  Kernel_dnt_medium(m=8, n=32, k=13, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 193.414 GFlop/s
-  Kernel_dnt_medium(m=8, n=32, k=16, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 216.01 GFlop/s
-  Kernel_dnt_medium(m=8, n=32, k=17, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 213.609 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=32, k=22, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 222.573 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=32, k=23, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 224.463 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=32, k=24, tile_m=2, tile_n=1, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 231.134 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=32, k=26, tile_m=2, tile_n=2, w=8, v=32, threads=128, grouping=16, minblocks=12) , # 230.134 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=32, k=32, tile_m=2, tile_n=1, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 238.795 GFlop/s
-  Kernel_dnt_largeDB1(m=8, n=64, k=8, tile_m=1, tile_n=4, w=4, v=48, threads=128, grouping=16, minblocks=12) , # 205.107 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=4, k=4, tile_m=1, tile_n=1, w=2, v=4, threads=96, grouping=16, minblocks=1) , # 25.2097 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 29.9919 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 35.1352 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=7, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 40.3827 GFlop/s
-  Kernel_dnt_small(m=9, n=4, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 40.9728 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 48.8693 GFlop/s
-  Kernel_dnt_small(m=9, n=4, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 57.4295 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=4, k=16, tile_m=1, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 60.1671 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 59.5034 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 80.7153 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 81.9869 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=24, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 78.1791 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=4, k=25, tile_m=1, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=1) , # 82.9701 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=4, k=26, tile_m=1, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=1) , # 84.3279 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=4, k=28, tile_m=1, tile_n=1, w=14, v=4, threads=96, grouping=16, minblocks=4) , # 92.4296 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=4, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=4) , # 97.0899 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=4, k=45, tile_m=1, tile_n=1, w=18, v=4, threads=96, grouping=16, minblocks=8) , # 97.9513 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 30.4526 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 37.3908 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 43.6465 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=7, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 49.939 GFlop/s
-  Kernel_dnt_small(m=9, n=5, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 49.3598 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 60.7052 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 71.4975 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=5, k=16, tile_m=1, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=12) , # 70.7421 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 73.9933 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 86.1888 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 88.3985 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 91.3193 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=5, k=25, tile_m=1, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=8) , # 98.0414 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=5, k=26, tile_m=1, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=4) , # 99.6254 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=5, k=28, tile_m=1, tile_n=1, w=14, v=4, threads=128, grouping=16, minblocks=1) , # 110.374 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=4) , # 115.467 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=5, k=45, tile_m=1, tile_n=1, w=18, v=4, threads=96, grouping=16, minblocks=1) , # 117.769 GFlop/s
-  Kernel_dnt_medium(m=9, n=6, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 35.7692 GFlop/s
-  Kernel_dnt_medium(m=9, n=6, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 43.884 GFlop/s
-  Kernel_dnt_medium(m=9, n=6, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 51.8037 GFlop/s
-  Kernel_dnt_small(m=9, n=6, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 58.9838 GFlop/s
-  Kernel_dnt_medium(m=9, n=6, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 63.1913 GFlop/s
-  Kernel_dnt_medium(m=9, n=6, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 78.6654 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=6, k=16, tile_m=1, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 87.0012 GFlop/s
-  Kernel_dnt_medium(m=9, n=6, k=17, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 84.4738 GFlop/s
-  Kernel_dnt_medium(m=9, n=6, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 101.406 GFlop/s
-  Kernel_dnt_medium(m=9, n=6, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 104.769 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=6, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=4) , # 108.241 GFlop/s
-  Kernel_dnt_medium(m=9, n=6, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 111.759 GFlop/s
-  Kernel_dnt_medium(m=9, n=6, k=32, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 118.358 GFlop/s
-  Kernel_dnt_medium(m=9, n=7, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 42.4018 GFlop/s
-  Kernel_dnt_medium(m=9, n=7, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 51.6611 GFlop/s
-  Kernel_dnt_medium(m=9, n=7, k=7, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 69.256 GFlop/s
-  Kernel_dnt_medium(m=9, n=7, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 84.5734 GFlop/s
-  Kernel_dnt_medium(m=9, n=7, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 99.4122 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=7, k=25, tile_m=1, tile_n=1, w=10, v=6, threads=96, grouping=16, minblocks=4) , # 127.018 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=7, k=26, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=1) , # 128.925 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=7, k=28, tile_m=1, tile_n=1, w=14, v=6, threads=128, grouping=16, minblocks=1) , # 142.303 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=7, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 143.679 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=7, k=45, tile_m=1, tile_n=1, w=16, v=6, threads=96, grouping=16, minblocks=4) , # 145.789 GFlop/s
-  Kernel_dnt_medium(m=9, n=8, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 48.1233 GFlop/s
-  Kernel_dnt_medium(m=9, n=8, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 57.2607 GFlop/s
-  Kernel_dnt_medium(m=9, n=8, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 67.6162 GFlop/s
-  Kernel_dnt_medium(m=9, n=8, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 76.9026 GFlop/s
-  Kernel_dnt_medium(m=9, n=8, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 82.1029 GFlop/s
-  Kernel_dnt_medium(m=9, n=8, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 99.4363 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=8, k=16, tile_m=1, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=1) , # 106.792 GFlop/s
-  Kernel_dnt_medium(m=9, n=8, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 103.155 GFlop/s
-  Kernel_dnt_medium(m=9, n=8, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 122.251 GFlop/s
-  Kernel_dnt_medium(m=9, n=8, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 125.713 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=8, k=24, tile_m=1, tile_n=1, w=12, v=8, threads=128, grouping=16, minblocks=8) , # 127.47 GFlop/s
-  Kernel_dnt_medium(m=9, n=8, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 127.087 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=8, k=32, tile_m=1, tile_n=1, w=12, v=8, threads=128, grouping=16, minblocks=12) , # 132.924 GFlop/s
-  Kernel_dnt_tiny(m=9, n=9, k=4, threads=128, grouping=16, minblocks=1) , # 62.4312 GFlop/s
-  Kernel_dnt_tiny(m=9, n=9, k=5, threads=96, grouping=16, minblocks=1) , # 74.0588 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 83.6127 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=7, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 92.4293 GFlop/s
-  Kernel_dnt_small(m=9, n=9, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 97.3911 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 107.815 GFlop/s
-  Kernel_dnt_small(m=9, n=9, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 123.717 GFlop/s
-  Kernel_dnt_small(m=9, n=9, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 123.42 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 126.933 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=22, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 140.116 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=23, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 144.441 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=24, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 147.669 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=25, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 152.349 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=26, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 155.592 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=28, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 155.64 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=32, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 159.535 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=9, k=45, tile_m=1, tile_n=1, w=16, v=8, threads=160, grouping=16, minblocks=1) , # 160.12 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=9, k=64, tile_m=1, tile_n=1, w=14, v=6, threads=128, grouping=16, minblocks=12) , # 160.483 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=9, k=81, tile_m=1, tile_n=1, w=14, v=6, threads=128, grouping=16, minblocks=12) , # 164.81 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=13, k=4, tile_m=1, tile_n=1, w=2, v=12, threads=128, grouping=16, minblocks=1) , # 68.546 GFlop/s
-  Kernel_dnt_tiny(m=9, n=13, k=5, threads=128, grouping=16, minblocks=1) , # 81.5548 GFlop/s
-  Kernel_dnt_small(m=9, n=13, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 86.6047 GFlop/s
-  Kernel_dnt_tiny(m=9, n=13, k=7, threads=128, grouping=16, minblocks=1) , # 104.773 GFlop/s
-  Kernel_dnt_medium(m=9, n=13, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 110.269 GFlop/s
-  Kernel_dnt_medium(m=9, n=13, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 118.614 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=13, k=13, tile_m=1, tile_n=2, w=6, v=10, threads=96, grouping=16, minblocks=8) , # 137.421 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=13, k=16, tile_m=1, tile_n=1, w=8, v=12, threads=128, grouping=16, minblocks=8) , # 148.198 GFlop/s
-  Kernel_dnt_medium(m=9, n=13, k=17, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 144.57 GFlop/s
-  Kernel_dnt_medium(m=9, n=13, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 157.619 GFlop/s
-  Kernel_dnt_medium(m=9, n=13, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 159.911 GFlop/s
-  Kernel_dnt_medium(m=9, n=13, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 164.48 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=13, k=25, tile_m=1, tile_n=2, w=10, v=6, threads=96, grouping=16, minblocks=12) , # 167.537 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=13, k=26, tile_m=1, tile_n=2, w=10, v=6, threads=96, grouping=16, minblocks=8) , # 171.427 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=13, k=28, tile_m=1, tile_n=2, w=14, v=6, threads=96, grouping=16, minblocks=12) , # 186.17 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=13, k=32, tile_m=1, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=8) , # 191.308 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=13, k=45, tile_m=1, tile_n=2, w=18, v=6, threads=128, grouping=16, minblocks=12) , # 196.238 GFlop/s
-  Kernel_dnt_small(m=9, n=16, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 76.4401 GFlop/s
-  Kernel_dnt_medium(m=9, n=16, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 90.0694 GFlop/s
-  Kernel_dnt_small(m=9, n=16, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 101.254 GFlop/s
-  Kernel_dnt_medium(m=9, n=16, k=8, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=8) , # 114.152 GFlop/s
-  Kernel_dnt_medium(m=9, n=16, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 125.152 GFlop/s
-  Kernel_dnt_medium(m=9, n=16, k=13, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 138.713 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=16, k=16, tile_m=1, tile_n=2, w=8, v=10, threads=96, grouping=16, minblocks=1) , # 161.565 GFlop/s
-  Kernel_dnt_medium(m=9, n=16, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 162.59 GFlop/s
-  Kernel_dnt_medium(m=9, n=16, k=22, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 167.882 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=16, k=23, tile_m=1, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=8) , # 166.582 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=16, k=24, tile_m=1, tile_n=2, w=12, v=14, threads=128, grouping=16, minblocks=12) , # 170.479 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=16, k=26, tile_m=1, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=8) , # 173.529 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=16, k=32, tile_m=1, tile_n=2, w=14, v=16, threads=128, grouping=16, minblocks=12) , # 179.16 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=16, k=64, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 207.542 GFlop/s
-  Kernel_dnt_medium(m=9, n=17, k=4, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 77.9597 GFlop/s
-  Kernel_dnt_medium(m=9, n=17, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 93.47 GFlop/s
-  Kernel_dnt_medium(m=9, n=17, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 98.6733 GFlop/s
-  Kernel_dnt_medium(m=9, n=17, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 116.283 GFlop/s
-  Kernel_dnt_medium(m=9, n=17, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 130.008 GFlop/s
-  Kernel_dnt_medium(m=9, n=17, k=13, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 146.013 GFlop/s
-  Kernel_dnt_medium(m=9, n=17, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 163.56 GFlop/s
-  Kernel_dnt_medium(m=9, n=17, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 162.657 GFlop/s
-  Kernel_dnt_medium(m=9, n=17, k=22, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=8) , # 165.859 GFlop/s
-  Kernel_dnt_medium(m=9, n=17, k=23, tile_m=1, tile_n=1, threads=224, grouping=16, minblocks=8) , # 162.634 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=17, k=24, tile_m=2, tile_n=1, w=8, v=10, threads=96, grouping=16, minblocks=1) , # 166.06 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=17, k=26, tile_m=1, tile_n=2, w=10, v=10, threads=96, grouping=16, minblocks=4) , # 167.993 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=17, k=32, tile_m=2, tile_n=1, w=16, v=10, threads=96, grouping=16, minblocks=12) , # 180.16 GFlop/s
-  Kernel_dnt_medium(m=9, n=22, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 90.7465 GFlop/s
-  Kernel_dnt_medium(m=9, n=22, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 106.972 GFlop/s
-  Kernel_dnt_medium(m=9, n=22, k=6, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=12) , # 111.035 GFlop/s
-  Kernel_dnt_medium(m=9, n=22, k=8, tile_m=1, tile_n=4, threads=96, grouping=16, minblocks=12) , # 132.298 GFlop/s
-  Kernel_dnt_medium(m=9, n=22, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 151.642 GFlop/s
-  Kernel_dnt_medium(m=9, n=22, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 172.574 GFlop/s
-  Kernel_dnt_medium(m=9, n=22, k=16, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 172.49 GFlop/s
-  Kernel_dnt_medium(m=9, n=22, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 170.487 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=22, k=22, tile_m=2, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 183.705 GFlop/s
-  Kernel_dnt_medium(m=9, n=22, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 191.689 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=22, k=24, tile_m=2, tile_n=2, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 194.866 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=22, k=26, tile_m=2, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 194.953 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=22, k=32, tile_m=2, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 207.422 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=22, k=64, tile_m=2, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 239.402 GFlop/s
-  Kernel_dnt_medium(m=9, n=23, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 94.256 GFlop/s
-  Kernel_dnt_medium(m=9, n=23, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 111.899 GFlop/s
-  Kernel_dnt_medium(m=9, n=23, k=6, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 114.731 GFlop/s
-  Kernel_dnt_medium(m=9, n=23, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 143.712 GFlop/s
-  Kernel_dnt_medium(m=9, n=23, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 157.699 GFlop/s
-  Kernel_dnt_medium(m=9, n=23, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 177.746 GFlop/s
-  Kernel_dnt_medium(m=9, n=23, k=16, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 177.57 GFlop/s
-  Kernel_dnt_medium(m=9, n=23, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 176.836 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=23, k=22, tile_m=2, tile_n=2, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 194.385 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=23, k=23, tile_m=2, tile_n=2, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 198.019 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=23, k=24, tile_m=2, tile_n=2, w=10, v=12, threads=128, grouping=16, minblocks=12) , # 203.27 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=23, k=26, tile_m=2, tile_n=1, w=10, v=12, threads=128, grouping=16, minblocks=12) , # 199.492 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=23, k=32, tile_m=1, tile_n=2, w=14, v=12, threads=128, grouping=16, minblocks=12) , # 209.275 GFlop/s
-  Kernel_dnt_medium(m=9, n=24, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 100.426 GFlop/s
-  Kernel_dnt_medium(m=9, n=24, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 117.722 GFlop/s
-  Kernel_dnt_medium(m=9, n=24, k=6, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=12) , # 122.677 GFlop/s
-  Kernel_dnt_medium(m=9, n=24, k=8, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 141.521 GFlop/s
-  Kernel_dnt_medium(m=9, n=24, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 165.569 GFlop/s
-  Kernel_dnt_medium(m=9, n=24, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 189.324 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=24, k=16, tile_m=1, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=1) , # 191.231 GFlop/s
-  Kernel_dnt_medium(m=9, n=24, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 187.441 GFlop/s
-  Kernel_dnt_medium(m=9, n=24, k=22, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 209.101 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=24, k=23, tile_m=2, tile_n=2, w=10, v=24, threads=128, grouping=16, minblocks=12) , # 207.575 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=24, k=24, tile_m=2, tile_n=2, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 215.864 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=24, k=26, tile_m=1, tile_n=2, w=10, v=24, threads=128, grouping=16, minblocks=12) , # 210.582 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=24, k=32, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 225.901 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=25, k=4, tile_m=2, tile_n=1, w=2, v=14, threads=128, grouping=16, minblocks=4) , # 107.355 GFlop/s
-  Kernel_dnt_medium(m=9, n=25, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 116.291 GFlop/s
-  Kernel_dnt_medium(m=9, n=25, k=7, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 132.632 GFlop/s
-  Kernel_dnt_medium(m=9, n=25, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 153.698 GFlop/s
-  Kernel_dnt_medium(m=9, n=25, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 192.195 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=25, k=25, tile_m=2, tile_n=1, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 219.162 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=25, k=26, tile_m=2, tile_n=1, w=12, v=12, threads=128, grouping=16, minblocks=12) , # 219.784 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=25, k=28, tile_m=2, tile_n=3, w=14, v=18, threads=96, grouping=16, minblocks=12) , # 229.143 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=25, k=32, tile_m=2, tile_n=3, w=16, v=18, threads=96, grouping=16, minblocks=12) , # 232.091 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=25, k=45, tile_m=1, tile_n=4, w=14, v=24, threads=96, grouping=16, minblocks=12) , # 239.491 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=26, k=4, tile_m=1, tile_n=2, w=2, v=26, threads=128, grouping=16, minblocks=4) , # 112.616 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=26, k=5, tile_m=3, tile_n=1, w=2, v=26, threads=96, grouping=16, minblocks=8) , # 114.528 GFlop/s
-  Kernel_dnt_medium(m=9, n=26, k=6, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=12) , # 129.406 GFlop/s
-  Kernel_dnt_medium(m=9, n=26, k=7, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 137.992 GFlop/s
-  Kernel_dnt_medium(m=9, n=26, k=8, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 148.898 GFlop/s
-  Kernel_dnt_medium(m=9, n=26, k=9, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 160.328 GFlop/s
-  Kernel_dnt_medium(m=9, n=26, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 200.731 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=26, k=16, tile_m=1, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=1) , # 192.481 GFlop/s
-  Kernel_dnt_medium(m=9, n=26, k=17, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=8) , # 191.617 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=26, k=22, tile_m=1, tile_n=2, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 201.724 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=26, k=23, tile_m=1, tile_n=2, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 205.283 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=26, k=24, tile_m=1, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=12) , # 215.418 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=26, k=25, tile_m=1, tile_n=2, w=12, v=14, threads=128, grouping=16, minblocks=12) , # 224.702 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=26, k=26, tile_m=1, tile_n=2, w=12, v=14, threads=128, grouping=16, minblocks=12) , # 225.99 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=26, k=28, tile_m=1, tile_n=4, w=14, v=16, threads=96, grouping=16, minblocks=12) , # 240.33 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=26, k=32, tile_m=1, tile_n=4, w=16, v=20, threads=96, grouping=16, minblocks=12) , # 246.812 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=26, k=45, tile_m=1, tile_n=4, w=16, v=26, threads=96, grouping=16, minblocks=12) , # 249.034 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=28, k=4, tile_m=1, tile_n=2, w=2, v=28, threads=128, grouping=16, minblocks=1) , # 121.338 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=28, k=5, tile_m=3, tile_n=1, w=2, v=28, threads=96, grouping=16, minblocks=8) , # 123.294 GFlop/s
-  Kernel_dnt_medium(m=9, n=28, k=7, tile_m=1, tile_n=4, threads=96, grouping=16, minblocks=12) , # 149.096 GFlop/s
-  Kernel_dnt_medium(m=9, n=28, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 170.708 GFlop/s
-  Kernel_dnt_medium(m=9, n=28, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 209.922 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=28, k=25, tile_m=1, tile_n=2, w=12, v=14, threads=128, grouping=16, minblocks=8) , # 234.576 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=28, k=26, tile_m=1, tile_n=2, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 240.981 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=28, k=28, tile_m=1, tile_n=2, w=14, v=14, threads=128, grouping=16, minblocks=8) , # 250.549 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=28, k=32, tile_m=1, tile_n=2, w=16, v=14, threads=128, grouping=16, minblocks=8) , # 255.13 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=28, k=45, tile_m=1, tile_n=4, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 263.838 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=32, k=4, tile_m=3, tile_n=1, w=2, v=32, threads=96, grouping=16, minblocks=4) , # 137.267 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=32, k=5, tile_m=3, tile_n=1, w=2, v=32, threads=96, grouping=16, minblocks=12) , # 141.586 GFlop/s
-  Kernel_dnt_medium(m=9, n=32, k=6, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 150.539 GFlop/s
-  Kernel_dnt_medium(m=9, n=32, k=7, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 168.582 GFlop/s
-  Kernel_dnt_medium(m=9, n=32, k=8, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 183.327 GFlop/s
-  Kernel_dnt_medium(m=9, n=32, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 192.731 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=32, k=13, tile_m=3, tile_n=1, w=6, v=30, threads=96, grouping=16, minblocks=12) , # 209.298 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=32, k=16, tile_m=3, tile_n=1, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 215.364 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=32, k=17, tile_m=2, tile_n=2, w=6, v=32, threads=96, grouping=16, minblocks=12) , # 212.232 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=32, k=22, tile_m=3, tile_n=1, w=8, v=20, threads=128, grouping=16, minblocks=12) , # 230.249 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=32, k=23, tile_m=3, tile_n=1, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 232.646 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=32, k=24, tile_m=3, tile_n=1, w=8, v=20, threads=128, grouping=16, minblocks=12) , # 239.302 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=32, k=25, tile_m=2, tile_n=3, w=10, v=32, threads=96, grouping=16, minblocks=12) , # 253.788 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=32, k=26, tile_m=3, tile_n=2, w=10, v=30, threads=96, grouping=16, minblocks=12) , # 254.099 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=32, k=28, tile_m=3, tile_n=2, w=14, v=32, threads=96, grouping=16, minblocks=12) , # 261.58 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=32, k=32, tile_m=3, tile_n=2, w=16, v=32, threads=128, grouping=16, minblocks=8) , # 266.524 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=32, k=45, tile_m=2, tile_n=2, w=10, v=32, threads=96, grouping=16, minblocks=12) , # 277.488 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=45, k=4, tile_m=5, tile_n=1, w=2, v=42, threads=96, grouping=16, minblocks=12) , # 133.76 GFlop/s
-  Kernel_dnt_medium(m=9, n=45, k=5, tile_m=1, tile_n=5, threads=96, grouping=16, minblocks=12) , # 143.893 GFlop/s
-  Kernel_dnt_medium(m=9, n=45, k=7, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 171.55 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=45, k=9, tile_m=2, tile_n=2, w=4, v=44, threads=128, grouping=16, minblocks=12) , # 194.717 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=45, k=13, tile_m=3, tile_n=2, w=6, v=32, threads=96, grouping=16, minblocks=12) , # 225.041 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=45, k=25, tile_m=3, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 260.831 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=45, k=26, tile_m=3, tile_n=2, w=10, v=38, threads=96, grouping=16, minblocks=12) , # 265.9 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=45, k=28, tile_m=2, tile_n=2, w=14, v=16, threads=160, grouping=16, minblocks=8) , # 275.862 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=45, k=32, tile_m=2, tile_n=4, w=12, v=24, threads=128, grouping=16, minblocks=8) , # 275.89 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=45, k=45, tile_m=2, tile_n=3, w=8, v=18, threads=96, grouping=16, minblocks=12) , # 284.511 GFlop/s
-  Kernel_dnt_medium(m=9, n=64, k=9, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 213.899 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=64, k=16, tile_m=3, tile_n=2, w=6, v=48, threads=96, grouping=16, minblocks=12) , # 262.958 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=64, k=22, tile_m=3, tile_n=2, w=6, v=32, threads=96, grouping=16, minblocks=12) , # 285.617 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=64, k=64, tile_m=3, tile_n=2, w=10, v=64, threads=128, grouping=16, minblocks=8) , # 319.273 GFlop/s
-  Kernel_dnt_largeDB1(m=9, n=81, k=9, tile_m=5, tile_n=2, w=2, v=52, threads=96, grouping=16, minblocks=12) , # 202.245 GFlop/s
-  Kernel_dnt_largeDB2(m=10, n=4, k=4, tile_m=1, tile_n=1, w=2, v=4, threads=96, grouping=16, minblocks=4) , # 28.1008 GFlop/s
-  Kernel_dnt_small(m=10, n=4, k=10, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 54.1832 GFlop/s
-  Kernel_dnt_medium(m=10, n=4, k=15, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 70.4501 GFlop/s
-  Kernel_dnt_tiny(m=10, n=10, k=4, threads=128, grouping=16, minblocks=1) , # 74.7338 GFlop/s
-  Kernel_dnt_medium(m=10, n=10, k=10, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 116.741 GFlop/s
-  Kernel_dnt_medium(m=10, n=10, k=15, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 141.061 GFlop/s
-  Kernel_dnt_largeDB1(m=10, n=10, k=100, tile_m=2, tile_n=2, w=20, v=10, threads=96, grouping=16, minblocks=12) , # 193.259 GFlop/s
-  Kernel_dnt_largeDB2(m=10, n=15, k=4, tile_m=1, tile_n=2, w=2, v=8, threads=96, grouping=16, minblocks=4) , # 81.7434 GFlop/s
-  Kernel_dnt_largeDB2(m=10, n=15, k=10, tile_m=2, tile_n=1, w=4, v=8, threads=96, grouping=16, minblocks=4) , # 137.343 GFlop/s
-  Kernel_dnt_largeDB2(m=10, n=15, k=15, tile_m=2, tile_n=1, w=6, v=8, threads=96, grouping=16, minblocks=1) , # 168.752 GFlop/s
-  Kernel_dnt_medium(m=10, n=100, k=10, tile_m=2, tile_n=4, threads=128, grouping=16, minblocks=4) , # 250.611 GFlop/s
-  Kernel_dnt_medium(m=11, n=11, k=11, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 148.474 GFlop/s
-  Kernel_dnt_largeDB1(m=11, n=11, k=121, tile_m=3, tile_n=2, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 206.461 GFlop/s
-  Kernel_dnt_medium(m=11, n=121, k=11, tile_m=3, tile_n=2, threads=256, grouping=16, minblocks=4) , # 264.615 GFlop/s
-  Kernel_dnt_small(m=12, n=12, k=12, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 154.228 GFlop/s
-  Kernel_dnt_largeDB1(m=12, n=12, k=144, tile_m=3, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=12) , # 249.09 GFlop/s
-  Kernel_dnt_largeDB1(m=12, n=144, k=12, tile_m=3, tile_n=3, w=6, v=80, threads=256, grouping=16, minblocks=4) , # 273.287 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=4, k=4, tile_m=1, tile_n=1, w=2, v=4, threads=96, grouping=16, minblocks=4) , # 35.8537 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 43.1223 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 50.5155 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=7, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 58.1156 GFlop/s
-  Kernel_dnt_small(m=13, n=4, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 56.8225 GFlop/s
-  Kernel_dnt_small(m=13, n=4, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 62.7402 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 81.1843 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=4, k=16, tile_m=1, tile_n=1, w=8, v=4, threads=128, grouping=16, minblocks=12) , # 82.3205 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 85.3823 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 106.3 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 104.38 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 103.008 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=4, k=25, tile_m=1, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=4) , # 102.905 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=26, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 107.426 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=4, k=28, tile_m=1, tile_n=1, w=14, v=4, threads=96, grouping=16, minblocks=1) , # 115.153 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=4, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=8) , # 116.235 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=4, k=45, tile_m=1, tile_n=1, w=20, v=4, threads=96, grouping=16, minblocks=4) , # 116.154 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 43.1026 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 52.3569 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 60.9248 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=7, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 68.9053 GFlop/s
-  Kernel_dnt_small(m=13, n=5, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 64.2414 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 74.1677 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 93.5165 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 94.8452 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 97.5907 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 110.275 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 112.051 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 114.338 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=5, k=25, tile_m=1, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=1) , # 115.183 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=5, k=26, tile_m=1, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=1) , # 116.18 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=5, k=28, tile_m=1, tile_n=1, w=14, v=4, threads=96, grouping=16, minblocks=4) , # 124.902 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=5, k=32, tile_m=1, tile_n=1, w=14, v=4, threads=96, grouping=16, minblocks=4) , # 124.762 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=5, k=45, tile_m=1, tile_n=1, w=18, v=4, threads=128, grouping=16, minblocks=8) , # 128.223 GFlop/s
-  Kernel_dnt_medium(m=13, n=6, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 50.8013 GFlop/s
-  Kernel_dnt_medium(m=13, n=6, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 61.8717 GFlop/s
-  Kernel_dnt_medium(m=13, n=6, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 72.4236 GFlop/s
-  Kernel_dnt_small(m=13, n=6, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 77.0262 GFlop/s
-  Kernel_dnt_medium(m=13, n=6, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 82.5687 GFlop/s
-  Kernel_dnt_medium(m=13, n=6, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 102.487 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=6, k=16, tile_m=1, tile_n=1, w=8, v=6, threads=128, grouping=16, minblocks=4) , # 112.36 GFlop/s
-  Kernel_dnt_medium(m=13, n=6, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 105.637 GFlop/s
-  Kernel_dnt_medium(m=13, n=6, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 126.591 GFlop/s
-  Kernel_dnt_medium(m=13, n=6, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 127.181 GFlop/s
-  Kernel_dnt_medium(m=13, n=6, k=24, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 131.17 GFlop/s
-  Kernel_dnt_medium(m=13, n=6, k=26, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 129.955 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=6, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 138.459 GFlop/s
-  Kernel_dnt_medium(m=13, n=7, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 59.9957 GFlop/s
-  Kernel_dnt_medium(m=13, n=7, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 72.1074 GFlop/s
-  Kernel_dnt_medium(m=13, n=7, k=7, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 95.9252 GFlop/s
-  Kernel_dnt_medium(m=13, n=7, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 103.151 GFlop/s
-  Kernel_dnt_medium(m=13, n=7, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 129.722 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=7, k=25, tile_m=1, tile_n=1, w=12, v=6, threads=96, grouping=16, minblocks=1) , # 153.809 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=7, k=26, tile_m=1, tile_n=1, w=12, v=6, threads=96, grouping=16, minblocks=8) , # 155.84 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=7, k=28, tile_m=1, tile_n=1, w=14, v=6, threads=128, grouping=16, minblocks=4) , # 160.527 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=7, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=128, grouping=16, minblocks=4) , # 168.672 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=7, k=45, tile_m=1, tile_n=1, w=18, v=6, threads=128, grouping=16, minblocks=4) , # 170.503 GFlop/s
-  Kernel_dnt_tiny(m=13, n=8, k=4, threads=128, grouping=16, minblocks=1) , # 64.3202 GFlop/s
-  Kernel_dnt_small(m=13, n=8, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 71.3921 GFlop/s
-  Kernel_dnt_small(m=13, n=8, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 81.3107 GFlop/s
-  Kernel_dnt_medium(m=13, n=8, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 99.8992 GFlop/s
-  Kernel_dnt_medium(m=13, n=8, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 106.433 GFlop/s
-  Kernel_dnt_medium(m=13, n=8, k=13, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 117.265 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=8, k=16, tile_m=1, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=8) , # 138.215 GFlop/s
-  Kernel_dnt_medium(m=13, n=8, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 139.52 GFlop/s
-  Kernel_dnt_medium(m=13, n=8, k=22, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 163.585 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=8, k=23, tile_m=1, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 147.91 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=8, k=24, tile_m=1, tile_n=2, w=12, v=6, threads=96, grouping=16, minblocks=1) , # 151.064 GFlop/s
-  Kernel_dnt_medium(m=13, n=8, k=26, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 151.357 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=8, k=32, tile_m=2, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=12) , # 157.473 GFlop/s
-  Kernel_dnt_tiny(m=13, n=9, k=4, threads=128, grouping=16, minblocks=1) , # 68.6834 GFlop/s
-  Kernel_dnt_tiny(m=13, n=9, k=5, threads=128, grouping=16, minblocks=1) , # 82.6413 GFlop/s
-  Kernel_dnt_small(m=13, n=9, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 87.8396 GFlop/s
-  Kernel_dnt_tiny(m=13, n=9, k=7, threads=128, grouping=16, minblocks=1) , # 105.779 GFlop/s
-  Kernel_dnt_medium(m=13, n=9, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 109.971 GFlop/s
-  Kernel_dnt_medium(m=13, n=9, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 118.002 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=9, k=13, tile_m=2, tile_n=1, w=6, v=6, threads=96, grouping=16, minblocks=8) , # 137.392 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=9, k=16, tile_m=1, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=1) , # 147.281 GFlop/s
-  Kernel_dnt_medium(m=13, n=9, k=17, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 143.348 GFlop/s
-  Kernel_dnt_medium(m=13, n=9, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 158.407 GFlop/s
-  Kernel_dnt_medium(m=13, n=9, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 160.165 GFlop/s
-  Kernel_dnt_medium(m=13, n=9, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 163.24 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=9, k=25, tile_m=2, tile_n=1, w=10, v=6, threads=96, grouping=16, minblocks=12) , # 172.498 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=9, k=26, tile_m=2, tile_n=1, w=10, v=6, threads=96, grouping=16, minblocks=8) , # 175.531 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=9, k=28, tile_m=2, tile_n=1, w=14, v=4, threads=96, grouping=16, minblocks=12) , # 187.173 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=9, k=32, tile_m=2, tile_n=1, w=16, v=8, threads=96, grouping=16, minblocks=1) , # 190.526 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=9, k=45, tile_m=2, tile_n=1, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 195.377 GFlop/s
-  Kernel_dnt_small(m=13, n=13, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 100.777 GFlop/s
-  Kernel_dnt_small(m=13, n=13, k=5, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 116.755 GFlop/s
-  Kernel_dnt_small(m=13, n=13, k=6, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 128.884 GFlop/s
-  Kernel_dnt_small(m=13, n=13, k=7, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=4) , # 143.945 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=8, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 141.808 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=9, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 155.464 GFlop/s
-  Kernel_dnt_small(m=13, n=13, k=13, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=8) , # 174.905 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 188.6 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 196.824 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=22, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 200.407 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=23, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=8) , # 192.756 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=24, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 194.026 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=13, k=25, tile_m=1, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=1) , # 204.499 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=13, k=26, tile_m=1, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 205.053 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=13, k=28, tile_m=2, tile_n=2, w=14, v=12, threads=96, grouping=16, minblocks=12) , # 218.849 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=13, k=32, tile_m=2, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=12) , # 223.821 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=13, k=45, tile_m=2, tile_n=2, w=16, v=12, threads=96, grouping=16, minblocks=12) , # 232.303 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=13, k=169, tile_m=2, tile_n=2, w=18, v=8, threads=96, grouping=16, minblocks=12) , # 258.16 GFlop/s
-  Kernel_dnt_small(m=13, n=16, k=4, tile_m=2, tile_n=2, threads=64, grouping=16, minblocks=4) , # 100.974 GFlop/s
-  Kernel_dnt_medium(m=13, n=16, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 114.075 GFlop/s
-  Kernel_dnt_medium(m=13, n=16, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 131.042 GFlop/s
-  Kernel_dnt_medium(m=13, n=16, k=8, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 148.468 GFlop/s
-  Kernel_dnt_medium(m=13, n=16, k=9, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=12) , # 153.966 GFlop/s
-  Kernel_dnt_medium(m=13, n=16, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 175.389 GFlop/s
-  Kernel_dnt_medium(m=13, n=16, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 210.814 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=16, k=17, tile_m=2, tile_n=2, w=6, v=16, threads=96, grouping=16, minblocks=1) , # 185.642 GFlop/s
-  Kernel_dnt_medium(m=13, n=16, k=22, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 212.052 GFlop/s
-  Kernel_dnt_medium(m=13, n=16, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 217.955 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=16, k=24, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 214.166 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=16, k=26, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 210.017 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=16, k=32, tile_m=2, tile_n=2, w=16, v=16, threads=96, grouping=16, minblocks=12) , # 232.99 GFlop/s
-  Kernel_dnt_medium(m=13, n=17, k=4, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 99.2194 GFlop/s
-  Kernel_dnt_medium(m=13, n=17, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 118.252 GFlop/s
-  Kernel_dnt_medium(m=13, n=17, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 135.183 GFlop/s
-  Kernel_dnt_medium(m=13, n=17, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 144.56 GFlop/s
-  Kernel_dnt_medium(m=13, n=17, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 156.989 GFlop/s
-  Kernel_dnt_medium(m=13, n=17, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 195.592 GFlop/s
-  Kernel_dnt_medium(m=13, n=17, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 218.026 GFlop/s
-  Kernel_dnt_medium(m=13, n=17, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 187.859 GFlop/s
-  Kernel_dnt_medium(m=13, n=17, k=22, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 222.018 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=17, k=23, tile_m=2, tile_n=2, w=6, v=16, threads=128, grouping=16, minblocks=12) , # 216.451 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=17, k=24, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 214.46 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=17, k=26, tile_m=2, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 211.202 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=17, k=32, tile_m=2, tile_n=2, w=16, v=12, threads=96, grouping=16, minblocks=12) , # 237.799 GFlop/s
-  Kernel_dnt_medium(m=13, n=22, k=4, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 117.05 GFlop/s
-  Kernel_dnt_medium(m=13, n=22, k=5, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 132.674 GFlop/s
-  Kernel_dnt_medium(m=13, n=22, k=6, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 147.212 GFlop/s
-  Kernel_dnt_medium(m=13, n=22, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 172.205 GFlop/s
-  Kernel_dnt_medium(m=13, n=22, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 181.465 GFlop/s
-  Kernel_dnt_medium(m=13, n=22, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 207.061 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=22, k=16, tile_m=2, tile_n=2, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 206.302 GFlop/s
-  Kernel_dnt_medium(m=13, n=22, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 204.952 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=22, k=22, tile_m=3, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 225.453 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=22, k=23, tile_m=2, tile_n=2, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 227.833 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=22, k=24, tile_m=3, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 239.227 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=22, k=26, tile_m=3, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 241.066 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=22, k=32, tile_m=3, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 252.527 GFlop/s
-  Kernel_dnt_medium(m=13, n=23, k=4, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 118.375 GFlop/s
-  Kernel_dnt_medium(m=13, n=23, k=5, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 136.973 GFlop/s
-  Kernel_dnt_medium(m=13, n=23, k=6, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 148.462 GFlop/s
-  Kernel_dnt_medium(m=13, n=23, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 174.284 GFlop/s
-  Kernel_dnt_medium(m=13, n=23, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 185.07 GFlop/s
-  Kernel_dnt_medium(m=13, n=23, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 214.408 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=23, k=16, tile_m=2, tile_n=2, w=8, v=22, threads=128, grouping=16, minblocks=12) , # 215.76 GFlop/s
-  Kernel_dnt_medium(m=13, n=23, k=17, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 217.951 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=23, k=22, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 227.875 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=23, k=23, tile_m=2, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 233.26 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=23, k=24, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 243.006 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=23, k=26, tile_m=2, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 235.319 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=23, k=32, tile_m=3, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 256.302 GFlop/s
-  Kernel_dnt_medium(m=13, n=24, k=4, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 126.462 GFlop/s
-  Kernel_dnt_medium(m=13, n=24, k=5, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 145.967 GFlop/s
-  Kernel_dnt_medium(m=13, n=24, k=6, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=12) , # 158.896 GFlop/s
-  Kernel_dnt_medium(m=13, n=24, k=8, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 182.54 GFlop/s
-  Kernel_dnt_medium(m=13, n=24, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 195.482 GFlop/s
-  Kernel_dnt_medium(m=13, n=24, k=13, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 203.566 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=24, k=16, tile_m=2, tile_n=2, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 223.93 GFlop/s
-  Kernel_dnt_medium(m=13, n=24, k=17, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 228.962 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=24, k=22, tile_m=2, tile_n=3, w=6, v=12, threads=96, grouping=16, minblocks=12) , # 243.549 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=24, k=23, tile_m=2, tile_n=2, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 244.933 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=24, k=24, tile_m=3, tile_n=2, w=12, v=24, threads=96, grouping=16, minblocks=12) , # 256.27 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=24, k=26, tile_m=3, tile_n=2, w=10, v=24, threads=96, grouping=16, minblocks=12) , # 253.677 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=24, k=32, tile_m=3, tile_n=2, w=12, v=24, threads=96, grouping=16, minblocks=12) , # 272.912 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=24, k=45, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 323.835 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=25, k=4, tile_m=2, tile_n=2, w=2, v=18, threads=96, grouping=16, minblocks=4) , # 139.434 GFlop/s
-  Kernel_dnt_medium(m=13, n=25, k=5, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 146.157 GFlop/s
-  Kernel_dnt_medium(m=13, n=25, k=7, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 169.341 GFlop/s
-  Kernel_dnt_medium(m=13, n=25, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 199.087 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=25, k=13, tile_m=2, tile_n=2, w=6, v=18, threads=96, grouping=16, minblocks=8) , # 222.344 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=25, k=25, tile_m=2, tile_n=3, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 283.473 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=25, k=26, tile_m=2, tile_n=3, w=12, v=14, threads=96, grouping=16, minblocks=12) , # 286.294 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=25, k=28, tile_m=2, tile_n=3, w=14, v=14, threads=96, grouping=16, minblocks=12) , # 298.297 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=25, k=32, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 300.302 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=25, k=45, tile_m=2, tile_n=3, w=12, v=20, threads=96, grouping=16, minblocks=12) , # 322.398 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=26, k=4, tile_m=2, tile_n=2, w=2, v=22, threads=96, grouping=16, minblocks=1) , # 142.206 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=26, k=5, tile_m=2, tile_n=2, w=2, v=26, threads=96, grouping=16, minblocks=1) , # 153.192 GFlop/s
-  Kernel_dnt_medium(m=13, n=26, k=6, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 165.607 GFlop/s
-  Kernel_dnt_medium(m=13, n=26, k=7, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 175.539 GFlop/s
-  Kernel_dnt_medium(m=13, n=26, k=8, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 191.191 GFlop/s
-  Kernel_dnt_medium(m=13, n=26, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 206.218 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=26, k=13, tile_m=2, tile_n=3, w=6, v=22, threads=96, grouping=16, minblocks=12) , # 236.552 GFlop/s
-  Kernel_dnt_medium(m=13, n=26, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 225.673 GFlop/s
-  Kernel_dnt_medium(m=13, n=26, k=17, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 241.87 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=26, k=22, tile_m=2, tile_n=2, w=6, v=26, threads=96, grouping=16, minblocks=12) , # 251.077 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=26, k=23, tile_m=2, tile_n=2, w=6, v=26, threads=96, grouping=16, minblocks=12) , # 255.001 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=26, k=24, tile_m=2, tile_n=3, w=12, v=14, threads=96, grouping=16, minblocks=12) , # 262.921 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=26, k=25, tile_m=2, tile_n=3, w=12, v=20, threads=96, grouping=16, minblocks=12) , # 290.699 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=26, k=26, tile_m=2, tile_n=3, w=12, v=26, threads=96, grouping=16, minblocks=12) , # 296.294 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=26, k=28, tile_m=2, tile_n=2, w=14, v=22, threads=96, grouping=16, minblocks=12) , # 306.437 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=26, k=32, tile_m=2, tile_n=3, w=12, v=14, threads=96, grouping=16, minblocks=12) , # 312.2 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=26, k=45, tile_m=2, tile_n=3, w=12, v=26, threads=96, grouping=16, minblocks=12) , # 333.855 GFlop/s
-  Kernel_dnt_medium(m=13, n=28, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 136.696 GFlop/s
-  Kernel_dnt_medium(m=13, n=28, k=5, tile_m=1, tile_n=4, threads=96, grouping=16, minblocks=12) , # 147.311 GFlop/s
-  Kernel_dnt_medium(m=13, n=28, k=7, tile_m=5, tile_n=1, threads=96, grouping=16, minblocks=12) , # 165.948 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=28, k=9, tile_m=2, tile_n=2, w=4, v=28, threads=128, grouping=16, minblocks=12) , # 197.709 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=28, k=13, tile_m=4, tile_n=2, w=6, v=22, threads=96, grouping=16, minblocks=12) , # 230.774 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=28, k=25, tile_m=1, tile_n=4, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 277.441 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=28, k=26, tile_m=1, tile_n=4, w=12, v=14, threads=96, grouping=16, minblocks=12) , # 282.085 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=28, k=28, tile_m=1, tile_n=4, w=10, v=26, threads=96, grouping=16, minblocks=12) , # 286.256 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=28, k=32, tile_m=1, tile_n=4, w=12, v=28, threads=96, grouping=16, minblocks=12) , # 294.744 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=28, k=45, tile_m=4, tile_n=2, w=12, v=28, threads=128, grouping=16, minblocks=8) , # 301.413 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=32, k=4, tile_m=4, tile_n=2, w=2, v=32, threads=96, grouping=16, minblocks=4) , # 147.822 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=32, k=5, tile_m=3, tile_n=2, w=2, v=32, threads=96, grouping=16, minblocks=12) , # 156.628 GFlop/s
-  Kernel_dnt_medium(m=13, n=32, k=6, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 181.813 GFlop/s
-  Kernel_dnt_medium(m=13, n=32, k=7, tile_m=5, tile_n=1, threads=96, grouping=16, minblocks=12) , # 188.684 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=32, k=8, tile_m=2, tile_n=2, w=4, v=32, threads=128, grouping=16, minblocks=12) , # 200.207 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=32, k=9, tile_m=2, tile_n=2, w=4, v=32, threads=128, grouping=16, minblocks=12) , # 223.308 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=32, k=13, tile_m=4, tile_n=2, w=6, v=26, threads=96, grouping=16, minblocks=12) , # 263.806 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=32, k=16, tile_m=2, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=8) , # 260.668 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=32, k=17, tile_m=2, tile_n=3, w=6, v=14, threads=96, grouping=16, minblocks=12) , # 247.911 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=32, k=22, tile_m=2, tile_n=3, w=6, v=16, threads=96, grouping=16, minblocks=12) , # 271.196 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=32, k=23, tile_m=2, tile_n=3, w=6, v=16, threads=96, grouping=16, minblocks=12) , # 275.98 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=32, k=24, tile_m=2, tile_n=2, w=12, v=24, threads=192, grouping=16, minblocks=8) , # 283.245 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=32, k=25, tile_m=2, tile_n=4, w=6, v=26, threads=96, grouping=16, minblocks=12) , # 302.793 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=32, k=26, tile_m=2, tile_n=4, w=12, v=32, threads=96, grouping=16, minblocks=8) , # 303.713 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=32, k=28, tile_m=2, tile_n=4, w=8, v=26, threads=96, grouping=16, minblocks=12) , # 314.111 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=32, k=32, tile_m=2, tile_n=4, w=16, v=16, threads=128, grouping=16, minblocks=8) , # 330.971 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=32, k=45, tile_m=2, tile_n=4, w=12, v=32, threads=96, grouping=16, minblocks=8) , # 336.419 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=45, k=4, tile_m=4, tile_n=2, w=2, v=36, threads=96, grouping=16, minblocks=8) , # 161.891 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=45, k=5, tile_m=3, tile_n=2, w=2, v=36, threads=128, grouping=16, minblocks=12) , # 174.168 GFlop/s
-  Kernel_dnt_medium(m=13, n=45, k=7, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 203.007 GFlop/s
-  Kernel_dnt_medium(m=13, n=45, k=9, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 235.887 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=45, k=13, tile_m=2, tile_n=3, w=6, v=36, threads=128, grouping=16, minblocks=8) , # 260.83 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=45, k=24, tile_m=2, tile_n=5, w=12, v=40, threads=96, grouping=16, minblocks=8) , # 328.273 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=45, k=25, tile_m=2, tile_n=3, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 318.496 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=45, k=26, tile_m=2, tile_n=3, w=12, v=36, threads=128, grouping=16, minblocks=8) , # 323.253 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=45, k=28, tile_m=2, tile_n=3, w=14, v=36, threads=128, grouping=16, minblocks=8) , # 338.61 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=45, k=32, tile_m=2, tile_n=5, w=12, v=38, threads=96, grouping=16, minblocks=8) , # 342.906 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=45, k=45, tile_m=2, tile_n=5, w=12, v=44, threads=96, grouping=16, minblocks=8) , # 366.795 GFlop/s
-  Kernel_dnt_largeDB1(m=13, n=169, k=13, tile_m=4, tile_n=3, w=6, v=96, threads=256, grouping=16, minblocks=1) , # 241.485 GFlop/s
-  Kernel_dnt_medium(m=14, n=14, k=14, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 197.885 GFlop/s
-  Kernel_dnt_medium(m=14, n=14, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 216.145 GFlop/s
-  Kernel_dnt_medium(m=14, n=14, k=29, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=4) , # 218.838 GFlop/s
-  Kernel_dnt_largeDB1(m=14, n=14, k=32, tile_m=2, tile_n=2, w=16, v=14, threads=96, grouping=16, minblocks=12) , # 224.281 GFlop/s
-  Kernel_dnt_largeDB1(m=14, n=14, k=196, tile_m=2, tile_n=2, w=16, v=12, threads=96, grouping=16, minblocks=12) , # 289.084 GFlop/s
-  Kernel_dnt_medium(m=14, n=16, k=14, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 213.982 GFlop/s
-  Kernel_dnt_medium(m=14, n=16, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 230.421 GFlop/s
-  Kernel_dnt_largeDB1(m=14, n=16, k=29, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 232.968 GFlop/s
-  Kernel_dnt_largeDB1(m=14, n=29, k=14, tile_m=2, tile_n=2, w=4, v=20, threads=128, grouping=16, minblocks=12) , # 231.308 GFlop/s
-  Kernel_dnt_largeDB1(m=14, n=29, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 267.108 GFlop/s
-  Kernel_dnt_largeDB1(m=14, n=29, k=29, tile_m=2, tile_n=2, w=10, v=20, threads=160, grouping=16, minblocks=8) , # 272.491 GFlop/s
-  Kernel_dnt_largeDB1(m=14, n=29, k=32, tile_m=2, tile_n=2, w=16, v=20, threads=160, grouping=16, minblocks=8) , # 292.149 GFlop/s
-  Kernel_dnt_medium(m=14, n=32, k=14, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 258.209 GFlop/s
-  Kernel_dnt_largeDB1(m=14, n=32, k=29, tile_m=2, tile_n=2, w=10, v=32, threads=160, grouping=16, minblocks=8) , # 311.422 GFlop/s
-  Kernel_dnt_largeDB1(m=14, n=32, k=32, tile_m=2, tile_n=2, w=16, v=32, threads=128, grouping=16, minblocks=8) , # 326.197 GFlop/s
-  Kernel_dnt_medium(m=14, n=196, k=14, tile_m=2, tile_n=6, threads=256, grouping=16, minblocks=1) , # 278.411 GFlop/s
-  Kernel_dnt_largeDB2(m=15, n=4, k=4, tile_m=1, tile_n=1, w=2, v=4, threads=96, grouping=16, minblocks=4) , # 41.0244 GFlop/s
-  Kernel_dnt_medium(m=15, n=4, k=10, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 76.5643 GFlop/s
-  Kernel_dnt_medium(m=15, n=4, k=15, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 101.102 GFlop/s
-  Kernel_dnt_largeDB2(m=15, n=10, k=4, tile_m=2, tile_n=1, w=2, v=10, threads=96, grouping=16, minblocks=4) , # 85.363 GFlop/s
-  Kernel_dnt_largeDB2(m=15, n=10, k=10, tile_m=1, tile_n=2, w=4, v=10, threads=96, grouping=16, minblocks=12) , # 138.924 GFlop/s
-  Kernel_dnt_largeDB2(m=15, n=10, k=15, tile_m=1, tile_n=2, w=6, v=10, threads=96, grouping=16, minblocks=12) , # 168.55 GFlop/s
-  Kernel_dnt_small(m=15, n=15, k=4, tile_m=2, tile_n=2, threads=64, grouping=16, minblocks=1) , # 119.369 GFlop/s
-  Kernel_dnt_medium(m=15, n=15, k=10, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 184.444 GFlop/s
-  Kernel_dnt_medium(m=15, n=15, k=15, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 226.439 GFlop/s
-  Kernel_dnt_largeDB1(m=15, n=15, k=225, tile_m=2, tile_n=2, w=16, v=10, threads=96, grouping=16, minblocks=12) , # 311.643 GFlop/s
-  Kernel_dnt_largeDB1(m=15, n=225, k=15, tile_m=3, tile_n=3, w=4, v=150, threads=384, grouping=16, minblocks=1) , # 258.751 GFlop/s
-  Kernel_dnt_medium(m=16, n=4, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 43.2513 GFlop/s
-  Kernel_dnt_medium(m=16, n=4, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 52.8509 GFlop/s
-  Kernel_dnt_tiny(m=16, n=4, k=6, threads=128, grouping=16, minblocks=1) , # 56.0623 GFlop/s
-  Kernel_dnt_medium(m=16, n=4, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 70.6265 GFlop/s
-  Kernel_dnt_medium(m=16, n=4, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 76.3591 GFlop/s
-  Kernel_dnt_medium(m=16, n=4, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 90.3877 GFlop/s
-  Kernel_dnt_medium(m=16, n=4, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 104.947 GFlop/s
-  Kernel_dnt_medium(m=16, n=4, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 108.128 GFlop/s
-  Kernel_dnt_medium(m=16, n=4, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 117.022 GFlop/s
-  Kernel_dnt_medium(m=16, n=4, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 118.619 GFlop/s
-  Kernel_dnt_medium(m=16, n=4, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 118.972 GFlop/s
-  Kernel_dnt_medium(m=16, n=4, k=26, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 116.617 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=4, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=12) , # 119.202 GFlop/s
-  Kernel_dnt_medium(m=16, n=5, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 53.2937 GFlop/s
-  Kernel_dnt_medium(m=16, n=5, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 64.8851 GFlop/s
-  Kernel_dnt_tiny(m=16, n=5, k=6, threads=128, grouping=16, minblocks=1) , # 68.9342 GFlop/s
-  Kernel_dnt_medium(m=16, n=5, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 84.6639 GFlop/s
-  Kernel_dnt_medium(m=16, n=5, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 91.9906 GFlop/s
-  Kernel_dnt_medium(m=16, n=5, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 107.42 GFlop/s
-  Kernel_dnt_medium(m=16, n=5, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 121.912 GFlop/s
-  Kernel_dnt_medium(m=16, n=5, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 125.062 GFlop/s
-  Kernel_dnt_medium(m=16, n=5, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 134.168 GFlop/s
-  Kernel_dnt_medium(m=16, n=5, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 127.673 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=5, k=24, tile_m=1, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=12) , # 129.534 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=5, k=26, tile_m=1, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=1) , # 127.182 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=12) , # 138.029 GFlop/s
-  Kernel_dnt_medium(m=16, n=6, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 63.7826 GFlop/s
-  Kernel_dnt_medium(m=16, n=6, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 77.3562 GFlop/s
-  Kernel_dnt_tiny(m=16, n=6, k=6, threads=128, grouping=16, minblocks=1) , # 81.9641 GFlop/s
-  Kernel_dnt_medium(m=16, n=6, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 99.2729 GFlop/s
-  Kernel_dnt_medium(m=16, n=6, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 108.16 GFlop/s
-  Kernel_dnt_medium(m=16, n=6, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 128.018 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=6, k=16, tile_m=1, tile_n=1, w=8, v=6, threads=128, grouping=16, minblocks=4) , # 134.069 GFlop/s
-  Kernel_dnt_medium(m=16, n=6, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 141.119 GFlop/s
-  Kernel_dnt_medium(m=16, n=6, k=22, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 147.402 GFlop/s
-  Kernel_dnt_medium(m=16, n=6, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 147.837 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=6, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=96, grouping=16, minblocks=8) , # 151.996 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=6, k=26, tile_m=1, tile_n=1, w=10, v=6, threads=96, grouping=16, minblocks=4) , # 149.231 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=6, k=32, tile_m=1, tile_n=1, w=16, v=6, threads=128, grouping=16, minblocks=12) , # 163.734 GFlop/s
-  Kernel_dnt_tiny(m=16, n=8, k=4, threads=128, grouping=16, minblocks=1) , # 78.0533 GFlop/s
-  Kernel_dnt_medium(m=16, n=8, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 91.3267 GFlop/s
-  Kernel_dnt_tiny(m=16, n=8, k=6, threads=128, grouping=16, minblocks=1) , # 105.373 GFlop/s
-  Kernel_dnt_small(m=16, n=8, k=8, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 124.195 GFlop/s
-  Kernel_dnt_medium(m=16, n=8, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 121.754 GFlop/s
-  Kernel_dnt_medium(m=16, n=8, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 150.445 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=8, k=16, tile_m=1, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=4) , # 166.502 GFlop/s
-  Kernel_dnt_medium(m=16, n=8, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 167.3 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=8, k=22, tile_m=1, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=4) , # 175.569 GFlop/s
-  Kernel_dnt_medium(m=16, n=8, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 178.527 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=8, k=24, tile_m=2, tile_n=1, w=12, v=8, threads=96, grouping=16, minblocks=4) , # 185.133 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=8, k=26, tile_m=1, tile_n=1, w=12, v=8, threads=128, grouping=16, minblocks=12) , # 178.92 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=8, k=32, tile_m=1, tile_n=1, w=16, v=8, threads=128, grouping=16, minblocks=1) , # 194.196 GFlop/s
-  Kernel_dnt_medium(m=16, n=9, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 82.0886 GFlop/s
-  Kernel_dnt_medium(m=16, n=9, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 98.1233 GFlop/s
-  Kernel_dnt_small(m=16, n=9, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 102.023 GFlop/s
-  Kernel_dnt_small(m=16, n=9, k=8, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=4) , # 120.113 GFlop/s
-  Kernel_dnt_medium(m=16, n=9, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 128.209 GFlop/s
-  Kernel_dnt_medium(m=16, n=9, k=13, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 149.02 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=9, k=16, tile_m=2, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 161.845 GFlop/s
-  Kernel_dnt_medium(m=16, n=9, k=17, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 166.142 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=9, k=22, tile_m=2, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 171.029 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=9, k=23, tile_m=2, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=4) , # 173.179 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=9, k=24, tile_m=2, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=8) , # 175.852 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=9, k=26, tile_m=2, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=1) , # 180.319 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=9, k=32, tile_m=2, tile_n=1, w=6, v=6, threads=96, grouping=16, minblocks=12) , # 179.384 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=9, k=64, tile_m=3, tile_n=2, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 213.459 GFlop/s
-  Kernel_dnt_small(m=16, n=13, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 101.905 GFlop/s
-  Kernel_dnt_small(m=16, n=13, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=8) , # 116.398 GFlop/s
-  Kernel_dnt_medium(m=16, n=13, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 127.421 GFlop/s
-  Kernel_dnt_small(m=16, n=13, k=8, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 146.46 GFlop/s
-  Kernel_dnt_medium(m=16, n=13, k=9, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 156.829 GFlop/s
-  Kernel_dnt_medium(m=16, n=13, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 189.636 GFlop/s
-  Kernel_dnt_medium(m=16, n=13, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 214.841 GFlop/s
-  Kernel_dnt_medium(m=16, n=13, k=17, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 191.644 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=13, k=22, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 210.521 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=13, k=23, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 214.991 GFlop/s
-  Kernel_dnt_medium(m=16, n=13, k=24, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 212.921 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=13, k=26, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 210.224 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=13, k=32, tile_m=2, tile_n=2, w=16, v=12, threads=128, grouping=16, minblocks=12) , # 234.974 GFlop/s
-  Kernel_dnt_medium(m=16, n=14, k=14, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 215.62 GFlop/s
-  Kernel_dnt_medium(m=16, n=14, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 230.5 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=14, k=29, tile_m=2, tile_n=1, w=8, v=14, threads=128, grouping=16, minblocks=12) , # 231.585 GFlop/s
-  Kernel_dnt_small(m=16, n=16, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 142.372 GFlop/s
-  Kernel_dnt_small(m=16, n=16, k=5, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 161.476 GFlop/s
-  Kernel_dnt_small(m=16, n=16, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=8) , # 180.677 GFlop/s
-  Kernel_dnt_small(m=16, n=16, k=8, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 205.549 GFlop/s
-  Kernel_dnt_small(m=16, n=16, k=9, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=4) , # 205.186 GFlop/s
-  Kernel_dnt_medium(m=16, n=16, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 240.903 GFlop/s
-  Kernel_dnt_medium(m=16, n=16, k=14, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 253.252 GFlop/s
-  Kernel_dnt_largeDB2(m=16, n=16, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 267.825 GFlop/s
-  Kernel_dnt_medium(m=16, n=16, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=8) , # 247.453 GFlop/s
-  Kernel_dnt_medium(m=16, n=16, k=22, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 268.121 GFlop/s
-  Kernel_dnt_medium(m=16, n=16, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 272.615 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=16, k=24, tile_m=2, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=12) , # 265.276 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=16, k=26, tile_m=2, tile_n=2, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 263.235 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=16, k=29, tile_m=2, tile_n=2, w=14, v=16, threads=128, grouping=16, minblocks=12) , # 270.638 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=16, k=32, tile_m=2, tile_n=2, w=14, v=14, threads=128, grouping=16, minblocks=12) , # 276.949 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=16, k=55, tile_m=2, tile_n=2, w=14, v=16, threads=128, grouping=16, minblocks=12) , # 303.184 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=16, k=64, tile_m=2, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 312.221 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=16, k=256, tile_m=2, tile_n=2, w=14, v=12, threads=128, grouping=16, minblocks=12) , # 341.89 GFlop/s
-  Kernel_dnt_medium(m=16, n=17, k=4, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=4) , # 113.047 GFlop/s
-  Kernel_dnt_medium(m=16, n=17, k=5, tile_m=1, tile_n=3, threads=96, grouping=16, minblocks=12) , # 135.825 GFlop/s
-  Kernel_dnt_medium(m=16, n=17, k=6, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 152.914 GFlop/s
-  Kernel_dnt_medium(m=16, n=17, k=8, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 165.821 GFlop/s
-  Kernel_dnt_medium(m=16, n=17, k=9, tile_m=1, tile_n=3, threads=96, grouping=16, minblocks=12) , # 179.436 GFlop/s
-  Kernel_dnt_medium(m=16, n=17, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 215.752 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=17, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 202.68 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=17, k=17, tile_m=3, tile_n=2, w=6, v=16, threads=128, grouping=16, minblocks=12) , # 210.423 GFlop/s
-  Kernel_dnt_medium(m=16, n=17, k=22, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 234.804 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=17, k=23, tile_m=1, tile_n=3, w=6, v=14, threads=128, grouping=16, minblocks=12) , # 235.716 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=17, k=24, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 241.704 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=17, k=26, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 235.825 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=17, k=32, tile_m=2, tile_n=3, w=12, v=6, threads=96, grouping=16, minblocks=12) , # 255.137 GFlop/s
-  Kernel_dnt_medium(m=16, n=22, k=4, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 138.141 GFlop/s
-  Kernel_dnt_medium(m=16, n=22, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 161.969 GFlop/s
-  Kernel_dnt_medium(m=16, n=22, k=6, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 169.805 GFlop/s
-  Kernel_dnt_medium(m=16, n=22, k=8, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 205.457 GFlop/s
-  Kernel_dnt_medium(m=16, n=22, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 217.014 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=22, k=13, tile_m=2, tile_n=2, w=4, v=22, threads=96, grouping=16, minblocks=12) , # 223.224 GFlop/s
-  Kernel_dnt_medium(m=16, n=22, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 253.21 GFlop/s
-  Kernel_dnt_medium(m=16, n=22, k=17, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 260.436 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=22, k=22, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 273.938 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=22, k=23, tile_m=2, tile_n=3, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 277.81 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=22, k=24, tile_m=2, tile_n=3, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 291.318 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=22, k=26, tile_m=2, tile_n=3, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 289.631 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=22, k=32, tile_m=2, tile_n=3, w=12, v=6, threads=96, grouping=16, minblocks=12) , # 305.311 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=22, k=64, tile_m=2, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 349.601 GFlop/s
-  Kernel_dnt_medium(m=16, n=23, k=4, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 143.468 GFlop/s
-  Kernel_dnt_medium(m=16, n=23, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 167.762 GFlop/s
-  Kernel_dnt_medium(m=16, n=23, k=6, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 176.832 GFlop/s
-  Kernel_dnt_medium(m=16, n=23, k=8, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 213.06 GFlop/s
-  Kernel_dnt_medium(m=16, n=23, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 226.28 GFlop/s
-  Kernel_dnt_medium(m=16, n=23, k=13, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 230.437 GFlop/s
-  Kernel_dnt_medium(m=16, n=23, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 263.178 GFlop/s
-  Kernel_dnt_medium(m=16, n=23, k=17, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 264.544 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=23, k=22, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 279.549 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=23, k=23, tile_m=2, tile_n=2, w=10, v=16, threads=128, grouping=16, minblocks=12) , # 282.297 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=23, k=24, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 295.553 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=23, k=26, tile_m=2, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 291.977 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=23, k=32, tile_m=2, tile_n=3, w=12, v=6, threads=96, grouping=16, minblocks=12) , # 313.606 GFlop/s
-  Kernel_dnt_medium(m=16, n=24, k=4, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 150.444 GFlop/s
-  Kernel_dnt_medium(m=16, n=24, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 174.489 GFlop/s
-  Kernel_dnt_medium(m=16, n=24, k=6, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 184.054 GFlop/s
-  Kernel_dnt_medium(m=16, n=24, k=8, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 207.226 GFlop/s
-  Kernel_dnt_medium(m=16, n=24, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 235.336 GFlop/s
-  Kernel_dnt_medium(m=16, n=24, k=13, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 239.748 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=24, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 283.218 GFlop/s
-  Kernel_dnt_medium(m=16, n=24, k=17, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 275.019 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=24, k=22, tile_m=2, tile_n=3, w=8, v=18, threads=96, grouping=16, minblocks=12) , # 298.156 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=24, k=23, tile_m=2, tile_n=3, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 302.868 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=24, k=24, tile_m=2, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 313.429 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=24, k=26, tile_m=2, tile_n=3, w=10, v=24, threads=96, grouping=16, minblocks=12) , # 309.598 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=24, k=32, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 328.287 GFlop/s
-  Kernel_dnt_medium(m=16, n=26, k=4, tile_m=1, tile_n=5, threads=128, grouping=16, minblocks=12) , # 145.64 GFlop/s
-  Kernel_dnt_medium(m=16, n=26, k=5, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 161.73 GFlop/s
-  Kernel_dnt_medium(m=16, n=26, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 166.297 GFlop/s
-  Kernel_dnt_medium(m=16, n=26, k=8, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 203.682 GFlop/s
-  Kernel_dnt_medium(m=16, n=26, k=9, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 211.795 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=26, k=13, tile_m=2, tile_n=2, w=6, v=26, threads=128, grouping=16, minblocks=12) , # 235.299 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=26, k=16, tile_m=2, tile_n=2, w=8, v=18, threads=128, grouping=16, minblocks=12) , # 273.171 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=26, k=17, tile_m=2, tile_n=2, w=8, v=18, threads=128, grouping=16, minblocks=12) , # 265.788 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=26, k=22, tile_m=2, tile_n=4, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 285.563 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=26, k=23, tile_m=2, tile_n=2, w=6, v=18, threads=128, grouping=16, minblocks=12) , # 284.848 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=26, k=24, tile_m=2, tile_n=2, w=8, v=18, threads=128, grouping=16, minblocks=12) , # 301.847 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=26, k=26, tile_m=2, tile_n=4, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 298.512 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=26, k=32, tile_m=2, tile_n=4, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 308.645 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=29, k=14, tile_m=2, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 264.624 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=29, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 294.66 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=29, k=29, tile_m=2, tile_n=2, w=6, v=24, threads=128, grouping=16, minblocks=12) , # 312.556 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=29, k=55, tile_m=2, tile_n=4, w=6, v=24, threads=96, grouping=16, minblocks=12) , # 360.672 GFlop/s
-  Kernel_dnt_small(m=16, n=32, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=4) , # 149.795 GFlop/s
-  Kernel_dnt_medium(m=16, n=32, k=5, tile_m=2, tile_n=2, threads=192, grouping=16, minblocks=8) , # 166.138 GFlop/s
-  Kernel_dnt_medium(m=16, n=32, k=6, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 189.982 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=32, k=8, tile_m=2, tile_n=2, w=4, v=24, threads=128, grouping=16, minblocks=12) , # 234.188 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=32, k=9, tile_m=2, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 239.327 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=32, k=13, tile_m=2, tile_n=2, w=6, v=24, threads=128, grouping=16, minblocks=12) , # 290.526 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=32, k=16, tile_m=2, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 326.65 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=32, k=17, tile_m=2, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 322.698 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=32, k=22, tile_m=2, tile_n=4, w=6, v=28, threads=96, grouping=16, minblocks=12) , # 328.078 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=32, k=23, tile_m=2, tile_n=2, w=6, v=24, threads=128, grouping=16, minblocks=12) , # 344.677 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=32, k=24, tile_m=2, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 358.185 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=32, k=26, tile_m=2, tile_n=2, w=6, v=24, threads=128, grouping=16, minblocks=12) , # 342.564 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=32, k=32, tile_m=2, tile_n=4, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 360.103 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=55, k=16, tile_m=2, tile_n=4, w=8, v=32, threads=128, grouping=16, minblocks=8) , # 331.33 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=55, k=29, tile_m=2, tile_n=4, w=8, v=40, threads=128, grouping=16, minblocks=8) , # 387.674 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=55, k=55, tile_m=2, tile_n=4, w=8, v=24, threads=128, grouping=16, minblocks=8) , # 430.218 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=64, k=9, tile_m=2, tile_n=4, w=4, v=40, threads=128, grouping=16, minblocks=4) , # 281.238 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=64, k=16, tile_m=2, tile_n=4, w=8, v=40, threads=128, grouping=16, minblocks=8) , # 374.147 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=64, k=22, tile_m=2, tile_n=4, w=8, v=40, threads=128, grouping=16, minblocks=8) , # 409.267 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=64, k=64, tile_m=2, tile_n=4, w=8, v=44, threads=128, grouping=16, minblocks=8) , # 500.346 GFlop/s
-  Kernel_dnt_largeDB1(m=16, n=256, k=16, tile_m=2, tile_n=6, w=6, v=168, threads=384, grouping=16, minblocks=1) , # 309.179 GFlop/s
-  Kernel_dnt_medium(m=17, n=4, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 44.4021 GFlop/s
-  Kernel_dnt_medium(m=17, n=4, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 54.1312 GFlop/s
-  Kernel_dnt_small(m=17, n=4, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 55.1151 GFlop/s
-  Kernel_dnt_medium(m=17, n=4, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 64.4064 GFlop/s
-  Kernel_dnt_medium(m=17, n=4, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 69.4042 GFlop/s
-  Kernel_dnt_medium(m=17, n=4, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 86.341 GFlop/s
-  Kernel_dnt_medium(m=17, n=4, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 99.1383 GFlop/s
-  Kernel_dnt_medium(m=17, n=4, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 98.4389 GFlop/s
-  Kernel_dnt_medium(m=17, n=4, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 113.713 GFlop/s
-  Kernel_dnt_medium(m=17, n=4, k=23, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 109.504 GFlop/s
-  Kernel_dnt_medium(m=17, n=4, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 109.247 GFlop/s
-  Kernel_dnt_medium(m=17, n=4, k=26, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 112.934 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=4, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=1) , # 116.496 GFlop/s
-  Kernel_dnt_medium(m=17, n=5, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 55.1226 GFlop/s
-  Kernel_dnt_medium(m=17, n=5, k=5, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 67.2537 GFlop/s
-  Kernel_dnt_small(m=17, n=5, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 67.5261 GFlop/s
-  Kernel_dnt_medium(m=17, n=5, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 78.5404 GFlop/s
-  Kernel_dnt_medium(m=17, n=5, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 86.2825 GFlop/s
-  Kernel_dnt_medium(m=17, n=5, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 106.81 GFlop/s
-  Kernel_dnt_medium(m=17, n=5, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 121.92 GFlop/s
-  Kernel_dnt_medium(m=17, n=5, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 122.006 GFlop/s
-  Kernel_dnt_medium(m=17, n=5, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 136.463 GFlop/s
-  Kernel_dnt_medium(m=17, n=5, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 132.002 GFlop/s
-  Kernel_dnt_medium(m=17, n=5, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 135.055 GFlop/s
-  Kernel_dnt_medium(m=17, n=5, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=4) , # 131.777 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=4) , # 138.231 GFlop/s
-  Kernel_dnt_tiny(m=17, n=6, k=4, threads=128, grouping=16, minblocks=1) , # 60.0659 GFlop/s
-  Kernel_dnt_small(m=17, n=6, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 69.3811 GFlop/s
-  Kernel_dnt_small(m=17, n=6, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 76.6485 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=6, k=8, tile_m=1, tile_n=1, w=4, v=6, threads=128, grouping=16, minblocks=1) , # 87.7851 GFlop/s
-  Kernel_dnt_medium(m=17, n=6, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 93.856 GFlop/s
-  Kernel_dnt_medium(m=17, n=6, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 121.148 GFlop/s
-  Kernel_dnt_medium(m=17, n=6, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 129.192 GFlop/s
-  Kernel_dnt_medium(m=17, n=6, k=17, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 129.614 GFlop/s
-  Kernel_dnt_medium(m=17, n=6, k=22, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=4) , # 140.116 GFlop/s
-  Kernel_dnt_medium(m=17, n=6, k=23, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=4) , # 138.103 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=6, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=128, grouping=16, minblocks=12) , # 142.037 GFlop/s
-  Kernel_dnt_medium(m=17, n=6, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=4) , # 145.376 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=6, k=32, tile_m=2, tile_n=2, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 150.065 GFlop/s
-  Kernel_dnt_small(m=17, n=8, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 73.5398 GFlop/s
-  Kernel_dnt_medium(m=17, n=8, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 84.7969 GFlop/s
-  Kernel_dnt_medium(m=17, n=8, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 90.287 GFlop/s
-  Kernel_dnt_medium(m=17, n=8, k=8, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=4) , # 110.66 GFlop/s
-  Kernel_dnt_medium(m=17, n=8, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 117.865 GFlop/s
-  Kernel_dnt_medium(m=17, n=8, k=13, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 136.931 GFlop/s
-  Kernel_dnt_medium(m=17, n=8, k=16, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 151.999 GFlop/s
-  Kernel_dnt_medium(m=17, n=8, k=17, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 153.384 GFlop/s
-  Kernel_dnt_medium(m=17, n=8, k=22, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 157.352 GFlop/s
-  Kernel_dnt_medium(m=17, n=8, k=23, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 157.04 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=8, k=24, tile_m=2, tile_n=3, w=12, v=6, threads=96, grouping=16, minblocks=12) , # 158.743 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=8, k=26, tile_m=2, tile_n=3, w=12, v=8, threads=96, grouping=16, minblocks=12) , # 158.262 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=8, k=32, tile_m=3, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=12) , # 178.979 GFlop/s
-  Kernel_dnt_small(m=17, n=9, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 77.9497 GFlop/s
-  Kernel_dnt_medium(m=17, n=9, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 93.1439 GFlop/s
-  Kernel_dnt_medium(m=17, n=9, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 98.5145 GFlop/s
-  Kernel_dnt_medium(m=17, n=9, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 115.668 GFlop/s
-  Kernel_dnt_medium(m=17, n=9, k=9, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 130.249 GFlop/s
-  Kernel_dnt_medium(m=17, n=9, k=13, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 150.565 GFlop/s
-  Kernel_dnt_medium(m=17, n=9, k=16, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 163.688 GFlop/s
-  Kernel_dnt_medium(m=17, n=9, k=17, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 167.344 GFlop/s
-  Kernel_dnt_medium(m=17, n=9, k=22, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 171.276 GFlop/s
-  Kernel_dnt_medium(m=17, n=9, k=23, tile_m=1, tile_n=1, threads=224, grouping=16, minblocks=8) , # 166.022 GFlop/s
-  Kernel_dnt_medium(m=17, n=9, k=24, tile_m=1, tile_n=1, threads=224, grouping=16, minblocks=8) , # 168.798 GFlop/s
-  Kernel_dnt_medium(m=17, n=9, k=26, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 168.829 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=9, k=32, tile_m=2, tile_n=3, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 184.866 GFlop/s
-  Kernel_dnt_medium(m=17, n=13, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 100.145 GFlop/s
-  Kernel_dnt_medium(m=17, n=13, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 118.278 GFlop/s
-  Kernel_dnt_medium(m=17, n=13, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 131.89 GFlop/s
-  Kernel_dnt_medium(m=17, n=13, k=8, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 149.14 GFlop/s
-  Kernel_dnt_medium(m=17, n=13, k=9, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 161.29 GFlop/s
-  Kernel_dnt_medium(m=17, n=13, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 199.157 GFlop/s
-  Kernel_dnt_medium(m=17, n=13, k=16, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 215.17 GFlop/s
-  Kernel_dnt_medium(m=17, n=13, k=17, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=4) , # 193.774 GFlop/s
-  Kernel_dnt_medium(m=17, n=13, k=22, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 220.321 GFlop/s
-  Kernel_dnt_medium(m=17, n=13, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 220.147 GFlop/s
-  Kernel_dnt_medium(m=17, n=13, k=24, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 222.453 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=13, k=26, tile_m=2, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 213.018 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=13, k=32, tile_m=2, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=12) , # 238.862 GFlop/s
-  Kernel_dnt_medium(m=17, n=16, k=4, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 116.716 GFlop/s
-  Kernel_dnt_medium(m=17, n=16, k=5, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 136.165 GFlop/s
-  Kernel_dnt_medium(m=17, n=16, k=6, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 154.74 GFlop/s
-  Kernel_dnt_medium(m=17, n=16, k=8, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 169.907 GFlop/s
-  Kernel_dnt_medium(m=17, n=16, k=9, tile_m=1, tile_n=2, threads=160, grouping=16, minblocks=12) , # 177.331 GFlop/s
-  Kernel_dnt_medium(m=17, n=16, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 203.746 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=16, k=16, tile_m=3, tile_n=1, w=4, v=10, threads=96, grouping=16, minblocks=4) , # 206.356 GFlop/s
-  Kernel_dnt_medium(m=17, n=16, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 207.944 GFlop/s
-  Kernel_dnt_medium(m=17, n=16, k=22, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 235.476 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=16, k=23, tile_m=3, tile_n=1, w=6, v=16, threads=128, grouping=16, minblocks=12) , # 235.699 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=16, k=24, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 245.438 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=16, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 240.279 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=16, k=32, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 257.664 GFlop/s
-  Kernel_dnt_small(m=17, n=17, k=4, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=4) , # 123.512 GFlop/s
-  Kernel_dnt_small(m=17, n=17, k=5, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=8) , # 144.444 GFlop/s
-  Kernel_dnt_medium(m=17, n=17, k=6, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 153.953 GFlop/s
-  Kernel_dnt_medium(m=17, n=17, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 179.063 GFlop/s
-  Kernel_dnt_medium(m=17, n=17, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 194.247 GFlop/s
-  Kernel_dnt_medium(m=17, n=17, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 227.787 GFlop/s
-  Kernel_dnt_medium(m=17, n=17, k=16, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 228.835 GFlop/s
-  Kernel_dnt_largeDB2(m=17, n=17, k=17, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 239.722 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=17, k=22, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 235.625 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=17, k=23, tile_m=2, tile_n=2, w=6, v=16, threads=128, grouping=16, minblocks=12) , # 237.176 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=17, k=24, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 240.597 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=17, k=26, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 240.047 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=17, k=32, tile_m=3, tile_n=2, w=14, v=12, threads=96, grouping=16, minblocks=12) , # 260.215 GFlop/s
-  Kernel_dnt_medium(m=17, n=22, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 138.391 GFlop/s
-  Kernel_dnt_medium(m=17, n=22, k=5, tile_m=1, tile_n=5, threads=128, grouping=16, minblocks=12) , # 148.4 GFlop/s
-  Kernel_dnt_medium(m=17, n=22, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 150.275 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=22, k=8, tile_m=2, tile_n=2, w=4, v=22, threads=128, grouping=16, minblocks=12) , # 182.307 GFlop/s
-  Kernel_dnt_medium(m=17, n=22, k=9, tile_m=1, tile_n=5, threads=96, grouping=16, minblocks=12) , # 187.291 GFlop/s
-  Kernel_dnt_medium(m=17, n=22, k=13, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 214.624 GFlop/s
-  Kernel_dnt_medium(m=17, n=22, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 246.559 GFlop/s
-  Kernel_dnt_medium(m=17, n=22, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 251.891 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=22, k=22, tile_m=3, tile_n=2, w=10, v=22, threads=96, grouping=16, minblocks=12) , # 245.288 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=22, k=23, tile_m=3, tile_n=2, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 245.432 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=22, k=24, tile_m=3, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 262.797 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=22, k=26, tile_m=3, tile_n=2, w=12, v=22, threads=96, grouping=16, minblocks=12) , # 257.52 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=22, k=32, tile_m=2, tile_n=2, w=16, v=22, threads=128, grouping=16, minblocks=8) , # 279.426 GFlop/s
-  Kernel_dnt_medium(m=17, n=23, k=4, tile_m=5, tile_n=1, threads=96, grouping=16, minblocks=12) , # 131.562 GFlop/s
-  Kernel_dnt_medium(m=17, n=23, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 153.614 GFlop/s
-  Kernel_dnt_medium(m=17, n=23, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 153.311 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=23, k=8, tile_m=2, tile_n=2, w=4, v=22, threads=128, grouping=16, minblocks=12) , # 183.993 GFlop/s
-  Kernel_dnt_medium(m=17, n=23, k=9, tile_m=1, tile_n=5, threads=96, grouping=16, minblocks=12) , # 192.159 GFlop/s
-  Kernel_dnt_medium(m=17, n=23, k=13, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 227.532 GFlop/s
-  Kernel_dnt_medium(m=17, n=23, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 253.516 GFlop/s
-  Kernel_dnt_medium(m=17, n=23, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 253.057 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=23, k=22, tile_m=2, tile_n=2, w=10, v=22, threads=128, grouping=16, minblocks=12) , # 263.902 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=23, k=23, tile_m=3, tile_n=2, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 257.187 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=23, k=24, tile_m=2, tile_n=2, w=10, v=14, threads=128, grouping=16, minblocks=12) , # 274.723 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=23, k=26, tile_m=3, tile_n=2, w=10, v=14, threads=96, grouping=16, minblocks=12) , # 264.933 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=23, k=32, tile_m=2, tile_n=2, w=16, v=16, threads=160, grouping=16, minblocks=8) , # 282.093 GFlop/s
-  Kernel_dnt_medium(m=17, n=24, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 149.438 GFlop/s
-  Kernel_dnt_medium(m=17, n=24, k=5, tile_m=1, tile_n=5, threads=128, grouping=16, minblocks=12) , # 160.205 GFlop/s
-  Kernel_dnt_medium(m=17, n=24, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 165.872 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=24, k=8, tile_m=2, tile_n=2, w=4, v=24, threads=128, grouping=16, minblocks=12) , # 196.795 GFlop/s
-  Kernel_dnt_medium(m=17, n=24, k=9, tile_m=1, tile_n=5, threads=96, grouping=16, minblocks=12) , # 203.363 GFlop/s
-  Kernel_dnt_medium(m=17, n=24, k=13, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 236.192 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=24, k=16, tile_m=2, tile_n=2, w=8, v=24, threads=128, grouping=16, minblocks=12) , # 260.019 GFlop/s
-  Kernel_dnt_medium(m=17, n=24, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 260.23 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=24, k=22, tile_m=3, tile_n=2, w=10, v=24, threads=96, grouping=16, minblocks=12) , # 265.399 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=24, k=23, tile_m=3, tile_n=2, w=8, v=24, threads=96, grouping=16, minblocks=12) , # 267.658 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=24, k=24, tile_m=2, tile_n=2, w=12, v=24, threads=128, grouping=16, minblocks=1) , # 276.151 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=24, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 280.206 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=24, k=32, tile_m=2, tile_n=2, w=16, v=24, threads=128, grouping=16, minblocks=8) , # 301.526 GFlop/s
-  Kernel_dnt_medium(m=17, n=26, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 155.546 GFlop/s
-  Kernel_dnt_medium(m=17, n=26, k=5, tile_m=1, tile_n=6, threads=96, grouping=16, minblocks=12) , # 155.547 GFlop/s
-  Kernel_dnt_medium(m=17, n=26, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 174.528 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=26, k=8, tile_m=2, tile_n=2, w=4, v=26, threads=128, grouping=16, minblocks=12) , # 205.713 GFlop/s
-  Kernel_dnt_medium(m=17, n=26, k=9, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 205.14 GFlop/s
-  Kernel_dnt_medium(m=17, n=26, k=13, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 243.482 GFlop/s
-  Kernel_dnt_medium(m=17, n=26, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 272.907 GFlop/s
-  Kernel_dnt_medium(m=17, n=26, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 275.819 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=26, k=22, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 277.137 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=26, k=23, tile_m=3, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 285.309 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=26, k=24, tile_m=3, tile_n=2, w=8, v=26, threads=96, grouping=16, minblocks=12) , # 292.828 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=26, k=26, tile_m=3, tile_n=2, w=10, v=14, threads=96, grouping=16, minblocks=12) , # 288.933 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=26, k=32, tile_m=2, tile_n=2, w=16, v=18, threads=160, grouping=16, minblocks=8) , # 317.652 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=32, k=4, tile_m=3, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 148.299 GFlop/s
-  Kernel_dnt_medium(m=17, n=32, k=5, tile_m=3, tile_n=1, threads=192, grouping=16, minblocks=8) , # 168.196 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=32, k=6, tile_m=3, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 182.522 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=32, k=8, tile_m=3, tile_n=2, w=4, v=28, threads=96, grouping=16, minblocks=12) , # 230.442 GFlop/s
-  Kernel_dnt_medium(m=17, n=32, k=9, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 233.382 GFlop/s
-  Kernel_dnt_medium(m=17, n=32, k=13, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 261.656 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=32, k=16, tile_m=3, tile_n=2, w=4, v=26, threads=128, grouping=16, minblocks=12) , # 304.612 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=32, k=17, tile_m=3, tile_n=2, w=8, v=28, threads=96, grouping=16, minblocks=12) , # 292.771 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=32, k=22, tile_m=3, tile_n=2, w=6, v=32, threads=128, grouping=16, minblocks=8) , # 305.08 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=32, k=23, tile_m=3, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 328.197 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=32, k=24, tile_m=3, tile_n=2, w=8, v=28, threads=96, grouping=16, minblocks=12) , # 335.43 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=32, k=26, tile_m=3, tile_n=2, w=8, v=28, threads=96, grouping=16, minblocks=12) , # 337.328 GFlop/s
-  Kernel_dnt_largeDB1(m=17, n=32, k=32, tile_m=3, tile_n=2, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 356.942 GFlop/s
-  Kernel_dnt_medium(m=22, n=4, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 57.5751 GFlop/s
-  Kernel_dnt_small(m=22, n=4, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 61.4088 GFlop/s
-  Kernel_dnt_medium(m=22, n=4, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 66.0702 GFlop/s
-  Kernel_dnt_medium(m=22, n=4, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 83.1265 GFlop/s
-  Kernel_dnt_medium(m=22, n=4, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 90.0009 GFlop/s
-  Kernel_dnt_medium(m=22, n=4, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 109.711 GFlop/s
-  Kernel_dnt_medium(m=22, n=4, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 119.067 GFlop/s
-  Kernel_dnt_medium(m=22, n=4, k=17, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 119.067 GFlop/s
-  Kernel_dnt_medium(m=22, n=4, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 126.35 GFlop/s
-  Kernel_dnt_medium(m=22, n=4, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 125.232 GFlop/s
-  Kernel_dnt_medium(m=22, n=4, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 126.365 GFlop/s
-  Kernel_dnt_medium(m=22, n=4, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 123.866 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=4, k=32, tile_m=1, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 128.16 GFlop/s
-  Kernel_dnt_tiny(m=22, n=5, k=4, threads=128, grouping=16, minblocks=1) , # 64.238 GFlop/s
-  Kernel_dnt_small(m=22, n=5, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 73.3009 GFlop/s
-  Kernel_dnt_medium(m=22, n=5, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 74.4677 GFlop/s
-  Kernel_dnt_medium(m=22, n=5, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 93.8793 GFlop/s
-  Kernel_dnt_medium(m=22, n=5, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 97.9858 GFlop/s
-  Kernel_dnt_medium(m=22, n=5, k=13, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 125.068 GFlop/s
-  Kernel_dnt_medium(m=22, n=5, k=16, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 136.417 GFlop/s
-  Kernel_dnt_medium(m=22, n=5, k=17, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 138.949 GFlop/s
-  Kernel_dnt_medium(m=22, n=5, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 145.653 GFlop/s
-  Kernel_dnt_medium(m=22, n=5, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 147.827 GFlop/s
-  Kernel_dnt_medium(m=22, n=5, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 141.609 GFlop/s
-  Kernel_dnt_medium(m=22, n=5, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 144.189 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=12) , # 146.023 GFlop/s
-  Kernel_dnt_small(m=22, n=6, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 69.8662 GFlop/s
-  Kernel_dnt_medium(m=22, n=6, k=5, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 77.9372 GFlop/s
-  Kernel_dnt_medium(m=22, n=6, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 84.6147 GFlop/s
-  Kernel_dnt_medium(m=22, n=6, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 106.018 GFlop/s
-  Kernel_dnt_medium(m=22, n=6, k=9, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=8) , # 109.232 GFlop/s
-  Kernel_dnt_medium(m=22, n=6, k=13, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 137.639 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=6, k=16, tile_m=2, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=1) , # 143.963 GFlop/s
-  Kernel_dnt_medium(m=22, n=6, k=17, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 147.12 GFlop/s
-  Kernel_dnt_medium(m=22, n=6, k=22, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=8) , # 147.34 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=6, k=23, tile_m=2, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 144.445 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=6, k=24, tile_m=2, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=1) , # 152.082 GFlop/s
-  Kernel_dnt_medium(m=22, n=6, k=26, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 150.145 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=6, k=32, tile_m=3, tile_n=2, w=16, v=4, threads=96, grouping=16, minblocks=12) , # 163.029 GFlop/s
-  Kernel_dnt_small(m=22, n=8, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 94.6278 GFlop/s
-  Kernel_dnt_medium(m=22, n=8, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 101.742 GFlop/s
-  Kernel_dnt_medium(m=22, n=8, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 113.174 GFlop/s
-  Kernel_dnt_medium(m=22, n=8, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 142.411 GFlop/s
-  Kernel_dnt_medium(m=22, n=8, k=9, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 145.287 GFlop/s
-  Kernel_dnt_medium(m=22, n=8, k=13, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 172.352 GFlop/s
-  Kernel_dnt_medium(m=22, n=8, k=16, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 187.276 GFlop/s
-  Kernel_dnt_medium(m=22, n=8, k=17, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=4) , # 184.837 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=8, k=22, tile_m=2, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 185.428 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=8, k=23, tile_m=1, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 187.194 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=8, k=24, tile_m=2, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=8) , # 197.07 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=8, k=26, tile_m=1, tile_n=2, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 190.52 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=8, k=32, tile_m=3, tile_n=2, w=16, v=8, threads=96, grouping=16, minblocks=12) , # 205.185 GFlop/s
-  Kernel_dnt_medium(m=22, n=9, k=4, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 89.3747 GFlop/s
-  Kernel_dnt_medium(m=22, n=9, k=5, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 106.787 GFlop/s
-  Kernel_dnt_medium(m=22, n=9, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 112.692 GFlop/s
-  Kernel_dnt_medium(m=22, n=9, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 139.231 GFlop/s
-  Kernel_dnt_medium(m=22, n=9, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 150.647 GFlop/s
-  Kernel_dnt_medium(m=22, n=9, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 176.971 GFlop/s
-  Kernel_dnt_medium(m=22, n=9, k=16, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=4) , # 172.625 GFlop/s
-  Kernel_dnt_medium(m=22, n=9, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=1) , # 179.675 GFlop/s
-  Kernel_dnt_medium(m=22, n=9, k=22, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 198.116 GFlop/s
-  Kernel_dnt_medium(m=22, n=9, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 201.354 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=9, k=24, tile_m=2, tile_n=2, w=12, v=6, threads=128, grouping=16, minblocks=12) , # 200.245 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=9, k=26, tile_m=2, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 197.52 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=9, k=32, tile_m=2, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 207.544 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=9, k=64, tile_m=2, tile_n=2, w=12, v=8, threads=96, grouping=16, minblocks=12) , # 239.452 GFlop/s
-  Kernel_dnt_medium(m=22, n=13, k=4, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 116.442 GFlop/s
-  Kernel_dnt_medium(m=22, n=13, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 133.637 GFlop/s
-  Kernel_dnt_medium(m=22, n=13, k=6, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 146.616 GFlop/s
-  Kernel_dnt_medium(m=22, n=13, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 171.063 GFlop/s
-  Kernel_dnt_medium(m=22, n=13, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 183.073 GFlop/s
-  Kernel_dnt_medium(m=22, n=13, k=13, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 223.261 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=13, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 214.711 GFlop/s
-  Kernel_dnt_medium(m=22, n=13, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=4) , # 224.809 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=13, k=22, tile_m=3, tile_n=2, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 221.172 GFlop/s
-  Kernel_dnt_medium(m=22, n=13, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=1) , # 228.978 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=13, k=24, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 233.378 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=13, k=26, tile_m=3, tile_n=2, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 236.465 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=13, k=32, tile_m=2, tile_n=3, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 250.128 GFlop/s
-  Kernel_dnt_medium(m=22, n=16, k=4, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 141.362 GFlop/s
-  Kernel_dnt_medium(m=22, n=16, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 165.072 GFlop/s
-  Kernel_dnt_medium(m=22, n=16, k=6, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 168.045 GFlop/s
-  Kernel_dnt_medium(m=22, n=16, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 208.282 GFlop/s
-  Kernel_dnt_medium(m=22, n=16, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 221.618 GFlop/s
-  Kernel_dnt_medium(m=22, n=16, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=8) , # 242.184 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=16, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 254.265 GFlop/s
-  Kernel_dnt_medium(m=22, n=16, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 270.21 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=16, k=22, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 275.664 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=16, k=23, tile_m=2, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 279.173 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=16, k=24, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 292.083 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=16, k=26, tile_m=2, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 290.449 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=16, k=32, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 308.173 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=16, k=64, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 357.117 GFlop/s
-  Kernel_dnt_medium(m=22, n=17, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 139.051 GFlop/s
-  Kernel_dnt_medium(m=22, n=17, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 159.925 GFlop/s
-  Kernel_dnt_medium(m=22, n=17, k=6, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 158.152 GFlop/s
-  Kernel_dnt_medium(m=22, n=17, k=8, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 188.223 GFlop/s
-  Kernel_dnt_medium(m=22, n=17, k=9, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 202.404 GFlop/s
-  Kernel_dnt_medium(m=22, n=17, k=13, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 224.16 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=17, k=16, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 245.41 GFlop/s
-  Kernel_dnt_medium(m=22, n=17, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 257.375 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=17, k=22, tile_m=2, tile_n=4, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 256.316 GFlop/s
-  Kernel_dnt_medium(m=22, n=17, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=1) , # 255.027 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=17, k=24, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 259.941 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=17, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 256.136 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=17, k=32, tile_m=2, tile_n=2, w=16, v=16, threads=128, grouping=16, minblocks=8) , # 275.263 GFlop/s
-  Kernel_dnt_small(m=22, n=22, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=4) , # 163.707 GFlop/s
-  Kernel_dnt_small(m=22, n=22, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=4) , # 187.588 GFlop/s
-  Kernel_dnt_medium(m=22, n=22, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 192.65 GFlop/s
-  Kernel_dnt_medium(m=22, n=22, k=8, tile_m=2, tile_n=2, threads=192, grouping=16, minblocks=8) , # 227.684 GFlop/s
-  Kernel_dnt_medium(m=22, n=22, k=9, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=1) , # 241.517 GFlop/s
-  Kernel_dnt_medium(m=22, n=22, k=13, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 290.16 GFlop/s
-  Kernel_dnt_medium(m=22, n=22, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 316.266 GFlop/s
-  Kernel_dnt_medium(m=22, n=22, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=1) , # 317.077 GFlop/s
-  Kernel_dnt_largeDB2(m=22, n=22, k=22, tile_m=3, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 330.052 GFlop/s
-  Kernel_dnt_medium(m=22, n=22, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=1) , # 308.901 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=22, k=24, tile_m=2, tile_n=2, w=8, v=22, threads=192, grouping=16, minblocks=8) , # 310.483 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=22, k=26, tile_m=2, tile_n=2, w=8, v=14, threads=192, grouping=16, minblocks=8) , # 317.329 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=22, k=32, tile_m=2, tile_n=2, w=16, v=22, threads=128, grouping=16, minblocks=4) , # 345.889 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=22, k=64, tile_m=3, tile_n=3, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 397.616 GFlop/s
-  Kernel_dnt_medium(m=22, n=23, k=4, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=4) , # 147.314 GFlop/s
-  Kernel_dnt_medium(m=22, n=23, k=5, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 165.555 GFlop/s
-  Kernel_dnt_medium(m=22, n=23, k=6, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 177.922 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=23, k=8, tile_m=3, tile_n=2, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 217.558 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=23, k=9, tile_m=3, tile_n=2, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 220.434 GFlop/s
-  Kernel_dnt_medium(m=22, n=23, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 270.773 GFlop/s
-  Kernel_dnt_medium(m=22, n=23, k=16, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 295.869 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=23, k=17, tile_m=3, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 281.315 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=23, k=22, tile_m=3, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 301.99 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=23, k=23, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 311.315 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=23, k=24, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 311.437 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=23, k=26, tile_m=2, tile_n=3, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 325.286 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=23, k=32, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 332.066 GFlop/s
-  Kernel_dnt_medium(m=22, n=24, k=4, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=8) , # 146.658 GFlop/s
-  Kernel_dnt_medium(m=22, n=24, k=5, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 172.584 GFlop/s
-  Kernel_dnt_medium(m=22, n=24, k=6, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 190.547 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=24, k=8, tile_m=3, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=12) , # 231.867 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=24, k=9, tile_m=2, tile_n=3, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 230.841 GFlop/s
-  Kernel_dnt_medium(m=22, n=24, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 283.717 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=24, k=16, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 305.622 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=24, k=17, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 300.284 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=24, k=22, tile_m=3, tile_n=2, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 321.992 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=24, k=23, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 330.118 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=24, k=24, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 337.228 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=24, k=26, tile_m=2, tile_n=3, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 342.548 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=24, k=32, tile_m=3, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 356.369 GFlop/s
-  Kernel_dnt_medium(m=22, n=26, k=4, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 150.577 GFlop/s
-  Kernel_dnt_medium(m=22, n=26, k=5, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 174.989 GFlop/s
-  Kernel_dnt_medium(m=22, n=26, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 196.805 GFlop/s
-  Kernel_dnt_medium(m=22, n=26, k=8, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 217.596 GFlop/s
-  Kernel_dnt_medium(m=22, n=26, k=9, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 231.7 GFlop/s
-  Kernel_dnt_medium(m=22, n=26, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 276.614 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=26, k=16, tile_m=3, tile_n=2, w=6, v=26, threads=160, grouping=16, minblocks=8) , # 268.495 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=26, k=17, tile_m=2, tile_n=3, w=6, v=14, threads=160, grouping=16, minblocks=8) , # 274.845 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=26, k=22, tile_m=2, tile_n=3, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 305.508 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=26, k=23, tile_m=2, tile_n=2, w=6, v=26, threads=160, grouping=16, minblocks=8) , # 307.774 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=26, k=24, tile_m=2, tile_n=3, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 312.05 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=26, k=26, tile_m=2, tile_n=3, w=4, v=18, threads=128, grouping=16, minblocks=12) , # 314.535 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=26, k=32, tile_m=2, tile_n=3, w=14, v=16, threads=128, grouping=16, minblocks=8) , # 328.943 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=32, k=4, tile_m=3, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=12) , # 173.713 GFlop/s
-  Kernel_dnt_medium(m=22, n=32, k=5, tile_m=2, tile_n=2, threads=192, grouping=16, minblocks=8) , # 199.383 GFlop/s
-  Kernel_dnt_medium(m=22, n=32, k=6, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 213.238 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=32, k=8, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 279.051 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=32, k=9, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 280.794 GFlop/s
-  Kernel_dnt_medium(m=22, n=32, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 317.355 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=32, k=16, tile_m=3, tile_n=2, w=8, v=32, threads=128, grouping=16, minblocks=8) , # 321.452 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=32, k=17, tile_m=3, tile_n=3, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 322.465 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=32, k=22, tile_m=2, tile_n=3, w=4, v=20, threads=128, grouping=16, minblocks=12) , # 368.406 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=32, k=23, tile_m=2, tile_n=3, w=6, v=32, threads=160, grouping=16, minblocks=8) , # 359.94 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=32, k=24, tile_m=2, tile_n=3, w=12, v=32, threads=128, grouping=16, minblocks=8) , # 374.035 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=32, k=26, tile_m=2, tile_n=3, w=4, v=20, threads=128, grouping=16, minblocks=12) , # 379.484 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=32, k=32, tile_m=2, tile_n=3, w=12, v=32, threads=128, grouping=16, minblocks=8) , # 392.581 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=64, k=9, tile_m=3, tile_n=4, w=4, v=40, threads=128, grouping=16, minblocks=4) , # 278.224 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=64, k=16, tile_m=3, tile_n=4, w=4, v=40, threads=128, grouping=16, minblocks=4) , # 364.597 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=64, k=22, tile_m=6, tile_n=2, w=4, v=32, threads=128, grouping=16, minblocks=1) , # 383.067 GFlop/s
-  Kernel_dnt_largeDB1(m=22, n=64, k=64, tile_m=3, tile_n=4, w=8, v=24, threads=128, grouping=16, minblocks=1) , # 504.56 GFlop/s
-  Kernel_dnt_medium(m=23, n=4, k=4, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 59.6814 GFlop/s
-  Kernel_dnt_small(m=23, n=4, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 63.3487 GFlop/s
-  Kernel_dnt_medium(m=23, n=4, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 68.454 GFlop/s
-  Kernel_dnt_medium(m=23, n=4, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 86.3208 GFlop/s
-  Kernel_dnt_medium(m=23, n=4, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 93.3249 GFlop/s
-  Kernel_dnt_medium(m=23, n=4, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=8) , # 111.101 GFlop/s
-  Kernel_dnt_medium(m=23, n=4, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 121.134 GFlop/s
-  Kernel_dnt_medium(m=23, n=4, k=17, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 121.05 GFlop/s
-  Kernel_dnt_medium(m=23, n=4, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 126.088 GFlop/s
-  Kernel_dnt_medium(m=23, n=4, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 125.969 GFlop/s
-  Kernel_dnt_medium(m=23, n=4, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 122.921 GFlop/s
-  Kernel_dnt_medium(m=23, n=4, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 127.127 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=4, k=32, tile_m=1, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 128.586 GFlop/s
-  Kernel_dnt_tiny(m=23, n=5, k=4, threads=128, grouping=16, minblocks=1) , # 66.3956 GFlop/s
-  Kernel_dnt_small(m=23, n=5, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 76.0417 GFlop/s
-  Kernel_dnt_medium(m=23, n=5, k=6, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 76.9185 GFlop/s
-  Kernel_dnt_medium(m=23, n=5, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 94.7903 GFlop/s
-  Kernel_dnt_medium(m=23, n=5, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 102.173 GFlop/s
-  Kernel_dnt_medium(m=23, n=5, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 124.782 GFlop/s
-  Kernel_dnt_medium(m=23, n=5, k=16, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 138.278 GFlop/s
-  Kernel_dnt_medium(m=23, n=5, k=17, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 140.85 GFlop/s
-  Kernel_dnt_medium(m=23, n=5, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 149.521 GFlop/s
-  Kernel_dnt_medium(m=23, n=5, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 144.145 GFlop/s
-  Kernel_dnt_medium(m=23, n=5, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 146.774 GFlop/s
-  Kernel_dnt_medium(m=23, n=5, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 149.841 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=8) , # 148.711 GFlop/s
-  Kernel_dnt_small(m=23, n=6, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 71.0708 GFlop/s
-  Kernel_dnt_medium(m=23, n=6, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 79.8984 GFlop/s
-  Kernel_dnt_medium(m=23, n=6, k=6, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 88.3131 GFlop/s
-  Kernel_dnt_medium(m=23, n=6, k=8, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 109.787 GFlop/s
-  Kernel_dnt_medium(m=23, n=6, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 112.176 GFlop/s
-  Kernel_dnt_medium(m=23, n=6, k=13, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 137.164 GFlop/s
-  Kernel_dnt_medium(m=23, n=6, k=16, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 149.132 GFlop/s
-  Kernel_dnt_medium(m=23, n=6, k=17, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 136.359 GFlop/s
-  Kernel_dnt_medium(m=23, n=6, k=22, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=4) , # 153.003 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=6, k=23, tile_m=1, tile_n=2, w=8, v=6, threads=96, grouping=16, minblocks=8) , # 148.475 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=6, k=24, tile_m=1, tile_n=2, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 154.711 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=6, k=26, tile_m=1, tile_n=2, w=8, v=4, threads=96, grouping=16, minblocks=1) , # 151.108 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=6, k=32, tile_m=2, tile_n=3, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 164.982 GFlop/s
-  Kernel_dnt_small(m=23, n=8, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 96.1136 GFlop/s
-  Kernel_dnt_medium(m=23, n=8, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 104.824 GFlop/s
-  Kernel_dnt_medium(m=23, n=8, k=6, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 117.471 GFlop/s
-  Kernel_dnt_medium(m=23, n=8, k=8, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=12) , # 147.094 GFlop/s
-  Kernel_dnt_medium(m=23, n=8, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 148.553 GFlop/s
-  Kernel_dnt_medium(m=23, n=8, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 178.719 GFlop/s
-  Kernel_dnt_medium(m=23, n=8, k=16, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 188.882 GFlop/s
-  Kernel_dnt_medium(m=23, n=8, k=17, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 180.998 GFlop/s
-  Kernel_dnt_medium(m=23, n=8, k=22, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=4) , # 190.243 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=8, k=23, tile_m=1, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 192.208 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=8, k=24, tile_m=1, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=1) , # 198.683 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=8, k=26, tile_m=1, tile_n=2, w=10, v=8, threads=128, grouping=16, minblocks=12) , # 196.116 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=8, k=32, tile_m=1, tile_n=2, w=12, v=8, threads=96, grouping=16, minblocks=1) , # 208.86 GFlop/s
-  Kernel_dnt_medium(m=23, n=9, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 94.4818 GFlop/s
-  Kernel_dnt_medium(m=23, n=9, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 111.971 GFlop/s
-  Kernel_dnt_medium(m=23, n=9, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 115.643 GFlop/s
-  Kernel_dnt_medium(m=23, n=9, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 144.455 GFlop/s
-  Kernel_dnt_medium(m=23, n=9, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 157.597 GFlop/s
-  Kernel_dnt_medium(m=23, n=9, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 184.356 GFlop/s
-  Kernel_dnt_medium(m=23, n=9, k=16, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=8) , # 177.395 GFlop/s
-  Kernel_dnt_medium(m=23, n=9, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 180.861 GFlop/s
-  Kernel_dnt_medium(m=23, n=9, k=22, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 204.892 GFlop/s
-  Kernel_dnt_medium(m=23, n=9, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 205.862 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=9, k=24, tile_m=2, tile_n=2, w=12, v=6, threads=128, grouping=16, minblocks=12) , # 205.963 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=9, k=26, tile_m=2, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 201.066 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=9, k=32, tile_m=2, tile_n=2, w=10, v=6, threads=96, grouping=16, minblocks=12) , # 210.534 GFlop/s
-  Kernel_dnt_medium(m=23, n=13, k=4, tile_m=4, tile_n=1, threads=96, grouping=16, minblocks=12) , # 116.674 GFlop/s
-  Kernel_dnt_medium(m=23, n=13, k=5, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 136.278 GFlop/s
-  Kernel_dnt_medium(m=23, n=13, k=6, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 148.585 GFlop/s
-  Kernel_dnt_medium(m=23, n=13, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 173.078 GFlop/s
-  Kernel_dnt_medium(m=23, n=13, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 185.538 GFlop/s
-  Kernel_dnt_medium(m=23, n=13, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 226.085 GFlop/s
-  Kernel_dnt_medium(m=23, n=13, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 216.852 GFlop/s
-  Kernel_dnt_medium(m=23, n=13, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 219.365 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=13, k=22, tile_m=2, tile_n=2, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 226.737 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=13, k=23, tile_m=3, tile_n=2, w=6, v=8, threads=96, grouping=16, minblocks=12) , # 232.991 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=13, k=24, tile_m=2, tile_n=3, w=12, v=8, threads=96, grouping=16, minblocks=12) , # 241.459 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=13, k=26, tile_m=3, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 239.493 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=13, k=32, tile_m=3, tile_n=2, w=12, v=8, threads=96, grouping=16, minblocks=12) , # 258.236 GFlop/s
-  Kernel_dnt_medium(m=23, n=16, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 147.182 GFlop/s
-  Kernel_dnt_medium(m=23, n=16, k=5, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 165.435 GFlop/s
-  Kernel_dnt_medium(m=23, n=16, k=6, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 175.112 GFlop/s
-  Kernel_dnt_medium(m=23, n=16, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 216.799 GFlop/s
-  Kernel_dnt_medium(m=23, n=16, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 227.299 GFlop/s
-  Kernel_dnt_medium(m=23, n=16, k=13, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 234.514 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=16, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 260.11 GFlop/s
-  Kernel_dnt_medium(m=23, n=16, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 266.036 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=16, k=22, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 279.926 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=16, k=23, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 284.497 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=16, k=24, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 297.891 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=16, k=26, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 297.501 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=16, k=32, tile_m=3, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 317.92 GFlop/s
-  Kernel_dnt_medium(m=23, n=17, k=4, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=12) , # 133.402 GFlop/s
-  Kernel_dnt_medium(m=23, n=17, k=5, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=12) , # 155.289 GFlop/s
-  Kernel_dnt_medium(m=23, n=17, k=6, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 160.956 GFlop/s
-  Kernel_dnt_medium(m=23, n=17, k=8, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 192.178 GFlop/s
-  Kernel_dnt_medium(m=23, n=17, k=9, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 207.496 GFlop/s
-  Kernel_dnt_medium(m=23, n=17, k=13, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 228.053 GFlop/s
-  Kernel_dnt_medium(m=23, n=17, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 253.335 GFlop/s
-  Kernel_dnt_medium(m=23, n=17, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 255.563 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=17, k=22, tile_m=2, tile_n=2, w=10, v=10, threads=128, grouping=16, minblocks=12) , # 265.383 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=17, k=23, tile_m=3, tile_n=2, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 252.781 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=17, k=24, tile_m=2, tile_n=2, w=10, v=10, threads=128, grouping=16, minblocks=12) , # 274.855 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=17, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 264.804 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=17, k=32, tile_m=2, tile_n=2, w=16, v=14, threads=192, grouping=16, minblocks=8) , # 281.666 GFlop/s
-  Kernel_dnt_medium(m=23, n=22, k=4, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=8) , # 146.324 GFlop/s
-  Kernel_dnt_medium(m=23, n=22, k=5, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 165.527 GFlop/s
-  Kernel_dnt_medium(m=23, n=22, k=6, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 177.939 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=22, k=8, tile_m=3, tile_n=2, w=4, v=20, threads=96, grouping=16, minblocks=12) , # 218.859 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=22, k=9, tile_m=2, tile_n=3, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 222.676 GFlop/s
-  Kernel_dnt_medium(m=23, n=22, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 270.777 GFlop/s
-  Kernel_dnt_medium(m=23, n=22, k=16, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 286.218 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=22, k=17, tile_m=2, tile_n=3, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 282.016 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=22, k=22, tile_m=2, tile_n=3, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 307.973 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=22, k=23, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 314.138 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=22, k=24, tile_m=2, tile_n=3, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 321.113 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=22, k=26, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 323.835 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=22, k=32, tile_m=2, tile_n=3, w=4, v=14, threads=96, grouping=16, minblocks=12) , # 340.251 GFlop/s
-  Kernel_dnt_medium(m=23, n=23, k=4, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=8) , # 160.698 GFlop/s
-  Kernel_dnt_medium(m=23, n=23, k=5, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 179.196 GFlop/s
-  Kernel_dnt_medium(m=23, n=23, k=6, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 200.307 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=23, k=8, tile_m=3, tile_n=2, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 225.962 GFlop/s
-  Kernel_dnt_medium(m=23, n=23, k=9, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 239.666 GFlop/s
-  Kernel_dnt_medium(m=23, n=23, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 286.552 GFlop/s
-  Kernel_dnt_medium(m=23, n=23, k=16, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 319.963 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=23, k=17, tile_m=3, tile_n=2, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 292.211 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=23, k=22, tile_m=2, tile_n=3, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 317.15 GFlop/s
-  Kernel_dnt_largeDB2(m=23, n=23, k=23, tile_m=3, tile_n=2, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 362.853 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=23, k=24, tile_m=2, tile_n=3, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 331.615 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=23, k=26, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 333.812 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=23, k=32, tile_m=2, tile_n=3, w=4, v=14, threads=96, grouping=16, minblocks=12) , # 352.432 GFlop/s
-  Kernel_dnt_medium(m=23, n=24, k=4, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=4) , # 151.249 GFlop/s
-  Kernel_dnt_medium(m=23, n=24, k=5, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 176.59 GFlop/s
-  Kernel_dnt_medium(m=23, n=24, k=6, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 196.262 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=24, k=8, tile_m=3, tile_n=2, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 239.385 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=24, k=9, tile_m=2, tile_n=3, w=4, v=20, threads=96, grouping=16, minblocks=12) , # 239.724 GFlop/s
-  Kernel_dnt_medium(m=23, n=24, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 291.1 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=24, k=16, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 312.142 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=24, k=17, tile_m=3, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 309.544 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=24, k=22, tile_m=2, tile_n=3, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 332.21 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=24, k=23, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 337.924 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=24, k=24, tile_m=3, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 345.783 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=24, k=26, tile_m=2, tile_n=3, w=10, v=20, threads=96, grouping=16, minblocks=12) , # 348.405 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=24, k=32, tile_m=2, tile_n=3, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 366.046 GFlop/s
-  Kernel_dnt_medium(m=23, n=26, k=4, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 153.591 GFlop/s
-  Kernel_dnt_medium(m=23, n=26, k=5, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 177.384 GFlop/s
-  Kernel_dnt_medium(m=23, n=26, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 202.501 GFlop/s
-  Kernel_dnt_medium(m=23, n=26, k=8, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 223.371 GFlop/s
-  Kernel_dnt_medium(m=23, n=26, k=9, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 239.736 GFlop/s
-  Kernel_dnt_medium(m=23, n=26, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 286.414 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=26, k=16, tile_m=2, tile_n=3, w=6, v=20, threads=160, grouping=16, minblocks=8) , # 278.305 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=26, k=17, tile_m=2, tile_n=3, w=6, v=20, threads=160, grouping=16, minblocks=8) , # 285.804 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=26, k=22, tile_m=2, tile_n=3, w=6, v=20, threads=160, grouping=16, minblocks=8) , # 308.631 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=26, k=23, tile_m=3, tile_n=2, w=6, v=26, threads=160, grouping=16, minblocks=8) , # 313.656 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=26, k=24, tile_m=2, tile_n=3, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 321.263 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=26, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=128, grouping=16, minblocks=8) , # 317.704 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=26, k=32, tile_m=2, tile_n=3, w=14, v=26, threads=128, grouping=16, minblocks=8) , # 340.048 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=32, k=4, tile_m=3, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=12) , # 180.711 GFlop/s
-  Kernel_dnt_medium(m=23, n=32, k=5, tile_m=3, tile_n=2, threads=192, grouping=16, minblocks=8) , # 200.317 GFlop/s
-  Kernel_dnt_medium(m=23, n=32, k=6, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 221.286 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=32, k=8, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 289.124 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=32, k=9, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 290.689 GFlop/s
-  Kernel_dnt_medium(m=23, n=32, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 327.89 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=32, k=16, tile_m=3, tile_n=2, w=8, v=32, threads=128, grouping=16, minblocks=8) , # 332.643 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=32, k=17, tile_m=3, tile_n=3, w=4, v=16, threads=96, grouping=16, minblocks=12) , # 334.409 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=32, k=22, tile_m=3, tile_n=2, w=10, v=32, threads=128, grouping=16, minblocks=8) , # 360.996 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=32, k=23, tile_m=3, tile_n=2, w=10, v=32, threads=128, grouping=16, minblocks=8) , # 369.126 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=32, k=24, tile_m=3, tile_n=2, w=12, v=32, threads=128, grouping=16, minblocks=8) , # 384.75 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=32, k=26, tile_m=3, tile_n=2, w=10, v=32, threads=128, grouping=16, minblocks=8) , # 381.494 GFlop/s
-  Kernel_dnt_largeDB1(m=23, n=32, k=32, tile_m=3, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=8) , # 398.604 GFlop/s
-  Kernel_dnt_tiny(m=24, n=4, k=4, threads=128, grouping=16, minblocks=1) , # 58.8119 GFlop/s
-  Kernel_dnt_small(m=24, n=4, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 67.0164 GFlop/s
-  Kernel_dnt_medium(m=24, n=4, k=6, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=1) , # 72.194 GFlop/s
-  Kernel_dnt_medium(m=24, n=4, k=8, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 89.6464 GFlop/s
-  Kernel_dnt_medium(m=24, n=4, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 98.0009 GFlop/s
-  Kernel_dnt_medium(m=24, n=4, k=13, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 115.513 GFlop/s
-  Kernel_dnt_medium(m=24, n=4, k=16, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=12) , # 123.069 GFlop/s
-  Kernel_dnt_medium(m=24, n=4, k=17, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 124.559 GFlop/s
-  Kernel_dnt_medium(m=24, n=4, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 128.978 GFlop/s
-  Kernel_dnt_medium(m=24, n=4, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 125.42 GFlop/s
-  Kernel_dnt_medium(m=24, n=4, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 128.156 GFlop/s
-  Kernel_dnt_medium(m=24, n=4, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 131.844 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=4, k=32, tile_m=1, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 132.646 GFlop/s
-  Kernel_dnt_tiny(m=24, n=5, k=4, threads=128, grouping=16, minblocks=1) , # 70.448 GFlop/s
-  Kernel_dnt_small(m=24, n=5, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 80.4972 GFlop/s
-  Kernel_dnt_medium(m=24, n=5, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 81.0577 GFlop/s
-  Kernel_dnt_medium(m=24, n=5, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 101.258 GFlop/s
-  Kernel_dnt_medium(m=24, n=5, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 107.347 GFlop/s
-  Kernel_dnt_medium(m=24, n=5, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 131.211 GFlop/s
-  Kernel_dnt_medium(m=24, n=5, k=16, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 143.808 GFlop/s
-  Kernel_dnt_medium(m=24, n=5, k=17, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 142.699 GFlop/s
-  Kernel_dnt_medium(m=24, n=5, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 153.077 GFlop/s
-  Kernel_dnt_medium(m=24, n=5, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 150.001 GFlop/s
-  Kernel_dnt_medium(m=24, n=5, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 152.933 GFlop/s
-  Kernel_dnt_medium(m=24, n=5, k=26, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=1) , # 147.417 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=5, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=8) , # 153.309 GFlop/s
-  Kernel_dnt_small(m=24, n=6, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 76.9814 GFlop/s
-  Kernel_dnt_medium(m=24, n=6, k=5, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 85.2808 GFlop/s
-  Kernel_dnt_medium(m=24, n=6, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 93.5526 GFlop/s
-  Kernel_dnt_medium(m=24, n=6, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 115.359 GFlop/s
-  Kernel_dnt_medium(m=24, n=6, k=9, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=4) , # 120.439 GFlop/s
-  Kernel_dnt_medium(m=24, n=6, k=13, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 144.87 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=6, k=16, tile_m=1, tile_n=2, w=8, v=4, threads=96, grouping=16, minblocks=8) , # 155.633 GFlop/s
-  Kernel_dnt_medium(m=24, n=6, k=17, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=4) , # 148.725 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=6, k=22, tile_m=1, tile_n=2, w=8, v=6, threads=96, grouping=16, minblocks=4) , # 154.487 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=6, k=23, tile_m=2, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=1) , # 156.025 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=6, k=24, tile_m=2, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 163.99 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=6, k=26, tile_m=2, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=12) , # 159.791 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=6, k=32, tile_m=2, tile_n=1, w=16, v=6, threads=128, grouping=16, minblocks=12) , # 171.985 GFlop/s
-  Kernel_dnt_small(m=24, n=8, k=4, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 102.382 GFlop/s
-  Kernel_dnt_medium(m=24, n=8, k=5, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 110.447 GFlop/s
-  Kernel_dnt_medium(m=24, n=8, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 123.269 GFlop/s
-  Kernel_dnt_medium(m=24, n=8, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 152.162 GFlop/s
-  Kernel_dnt_medium(m=24, n=8, k=9, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=4) , # 157.455 GFlop/s
-  Kernel_dnt_medium(m=24, n=8, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 185.221 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=8, k=16, tile_m=1, tile_n=2, w=8, v=6, threads=96, grouping=16, minblocks=4) , # 196.938 GFlop/s
-  Kernel_dnt_medium(m=24, n=8, k=17, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 189.416 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=8, k=22, tile_m=1, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 199.914 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=8, k=23, tile_m=1, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=1) , # 200.887 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=8, k=24, tile_m=2, tile_n=1, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 209.127 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=8, k=26, tile_m=2, tile_n=1, w=10, v=8, threads=128, grouping=16, minblocks=12) , # 205.917 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=8, k=32, tile_m=2, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=1) , # 218.41 GFlop/s
-  Kernel_dnt_medium(m=24, n=9, k=4, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 98.6797 GFlop/s
-  Kernel_dnt_medium(m=24, n=9, k=5, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 118.095 GFlop/s
-  Kernel_dnt_medium(m=24, n=9, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 123.841 GFlop/s
-  Kernel_dnt_medium(m=24, n=9, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 150.841 GFlop/s
-  Kernel_dnt_medium(m=24, n=9, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 164.779 GFlop/s
-  Kernel_dnt_medium(m=24, n=9, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 192.82 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=9, k=16, tile_m=2, tile_n=2, w=8, v=6, threads=128, grouping=16, minblocks=12) , # 192.434 GFlop/s
-  Kernel_dnt_medium(m=24, n=9, k=17, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=1) , # 191.25 GFlop/s
-  Kernel_dnt_medium(m=24, n=9, k=22, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 209.088 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=9, k=23, tile_m=2, tile_n=1, w=10, v=6, threads=128, grouping=16, minblocks=12) , # 204.604 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=9, k=24, tile_m=2, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 216.095 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=9, k=26, tile_m=2, tile_n=2, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 211.244 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=9, k=32, tile_m=2, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 227.824 GFlop/s
-  Kernel_dnt_medium(m=24, n=13, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 125.487 GFlop/s
-  Kernel_dnt_medium(m=24, n=13, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 146.004 GFlop/s
-  Kernel_dnt_medium(m=24, n=13, k=6, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=12) , # 160.137 GFlop/s
-  Kernel_dnt_medium(m=24, n=13, k=8, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 183.429 GFlop/s
-  Kernel_dnt_medium(m=24, n=13, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 196.169 GFlop/s
-  Kernel_dnt_medium(m=24, n=13, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=1) , # 210.09 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=13, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 243.961 GFlop/s
-  Kernel_dnt_medium(m=24, n=13, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 233.808 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=13, k=22, tile_m=2, tile_n=3, w=6, v=12, threads=96, grouping=16, minblocks=12) , # 244.295 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=13, k=23, tile_m=2, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 245.584 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=13, k=24, tile_m=3, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 253.032 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=13, k=26, tile_m=3, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 252.69 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=13, k=32, tile_m=2, tile_n=3, w=12, v=12, threads=96, grouping=16, minblocks=12) , # 271.274 GFlop/s
-  Kernel_dnt_medium(m=24, n=16, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 151.035 GFlop/s
-  Kernel_dnt_medium(m=24, n=16, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 177.041 GFlop/s
-  Kernel_dnt_medium(m=24, n=16, k=6, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=12) , # 183.2 GFlop/s
-  Kernel_dnt_medium(m=24, n=16, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 220.011 GFlop/s
-  Kernel_dnt_medium(m=24, n=16, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 237.976 GFlop/s
-  Kernel_dnt_medium(m=24, n=16, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=8) , # 255.121 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=16, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 283.257 GFlop/s
-  Kernel_dnt_medium(m=24, n=16, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 282.576 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=16, k=22, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 305.434 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=16, k=23, tile_m=2, tile_n=2, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 305.948 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=16, k=24, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 312.346 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=16, k=26, tile_m=2, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 311.766 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=16, k=32, tile_m=2, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=12) , # 330.08 GFlop/s
-  Kernel_dnt_medium(m=24, n=17, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 148.753 GFlop/s
-  Kernel_dnt_medium(m=24, n=17, k=5, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 172.254 GFlop/s
-  Kernel_dnt_medium(m=24, n=17, k=6, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 170.444 GFlop/s
-  Kernel_dnt_medium(m=24, n=17, k=8, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 202.085 GFlop/s
-  Kernel_dnt_medium(m=24, n=17, k=9, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 220.336 GFlop/s
-  Kernel_dnt_medium(m=24, n=17, k=13, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 241.006 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=17, k=16, tile_m=2, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=12) , # 267.336 GFlop/s
-  Kernel_dnt_medium(m=24, n=17, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 269.754 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=17, k=22, tile_m=2, tile_n=4, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 278.395 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=17, k=23, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 270.301 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=17, k=24, tile_m=2, tile_n=2, w=6, v=16, threads=128, grouping=16, minblocks=12) , # 282.786 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=17, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 278.266 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=17, k=32, tile_m=2, tile_n=2, w=16, v=16, threads=128, grouping=16, minblocks=4) , # 299.296 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=22, k=4, tile_m=3, tile_n=2, w=2, v=12, threads=96, grouping=16, minblocks=12) , # 146.407 GFlop/s
-  Kernel_dnt_medium(m=24, n=22, k=5, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 171.925 GFlop/s
-  Kernel_dnt_medium(m=24, n=22, k=6, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 190.105 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=22, k=8, tile_m=3, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 231.681 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=22, k=9, tile_m=3, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 233.468 GFlop/s
-  Kernel_dnt_medium(m=24, n=22, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 284.038 GFlop/s
-  Kernel_dnt_medium(m=24, n=22, k=16, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 308.103 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=22, k=17, tile_m=2, tile_n=3, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 301.954 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=22, k=22, tile_m=2, tile_n=3, w=8, v=18, threads=96, grouping=16, minblocks=12) , # 325.781 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=22, k=23, tile_m=2, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 331.261 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=22, k=24, tile_m=2, tile_n=3, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 338.308 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=22, k=26, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 343.473 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=22, k=32, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 356.001 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=23, k=4, tile_m=3, tile_n=2, w=2, v=12, threads=96, grouping=16, minblocks=12) , # 151.001 GFlop/s
-  Kernel_dnt_medium(m=24, n=23, k=5, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 176.59 GFlop/s
-  Kernel_dnt_medium(m=24, n=23, k=6, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 196.204 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=23, k=8, tile_m=3, tile_n=2, w=4, v=20, threads=96, grouping=16, minblocks=12) , # 239.901 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=23, k=9, tile_m=2, tile_n=3, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 239.093 GFlop/s
-  Kernel_dnt_medium(m=24, n=23, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 292.274 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=23, k=16, tile_m=2, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 315.493 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=23, k=17, tile_m=2, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 311.324 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=23, k=22, tile_m=2, tile_n=3, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 335.112 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=23, k=23, tile_m=3, tile_n=2, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 341.553 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=23, k=24, tile_m=3, tile_n=2, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 347.719 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=23, k=26, tile_m=2, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 351.889 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=23, k=32, tile_m=3, tile_n=2, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 367.949 GFlop/s
-  Kernel_dnt_medium(m=24, n=24, k=4, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=8) , # 171.861 GFlop/s
-  Kernel_dnt_medium(m=24, n=24, k=5, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 199.591 GFlop/s
-  Kernel_dnt_medium(m=24, n=24, k=6, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 223.508 GFlop/s
-  Kernel_dnt_medium(m=24, n=24, k=8, tile_m=3, tile_n=3, threads=128, grouping=16, minblocks=8) , # 252.144 GFlop/s
-  Kernel_dnt_medium(m=24, n=24, k=9, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 270.155 GFlop/s
-  Kernel_dnt_medium(m=24, n=24, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 316.953 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=24, k=16, tile_m=3, tile_n=3, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 346.718 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=24, k=17, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 331.579 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=24, k=22, tile_m=2, tile_n=3, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 362.792 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=24, k=23, tile_m=2, tile_n=3, w=8, v=16, threads=96, grouping=16, minblocks=12) , # 369.879 GFlop/s
-  Kernel_dnt_largeDB2(m=24, n=24, k=24, tile_m=2, tile_n=3, w=12, v=24, threads=96, grouping=16, minblocks=12) , # 411.88 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=24, k=26, tile_m=3, tile_n=2, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 372.117 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=24, k=32, tile_m=3, tile_n=3, w=8, v=10, threads=96, grouping=16, minblocks=12) , # 401.738 GFlop/s
-  Kernel_dnt_largeDB2(m=24, n=24, k=45, tile_m=3, tile_n=3, w=12, v=24, threads=96, grouping=16, minblocks=8) , # 443.769 GFlop/s
-  Kernel_dnt_medium(m=24, n=26, k=4, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 165.895 GFlop/s
-  Kernel_dnt_medium(m=24, n=26, k=5, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 192.911 GFlop/s
-  Kernel_dnt_medium(m=24, n=26, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 216.881 GFlop/s
-  Kernel_dnt_medium(m=24, n=26, k=8, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 240.006 GFlop/s
-  Kernel_dnt_medium(m=24, n=26, k=9, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 255.794 GFlop/s
-  Kernel_dnt_medium(m=24, n=26, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 304.306 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=26, k=16, tile_m=3, tile_n=2, w=8, v=26, threads=128, grouping=16, minblocks=8) , # 296.427 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=26, k=17, tile_m=2, tile_n=3, w=6, v=20, threads=160, grouping=16, minblocks=8) , # 300.411 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=26, k=22, tile_m=2, tile_n=3, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 335.764 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=26, k=23, tile_m=2, tile_n=2, w=6, v=26, threads=160, grouping=16, minblocks=8) , # 332.247 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=26, k=24, tile_m=2, tile_n=3, w=12, v=20, threads=160, grouping=16, minblocks=8) , # 341.77 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=26, k=26, tile_m=2, tile_n=3, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 345.182 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=26, k=32, tile_m=2, tile_n=3, w=14, v=16, threads=128, grouping=16, minblocks=8) , # 358.776 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=32, k=4, tile_m=3, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=12) , # 188.795 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=32, k=5, tile_m=3, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=12) , # 202.909 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=32, k=6, tile_m=4, tile_n=2, w=2, v=20, threads=96, grouping=16, minblocks=12) , # 216.291 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=32, k=8, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 301.015 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=32, k=9, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 301.38 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=32, k=13, tile_m=3, tile_n=2, w=6, v=20, threads=160, grouping=16, minblocks=8) , # 306.849 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=32, k=16, tile_m=3, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 358.411 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=32, k=17, tile_m=3, tile_n=2, w=8, v=22, threads=128, grouping=16, minblocks=8) , # 348.821 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=32, k=22, tile_m=3, tile_n=2, w=8, v=28, threads=128, grouping=16, minblocks=8) , # 382.529 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=32, k=23, tile_m=3, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 388.857 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=32, k=24, tile_m=3, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=8) , # 396.116 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=32, k=26, tile_m=3, tile_n=3, w=6, v=16, threads=96, grouping=16, minblocks=12) , # 397.018 GFlop/s
-  Kernel_dnt_largeDB1(m=24, n=32, k=32, tile_m=3, tile_n=2, w=8, v=28, threads=128, grouping=16, minblocks=8) , # 417.571 GFlop/s
-  Kernel_dnt_largeDB2(m=24, n=32, k=45, tile_m=2, tile_n=4, w=12, v=30, threads=96, grouping=16, minblocks=8) , # 482.675 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=4, k=4, tile_m=1, tile_n=1, w=2, v=4, threads=128, grouping=16, minblocks=4) , # 61.5545 GFlop/s
-  Kernel_dnt_small(m=25, n=4, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 69.6079 GFlop/s
-  Kernel_dnt_medium(m=25, n=4, k=7, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 75.6721 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=4, k=9, tile_m=1, tile_n=1, w=4, v=4, threads=128, grouping=16, minblocks=4) , # 91.7531 GFlop/s
-  Kernel_dnt_medium(m=25, n=4, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 113.536 GFlop/s
-  Kernel_dnt_medium(m=25, n=4, k=25, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 127.9 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=4, k=26, tile_m=1, tile_n=1, w=10, v=4, threads=128, grouping=16, minblocks=12) , # 127.537 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=4, k=28, tile_m=2, tile_n=1, w=14, v=2, threads=128, grouping=16, minblocks=12) , # 134.943 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=4, k=32, tile_m=1, tile_n=2, w=16, v=4, threads=128, grouping=16, minblocks=12) , # 139.857 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=4, k=45, tile_m=2, tile_n=1, w=16, v=4, threads=96, grouping=16, minblocks=12) , # 139.994 GFlop/s
-  Kernel_dnt_small(m=25, n=5, k=4, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 72.4794 GFlop/s
-  Kernel_dnt_small(m=25, n=5, k=5, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 84.872 GFlop/s
-  Kernel_dnt_medium(m=25, n=5, k=7, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 92.8771 GFlop/s
-  Kernel_dnt_medium(m=25, n=5, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 112.844 GFlop/s
-  Kernel_dnt_medium(m=25, n=5, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 137.821 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=5, k=25, tile_m=1, tile_n=1, w=10, v=4, threads=128, grouping=16, minblocks=4) , # 152.264 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=5, k=26, tile_m=1, tile_n=1, w=10, v=2, threads=128, grouping=16, minblocks=12) , # 152.747 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=5, k=28, tile_m=2, tile_n=3, w=14, v=4, threads=96, grouping=16, minblocks=12) , # 159.29 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=5, k=32, tile_m=1, tile_n=1, w=16, v=2, threads=128, grouping=16, minblocks=8) , # 164.744 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=5, k=45, tile_m=1, tile_n=1, w=16, v=2, threads=128, grouping=16, minblocks=12) , # 167.914 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=7, k=4, tile_m=2, tile_n=1, w=2, v=4, threads=96, grouping=16, minblocks=4) , # 90.9178 GFlop/s
-  Kernel_dnt_medium(m=25, n=7, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 97.037 GFlop/s
-  Kernel_dnt_medium(m=25, n=7, k=7, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 121.779 GFlop/s
-  Kernel_dnt_medium(m=25, n=7, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 138.286 GFlop/s
-  Kernel_dnt_medium(m=25, n=7, k=13, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 166.702 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=7, k=25, tile_m=2, tile_n=1, w=10, v=4, threads=128, grouping=16, minblocks=12) , # 194.814 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=7, k=26, tile_m=2, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=4) , # 193.702 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=7, k=28, tile_m=3, tile_n=1, w=14, v=4, threads=128, grouping=16, minblocks=12) , # 204.432 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=7, k=32, tile_m=2, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=12) , # 210.429 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=7, k=45, tile_m=2, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=8) , # 212.74 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=9, k=4, tile_m=3, tile_n=1, w=2, v=6, threads=96, grouping=16, minblocks=1) , # 105.945 GFlop/s
-  Kernel_dnt_medium(m=25, n=9, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 117.846 GFlop/s
-  Kernel_dnt_medium(m=25, n=9, k=7, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 138.732 GFlop/s
-  Kernel_dnt_medium(m=25, n=9, k=9, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 162.802 GFlop/s
-  Kernel_dnt_medium(m=25, n=9, k=13, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 191.872 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=9, k=25, tile_m=2, tile_n=1, w=10, v=6, threads=128, grouping=16, minblocks=12) , # 220.007 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=9, k=26, tile_m=2, tile_n=1, w=12, v=4, threads=128, grouping=16, minblocks=12) , # 217.621 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=9, k=28, tile_m=1, tile_n=2, w=14, v=4, threads=128, grouping=16, minblocks=12) , # 231.076 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=9, k=32, tile_m=2, tile_n=3, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 231.658 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=9, k=45, tile_m=3, tile_n=3, w=16, v=6, threads=96, grouping=16, minblocks=8) , # 234.791 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=13, k=4, tile_m=2, tile_n=2, w=2, v=10, threads=96, grouping=16, minblocks=4) , # 136.976 GFlop/s
-  Kernel_dnt_medium(m=25, n=13, k=5, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 145.977 GFlop/s
-  Kernel_dnt_medium(m=25, n=13, k=7, tile_m=1, tile_n=3, threads=128, grouping=16, minblocks=12) , # 170.376 GFlop/s
-  Kernel_dnt_medium(m=25, n=13, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 195.465 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=13, k=13, tile_m=2, tile_n=2, w=6, v=10, threads=96, grouping=16, minblocks=12) , # 223.713 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=13, k=25, tile_m=3, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 281.301 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=13, k=26, tile_m=3, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 285.113 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=13, k=28, tile_m=3, tile_n=2, w=10, v=12, threads=96, grouping=16, minblocks=12) , # 292.875 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=13, k=32, tile_m=2, tile_n=2, w=16, v=12, threads=96, grouping=16, minblocks=12) , # 293.811 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=13, k=45, tile_m=3, tile_n=2, w=16, v=8, threads=128, grouping=16, minblocks=8) , # 308.806 GFlop/s
-  Kernel_dnt_medium(m=25, n=25, k=4, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 167.314 GFlop/s
-  Kernel_dnt_medium(m=25, n=25, k=5, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 197.231 GFlop/s
-  Kernel_dnt_medium(m=25, n=25, k=7, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 226.575 GFlop/s
-  Kernel_dnt_medium(m=25, n=25, k=9, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 266.2 GFlop/s
-  Kernel_dnt_largeDB1(m=25, n=25, k=13, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 287.179 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=25, k=25, tile_m=3, tile_n=2, w=10, v=20, threads=128, grouping=16, minblocks=8) , # 355.515 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=25, k=26, tile_m=2, tile_n=4, w=10, v=24, threads=128, grouping=16, minblocks=8) , # 353.566 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=25, k=28, tile_m=3, tile_n=2, w=14, v=10, threads=128, grouping=16, minblocks=8) , # 367.79 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=25, k=32, tile_m=2, tile_n=3, w=14, v=12, threads=128, grouping=16, minblocks=8) , # 369.423 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=25, k=45, tile_m=2, tile_n=4, w=10, v=24, threads=96, grouping=16, minblocks=8) , # 388.688 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=26, k=4, tile_m=4, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 167.072 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=26, k=5, tile_m=4, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 182.501 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=26, k=7, tile_m=3, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=12) , # 222.916 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=26, k=9, tile_m=3, tile_n=2, w=4, v=26, threads=128, grouping=16, minblocks=8) , # 246.76 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=26, k=13, tile_m=3, tile_n=3, w=6, v=12, threads=96, grouping=16, minblocks=12) , # 295.802 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=26, k=25, tile_m=2, tile_n=3, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 359.971 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=26, k=26, tile_m=2, tile_n=3, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 366.555 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=26, k=28, tile_m=3, tile_n=2, w=14, v=10, threads=128, grouping=16, minblocks=8) , # 378.99 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=26, k=32, tile_m=2, tile_n=3, w=14, v=26, threads=128, grouping=16, minblocks=8) , # 387.081 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=26, k=45, tile_m=3, tile_n=2, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 407.931 GFlop/s
-  Kernel_dnt_largeDB1(m=25, n=28, k=4, tile_m=3, tile_n=2, w=2, v=14, threads=128, grouping=16, minblocks=12) , # 166.646 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=28, k=5, tile_m=3, tile_n=2, w=2, v=14, threads=128, grouping=16, minblocks=12) , # 191.501 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=28, k=7, tile_m=3, tile_n=2, w=2, v=18, threads=128, grouping=16, minblocks=12) , # 235.127 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=28, k=9, tile_m=3, tile_n=2, w=4, v=28, threads=128, grouping=16, minblocks=8) , # 263.105 GFlop/s
-  Kernel_dnt_medium(m=25, n=28, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 315.323 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=28, k=25, tile_m=2, tile_n=4, w=10, v=28, threads=96, grouping=16, minblocks=4) , # 381.239 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=28, k=26, tile_m=2, tile_n=4, w=10, v=28, threads=96, grouping=16, minblocks=1) , # 385.88 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=28, k=28, tile_m=3, tile_n=2, w=14, v=28, threads=128, grouping=16, minblocks=8) , # 395.875 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=28, k=32, tile_m=3, tile_n=2, w=14, v=10, threads=128, grouping=16, minblocks=8) , # 398.113 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=28, k=45, tile_m=3, tile_n=2, w=12, v=28, threads=128, grouping=16, minblocks=8) , # 434.445 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=32, k=4, tile_m=5, tile_n=2, w=2, v=14, threads=96, grouping=16, minblocks=12) , # 171.986 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=32, k=5, tile_m=5, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 206.566 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=32, k=7, tile_m=5, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 241.952 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=32, k=9, tile_m=2, tile_n=4, w=4, v=28, threads=128, grouping=16, minblocks=8) , # 267.123 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=32, k=13, tile_m=2, tile_n=4, w=6, v=28, threads=128, grouping=16, minblocks=8) , # 303.399 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=32, k=25, tile_m=2, tile_n=4, w=10, v=28, threads=128, grouping=16, minblocks=8) , # 376.527 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=32, k=26, tile_m=4, tile_n=2, w=12, v=22, threads=128, grouping=16, minblocks=8) , # 388.829 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=32, k=28, tile_m=4, tile_n=2, w=12, v=24, threads=128, grouping=16, minblocks=8) , # 396.268 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=32, k=32, tile_m=2, tile_n=4, w=16, v=30, threads=128, grouping=16, minblocks=4) , # 402.903 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=32, k=45, tile_m=5, tile_n=2, w=12, v=16, threads=96, grouping=16, minblocks=8) , # 426.505 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=45, k=4, tile_m=5, tile_n=2, w=2, v=30, threads=128, grouping=16, minblocks=1) , # 179.84 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=45, k=5, tile_m=5, tile_n=2, w=2, v=24, threads=128, grouping=16, minblocks=8) , # 207.379 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=45, k=7, tile_m=5, tile_n=2, w=2, v=30, threads=128, grouping=16, minblocks=1) , # 230.203 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=45, k=9, tile_m=5, tile_n=2, w=4, v=24, threads=128, grouping=16, minblocks=8) , # 275.085 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=45, k=13, tile_m=2, tile_n=5, w=6, v=30, threads=128, grouping=16, minblocks=1) , # 310.536 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=45, k=25, tile_m=3, tile_n=4, w=10, v=40, threads=128, grouping=16, minblocks=4) , # 383.964 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=45, k=26, tile_m=2, tile_n=5, w=10, v=20, threads=256, grouping=16, minblocks=4) , # 382.733 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=45, k=28, tile_m=3, tile_n=4, w=14, v=44, threads=128, grouping=16, minblocks=1) , # 405.725 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=45, k=32, tile_m=3, tile_n=4, w=16, v=44, threads=128, grouping=16, minblocks=4) , # 416.094 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=45, k=45, tile_m=2, tile_n=5, w=20, v=30, threads=192, grouping=16, minblocks=4) , # 435.914 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=4, k=4, tile_m=1, tile_n=1, w=2, v=4, threads=128, grouping=16, minblocks=4) , # 64.5163 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=5, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 61.4003 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 71.0928 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=7, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 81.2663 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=8, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 87.9086 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=4, k=9, tile_m=1, tile_n=1, w=4, v=4, threads=128, grouping=16, minblocks=4) , # 95.039 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 117.469 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=16, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 125.593 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=17, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 123.868 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=22, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 126.451 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=23, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 128.35 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=24, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 131.294 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=4, k=25, tile_m=1, tile_n=2, w=12, v=4, threads=96, grouping=16, minblocks=1) , # 128.096 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=4, k=26, tile_m=1, tile_n=2, w=12, v=4, threads=96, grouping=16, minblocks=4) , # 130.166 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=4, k=28, tile_m=2, tile_n=1, w=14, v=4, threads=96, grouping=16, minblocks=4) , # 136.84 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=4, k=32, tile_m=1, tile_n=2, w=16, v=4, threads=96, grouping=16, minblocks=8) , # 140.687 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=4, k=45, tile_m=1, tile_n=2, w=16, v=4, threads=96, grouping=16, minblocks=8) , # 141.608 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=5, k=4, tile_m=1, tile_n=2, w=2, v=4, threads=96, grouping=16, minblocks=1) , # 69.7487 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=5, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 74.0129 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 83.8041 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=7, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 93.9083 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 98.7557 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 106.652 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=13, tile_m=1, tile_n=6, threads=96, grouping=16, minblocks=12) , # 130.365 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=16, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 135.751 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=17, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 135.026 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=22, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=4) , # 140.428 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=23, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=8) , # 142.897 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=5, k=24, tile_m=1, tile_n=1, w=12, v=4, threads=160, grouping=16, minblocks=12) , # 141.37 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=5, k=25, tile_m=3, tile_n=2, w=12, v=4, threads=96, grouping=16, minblocks=12) , # 148.961 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=5, k=26, tile_m=3, tile_n=2, w=12, v=4, threads=96, grouping=16, minblocks=12) , # 150.882 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=5, k=28, tile_m=3, tile_n=2, w=14, v=4, threads=96, grouping=16, minblocks=12) , # 160.591 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=5, k=32, tile_m=2, tile_n=3, w=16, v=2, threads=96, grouping=16, minblocks=12) , # 163.472 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=5, k=45, tile_m=2, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=12) , # 163.834 GFlop/s
-  Kernel_dnt_medium(m=26, n=6, k=4, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 72.6709 GFlop/s
-  Kernel_dnt_medium(m=26, n=6, k=5, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 87.4288 GFlop/s
-  Kernel_dnt_medium(m=26, n=6, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 99.3344 GFlop/s
-  Kernel_dnt_medium(m=26, n=6, k=8, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 118.582 GFlop/s
-  Kernel_dnt_medium(m=26, n=6, k=9, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 126.842 GFlop/s
-  Kernel_dnt_medium(m=26, n=6, k=13, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 153.58 GFlop/s
-  Kernel_dnt_medium(m=26, n=6, k=16, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=4) , # 159.739 GFlop/s
-  Kernel_dnt_medium(m=26, n=6, k=17, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=4) , # 157.425 GFlop/s
-  Kernel_dnt_medium(m=26, n=6, k=22, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 163.987 GFlop/s
-  Kernel_dnt_medium(m=26, n=6, k=23, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=8) , # 166.214 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=6, k=24, tile_m=1, tile_n=1, w=12, v=6, threads=160, grouping=16, minblocks=12) , # 167.712 GFlop/s
-  Kernel_dnt_medium(m=26, n=6, k=26, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=1) , # 165.846 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=6, k=32, tile_m=1, tile_n=1, w=12, v=6, threads=160, grouping=16, minblocks=12) , # 174.271 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=7, k=4, tile_m=2, tile_n=1, w=2, v=4, threads=96, grouping=16, minblocks=1) , # 93.3904 GFlop/s
-  Kernel_dnt_medium(m=26, n=7, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 98.4269 GFlop/s
-  Kernel_dnt_medium(m=26, n=7, k=7, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 129.184 GFlop/s
-  Kernel_dnt_medium(m=26, n=7, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 146.313 GFlop/s
-  Kernel_dnt_medium(m=26, n=7, k=13, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 174.525 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=7, k=25, tile_m=2, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=1) , # 196.272 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=7, k=26, tile_m=2, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=4) , # 199.207 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=7, k=28, tile_m=3, tile_n=1, w=14, v=4, threads=128, grouping=16, minblocks=12) , # 208.391 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=7, k=32, tile_m=2, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=1) , # 213.658 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=7, k=45, tile_m=2, tile_n=1, w=12, v=6, threads=96, grouping=16, minblocks=8) , # 218.996 GFlop/s
-  Kernel_dnt_medium(m=26, n=8, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 94.6073 GFlop/s
-  Kernel_dnt_medium(m=26, n=8, k=5, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 104.199 GFlop/s
-  Kernel_dnt_medium(m=26, n=8, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 120.103 GFlop/s
-  Kernel_dnt_medium(m=26, n=8, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 147.207 GFlop/s
-  Kernel_dnt_medium(m=26, n=8, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 158.986 GFlop/s
-  Kernel_dnt_medium(m=26, n=8, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 184.007 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=8, k=16, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 185.8 GFlop/s
-  Kernel_dnt_medium(m=26, n=8, k=17, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=8) , # 184.285 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=8, k=22, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 191.661 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=8, k=23, tile_m=2, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 194.119 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=8, k=24, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 203.357 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=8, k=26, tile_m=2, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 201.388 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=8, k=32, tile_m=2, tile_n=2, w=14, v=6, threads=128, grouping=16, minblocks=12) , # 214.072 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=9, k=4, tile_m=3, tile_n=1, w=2, v=6, threads=96, grouping=16, minblocks=4) , # 109.036 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=5, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 114.163 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 131.35 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=7, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 144.626 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=8, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 157.793 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=9, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 169.191 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=13, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=4) , # 189.564 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=16, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 197.735 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=17, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=8) , # 202.974 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=22, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 205.221 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=23, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 209.048 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=9, k=24, tile_m=2, tile_n=1, w=12, v=4, threads=128, grouping=16, minblocks=12) , # 218.442 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=9, k=25, tile_m=2, tile_n=1, w=12, v=4, threads=128, grouping=16, minblocks=12) , # 224.446 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=9, k=26, tile_m=2, tile_n=1, w=12, v=4, threads=128, grouping=16, minblocks=12) , # 226.888 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=9, k=28, tile_m=2, tile_n=1, w=14, v=8, threads=128, grouping=16, minblocks=1) , # 238.998 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=9, k=32, tile_m=2, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=8) , # 238.306 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=9, k=45, tile_m=2, tile_n=1, w=18, v=8, threads=128, grouping=16, minblocks=4) , # 247.183 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=13, k=4, tile_m=2, tile_n=2, w=2, v=10, threads=96, grouping=16, minblocks=4) , # 141.329 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=13, k=5, tile_m=2, tile_n=2, w=2, v=10, threads=96, grouping=16, minblocks=1) , # 147.765 GFlop/s
-  Kernel_dnt_medium(m=26, n=13, k=6, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 164.444 GFlop/s
-  Kernel_dnt_medium(m=26, n=13, k=7, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 180.199 GFlop/s
-  Kernel_dnt_medium(m=26, n=13, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 189.61 GFlop/s
-  Kernel_dnt_medium(m=26, n=13, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 206.587 GFlop/s
-  Kernel_dnt_medium(m=26, n=13, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 243.394 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=13, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 244.889 GFlop/s
-  Kernel_dnt_medium(m=26, n=13, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 248.672 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=13, k=22, tile_m=2, tile_n=2, w=6, v=10, threads=96, grouping=16, minblocks=12) , # 250.837 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=13, k=23, tile_m=3, tile_n=2, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 251.925 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=13, k=24, tile_m=2, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 262.097 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=13, k=25, tile_m=3, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 287.926 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=13, k=26, tile_m=2, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 292.748 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=13, k=28, tile_m=2, tile_n=2, w=14, v=10, threads=96, grouping=16, minblocks=12) , # 305.399 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=13, k=32, tile_m=2, tile_n=2, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 307.713 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=13, k=45, tile_m=2, tile_n=2, w=10, v=6, threads=96, grouping=16, minblocks=12) , # 321.334 GFlop/s
-  Kernel_dnt_medium(m=26, n=16, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 152.877 GFlop/s
-  Kernel_dnt_medium(m=26, n=16, k=5, tile_m=5, tile_n=1, threads=96, grouping=16, minblocks=12) , # 155.57 GFlop/s
-  Kernel_dnt_medium(m=26, n=16, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 170.247 GFlop/s
-  Kernel_dnt_small(m=26, n=16, k=8, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 201.911 GFlop/s
-  Kernel_dnt_medium(m=26, n=16, k=9, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 223.126 GFlop/s
-  Kernel_dnt_medium(m=26, n=16, k=13, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 248.219 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=16, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 272.563 GFlop/s
-  Kernel_dnt_medium(m=26, n=16, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 278.933 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=16, k=22, tile_m=2, tile_n=4, w=10, v=10, threads=96, grouping=16, minblocks=12) , # 283.175 GFlop/s
-  Kernel_dnt_medium(m=26, n=16, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=4) , # 283.731 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=16, k=24, tile_m=2, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=1) , # 283.395 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=16, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=12) , # 289.704 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=16, k=32, tile_m=2, tile_n=2, w=16, v=16, threads=128, grouping=16, minblocks=1) , # 312.21 GFlop/s
-  Kernel_dnt_medium(m=26, n=17, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 155.536 GFlop/s
-  Kernel_dnt_medium(m=26, n=17, k=5, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 152.251 GFlop/s
-  Kernel_dnt_medium(m=26, n=17, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 174.981 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=17, k=8, tile_m=2, tile_n=2, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 203.653 GFlop/s
-  Kernel_dnt_medium(m=26, n=17, k=9, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 229.052 GFlop/s
-  Kernel_dnt_medium(m=26, n=17, k=13, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 254.23 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=17, k=16, tile_m=2, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=12) , # 281.091 GFlop/s
-  Kernel_dnt_medium(m=26, n=17, k=17, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 285.713 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=17, k=22, tile_m=3, tile_n=2, w=8, v=14, threads=96, grouping=16, minblocks=12) , # 275.4 GFlop/s
-  Kernel_dnt_medium(m=26, n=17, k=23, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=4) , # 284.987 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=17, k=24, tile_m=2, tile_n=2, w=6, v=14, threads=128, grouping=16, minblocks=12) , # 298.462 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=17, k=26, tile_m=2, tile_n=2, w=6, v=8, threads=128, grouping=16, minblocks=12) , # 287.445 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=17, k=32, tile_m=2, tile_n=2, w=16, v=12, threads=160, grouping=16, minblocks=8) , # 314.433 GFlop/s
-  Kernel_dnt_medium(m=26, n=22, k=4, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 149.972 GFlop/s
-  Kernel_dnt_medium(m=26, n=22, k=5, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 176.08 GFlop/s
-  Kernel_dnt_medium(m=26, n=22, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 196.809 GFlop/s
-  Kernel_dnt_medium(m=26, n=22, k=8, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 217.745 GFlop/s
-  Kernel_dnt_medium(m=26, n=22, k=9, tile_m=4, tile_n=2, threads=128, grouping=16, minblocks=8) , # 220.047 GFlop/s
-  Kernel_dnt_medium(m=26, n=22, k=13, tile_m=2, tile_n=4, threads=96, grouping=16, minblocks=8) , # 262.523 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=22, k=16, tile_m=3, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=12) , # 289.65 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=22, k=17, tile_m=2, tile_n=3, w=6, v=12, threads=160, grouping=16, minblocks=8) , # 275.462 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=22, k=22, tile_m=2, tile_n=3, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 306.524 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=22, k=23, tile_m=2, tile_n=2, w=6, v=22, threads=160, grouping=16, minblocks=8) , # 306.629 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=22, k=24, tile_m=2, tile_n=3, w=12, v=22, threads=128, grouping=16, minblocks=8) , # 312.951 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=22, k=26, tile_m=2, tile_n=3, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 316.347 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=22, k=32, tile_m=3, tile_n=2, w=14, v=22, threads=128, grouping=16, minblocks=8) , # 331.192 GFlop/s
-  Kernel_dnt_medium(m=26, n=23, k=4, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 154.026 GFlop/s
-  Kernel_dnt_medium(m=26, n=23, k=5, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 179.309 GFlop/s
-  Kernel_dnt_medium(m=26, n=23, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 202.375 GFlop/s
-  Kernel_dnt_medium(m=26, n=23, k=8, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 222.858 GFlop/s
-  Kernel_dnt_medium(m=26, n=23, k=9, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 221.968 GFlop/s
-  Kernel_dnt_medium(m=26, n=23, k=13, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 273.966 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=23, k=16, tile_m=3, tile_n=2, w=6, v=12, threads=160, grouping=16, minblocks=8) , # 276.664 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=23, k=17, tile_m=2, tile_n=3, w=6, v=12, threads=160, grouping=16, minblocks=8) , # 285.445 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=23, k=22, tile_m=2, tile_n=3, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 317.821 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=23, k=23, tile_m=2, tile_n=2, w=6, v=12, threads=160, grouping=16, minblocks=8) , # 307.93 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=23, k=24, tile_m=2, tile_n=3, w=12, v=12, threads=160, grouping=16, minblocks=8) , # 320.822 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=23, k=26, tile_m=2, tile_n=3, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 327.373 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=23, k=32, tile_m=2, tile_n=3, w=14, v=14, threads=128, grouping=16, minblocks=8) , # 341.076 GFlop/s
-  Kernel_dnt_medium(m=26, n=24, k=4, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 166.334 GFlop/s
-  Kernel_dnt_medium(m=26, n=24, k=5, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 194.858 GFlop/s
-  Kernel_dnt_medium(m=26, n=24, k=6, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 217.359 GFlop/s
-  Kernel_dnt_medium(m=26, n=24, k=8, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 240.36 GFlop/s
-  Kernel_dnt_medium(m=26, n=24, k=9, tile_m=4, tile_n=2, threads=128, grouping=16, minblocks=8) , # 240.63 GFlop/s
-  Kernel_dnt_medium(m=26, n=24, k=13, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 284.219 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=24, k=16, tile_m=3, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 317.599 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=24, k=17, tile_m=3, tile_n=2, w=6, v=24, threads=160, grouping=16, minblocks=8) , # 300.196 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=24, k=22, tile_m=2, tile_n=3, w=4, v=16, threads=128, grouping=16, minblocks=12) , # 333.184 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=24, k=23, tile_m=2, tile_n=2, w=6, v=24, threads=160, grouping=16, minblocks=8) , # 332.175 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=24, k=24, tile_m=2, tile_n=3, w=12, v=24, threads=128, grouping=16, minblocks=8) , # 342.541 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=24, k=26, tile_m=2, tile_n=3, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 342.458 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=24, k=32, tile_m=3, tile_n=2, w=14, v=24, threads=128, grouping=16, minblocks=8) , # 360.604 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=25, k=4, tile_m=4, tile_n=2, w=2, v=18, threads=96, grouping=16, minblocks=12) , # 167.244 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=25, k=5, tile_m=3, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=12) , # 188.512 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=25, k=7, tile_m=3, tile_n=2, w=2, v=14, threads=128, grouping=16, minblocks=12) , # 217.789 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=25, k=9, tile_m=2, tile_n=3, w=4, v=24, threads=128, grouping=16, minblocks=8) , # 242.956 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=25, k=13, tile_m=2, tile_n=4, w=6, v=18, threads=96, grouping=16, minblocks=12) , # 304.863 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=25, k=25, tile_m=2, tile_n=3, w=12, v=22, threads=128, grouping=16, minblocks=8) , # 357.372 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=25, k=26, tile_m=3, tile_n=2, w=10, v=16, threads=128, grouping=16, minblocks=8) , # 362.44 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=25, k=28, tile_m=2, tile_n=3, w=14, v=24, threads=128, grouping=16, minblocks=8) , # 380.957 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=25, k=32, tile_m=2, tile_n=3, w=12, v=24, threads=128, grouping=16, minblocks=8) , # 388.464 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=25, k=45, tile_m=2, tile_n=4, w=12, v=22, threads=96, grouping=16, minblocks=8) , # 405.487 GFlop/s
-  Kernel_dnt_medium(m=26, n=26, k=4, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=4) , # 175.533 GFlop/s
-  Kernel_dnt_medium(m=26, n=26, k=5, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 195.723 GFlop/s
-  Kernel_dnt_medium(m=26, n=26, k=6, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 223.837 GFlop/s
-  Kernel_dnt_medium(m=26, n=26, k=7, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 238.031 GFlop/s
-  Kernel_dnt_medium(m=26, n=26, k=8, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 260.398 GFlop/s
-  Kernel_dnt_medium(m=26, n=26, k=9, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 281.056 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=26, k=13, tile_m=2, tile_n=4, w=6, v=18, threads=96, grouping=16, minblocks=12) , # 317.738 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=26, k=16, tile_m=3, tile_n=2, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 332.873 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=26, k=17, tile_m=2, tile_n=3, w=6, v=16, threads=160, grouping=16, minblocks=8) , # 315.978 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=26, k=22, tile_m=2, tile_n=3, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 350.804 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=26, k=23, tile_m=2, tile_n=3, w=6, v=26, threads=160, grouping=16, minblocks=8) , # 348.123 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=26, k=24, tile_m=2, tile_n=3, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 356.594 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=26, k=25, tile_m=2, tile_n=4, w=12, v=24, threads=96, grouping=16, minblocks=8) , # 375.765 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=26, k=26, tile_m=2, tile_n=3, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 381.742 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=26, k=28, tile_m=2, tile_n=4, w=14, v=26, threads=128, grouping=16, minblocks=8) , # 396.724 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=26, k=32, tile_m=2, tile_n=3, w=14, v=26, threads=128, grouping=16, minblocks=8) , # 401.65 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=26, k=45, tile_m=2, tile_n=4, w=12, v=24, threads=96, grouping=16, minblocks=8) , # 425.671 GFlop/s
-  Kernel_dnt_medium(m=26, n=28, k=4, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 174.838 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=28, k=5, tile_m=3, tile_n=2, w=2, v=14, threads=128, grouping=16, minblocks=12) , # 200.558 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=28, k=7, tile_m=3, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=12) , # 246.118 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=28, k=9, tile_m=3, tile_n=2, w=4, v=28, threads=128, grouping=16, minblocks=8) , # 273.477 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=28, k=13, tile_m=2, tile_n=4, w=6, v=16, threads=96, grouping=16, minblocks=12) , # 332.816 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=28, k=25, tile_m=2, tile_n=4, w=10, v=28, threads=96, grouping=16, minblocks=8) , # 397.022 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=28, k=26, tile_m=2, tile_n=4, w=10, v=28, threads=96, grouping=16, minblocks=4) , # 404.741 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=28, k=28, tile_m=3, tile_n=2, w=10, v=24, threads=128, grouping=16, minblocks=8) , # 414.939 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=28, k=32, tile_m=3, tile_n=2, w=12, v=24, threads=128, grouping=16, minblocks=8) , # 426.043 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=28, k=45, tile_m=2, tile_n=4, w=12, v=28, threads=96, grouping=16, minblocks=8) , # 457.514 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=32, k=4, tile_m=5, tile_n=2, w=2, v=14, threads=96, grouping=16, minblocks=12) , # 176.504 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=32, k=5, tile_m=5, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 212.767 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=32, k=6, tile_m=5, tile_n=2, w=2, v=18, threads=96, grouping=16, minblocks=12) , # 222.341 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=32, k=7, tile_m=5, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 247.293 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=32, k=8, tile_m=3, tile_n=3, w=4, v=28, threads=128, grouping=16, minblocks=8) , # 245.658 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=32, k=9, tile_m=2, tile_n=4, w=4, v=28, threads=128, grouping=16, minblocks=8) , # 280.034 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=32, k=13, tile_m=2, tile_n=4, w=6, v=16, threads=128, grouping=16, minblocks=8) , # 316.971 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=32, k=16, tile_m=2, tile_n=4, w=8, v=28, threads=128, grouping=16, minblocks=8) , # 335.651 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=32, k=17, tile_m=2, tile_n=4, w=8, v=24, threads=128, grouping=16, minblocks=8) , # 325.543 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=32, k=22, tile_m=2, tile_n=4, w=8, v=28, threads=128, grouping=16, minblocks=8) , # 358.85 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=32, k=23, tile_m=2, tile_n=4, w=8, v=28, threads=128, grouping=16, minblocks=8) , # 365.224 GFlop/s
-  Kernel_dnt_largeDB1(m=26, n=32, k=24, tile_m=2, tile_n=4, w=12, v=14, threads=128, grouping=16, minblocks=8) , # 382.529 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=32, k=25, tile_m=2, tile_n=4, w=12, v=32, threads=128, grouping=16, minblocks=1) , # 399.183 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=32, k=26, tile_m=2, tile_n=4, w=12, v=32, threads=128, grouping=16, minblocks=8) , # 404.75 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=32, k=28, tile_m=2, tile_n=4, w=10, v=32, threads=128, grouping=16, minblocks=8) , # 409.577 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=32, k=32, tile_m=4, tile_n=2, w=16, v=32, threads=128, grouping=16, minblocks=1) , # 426.515 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=32, k=45, tile_m=5, tile_n=2, w=12, v=24, threads=96, grouping=16, minblocks=8) , # 442.282 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=45, k=4, tile_m=3, tile_n=2, w=2, v=16, threads=224, grouping=16, minblocks=1) , # 155.312 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=45, k=5, tile_m=6, tile_n=2, w=2, v=26, threads=128, grouping=16, minblocks=8) , # 204.843 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=45, k=7, tile_m=6, tile_n=2, w=2, v=18, threads=128, grouping=16, minblocks=8) , # 233.548 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=45, k=9, tile_m=5, tile_n=3, w=4, v=24, threads=96, grouping=16, minblocks=8) , # 262.492 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=45, k=13, tile_m=2, tile_n=5, w=6, v=36, threads=128, grouping=16, minblocks=1) , # 318.4 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=45, k=25, tile_m=2, tile_n=5, w=10, v=44, threads=128, grouping=16, minblocks=1) , # 393.097 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=45, k=26, tile_m=2, tile_n=5, w=10, v=44, threads=128, grouping=16, minblocks=4) , # 399.976 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=45, k=28, tile_m=3, tile_n=4, w=14, v=44, threads=128, grouping=16, minblocks=1) , # 422.791 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=45, k=32, tile_m=3, tile_n=4, w=16, v=44, threads=128, grouping=16, minblocks=4) , # 436.141 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=45, k=45, tile_m=2, tile_n=5, w=16, v=44, threads=192, grouping=16, minblocks=4) , # 455.227 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=4, k=4, tile_m=1, tile_n=1, w=2, v=4, threads=128, grouping=16, minblocks=1) , # 69.7132 GFlop/s
-  Kernel_dnt_medium(m=28, n=4, k=5, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 66.2641 GFlop/s
-  Kernel_dnt_medium(m=28, n=4, k=7, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 84.8842 GFlop/s
-  Kernel_dnt_medium(m=28, n=4, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 102.249 GFlop/s
-  Kernel_dnt_medium(m=28, n=4, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 122.511 GFlop/s
-  Kernel_dnt_medium(m=28, n=4, k=25, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=4) , # 131.812 GFlop/s
-  Kernel_dnt_medium(m=28, n=4, k=26, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=4) , # 133.779 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=4, k=28, tile_m=1, tile_n=2, w=14, v=4, threads=96, grouping=16, minblocks=8) , # 139.798 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=4, k=32, tile_m=1, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=12) , # 141.831 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=4, k=45, tile_m=2, tile_n=1, w=18, v=4, threads=128, grouping=16, minblocks=1) , # 141.966 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=5, k=4, tile_m=1, tile_n=2, w=2, v=4, threads=96, grouping=16, minblocks=4) , # 74.4649 GFlop/s
-  Kernel_dnt_medium(m=28, n=5, k=5, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=12) , # 79.7849 GFlop/s
-  Kernel_dnt_medium(m=28, n=5, k=7, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 94.6668 GFlop/s
-  Kernel_dnt_medium(m=28, n=5, k=9, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 113.375 GFlop/s
-  Kernel_dnt_medium(m=28, n=5, k=13, tile_m=1, tile_n=6, threads=96, grouping=16, minblocks=12) , # 137.689 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=5, k=25, tile_m=2, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=1) , # 154.897 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=5, k=26, tile_m=2, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=1) , # 157.88 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=5, k=28, tile_m=1, tile_n=2, w=14, v=4, threads=128, grouping=16, minblocks=12) , # 163.76 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=5, k=32, tile_m=1, tile_n=2, w=16, v=4, threads=128, grouping=16, minblocks=12) , # 166.725 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=5, k=45, tile_m=2, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=12) , # 170.449 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=7, k=4, tile_m=2, tile_n=2, w=2, v=4, threads=96, grouping=16, minblocks=4) , # 96.7805 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=7, k=5, tile_m=2, tile_n=2, w=2, v=4, threads=96, grouping=16, minblocks=1) , # 97.3331 GFlop/s
-  Kernel_dnt_medium(m=28, n=7, k=7, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 123.661 GFlop/s
-  Kernel_dnt_medium(m=28, n=7, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 145.578 GFlop/s
-  Kernel_dnt_medium(m=28, n=7, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 178.204 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=7, k=25, tile_m=2, tile_n=2, w=12, v=6, threads=128, grouping=16, minblocks=12) , # 199.125 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=7, k=26, tile_m=2, tile_n=2, w=12, v=2, threads=96, grouping=16, minblocks=12) , # 201.107 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=7, k=28, tile_m=2, tile_n=2, w=14, v=6, threads=96, grouping=16, minblocks=12) , # 211.525 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=7, k=32, tile_m=2, tile_n=2, w=16, v=6, threads=96, grouping=16, minblocks=12) , # 215.029 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=7, k=45, tile_m=2, tile_n=2, w=12, v=4, threads=96, grouping=16, minblocks=12) , # 222.228 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=9, k=4, tile_m=3, tile_n=1, w=2, v=6, threads=96, grouping=16, minblocks=1) , # 117.282 GFlop/s
-  Kernel_dnt_medium(m=28, n=9, k=5, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 122.678 GFlop/s
-  Kernel_dnt_medium(m=28, n=9, k=7, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 156.349 GFlop/s
-  Kernel_dnt_medium(m=28, n=9, k=9, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 183.005 GFlop/s
-  Kernel_dnt_medium(m=28, n=9, k=13, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 200.618 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=9, k=25, tile_m=2, tile_n=1, w=12, v=4, threads=128, grouping=16, minblocks=12) , # 238.125 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=9, k=26, tile_m=2, tile_n=1, w=12, v=4, threads=128, grouping=16, minblocks=12) , # 240.037 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=9, k=28, tile_m=2, tile_n=1, w=14, v=8, threads=128, grouping=16, minblocks=8) , # 249.198 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=9, k=32, tile_m=2, tile_n=1, w=16, v=8, threads=128, grouping=16, minblocks=4) , # 254.885 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=9, k=45, tile_m=2, tile_n=1, w=16, v=8, threads=128, grouping=16, minblocks=4) , # 260.931 GFlop/s
-  Kernel_dnt_medium(m=28, n=13, k=4, tile_m=4, tile_n=1, threads=128, grouping=16, minblocks=12) , # 135.514 GFlop/s
-  Kernel_dnt_medium(m=28, n=13, k=5, tile_m=4, tile_n=1, threads=96, grouping=16, minblocks=12) , # 148.634 GFlop/s
-  Kernel_dnt_medium(m=28, n=13, k=7, tile_m=4, tile_n=1, threads=96, grouping=16, minblocks=12) , # 181.031 GFlop/s
-  Kernel_dnt_medium(m=28, n=13, k=9, tile_m=4, tile_n=1, threads=96, grouping=16, minblocks=12) , # 204.184 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=13, k=13, tile_m=4, tile_n=2, w=6, v=10, threads=96, grouping=16, minblocks=12) , # 231.477 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=13, k=25, tile_m=4, tile_n=1, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 276.693 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=13, k=26, tile_m=4, tile_n=1, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 280.226 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=13, k=28, tile_m=4, tile_n=1, w=14, v=10, threads=96, grouping=16, minblocks=12) , # 287.948 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=13, k=32, tile_m=4, tile_n=1, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 293.103 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=13, k=45, tile_m=4, tile_n=1, w=12, v=10, threads=96, grouping=16, minblocks=12) , # 304.228 GFlop/s
-  Kernel_dnt_medium(m=28, n=25, k=4, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=4) , # 168.069 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=25, k=5, tile_m=4, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 193.423 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=25, k=7, tile_m=4, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 225.794 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=25, k=9, tile_m=2, tile_n=3, w=4, v=22, threads=128, grouping=16, minblocks=8) , # 258.556 GFlop/s
-  Kernel_dnt_medium(m=28, n=25, k=13, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 320.669 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=25, k=25, tile_m=2, tile_n=3, w=12, v=18, threads=128, grouping=16, minblocks=8) , # 381.261 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=25, k=26, tile_m=2, tile_n=3, w=10, v=12, threads=128, grouping=16, minblocks=8) , # 384.478 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=25, k=28, tile_m=2, tile_n=3, w=10, v=12, threads=128, grouping=16, minblocks=8) , # 396.377 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=25, k=32, tile_m=2, tile_n=3, w=12, v=14, threads=128, grouping=16, minblocks=8) , # 412.267 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=25, k=45, tile_m=2, tile_n=3, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 427.011 GFlop/s
-  Kernel_dnt_medium(m=28, n=26, k=4, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=1) , # 176.915 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=26, k=5, tile_m=4, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 202.981 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=26, k=7, tile_m=4, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 237.458 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=26, k=9, tile_m=2, tile_n=3, w=4, v=26, threads=128, grouping=16, minblocks=1) , # 271.994 GFlop/s
-  Kernel_dnt_medium(m=28, n=26, k=13, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 334.498 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=26, k=25, tile_m=2, tile_n=3, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 400.225 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=26, k=26, tile_m=2, tile_n=3, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 410.723 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=26, k=28, tile_m=2, tile_n=3, w=14, v=18, threads=128, grouping=16, minblocks=8) , # 417.684 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=26, k=32, tile_m=2, tile_n=3, w=12, v=22, threads=128, grouping=16, minblocks=8) , # 431.942 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=26, k=45, tile_m=4, tile_n=2, w=12, v=26, threads=96, grouping=16, minblocks=8) , # 456.463 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=28, k=4, tile_m=5, tile_n=2, w=2, v=10, threads=96, grouping=16, minblocks=12) , # 179.862 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=28, k=5, tile_m=5, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 210.103 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=28, k=7, tile_m=5, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 242.486 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=28, k=9, tile_m=5, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 266.488 GFlop/s
-  Kernel_dnt_medium(m=28, n=28, k=13, tile_m=2, tile_n=4, threads=128, grouping=16, minblocks=1) , # 311.697 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=28, k=25, tile_m=2, tile_n=4, w=12, v=24, threads=128, grouping=16, minblocks=8) , # 374.666 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=28, k=26, tile_m=2, tile_n=5, w=10, v=26, threads=96, grouping=16, minblocks=8) , # 379.954 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=28, k=28, tile_m=2, tile_n=4, w=14, v=28, threads=128, grouping=16, minblocks=1) , # 385.627 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=28, k=32, tile_m=2, tile_n=4, w=16, v=28, threads=128, grouping=16, minblocks=4) , # 399.675 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=28, k=45, tile_m=2, tile_n=5, w=10, v=14, threads=96, grouping=16, minblocks=8) , # 419.193 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=32, k=4, tile_m=5, tile_n=2, w=2, v=12, threads=96, grouping=16, minblocks=12) , # 190.475 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=32, k=5, tile_m=5, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 226.849 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=32, k=7, tile_m=5, tile_n=2, w=2, v=16, threads=96, grouping=16, minblocks=12) , # 265.598 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=32, k=9, tile_m=2, tile_n=4, w=4, v=24, threads=128, grouping=16, minblocks=4) , # 294.248 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=32, k=13, tile_m=4, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=8) , # 336.212 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=32, k=25, tile_m=2, tile_n=4, w=12, v=24, threads=128, grouping=16, minblocks=8) , # 425.078 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=32, k=26, tile_m=2, tile_n=4, w=12, v=20, threads=128, grouping=16, minblocks=8) , # 430.851 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=32, k=28, tile_m=2, tile_n=4, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 436.482 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=32, k=32, tile_m=2, tile_n=4, w=16, v=32, threads=128, grouping=16, minblocks=4) , # 454.724 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=32, k=45, tile_m=5, tile_n=2, w=12, v=24, threads=96, grouping=16, minblocks=8) , # 470.523 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=45, k=4, tile_m=6, tile_n=2, w=2, v=32, threads=128, grouping=16, minblocks=4) , # 162.232 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=45, k=5, tile_m=6, tile_n=2, w=2, v=24, threads=128, grouping=16, minblocks=8) , # 213.556 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=45, k=7, tile_m=6, tile_n=2, w=2, v=18, threads=128, grouping=16, minblocks=8) , # 248.9 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=45, k=9, tile_m=3, tile_n=4, w=4, v=22, threads=128, grouping=16, minblocks=4) , # 278.037 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=45, k=13, tile_m=2, tile_n=5, w=6, v=32, threads=128, grouping=16, minblocks=4) , # 339.473 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=45, k=25, tile_m=2, tile_n=5, w=10, v=36, threads=128, grouping=16, minblocks=4) , # 421.292 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=45, k=26, tile_m=2, tile_n=5, w=10, v=36, threads=128, grouping=16, minblocks=1) , # 425.013 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=45, k=28, tile_m=3, tile_n=4, w=14, v=42, threads=128, grouping=16, minblocks=1) , # 443.193 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=45, k=32, tile_m=2, tile_n=5, w=16, v=40, threads=224, grouping=16, minblocks=4) , # 462.217 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=45, k=45, tile_m=2, tile_n=5, w=16, v=40, threads=192, grouping=16, minblocks=4) , # 490.812 GFlop/s
-  Kernel_dnt_medium(m=29, n=14, k=14, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 242.078 GFlop/s
-  Kernel_dnt_medium(m=29, n=14, k=16, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 258.248 GFlop/s
-  Kernel_dnt_largeDB1(m=29, n=14, k=29, tile_m=2, tile_n=2, w=8, v=14, threads=128, grouping=16, minblocks=8) , # 274.397 GFlop/s
-  Kernel_dnt_largeDB1(m=29, n=14, k=32, tile_m=2, tile_n=2, w=16, v=10, threads=160, grouping=16, minblocks=8) , # 293.429 GFlop/s
-  Kernel_dnt_medium(m=29, n=16, k=14, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 277.48 GFlop/s
-  Kernel_dnt_largeDB1(m=29, n=16, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 295.779 GFlop/s
-  Kernel_dnt_largeDB1(m=29, n=16, k=29, tile_m=2, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=8) , # 310.193 GFlop/s
-  Kernel_dnt_largeDB1(m=29, n=16, k=55, tile_m=2, tile_n=4, w=6, v=6, threads=96, grouping=16, minblocks=12) , # 360.532 GFlop/s
-  Kernel_dnt_largeDB1(m=29, n=29, k=14, tile_m=2, tile_n=4, w=4, v=16, threads=128, grouping=16, minblocks=8) , # 309.036 GFlop/s
-  Kernel_dnt_largeDB1(m=29, n=29, k=16, tile_m=4, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 321.264 GFlop/s
-  Kernel_dnt_largeDB2(m=29, n=29, k=29, tile_m=2, tile_n=5, w=10, v=22, threads=96, grouping=16, minblocks=8) , # 397.654 GFlop/s
-  Kernel_dnt_largeDB1(m=29, n=29, k=32, tile_m=2, tile_n=4, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 395.307 GFlop/s
-  Kernel_dnt_largeDB1(m=29, n=29, k=55, tile_m=2, tile_n=4, w=8, v=22, threads=128, grouping=16, minblocks=8) , # 431.556 GFlop/s
-  Kernel_dnt_largeDB1(m=29, n=32, k=14, tile_m=3, tile_n=3, w=4, v=24, threads=128, grouping=16, minblocks=8) , # 331.383 GFlop/s
-  Kernel_dnt_largeDB1(m=29, n=32, k=29, tile_m=4, tile_n=2, w=10, v=24, threads=128, grouping=16, minblocks=8) , # 423.499 GFlop/s
-  Kernel_dnt_largeDB1(m=29, n=32, k=32, tile_m=2, tile_n=4, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 433.652 GFlop/s
-  Kernel_dnt_largeDB1(m=29, n=32, k=55, tile_m=2, tile_n=4, w=8, v=14, threads=128, grouping=16, minblocks=8) , # 478.124 GFlop/s
-  Kernel_dnt_largeDB1(m=29, n=55, k=16, tile_m=4, tile_n=4, w=8, v=38, threads=128, grouping=16, minblocks=4) , # 326.811 GFlop/s
-  Kernel_dnt_largeDB1(m=29, n=55, k=29, tile_m=5, tile_n=3, w=10, v=44, threads=160, grouping=16, minblocks=4) , # 384.341 GFlop/s
-  Kernel_dnt_largeDB1(m=29, n=55, k=32, tile_m=4, tile_n=4, w=8, v=34, threads=128, grouping=16, minblocks=1) , # 424.502 GFlop/s
-  Kernel_dnt_largeDB1(m=29, n=55, k=55, tile_m=3, tile_n=5, w=6, v=30, threads=128, grouping=16, minblocks=1) , # 465.271 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=4, k=4, tile_m=1, tile_n=1, w=2, v=4, threads=128, grouping=16, minblocks=1) , # 78.1605 GFlop/s
-  Kernel_dnt_tiny(m=32, n=4, k=5, threads=128, grouping=16, minblocks=1) , # 75.2026 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=6, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 84.3077 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=7, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 95.6134 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 107.39 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=9, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 112.586 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=13, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=12) , # 129.333 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=16, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=8) , # 132.816 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=17, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=8) , # 132.452 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=22, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=4) , # 135.963 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=23, tile_m=1, tile_n=1, threads=160, grouping=16, minblocks=1) , # 136.381 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=4, k=24, tile_m=1, tile_n=1, w=8, v=4, threads=128, grouping=16, minblocks=12) , # 137.282 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=4, k=25, tile_m=1, tile_n=1, w=8, v=4, threads=128, grouping=16, minblocks=12) , # 139.087 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=4, k=26, tile_m=1, tile_n=1, w=12, v=4, threads=128, grouping=16, minblocks=12) , # 140.533 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=4, k=28, tile_m=2, tile_n=1, w=14, v=4, threads=128, grouping=16, minblocks=12) , # 143.079 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=4, k=32, tile_m=2, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=4) , # 146.474 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=4, k=45, tile_m=2, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=8) , # 148.211 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=5, k=4, tile_m=2, tile_n=1, w=2, v=4, threads=96, grouping=16, minblocks=4) , # 86.8186 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 89.287 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 101.216 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=7, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 114.046 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 125.677 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 130.748 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=13, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 148.413 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=16, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=4) , # 153.149 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=17, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=4) , # 156.458 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=22, tile_m=2, tile_n=1, threads=160, grouping=16, minblocks=1) , # 158.723 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=5, k=23, tile_m=2, tile_n=1, w=6, v=2, threads=96, grouping=16, minblocks=4) , # 154.957 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=5, k=24, tile_m=2, tile_n=1, w=8, v=4, threads=128, grouping=16, minblocks=12) , # 157.474 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=5, k=25, tile_m=2, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=12) , # 164.898 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=5, k=26, tile_m=2, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=4) , # 166.861 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=5, k=28, tile_m=2, tile_n=1, w=10, v=4, threads=96, grouping=16, minblocks=1) , # 169.47 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=5, k=32, tile_m=2, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=12) , # 174.113 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=5, k=45, tile_m=2, tile_n=1, w=16, v=4, threads=128, grouping=16, minblocks=4) , # 177.946 GFlop/s
-  Kernel_dnt_small(m=32, n=6, k=4, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 97.4182 GFlop/s
-  Kernel_dnt_medium(m=32, n=6, k=5, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 106.15 GFlop/s
-  Kernel_dnt_medium(m=32, n=6, k=6, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=1) , # 119.531 GFlop/s
-  Kernel_dnt_medium(m=32, n=6, k=8, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 148.581 GFlop/s
-  Kernel_dnt_medium(m=32, n=6, k=9, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=8) , # 153.276 GFlop/s
-  Kernel_dnt_medium(m=32, n=6, k=13, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=4) , # 172.995 GFlop/s
-  Kernel_dnt_medium(m=32, n=6, k=16, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=8) , # 179.544 GFlop/s
-  Kernel_dnt_medium(m=32, n=6, k=17, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 177.212 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=6, k=22, tile_m=2, tile_n=1, w=8, v=6, threads=128, grouping=16, minblocks=12) , # 177.592 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=6, k=23, tile_m=2, tile_n=1, w=8, v=6, threads=128, grouping=16, minblocks=12) , # 179.563 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=6, k=24, tile_m=2, tile_n=1, w=8, v=6, threads=128, grouping=16, minblocks=12) , # 184.834 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=6, k=26, tile_m=2, tile_n=1, w=6, v=6, threads=96, grouping=16, minblocks=1) , # 181.915 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=6, k=32, tile_m=2, tile_n=1, w=8, v=4, threads=128, grouping=16, minblocks=12) , # 191.164 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=7, k=4, tile_m=2, tile_n=2, w=2, v=4, threads=96, grouping=16, minblocks=12) , # 113.424 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=7, k=5, tile_m=2, tile_n=2, w=2, v=4, threads=96, grouping=16, minblocks=4) , # 112.889 GFlop/s
-  Kernel_dnt_medium(m=32, n=7, k=7, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=12) , # 139.831 GFlop/s
-  Kernel_dnt_medium(m=32, n=7, k=9, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 162.492 GFlop/s
-  Kernel_dnt_medium(m=32, n=7, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 191.194 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=7, k=25, tile_m=2, tile_n=2, w=12, v=6, threads=96, grouping=16, minblocks=12) , # 216.084 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=7, k=26, tile_m=2, tile_n=2, w=10, v=6, threads=96, grouping=16, minblocks=12) , # 218.187 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=7, k=28, tile_m=2, tile_n=2, w=10, v=4, threads=96, grouping=16, minblocks=12) , # 222.478 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=7, k=32, tile_m=2, tile_n=2, w=12, v=6, threads=96, grouping=16, minblocks=12) , # 228.388 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=7, k=45, tile_m=2, tile_n=2, w=12, v=4, threads=96, grouping=16, minblocks=12) , # 233.435 GFlop/s
-  Kernel_dnt_small(m=32, n=8, k=4, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=8) , # 125.786 GFlop/s
-  Kernel_dnt_small(m=32, n=8, k=5, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=1) , # 129.29 GFlop/s
-  Kernel_dnt_small(m=32, n=8, k=6, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=8) , # 143.901 GFlop/s
-  Kernel_dnt_medium(m=32, n=8, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 174.913 GFlop/s
-  Kernel_dnt_medium(m=32, n=8, k=9, tile_m=1, tile_n=2, threads=128, grouping=16, minblocks=12) , # 185.745 GFlop/s
-  Kernel_dnt_medium(m=32, n=8, k=13, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=8) , # 206.098 GFlop/s
-  Kernel_dnt_medium(m=32, n=8, k=16, tile_m=2, tile_n=1, threads=128, grouping=16, minblocks=1) , # 214.735 GFlop/s
-  Kernel_dnt_medium(m=32, n=8, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 213.369 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=8, k=22, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 222.523 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=8, k=23, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 223.88 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=8, k=24, tile_m=2, tile_n=1, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 231.024 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=8, k=26, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 229.882 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=8, k=32, tile_m=2, tile_n=2, w=12, v=8, threads=96, grouping=16, minblocks=12) , # 239.979 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=9, k=4, tile_m=2, tile_n=2, w=2, v=6, threads=96, grouping=16, minblocks=12) , # 132.73 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=9, k=5, tile_m=2, tile_n=2, w=2, v=6, threads=96, grouping=16, minblocks=8) , # 135.487 GFlop/s
-  Kernel_dnt_medium(m=32, n=9, k=6, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 145.86 GFlop/s
-  Kernel_dnt_medium(m=32, n=9, k=7, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 164.668 GFlop/s
-  Kernel_dnt_medium(m=32, n=9, k=8, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 182.062 GFlop/s
-  Kernel_dnt_medium(m=32, n=9, k=9, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 189.732 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=9, k=13, tile_m=1, tile_n=3, w=6, v=6, threads=96, grouping=16, minblocks=12) , # 213.509 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=9, k=16, tile_m=2, tile_n=2, w=8, v=6, threads=128, grouping=16, minblocks=12) , # 219.794 GFlop/s
-  Kernel_dnt_medium(m=32, n=9, k=17, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 215.226 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=9, k=22, tile_m=1, tile_n=3, w=6, v=6, threads=128, grouping=16, minblocks=12) , # 226.772 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=9, k=23, tile_m=2, tile_n=3, w=6, v=6, threads=96, grouping=16, minblocks=12) , # 230.82 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=9, k=24, tile_m=1, tile_n=3, w=8, v=6, threads=128, grouping=16, minblocks=12) , # 239.49 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=9, k=25, tile_m=2, tile_n=2, w=10, v=6, threads=96, grouping=16, minblocks=12) , # 252.716 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=9, k=26, tile_m=2, tile_n=3, w=10, v=6, threads=96, grouping=16, minblocks=12) , # 257.379 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=9, k=28, tile_m=1, tile_n=3, w=14, v=6, threads=128, grouping=16, minblocks=12) , # 260.597 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=9, k=32, tile_m=2, tile_n=3, w=16, v=8, threads=128, grouping=16, minblocks=8) , # 267.55 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=9, k=45, tile_m=1, tile_n=3, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 273.232 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=13, k=4, tile_m=2, tile_n=2, w=2, v=12, threads=128, grouping=16, minblocks=12) , # 150.16 GFlop/s
-  Kernel_dnt_medium(m=32, n=13, k=5, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=12) , # 162.28 GFlop/s
-  Kernel_dnt_medium(m=32, n=13, k=6, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 181.421 GFlop/s
-  Kernel_dnt_medium(m=32, n=13, k=7, tile_m=2, tile_n=4, threads=96, grouping=16, minblocks=12) , # 200.411 GFlop/s
-  Kernel_dnt_medium(m=32, n=13, k=8, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=12) , # 218.093 GFlop/s
-  Kernel_dnt_medium(m=32, n=13, k=9, tile_m=3, tile_n=2, threads=96, grouping=16, minblocks=12) , # 222.138 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=13, k=13, tile_m=2, tile_n=4, w=6, v=8, threads=96, grouping=16, minblocks=12) , # 265.867 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=13, k=16, tile_m=2, tile_n=2, w=8, v=8, threads=128, grouping=16, minblocks=12) , # 281.835 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=13, k=17, tile_m=2, tile_n=4, w=6, v=8, threads=96, grouping=16, minblocks=12) , # 263.517 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=13, k=22, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=8) , # 273.854 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=13, k=23, tile_m=2, tile_n=2, w=6, v=10, threads=128, grouping=16, minblocks=12) , # 288.889 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=13, k=24, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 292.866 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=13, k=25, tile_m=4, tile_n=2, w=12, v=6, threads=96, grouping=16, minblocks=8) , # 299.633 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=13, k=26, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 305.955 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=13, k=28, tile_m=2, tile_n=4, w=14, v=12, threads=128, grouping=16, minblocks=8) , # 315.29 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=13, k=32, tile_m=4, tile_n=2, w=16, v=10, threads=128, grouping=16, minblocks=8) , # 339.092 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=13, k=45, tile_m=2, tile_n=4, w=16, v=12, threads=128, grouping=16, minblocks=8) , # 341.117 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=14, k=14, tile_m=2, tile_n=2, w=6, v=14, threads=128, grouping=16, minblocks=12) , # 271.737 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=14, k=29, tile_m=2, tile_n=2, w=6, v=14, threads=128, grouping=16, minblocks=12) , # 313.057 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=14, k=32, tile_m=2, tile_n=2, w=8, v=10, threads=128, grouping=16, minblocks=12) , # 340.64 GFlop/s
-  Kernel_dnt_small(m=32, n=16, k=4, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=1) , # 151.321 GFlop/s
-  Kernel_dnt_medium(m=32, n=16, k=5, tile_m=2, tile_n=2, threads=192, grouping=16, minblocks=8) , # 166.987 GFlop/s
-  Kernel_dnt_medium(m=32, n=16, k=6, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=1) , # 189.814 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=16, k=8, tile_m=2, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=12) , # 237.248 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=16, k=9, tile_m=2, tile_n=2, w=4, v=8, threads=128, grouping=16, minblocks=12) , # 241.881 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=16, k=13, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 292.252 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=16, k=16, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 329.973 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=16, k=17, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 324.51 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=16, k=22, tile_m=2, tile_n=4, w=6, v=10, threads=96, grouping=16, minblocks=12) , # 333.461 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=16, k=23, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 344.66 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=16, k=24, tile_m=2, tile_n=2, w=8, v=12, threads=128, grouping=16, minblocks=12) , # 358.655 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=16, k=26, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 347.137 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=16, k=32, tile_m=2, tile_n=4, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 362.722 GFlop/s
-  Kernel_dnt_medium(m=32, n=17, k=4, tile_m=2, tile_n=2, threads=160, grouping=16, minblocks=8) , # 144.864 GFlop/s
-  Kernel_dnt_medium(m=32, n=17, k=5, tile_m=2, tile_n=3, threads=96, grouping=16, minblocks=1) , # 169.7 GFlop/s
-  Kernel_dnt_medium(m=32, n=17, k=6, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 186.207 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=17, k=8, tile_m=2, tile_n=3, w=4, v=14, threads=96, grouping=16, minblocks=12) , # 231.895 GFlop/s
-  Kernel_dnt_medium(m=32, n=17, k=9, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 237.103 GFlop/s
-  Kernel_dnt_medium(m=32, n=17, k=13, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 285.362 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=17, k=16, tile_m=2, tile_n=3, w=4, v=14, threads=96, grouping=16, minblocks=12) , # 298.281 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=17, k=17, tile_m=2, tile_n=3, w=8, v=14, threads=96, grouping=16, minblocks=12) , # 294.427 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=17, k=22, tile_m=2, tile_n=3, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 321.363 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=17, k=23, tile_m=2, tile_n=3, w=4, v=14, threads=96, grouping=16, minblocks=12) , # 314.354 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=17, k=24, tile_m=2, tile_n=3, w=6, v=14, threads=96, grouping=16, minblocks=12) , # 333.041 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=17, k=26, tile_m=2, tile_n=3, w=6, v=6, threads=96, grouping=16, minblocks=12) , # 323.24 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=17, k=32, tile_m=2, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 351.318 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=22, k=4, tile_m=3, tile_n=2, w=2, v=12, threads=128, grouping=16, minblocks=12) , # 174.057 GFlop/s
-  Kernel_dnt_medium(m=32, n=22, k=5, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 195.309 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=22, k=6, tile_m=3, tile_n=2, w=2, v=12, threads=128, grouping=16, minblocks=12) , # 213.72 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=22, k=8, tile_m=4, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 264.277 GFlop/s
-  Kernel_dnt_medium(m=32, n=22, k=9, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 280.289 GFlop/s
-  Kernel_dnt_medium(m=32, n=22, k=13, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 325.002 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=22, k=16, tile_m=3, tile_n=2, w=4, v=14, threads=128, grouping=16, minblocks=12) , # 348.283 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=22, k=17, tile_m=2, tile_n=4, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 337.15 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=22, k=22, tile_m=3, tile_n=2, w=10, v=20, threads=128, grouping=16, minblocks=8) , # 351.551 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=22, k=23, tile_m=4, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 363.288 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=22, k=24, tile_m=2, tile_n=4, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 385.833 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=22, k=26, tile_m=2, tile_n=4, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 378.454 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=22, k=32, tile_m=2, tile_n=4, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 407.594 GFlop/s
-  Kernel_dnt_medium(m=32, n=23, k=4, tile_m=3, tile_n=2, threads=160, grouping=16, minblocks=8) , # 170.118 GFlop/s
-  Kernel_dnt_medium(m=32, n=23, k=5, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 202.087 GFlop/s
-  Kernel_dnt_medium(m=32, n=23, k=6, tile_m=2, tile_n=3, threads=160, grouping=16, minblocks=8) , # 219.29 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=23, k=8, tile_m=4, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 272.379 GFlop/s
-  Kernel_dnt_medium(m=32, n=23, k=9, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 291.61 GFlop/s
-  Kernel_dnt_medium(m=32, n=23, k=13, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 337.911 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=23, k=16, tile_m=2, tile_n=4, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 358.681 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=23, k=17, tile_m=2, tile_n=4, w=8, v=10, threads=96, grouping=16, minblocks=12) , # 349.834 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=23, k=22, tile_m=2, tile_n=3, w=10, v=12, threads=128, grouping=16, minblocks=8) , # 361.851 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=23, k=23, tile_m=4, tile_n=2, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 374.412 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=23, k=24, tile_m=2, tile_n=4, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 395.474 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=23, k=26, tile_m=2, tile_n=4, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 392.455 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=23, k=32, tile_m=2, tile_n=4, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 419.821 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=24, k=4, tile_m=4, tile_n=2, w=2, v=12, threads=96, grouping=16, minblocks=12) , # 168.649 GFlop/s
-  Kernel_dnt_medium(m=32, n=24, k=5, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=1) , # 192.606 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=24, k=6, tile_m=4, tile_n=2, w=2, v=12, threads=96, grouping=16, minblocks=4) , # 218.903 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=24, k=8, tile_m=2, tile_n=4, w=4, v=14, threads=96, grouping=16, minblocks=12) , # 279.775 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=24, k=9, tile_m=3, tile_n=3, w=4, v=12, threads=96, grouping=16, minblocks=12) , # 275.596 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=24, k=13, tile_m=2, tile_n=4, w=6, v=12, threads=96, grouping=16, minblocks=12) , # 328.765 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=24, k=16, tile_m=2, tile_n=4, w=8, v=14, threads=96, grouping=16, minblocks=12) , # 373.707 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=24, k=17, tile_m=2, tile_n=4, w=8, v=10, threads=96, grouping=16, minblocks=12) , # 364.783 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=24, k=22, tile_m=2, tile_n=3, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 383.032 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=24, k=23, tile_m=2, tile_n=3, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 390.4 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=24, k=24, tile_m=2, tile_n=4, w=8, v=10, threads=96, grouping=16, minblocks=12) , # 411.108 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=24, k=26, tile_m=2, tile_n=4, w=8, v=12, threads=96, grouping=16, minblocks=12) , # 409.018 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=24, k=32, tile_m=2, tile_n=4, w=8, v=10, threads=96, grouping=16, minblocks=12) , # 438.697 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=24, k=45, tile_m=2, tile_n=4, w=12, v=18, threads=96, grouping=16, minblocks=8) , # 478.687 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=25, k=4, tile_m=4, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=8) , # 184.135 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=25, k=5, tile_m=5, tile_n=2, w=2, v=14, threads=96, grouping=16, minblocks=12) , # 204.72 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=25, k=7, tile_m=5, tile_n=2, w=2, v=14, threads=96, grouping=16, minblocks=12) , # 239.808 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=25, k=9, tile_m=2, tile_n=4, w=4, v=22, threads=128, grouping=16, minblocks=1) , # 271.023 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=25, k=13, tile_m=2, tile_n=5, w=6, v=22, threads=96, grouping=16, minblocks=4) , # 313.779 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=25, k=25, tile_m=4, tile_n=2, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 386.311 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=25, k=26, tile_m=2, tile_n=4, w=10, v=16, threads=128, grouping=16, minblocks=8) , # 389.664 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=25, k=28, tile_m=2, tile_n=5, w=14, v=24, threads=96, grouping=16, minblocks=8) , # 397.586 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=25, k=32, tile_m=4, tile_n=2, w=16, v=24, threads=128, grouping=16, minblocks=1) , # 409.68 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=25, k=45, tile_m=2, tile_n=5, w=12, v=10, threads=96, grouping=16, minblocks=8) , # 426.761 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=26, k=4, tile_m=4, tile_n=2, w=2, v=18, threads=128, grouping=16, minblocks=8) , # 190.663 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=26, k=5, tile_m=5, tile_n=2, w=2, v=14, threads=96, grouping=16, minblocks=12) , # 211.617 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=26, k=6, tile_m=5, tile_n=2, w=2, v=14, threads=96, grouping=16, minblocks=12) , # 220.557 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=26, k=7, tile_m=5, tile_n=2, w=2, v=14, threads=96, grouping=16, minblocks=12) , # 246.023 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=26, k=8, tile_m=3, tile_n=3, w=4, v=22, threads=128, grouping=16, minblocks=8) , # 246.38 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=26, k=9, tile_m=2, tile_n=4, w=4, v=14, threads=128, grouping=16, minblocks=8) , # 280.415 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=26, k=13, tile_m=2, tile_n=4, w=4, v=22, threads=128, grouping=16, minblocks=8) , # 323.047 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=26, k=16, tile_m=2, tile_n=4, w=8, v=22, threads=128, grouping=16, minblocks=8) , # 336.964 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=26, k=17, tile_m=4, tile_n=2, w=6, v=22, threads=160, grouping=16, minblocks=8) , # 335.578 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=26, k=22, tile_m=2, tile_n=4, w=8, v=22, threads=128, grouping=16, minblocks=8) , # 363.449 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=26, k=23, tile_m=2, tile_n=4, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 370.605 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=26, k=24, tile_m=4, tile_n=2, w=12, v=14, threads=128, grouping=16, minblocks=8) , # 386.132 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=26, k=25, tile_m=2, tile_n=4, w=12, v=18, threads=128, grouping=16, minblocks=8) , # 398.053 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=26, k=26, tile_m=4, tile_n=2, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 399.369 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=26, k=28, tile_m=4, tile_n=2, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 407.816 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=26, k=32, tile_m=4, tile_n=2, w=16, v=26, threads=128, grouping=16, minblocks=1) , # 425.774 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=26, k=45, tile_m=2, tile_n=5, w=12, v=12, threads=96, grouping=16, minblocks=8) , # 446.509 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=28, k=4, tile_m=4, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=8) , # 201.528 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=28, k=5, tile_m=4, tile_n=2, w=2, v=20, threads=128, grouping=16, minblocks=8) , # 209.83 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=28, k=7, tile_m=4, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=8) , # 243.583 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=28, k=9, tile_m=2, tile_n=4, w=4, v=16, threads=128, grouping=16, minblocks=1) , # 296.73 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=28, k=13, tile_m=2, tile_n=4, w=4, v=20, threads=128, grouping=16, minblocks=8) , # 340.313 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=28, k=25, tile_m=2, tile_n=4, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 425.713 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=28, k=26, tile_m=4, tile_n=2, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 426.391 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=28, k=28, tile_m=4, tile_n=2, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 434.061 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=28, k=32, tile_m=4, tile_n=2, w=16, v=28, threads=128, grouping=16, minblocks=1) , # 453.918 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=28, k=45, tile_m=2, tile_n=5, w=12, v=12, threads=96, grouping=16, minblocks=8) , # 474.442 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=29, k=14, tile_m=2, tile_n=4, w=4, v=16, threads=128, grouping=16, minblocks=8) , # 343.714 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=29, k=29, tile_m=2, tile_n=4, w=10, v=18, threads=128, grouping=16, minblocks=8) , # 425.393 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=29, k=32, tile_m=2, tile_n=4, w=12, v=14, threads=128, grouping=16, minblocks=8) , # 439.946 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=29, k=55, tile_m=2, tile_n=4, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 487.985 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=32, k=4, tile_m=4, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=8) , # 220.256 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=32, k=5, tile_m=4, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=8) , # 233.012 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=32, k=6, tile_m=4, tile_n=2, w=2, v=20, threads=128, grouping=16, minblocks=8) , # 233.277 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=32, k=7, tile_m=4, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=8) , # 269.642 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=32, k=8, tile_m=3, tile_n=3, w=4, v=16, threads=128, grouping=16, minblocks=1) , # 288.605 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=32, k=9, tile_m=2, tile_n=4, w=4, v=16, threads=128, grouping=16, minblocks=4) , # 330.576 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=32, k=13, tile_m=2, tile_n=4, w=4, v=16, threads=128, grouping=16, minblocks=4) , # 378.511 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=32, k=14, tile_m=2, tile_n=4, w=6, v=20, threads=128, grouping=16, minblocks=8) , # 370.201 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=32, k=16, tile_m=2, tile_n=4, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 415.932 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=32, k=17, tile_m=2, tile_n=4, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 408.083 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=32, k=22, tile_m=2, tile_n=4, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 439.077 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=32, k=23, tile_m=2, tile_n=4, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 450.644 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=32, k=24, tile_m=2, tile_n=4, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 457.257 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=32, k=25, tile_m=4, tile_n=2, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 471.97 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=32, k=26, tile_m=2, tile_n=4, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 482.604 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=32, k=28, tile_m=2, tile_n=4, w=10, v=12, threads=128, grouping=16, minblocks=8) , # 485.43 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=32, k=29, tile_m=2, tile_n=4, w=10, v=20, threads=128, grouping=16, minblocks=8) , # 470.358 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=32, k=32, tile_m=2, tile_n=4, w=12, v=20, threads=128, grouping=16, minblocks=8) , # 509.322 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=32, k=45, tile_m=2, tile_n=4, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 526.52 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=32, k=55, tile_m=2, tile_n=4, w=8, v=20, threads=128, grouping=16, minblocks=8) , # 531.47 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=45, k=4, tile_m=4, tile_n=2, w=2, v=34, threads=192, grouping=16, minblocks=1) , # 193.676 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=45, k=5, tile_m=4, tile_n=2, w=2, v=24, threads=192, grouping=16, minblocks=1) , # 201.497 GFlop/s
-  Kernel_dnt_medium(m=32, n=45, k=7, tile_m=2, tile_n=3, threads=256, grouping=16, minblocks=4) , # 238.295 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=45, k=9, tile_m=4, tile_n=3, w=4, v=28, threads=128, grouping=16, minblocks=4) , # 315.514 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=45, k=13, tile_m=4, tile_n=3, w=6, v=24, threads=128, grouping=16, minblocks=1) , # 372.936 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=45, k=25, tile_m=4, tile_n=3, w=8, v=20, threads=128, grouping=16, minblocks=1) , # 481.689 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=45, k=26, tile_m=4, tile_n=3, w=12, v=24, threads=128, grouping=16, minblocks=4) , # 483.916 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=45, k=28, tile_m=4, tile_n=3, w=14, v=28, threads=128, grouping=16, minblocks=1) , # 503.765 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=45, k=32, tile_m=4, tile_n=3, w=8, v=28, threads=128, grouping=16, minblocks=1) , # 523.025 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=45, k=45, tile_m=4, tile_n=3, w=12, v=32, threads=128, grouping=16, minblocks=1) , # 536.898 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=55, k=29, tile_m=4, tile_n=4, w=8, v=36, threads=128, grouping=16, minblocks=4) , # 447.064 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=55, k=32, tile_m=4, tile_n=4, w=4, v=26, threads=128, grouping=16, minblocks=1) , # 477.495 GFlop/s
-  Kernel_dnt_largeDB1(m=32, n=55, k=55, tile_m=3, tile_n=5, w=6, v=24, threads=128, grouping=16, minblocks=1) , # 518.157 GFlop/s
-  Kernel_dnt_medium(m=36, n=6, k=6, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 113.312 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=4, k=4, tile_m=1, tile_n=2, w=2, v=4, threads=96, grouping=16, minblocks=1) , # 90.7503 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=4, k=5, tile_m=1, tile_n=2, w=2, v=4, threads=96, grouping=16, minblocks=12) , # 88.8845 GFlop/s
-  Kernel_dnt_medium(m=45, n=4, k=7, tile_m=1, tile_n=2, threads=96, grouping=16, minblocks=1) , # 109.043 GFlop/s
-  Kernel_dnt_medium(m=45, n=4, k=9, tile_m=1, tile_n=4, threads=96, grouping=16, minblocks=12) , # 119.668 GFlop/s
-  Kernel_dnt_medium(m=45, n=4, k=13, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 126.187 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=4, k=25, tile_m=1, tile_n=2, w=10, v=2, threads=128, grouping=16, minblocks=12) , # 142.394 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=4, k=26, tile_m=1, tile_n=2, w=10, v=4, threads=96, grouping=16, minblocks=8) , # 143.612 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=4, k=28, tile_m=3, tile_n=1, w=14, v=4, threads=192, grouping=16, minblocks=8) , # 147.113 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=4, k=32, tile_m=1, tile_n=2, w=8, v=4, threads=128, grouping=16, minblocks=12) , # 149.4 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=4, k=45, tile_m=1, tile_n=2, w=12, v=4, threads=128, grouping=16, minblocks=8) , # 150.684 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=5, k=4, tile_m=3, tile_n=1, w=2, v=4, threads=96, grouping=16, minblocks=12) , # 101.474 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=5, k=5, tile_m=3, tile_n=1, w=2, v=4, threads=96, grouping=16, minblocks=12) , # 101.829 GFlop/s
-  Kernel_dnt_medium(m=45, n=5, k=7, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 124.597 GFlop/s
-  Kernel_dnt_medium(m=45, n=5, k=9, tile_m=3, tile_n=1, threads=96, grouping=16, minblocks=12) , # 138.834 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=5, k=13, tile_m=3, tile_n=1, w=6, v=4, threads=96, grouping=16, minblocks=12) , # 148.846 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=5, k=25, tile_m=3, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=12) , # 168.184 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=5, k=26, tile_m=3, tile_n=1, w=8, v=4, threads=96, grouping=16, minblocks=12) , # 171.306 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=5, k=28, tile_m=3, tile_n=2, w=14, v=4, threads=96, grouping=16, minblocks=8) , # 173.248 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=5, k=32, tile_m=1, tile_n=3, w=8, v=4, threads=96, grouping=16, minblocks=12) , # 179.706 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=5, k=45, tile_m=3, tile_n=1, w=12, v=4, threads=96, grouping=16, minblocks=12) , # 180.372 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=7, k=4, tile_m=2, tile_n=2, w=2, v=4, threads=96, grouping=16, minblocks=4) , # 120.397 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=7, k=5, tile_m=2, tile_n=2, w=2, v=6, threads=96, grouping=16, minblocks=4) , # 130.96 GFlop/s
-  Kernel_dnt_medium(m=45, n=7, k=7, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 150.737 GFlop/s
-  Kernel_dnt_medium(m=45, n=7, k=9, tile_m=1, tile_n=4, threads=96, grouping=16, minblocks=12) , # 173.029 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=7, k=13, tile_m=3, tile_n=2, w=6, v=4, threads=96, grouping=16, minblocks=12) , # 191.272 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=7, k=25, tile_m=3, tile_n=2, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 222.433 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=7, k=26, tile_m=3, tile_n=2, w=8, v=4, threads=96, grouping=16, minblocks=12) , # 220.248 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=7, k=28, tile_m=3, tile_n=2, w=14, v=6, threads=160, grouping=16, minblocks=8) , # 229.232 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=7, k=32, tile_m=3, tile_n=2, w=16, v=6, threads=128, grouping=16, minblocks=8) , # 232.684 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=7, k=45, tile_m=5, tile_n=1, w=8, v=6, threads=96, grouping=16, minblocks=12) , # 240.56 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=9, k=4, tile_m=3, tile_n=2, w=2, v=8, threads=96, grouping=16, minblocks=1) , # 130.378 GFlop/s
-  Kernel_dnt_medium(m=45, n=9, k=5, tile_m=5, tile_n=1, threads=96, grouping=16, minblocks=12) , # 142.506 GFlop/s
-  Kernel_dnt_medium(m=45, n=9, k=7, tile_m=1, tile_n=5, threads=96, grouping=16, minblocks=12) , # 167.682 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=9, k=9, tile_m=3, tile_n=2, w=4, v=4, threads=96, grouping=16, minblocks=12) , # 190.947 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=9, k=13, tile_m=3, tile_n=2, w=6, v=6, threads=96, grouping=16, minblocks=12) , # 223.144 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=9, k=25, tile_m=3, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 258.374 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=9, k=26, tile_m=3, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 260.559 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=9, k=28, tile_m=3, tile_n=2, w=10, v=8, threads=96, grouping=16, minblocks=12) , # 266.255 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=9, k=32, tile_m=3, tile_n=2, w=12, v=6, threads=128, grouping=16, minblocks=8) , # 271.239 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=9, k=45, tile_m=3, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=12) , # 288.261 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=13, k=4, tile_m=5, tile_n=1, w=2, v=8, threads=128, grouping=16, minblocks=12) , # 161.582 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=13, k=5, tile_m=3, tile_n=2, w=2, v=8, threads=128, grouping=16, minblocks=12) , # 174.113 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=13, k=7, tile_m=5, tile_n=2, w=2, v=10, threads=96, grouping=16, minblocks=12) , # 201.625 GFlop/s
-  Kernel_dnt_medium(m=45, n=13, k=9, tile_m=3, tile_n=2, threads=128, grouping=16, minblocks=8) , # 234.915 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=13, k=13, tile_m=3, tile_n=2, w=6, v=8, threads=128, grouping=16, minblocks=8) , # 255.57 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=13, k=24, tile_m=5, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=8) , # 327.987 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=13, k=25, tile_m=3, tile_n=2, w=12, v=6, threads=128, grouping=16, minblocks=8) , # 314.759 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=13, k=26, tile_m=3, tile_n=2, w=12, v=12, threads=128, grouping=16, minblocks=8) , # 320.527 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=13, k=28, tile_m=5, tile_n=2, w=10, v=10, threads=96, grouping=16, minblocks=8) , # 333.834 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=13, k=32, tile_m=5, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=8) , # 346.121 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=13, k=45, tile_m=5, tile_n=2, w=12, v=12, threads=96, grouping=16, minblocks=8) , # 371.646 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=24, k=13, tile_m=3, tile_n=3, w=6, v=16, threads=128, grouping=16, minblocks=8) , # 369.651 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=24, k=24, tile_m=3, tile_n=3, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 456.36 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=24, k=32, tile_m=3, tile_n=3, w=8, v=16, threads=128, grouping=16, minblocks=8) , # 476.863 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=24, k=45, tile_m=3, tile_n=4, w=8, v=16, threads=96, grouping=16, minblocks=8) , # 507.03 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=25, k=4, tile_m=6, tile_n=2, w=2, v=14, threads=128, grouping=16, minblocks=8) , # 181.279 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=25, k=5, tile_m=5, tile_n=2, w=2, v=14, threads=128, grouping=16, minblocks=8) , # 210.509 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=25, k=7, tile_m=5, tile_n=2, w=2, v=14, threads=128, grouping=16, minblocks=4) , # 229.999 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=25, k=9, tile_m=5, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=8) , # 293.374 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=25, k=13, tile_m=5, tile_n=2, w=4, v=14, threads=128, grouping=16, minblocks=4) , # 304.438 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=25, k=25, tile_m=3, tile_n=4, w=10, v=22, threads=128, grouping=16, minblocks=1) , # 377.937 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=25, k=26, tile_m=3, tile_n=4, w=10, v=24, threads=128, grouping=16, minblocks=4) , # 376.764 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=25, k=28, tile_m=5, tile_n=2, w=14, v=24, threads=192, grouping=16, minblocks=4) , # 394.568 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=25, k=32, tile_m=3, tile_n=4, w=16, v=24, threads=128, grouping=16, minblocks=1) , # 419.218 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=25, k=45, tile_m=5, tile_n=2, w=16, v=24, threads=192, grouping=16, minblocks=4) , # 435.39 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=26, k=4, tile_m=6, tile_n=2, w=2, v=14, threads=128, grouping=16, minblocks=8) , # 184.281 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=26, k=5, tile_m=5, tile_n=2, w=2, v=14, threads=128, grouping=16, minblocks=8) , # 211.405 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=26, k=7, tile_m=5, tile_n=2, w=2, v=12, threads=128, grouping=16, minblocks=8) , # 242.135 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=26, k=9, tile_m=5, tile_n=2, w=2, v=14, threads=128, grouping=16, minblocks=8) , # 277.095 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=26, k=13, tile_m=5, tile_n=2, w=4, v=22, threads=128, grouping=16, minblocks=1) , # 322.208 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=26, k=25, tile_m=5, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=8) , # 394.731 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=26, k=26, tile_m=5, tile_n=2, w=4, v=14, threads=128, grouping=16, minblocks=8) , # 401.24 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=26, k=28, tile_m=5, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=8) , # 436.355 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=26, k=32, tile_m=5, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=8) , # 444.707 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=26, k=45, tile_m=5, tile_n=2, w=4, v=14, threads=128, grouping=16, minblocks=8) , # 470.147 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=28, k=4, tile_m=6, tile_n=2, w=2, v=14, threads=128, grouping=16, minblocks=8) , # 196.839 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=28, k=5, tile_m=5, tile_n=2, w=2, v=14, threads=128, grouping=16, minblocks=8) , # 224.568 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=28, k=7, tile_m=5, tile_n=2, w=2, v=14, threads=128, grouping=16, minblocks=8) , # 263.736 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=28, k=9, tile_m=5, tile_n=2, w=2, v=14, threads=128, grouping=16, minblocks=8) , # 293.355 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=28, k=13, tile_m=5, tile_n=2, w=4, v=14, threads=128, grouping=16, minblocks=4) , # 340.659 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=28, k=25, tile_m=5, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=8) , # 422.701 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=28, k=26, tile_m=5, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=8) , # 427.927 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=28, k=28, tile_m=5, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=8) , # 465.948 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=28, k=32, tile_m=5, tile_n=2, w=4, v=10, threads=128, grouping=16, minblocks=8) , # 474.663 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=28, k=45, tile_m=5, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=8) , # 500.869 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=32, k=4, tile_m=6, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=8) , # 218.515 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=32, k=5, tile_m=6, tile_n=2, w=2, v=16, threads=128, grouping=16, minblocks=8) , # 224.185 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=32, k=7, tile_m=6, tile_n=2, w=2, v=10, threads=128, grouping=16, minblocks=8) , # 257.346 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=32, k=9, tile_m=6, tile_n=2, w=4, v=16, threads=128, grouping=16, minblocks=4) , # 300.997 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=32, k=13, tile_m=3, tile_n=4, w=6, v=16, threads=128, grouping=16, minblocks=1) , # 370.865 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=32, k=24, tile_m=3, tile_n=4, w=12, v=16, threads=128, grouping=16, minblocks=1) , # 474.921 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=32, k=25, tile_m=3, tile_n=4, w=12, v=16, threads=128, grouping=16, minblocks=1) , # 459.048 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=32, k=26, tile_m=3, tile_n=4, w=12, v=16, threads=128, grouping=16, minblocks=4) , # 472.758 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=32, k=28, tile_m=3, tile_n=4, w=14, v=16, threads=128, grouping=16, minblocks=1) , # 494.885 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=32, k=32, tile_m=3, tile_n=4, w=12, v=16, threads=128, grouping=16, minblocks=4) , # 504.584 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=32, k=45, tile_m=3, tile_n=4, w=12, v=16, threads=128, grouping=16, minblocks=1) , # 536.655 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=45, k=4, tile_m=6, tile_n=2, w=2, v=28, threads=256, grouping=16, minblocks=4) , # 178.318 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=45, k=5, tile_m=5, tile_n=2, w=2, v=28, threads=256, grouping=16, minblocks=4) , # 199.013 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=45, k=7, tile_m=3, tile_n=2, w=2, v=30, threads=352, grouping=16, minblocks=4) , # 229.112 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=45, k=9, tile_m=3, tile_n=3, w=4, v=28, threads=256, grouping=16, minblocks=4) , # 291.982 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=45, k=13, tile_m=3, tile_n=6, w=6, v=24, threads=128, grouping=16, minblocks=4) , # 360.044 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=45, k=24, tile_m=6, tile_n=3, w=12, v=28, threads=128, grouping=16, minblocks=4) , # 456.144 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=45, k=25, tile_m=6, tile_n=3, w=10, v=28, threads=128, grouping=16, minblocks=1) , # 450.391 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=45, k=26, tile_m=3, tile_n=6, w=10, v=28, threads=128, grouping=16, minblocks=1) , # 457.692 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=45, k=28, tile_m=3, tile_n=6, w=14, v=22, threads=128, grouping=16, minblocks=1) , # 480.917 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=45, k=32, tile_m=3, tile_n=6, w=16, v=28, threads=128, grouping=16, minblocks=1) , # 511.25 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=45, k=45, tile_m=3, tile_n=6, w=16, v=28, threads=128, grouping=16, minblocks=1) , # 534.417 GFlop/s
-  Kernel_dnt_medium(m=49, n=7, k=7, tile_m=3, tile_n=1, threads=128, grouping=16, minblocks=8) , # 145.44 GFlop/s
-  Kernel_dnt_largeDB1(m=55, n=16, k=16, tile_m=3, tile_n=3, w=8, v=12, threads=128, grouping=16, minblocks=8) , # 322.352 GFlop/s
-  Kernel_dnt_largeDB1(m=55, n=16, k=29, tile_m=3, tile_n=3, w=6, v=8, threads=128, grouping=16, minblocks=8) , # 369.726 GFlop/s
-  Kernel_dnt_largeDB1(m=55, n=16, k=55, tile_m=5, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=8) , # 426.451 GFlop/s
-  Kernel_dnt_largeDB1(m=55, n=29, k=16, tile_m=3, tile_n=5, w=8, v=20, threads=128, grouping=16, minblocks=1) , # 339.155 GFlop/s
-  Kernel_dnt_largeDB1(m=55, n=29, k=29, tile_m=3, tile_n=5, w=10, v=26, threads=160, grouping=16, minblocks=4) , # 383.513 GFlop/s
-  Kernel_dnt_largeDB1(m=55, n=29, k=32, tile_m=3, tile_n=5, w=8, v=20, threads=128, grouping=16, minblocks=1) , # 427.971 GFlop/s
-  Kernel_dnt_largeDB1(m=55, n=29, k=55, tile_m=3, tile_n=5, w=6, v=20, threads=128, grouping=16, minblocks=4) , # 466.603 GFlop/s
-  Kernel_dnt_largeDB1(m=55, n=32, k=29, tile_m=5, tile_n=3, w=4, v=16, threads=128, grouping=16, minblocks=1) , # 421.352 GFlop/s
-  Kernel_dnt_largeDB1(m=55, n=32, k=32, tile_m=5, tile_n=3, w=8, v=16, threads=128, grouping=16, minblocks=1) , # 461.927 GFlop/s
-  Kernel_dnt_largeDB1(m=55, n=32, k=55, tile_m=5, tile_n=3, w=6, v=20, threads=128, grouping=16, minblocks=4) , # 500.36 GFlop/s
-  Kernel_dnt_largeDB1(m=55, n=55, k=16, tile_m=5, tile_n=5, w=6, v=26, threads=128, grouping=16, minblocks=1) , # 361.626 GFlop/s
-  Kernel_dnt_largeDB1(m=55, n=55, k=29, tile_m=5, tile_n=5, w=10, v=30, threads=128, grouping=16, minblocks=1) , # 408.729 GFlop/s
-  Kernel_dnt_largeDB1(m=55, n=55, k=32, tile_m=5, tile_n=5, w=6, v=26, threads=128, grouping=16, minblocks=1) , # 501.123 GFlop/s
-  Kernel_dnt_largeDB1(m=55, n=55, k=55, tile_m=5, tile_n=5, w=6, v=26, threads=128, grouping=16, minblocks=1) , # 588.05 GFlop/s
-  Kernel_dnt_medium(m=64, n=8, k=8, tile_m=2, tile_n=2, threads=128, grouping=16, minblocks=8) , # 213.145 GFlop/s
-  Kernel_dnt_medium(m=64, n=9, k=9, tile_m=2, tile_n=3, threads=128, grouping=16, minblocks=8) , # 240.201 GFlop/s
-  Kernel_dnt_largeDB1(m=64, n=9, k=16, tile_m=2, tile_n=3, w=4, v=6, threads=96, grouping=16, minblocks=12) , # 263.151 GFlop/s
-  Kernel_dnt_largeDB1(m=64, n=9, k=22, tile_m=2, tile_n=3, w=6, v=4, threads=96, grouping=16, minblocks=12) , # 286.988 GFlop/s
-  Kernel_dnt_largeDB1(m=64, n=9, k=64, tile_m=2, tile_n=3, w=10, v=8, threads=128, grouping=16, minblocks=8) , # 319.492 GFlop/s
-  Kernel_dnt_largeDB1(m=64, n=16, k=9, tile_m=2, tile_n=4, w=4, v=10, threads=128, grouping=16, minblocks=8) , # 283.571 GFlop/s
-  Kernel_dnt_largeDB1(m=64, n=16, k=16, tile_m=2, tile_n=4, w=8, v=10, threads=128, grouping=16, minblocks=8) , # 379.404 GFlop/s
-  Kernel_dnt_largeDB1(m=64, n=16, k=22, tile_m=2, tile_n=4, w=8, v=8, threads=128, grouping=16, minblocks=8) , # 408.89 GFlop/s
-  Kernel_dnt_largeDB1(m=64, n=16, k=64, tile_m=2, tile_n=4, w=8, v=10, threads=128, grouping=16, minblocks=8) , # 501.245 GFlop/s
-  Kernel_dnt_largeDB1(m=64, n=22, k=9, tile_m=6, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=1) , # 271.107 GFlop/s
-  Kernel_dnt_largeDB1(m=64, n=22, k=16, tile_m=2, tile_n=6, w=8, v=14, threads=128, grouping=16, minblocks=1) , # 369.789 GFlop/s
-  Kernel_dnt_largeDB1(m=64, n=22, k=22, tile_m=6, tile_n=2, w=4, v=12, threads=128, grouping=16, minblocks=4) , # 383.088 GFlop/s
-  Kernel_dnt_largeDB1(m=64, n=22, k=64, tile_m=2, tile_n=6, w=8, v=2, threads=128, grouping=16, minblocks=4) , # 507.361 GFlop/s
-  Kernel_dnt_largeDB1(m=64, n=64, k=9, tile_m=4, tile_n=4, w=4, v=16, threads=256, grouping=16, minblocks=1) , # 271.502 GFlop/s
-  Kernel_dnt_largeDB1(m=64, n=64, k=16, tile_m=4, tile_n=4, w=6, v=16, threads=256, grouping=16, minblocks=1) , # 363.539 GFlop/s
-  Kernel_dnt_largeDB1(m=64, n=64, k=22, tile_m=4, tile_n=4, w=8, v=16, threads=256, grouping=16, minblocks=1) , # 410.791 GFlop/s
-  Kernel_dnt_largeDB1(m=64, n=64, k=64, tile_m=3, tile_n=6, w=16, v=32, threads=256, grouping=16, minblocks=1) , # 563.614 GFlop/s
-  Kernel_dnt_largeDB1(m=78, n=78, k=78, tile_m=5, tile_n=5, w=8, v=26, threads=256, grouping=16, minblocks=1) , # 589.26 GFlop/s
-  Kernel_dnt_largeDB1(m=81, n=9, k=9, tile_m=3, tile_n=3, w=4, v=6, threads=128, grouping=16, minblocks=8) , # 189.642 GFlop/s
-  Kernel_dnt_largeDB1(m=96, n=96, k=96, tile_m=6, tile_n=3, w=14, v=48, threads=512, grouping=16, minblocks=1) , # 614.588 GFlop/s
-  Kernel_dnt_medium(m=100, n=10, k=10, tile_m=2, tile_n=2, threads=256, grouping=16, minblocks=4) , # 226.917 GFlop/s
-  Kernel_dnt_medium(m=121, n=11, k=11, tile_m=5, tile_n=3, threads=128, grouping=16, minblocks=1) , # 233.211 GFlop/s
-  Kernel_dnt_largeDB1(m=144, n=12, k=12, tile_m=2, tile_n=4, w=6, v=8, threads=288, grouping=16, minblocks=4) , # 268.209 GFlop/s
-  Kernel_dnt_largeDB1(m=169, n=13, k=13, tile_m=3, tile_n=4, w=6, v=10, threads=256, grouping=16, minblocks=1) , # 221.427 GFlop/s
-  Kernel_dnt_medium(m=196, n=14, k=14, tile_m=6, tile_n=2, threads=256, grouping=16, minblocks=1) , # 243.838 GFlop/s
-  Kernel_dnt_largeDB1(m=225, n=15, k=15, tile_m=3, tile_n=3, w=4, v=12, threads=384, grouping=16, minblocks=1) , # 248.307 GFlop/s
-  Kernel_dnt_largeDB1(m=256, n=16, k=16, tile_m=2, tile_n=6, w=6, v=10, threads=384, grouping=16, minblocks=1) , # 309.19 GFlop/s
+{"m": 4, "n": 4, "k": 4, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 16.5663},
+{"m": 4, "n": 4, "k": 5, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 20.1639},
+{"m": 4, "n": 4, "k": 6, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 23.5514},
+{"m": 4, "n": 4, "k": 7, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 27.508},
+{"m": 4, "n": 4, "k": 8, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 31.7227},
+{"m": 4, "n": 4, "k": 9, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 34.2669},
+{"m": 4, "n": 4, "k": 10, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 37.6563},
+{"m": 4, "n": 4, "k": 13, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 45.9102},
+{"m": 4, "n": 4, "k": 15, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 51.3947},
+{"m": 4, "n": 4, "k": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 54.8645},
+{"m": 4, "n": 4, "k": 17, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 54.3192},
+{"m": 4, "n": 4, "k": 22, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 62.9255},
+{"m": 4, "n": 4, "k": 23, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 60.6683},
+{"m": 4, "n": 4, "k": 24, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 62.8983},
+{"m": 4, "n": 4, "k": 25, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 50.8246},
+{"m": 4, "n": 4, "k": 26, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 53.309},
+{"m": 4, "n": 4, "k": 28, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 54.7759},
+{"m": 4, "n": 4, "k": 32, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 58.5147},
+{"m": 4, "n": 4, "k": 45, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 55.094},
+{"m": 4, "n": 5, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 14.9148},
+{"m": 4, "n": 5, "k": 5, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 18.1077},
+{"m": 4, "n": 5, "k": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 21.2783},
+{"m": 4, "n": 5, "k": 7, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 25.2832},
+{"m": 4, "n": 5, "k": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 29.5849},
+{"m": 4, "n": 5, "k": 9, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 30.8254},
+{"m": 4, "n": 5, "k": 13, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 42.687},
+{"m": 4, "n": 5, "k": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 52.9062},
+{"m": 4, "n": 5, "k": 17, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 51.922},
+{"m": 4, "n": 5, "k": 22, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 48.5357},
+{"m": 4, "n": 5, "k": 23, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 50.2012},
+{"m": 4, "n": 5, "k": 24, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 50.9804},
+{"m": 4, "n": 5, "k": 25, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 45.0794},
+{"m": 4, "n": 5, "k": 26, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 46.9644},
+{"m": 4, "n": 5, "k": 28, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 44.74},
+{"m": 4, "n": 5, "k": 32, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 47.0079},
+{"m": 4, "n": 5, "k": 45, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 39.578},
+{"m": 4, "n": 6, "k": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 17.7217},
+{"m": 4, "n": 6, "k": 5, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 21.2885},
+{"m": 4, "n": 6, "k": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 26.0691},
+{"m": 4, "n": 6, "k": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 35.3897},
+{"m": 4, "n": 6, "k": 9, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 36.1752},
+{"m": 4, "n": 6, "k": 13, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 50.7414},
+{"m": 4, "n": 6, "k": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 62.3605},
+{"m": 4, "n": 6, "k": 17, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 52.168},
+{"m": 4, "n": 6, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 61.4407},
+{"m": 4, "n": 6, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 63.1415},
+{"m": 4, "n": 6, "k": 24, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 59.2859},
+{"m": 4, "n": 6, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 63.6068},
+{"m": 4, "n": 6, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 66.9879},
+{"m": 4, "n": 7, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 20.3949},
+{"m": 4, "n": 7, "k": 5, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 25.5066},
+{"m": 4, "n": 7, "k": 7, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 34.4269},
+{"m": 4, "n": 7, "k": 9, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 41.6453},
+{"m": 4, "n": 7, "k": 13, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 57.6433},
+{"m": 4, "n": 7, "k": 25, "tile_m": 1, "tile_n": 1, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 70.7435},
+{"m": 4, "n": 7, "k": 26, "tile_m": 1, "tile_n": 1, "w": 12, "v": 6, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 72.8932},
+{"m": 4, "n": 7, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 81.1008},
+{"m": 4, "n": 7, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 87.9914},
+{"m": 4, "n": 7, "k": 45, "tile_m": 1, "tile_n": 1, "w": 18, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 89.4636},
+{"m": 4, "n": 8, "k": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 24.016},
+{"m": 4, "n": 8, "k": 5, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 28.6828},
+{"m": 4, "n": 8, "k": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 34.4605},
+{"m": 4, "n": 8, "k": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 45.9955},
+{"m": 4, "n": 8, "k": 9, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 48.4776},
+{"m": 4, "n": 8, "k": 13, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 54.9661},
+{"m": 4, "n": 8, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 64.3579},
+{"m": 4, "n": 8, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 67.3422},
+{"m": 4, "n": 8, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 80.9386},
+{"m": 4, "n": 8, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 83.121},
+{"m": 4, "n": 8, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 72.6651},
+{"m": 4, "n": 8, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 74.4863},
+{"m": 4, "n": 8, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 8, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 83.7638},
+{"m": 4, "n": 9, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 24.1362},
+{"m": 4, "n": 9, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 29.7245},
+{"m": 4, "n": 9, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 34.6329},
+{"m": 4, "n": 9, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 39.4845},
+{"m": 4, "n": 9, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 44.6668},
+{"m": 4, "n": 9, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 49.1063},
+{"m": 4, "n": 9, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 58.1283},
+{"m": 4, "n": 9, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 66.7055},
+{"m": 4, "n": 9, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 69.4121},
+{"m": 4, "n": 9, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 81.2228},
+{"m": 4, "n": 9, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 83.4097},
+{"m": 4, "n": 9, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 79.1819},
+{"m": 4, "n": 9, "k": 25, "tile_m": 1, "tile_n": 1, "w": 10, "v": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 80.8055},
+{"m": 4, "n": 9, "k": 26, "tile_m": 1, "tile_n": 1, "w": 10, "v": 6, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 82.8333},
+{"m": 4, "n": 9, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 91.3053},
+{"m": 4, "n": 9, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 92.4279},
+{"m": 4, "n": 9, "k": 45, "tile_m": 1, "tile_n": 1, "w": 18, "v": 6, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 97.8429},
+{"m": 4, "n": 10, "k": 4, "tile_m": 1, "tile_n": 1, "w": 2, "v": 10, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 27.7177},
+{"m": 4, "n": 10, "k": 10, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 52.2698},
+{"m": 4, "n": 10, "k": 15, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 70.3125},
+{"m": 4, "n": 13, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 34.7964},
+{"m": 4, "n": 13, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 42.8558},
+{"m": 4, "n": 13, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 49.8578},
+{"m": 4, "n": 13, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 56.807},
+{"m": 4, "n": 13, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 56.9443},
+{"m": 4, "n": 13, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 62.3945},
+{"m": 4, "n": 13, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 82.5655},
+{"m": 4, "n": 13, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 95.0394},
+{"m": 4, "n": 13, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 98.1766},
+{"m": 4, "n": 13, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 106.482},
+{"m": 4, "n": 13, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 99.1141},
+{"m": 4, "n": 13, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 102.229},
+{"m": 4, "n": 13, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 104.392},
+{"m": 4, "n": 13, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 107.25},
+{"m": 4, "n": 13, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 10, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 112.358},
+{"m": 4, "n": 13, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 10, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 117.253},
+{"m": 4, "n": 13, "k": 45, "tile_m": 1, "tile_n": 1, "w": 20, "v": 12, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 117.218},
+{"m": 4, "n": 15, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 39.8849},
+{"m": 4, "n": 15, "k": 10, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 76.3306},
+{"m": 4, "n": 15, "k": 15, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 100.748},
+{"m": 4, "n": 16, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 43.4494},
+{"m": 4, "n": 16, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 53.0611},
+{"m": 4, "n": 16, "k": 6, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 56.7665},
+{"m": 4, "n": 16, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 71.163},
+{"m": 4, "n": 16, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 75.903},
+{"m": 4, "n": 16, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 101.297},
+{"m": 4, "n": 16, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 112.777},
+{"m": 4, "n": 16, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 114.289},
+{"m": 4, "n": 16, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 117.51},
+{"m": 4, "n": 16, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 118.855},
+{"m": 4, "n": 16, "k": 24, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 116.045},
+{"m": 4, "n": 16, "k": 26, "tile_m": 1, "tile_n": 1, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 109.271},
+{"m": 4, "n": 16, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 119.269},
+{"m": 4, "n": 17, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 44.3641},
+{"m": 4, "n": 17, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 54.048},
+{"m": 4, "n": 17, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 56.5091},
+{"m": 4, "n": 17, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 71.3946},
+{"m": 4, "n": 17, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 76.8119},
+{"m": 4, "n": 17, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 99.368},
+{"m": 4, "n": 17, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 109.498},
+{"m": 4, "n": 17, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 98.7893},
+{"m": 4, "n": 17, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 113.492},
+{"m": 4, "n": 17, "k": 23, "tile_m": 1, "tile_n": 1, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 99.7952},
+{"m": 4, "n": 17, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 107.141},
+{"m": 4, "n": 17, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 106.081},
+{"m": 4, "n": 17, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 6, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 113.471},
+{"m": 4, "n": 22, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 57.4498},
+{"m": 4, "n": 22, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 62.5018},
+{"m": 4, "n": 22, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 72.8839},
+{"m": 4, "n": 22, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 91.5999},
+{"m": 4, "n": 22, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 99.159},
+{"m": 4, "n": 22, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 118.024},
+{"m": 4, "n": 22, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 120.717},
+{"m": 4, "n": 22, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 121.506},
+{"m": 4, "n": 22, "k": 22, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 120.919},
+{"m": 4, "n": 22, "k": 23, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 116.314},
+{"m": 4, "n": 22, "k": 24, "tile_m": 1, "tile_n": 1, "w": 8, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 121.22},
+{"m": 4, "n": 22, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 117.406},
+{"m": 4, "n": 22, "k": 32, "tile_m": 1, "tile_n": 1, "w": 8, "v": 20, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 127.401},
+{"m": 4, "n": 23, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 59.7783},
+{"m": 4, "n": 23, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 64.7027},
+{"m": 4, "n": 23, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 75.5435},
+{"m": 4, "n": 23, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 94.7326},
+{"m": 4, "n": 23, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 102.115},
+{"m": 4, "n": 23, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 109.914},
+{"m": 4, "n": 23, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 123.335},
+{"m": 4, "n": 23, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 110.912},
+{"m": 4, "n": 23, "k": 22, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 118.425},
+{"m": 4, "n": 23, "k": 23, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 119.87},
+{"m": 4, "n": 23, "k": 24, "tile_m": 1, "tile_n": 1, "w": 10, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 119.172},
+{"m": 4, "n": 23, "k": 26, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 119.54},
+{"m": 4, "n": 23, "k": 32, "tile_m": 1, "tile_n": 1, "w": 8, "v": 20, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 127.587},
+{"m": 4, "n": 24, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 58.0271},
+{"m": 4, "n": 24, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 67.3989},
+{"m": 4, "n": 24, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 78.5843},
+{"m": 4, "n": 24, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 90.4024},
+{"m": 4, "n": 24, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 107.128},
+{"m": 4, "n": 24, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 115.396},
+{"m": 4, "n": 24, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 24, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 117.543},
+{"m": 4, "n": 24, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 115.374},
+{"m": 4, "n": 24, "k": 22, "tile_m": 1, "tile_n": 1, "w": 8, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 123.01},
+{"m": 4, "n": 24, "k": 23, "tile_m": 1, "tile_n": 1, "w": 8, "v": 24, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 121.888},
+{"m": 4, "n": 24, "k": 24, "tile_m": 1, "tile_n": 1, "w": 8, "v": 24, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 126.228},
+{"m": 4, "n": 24, "k": 26, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 124.519},
+{"m": 4, "n": 24, "k": 32, "tile_m": 1, "tile_n": 1, "w": 8, "v": 22, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 131.226},
+{"m": 4, "n": 25, "k": 4, "tile_m": 2, "tile_n": 1, "w": 2, "v": 24, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 59.7499},
+{"m": 4, "n": 25, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 65.252},
+{"m": 4, "n": 25, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 77.9696},
+{"m": 4, "n": 25, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 89.8186},
+{"m": 4, "n": 25, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 112.687},
+{"m": 4, "n": 25, "k": 25, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 129.771},
+{"m": 4, "n": 25, "k": 26, "tile_m": 2, "tile_n": 1, "w": 12, "v": 22, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 127.735},
+{"m": 4, "n": 25, "k": 28, "tile_m": 2, "tile_n": 1, "w": 14, "v": 24, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 135.101},
+{"m": 4, "n": 25, "k": 32, "tile_m": 2, "tile_n": 1, "w": 16, "v": 24, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 139.761},
+{"m": 4, "n": 25, "k": 45, "tile_m": 2, "tile_n": 1, "w": 16, "v": 24, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 140.077},
+{"m": 4, "n": 26, "k": 4, "tile_m": 1, "tile_n": 1, "w": 2, "v": 26, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 63.4377},
+{"m": 4, "n": 26, "k": 5, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 61.4438},
+{"m": 4, "n": 26, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 71.391},
+{"m": 4, "n": 26, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 81.5028},
+{"m": 4, "n": 26, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 87.1416},
+{"m": 4, "n": 26, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 95.4329},
+{"m": 4, "n": 26, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 117.999},
+{"m": 4, "n": 26, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 118.965},
+{"m": 4, "n": 26, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 117.606},
+{"m": 4, "n": 26, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 124.959},
+{"m": 4, "n": 26, "k": 23, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 125.45},
+{"m": 4, "n": 26, "k": 24, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 128.616},
+{"m": 4, "n": 26, "k": 25, "tile_m": 2, "tile_n": 1, "w": 12, "v": 14, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 128.125},
+{"m": 4, "n": 26, "k": 26, "tile_m": 2, "tile_n": 1, "w": 12, "v": 22, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 130.88},
+{"m": 4, "n": 26, "k": 28, "tile_m": 2, "tile_n": 1, "w": 14, "v": 26, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 137.164},
+{"m": 4, "n": 26, "k": 32, "tile_m": 2, "tile_n": 1, "w": 16, "v": 24, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 141.257},
+{"m": 4, "n": 26, "k": 45, "tile_m": 2, "tile_n": 1, "w": 16, "v": 14, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 140.164},
+{"m": 4, "n": 28, "k": 4, "tile_m": 1, "tile_n": 1, "w": 2, "v": 28, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 68.2828},
+{"m": 4, "n": 28, "k": 5, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 65.6686},
+{"m": 4, "n": 28, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 83.3092},
+{"m": 4, "n": 28, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 100.922},
+{"m": 4, "n": 28, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 123.15},
+{"m": 4, "n": 28, "k": 25, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 133.073},
+{"m": 4, "n": 28, "k": 26, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 134.749},
+{"m": 4, "n": 28, "k": 28, "tile_m": 2, "tile_n": 1, "w": 14, "v": 28, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 140.056},
+{"m": 4, "n": 28, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 28, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 141.483},
+{"m": 4, "n": 28, "k": 45, "tile_m": 1, "tile_n": 1, "w": 12, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 142.643},
+{"m": 4, "n": 32, "k": 4, "tile_m": 1, "tile_n": 1, "w": 2, "v": 32, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 78.1248},
+{"m": 4, "n": 32, "k": 5, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 74.5054},
+{"m": 4, "n": 32, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 85.0733},
+{"m": 4, "n": 32, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 94.5942},
+{"m": 4, "n": 32, "k": 8, "tile_m": 1, "tile_n": 1, "w": 4, "v": 32, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 101.579},
+{"m": 4, "n": 32, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 114.088},
+{"m": 4, "n": 32, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 127.948},
+{"m": 4, "n": 32, "k": 16, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 129.951},
+{"m": 4, "n": 32, "k": 17, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 129.899},
+{"m": 4, "n": 32, "k": 22, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 133.965},
+{"m": 4, "n": 32, "k": 23, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 135.677},
+{"m": 4, "n": 32, "k": 24, "tile_m": 1, "tile_n": 1, "w": 8, "v": 32, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 137.129},
+{"m": 4, "n": 32, "k": 25, "tile_m": 1, "tile_n": 1, "w": 12, "v": 32, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 138.999},
+{"m": 4, "n": 32, "k": 26, "tile_m": 1, "tile_n": 1, "w": 8, "v": 32, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 140.06},
+{"m": 4, "n": 32, "k": 28, "tile_m": 2, "tile_n": 1, "w": 14, "v": 20, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 142.731},
+{"m": 4, "n": 32, "k": 32, "tile_m": 1, "tile_n": 1, "w": 12, "v": 32, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 146.525},
+{"m": 4, "n": 32, "k": 45, "tile_m": 2, "tile_n": 1, "w": 16, "v": 32, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 148.422},
+{"m": 4, "n": 45, "k": 4, "tile_m": 2, "tile_n": 1, "w": 2, "v": 24, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 89.1846},
+{"m": 4, "n": 45, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 90.7481},
+{"m": 4, "n": 45, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 112.025},
+{"m": 4, "n": 45, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 123.37},
+{"m": 4, "n": 45, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 132.048},
+{"m": 4, "n": 45, "k": 25, "tile_m": 2, "tile_n": 1, "w": 10, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 142.681},
+{"m": 4, "n": 45, "k": 26, "tile_m": 2, "tile_n": 1, "w": 10, "v": 32, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 144.113},
+{"m": 4, "n": 45, "k": 28, "tile_m": 2, "tile_n": 1, "w": 14, "v": 32, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 147.358},
+{"m": 4, "n": 45, "k": 32, "tile_m": 2, "tile_n": 1, "w": 8, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 150.112},
+{"m": 4, "n": 45, "k": 45, "tile_m": 1, "tile_n": 1, "w": 12, "v": 26, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 150.749},
+{"m": 5, "n": 4, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 14.8425},
+{"m": 5, "n": 4, "k": 5, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 17.8923},
+{"m": 5, "n": 4, "k": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 20.6833},
+{"m": 5, "n": 4, "k": 7, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 25.0033},
+{"m": 5, "n": 4, "k": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 28.7395},
+{"m": 5, "n": 4, "k": 9, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 30.3363},
+{"m": 5, "n": 4, "k": 13, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 35.8017},
+{"m": 5, "n": 4, "k": 16, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 35.9461},
+{"m": 5, "n": 4, "k": 17, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 34.9185},
+{"m": 5, "n": 4, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 37.0424},
+{"m": 5, "n": 4, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 37.32},
+{"m": 5, "n": 4, "k": 24, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 50.5776},
+{"m": 5, "n": 4, "k": 25, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 42.9798},
+{"m": 5, "n": 4, "k": 26, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 46.6834},
+{"m": 5, "n": 4, "k": 28, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 44.9266},
+{"m": 5, "n": 4, "k": 32, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 46.7652},
+{"m": 5, "n": 4, "k": 45, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 39.2713},
+{"m": 5, "n": 5, "k": 4, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 23.8033},
+{"m": 5, "n": 5, "k": 5, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 29.5496},
+{"m": 5, "n": 5, "k": 6, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 33.673},
+{"m": 5, "n": 5, "k": 7, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 39.8149},
+{"m": 5, "n": 5, "k": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 37.8978},
+{"m": 5, "n": 5, "k": 9, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 48.7651},
+{"m": 5, "n": 5, "k": 13, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 55.6173},
+{"m": 5, "n": 5, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 58.79},
+{"m": 5, "n": 5, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 60.0103},
+{"m": 5, "n": 5, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 64.9733},
+{"m": 5, "n": 5, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 66.7856},
+{"m": 5, "n": 5, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 68.8446},
+{"m": 5, "n": 5, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 69.5795},
+{"m": 5, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 73.6718},
+{"m": 5, "n": 5, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 78.9513},
+{"m": 5, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 85.3813},
+{"m": 5, "n": 5, "k": 45, "tile_m": 1, "tile_n": 1, "w": 18, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 85.4611},
+{"m": 5, "n": 6, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 20.9988},
+{"m": 5, "n": 6, "k": 5, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 25.4954},
+{"m": 5, "n": 6, "k": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 31.0513},
+{"m": 5, "n": 6, "k": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 39.6543},
+{"m": 5, "n": 6, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 37.5652},
+{"m": 5, "n": 6, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 49.3659},
+{"m": 5, "n": 6, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 58.1624},
+{"m": 5, "n": 6, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 52.8571},
+{"m": 5, "n": 6, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 69.8459},
+{"m": 5, "n": 6, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 72.2008},
+{"m": 5, "n": 6, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 74.465},
+{"m": 5, "n": 6, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 78.7224},
+{"m": 5, "n": 6, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 81.0562},
+{"m": 5, "n": 7, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 23.7332},
+{"m": 5, "n": 7, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 29.2419},
+{"m": 5, "n": 7, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 38.8739},
+{"m": 5, "n": 7, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 47.5812},
+{"m": 5, "n": 7, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 63.0682},
+{"m": 5, "n": 7, "k": 25, "tile_m": 1, "tile_n": 1, "w": 10, "v": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 79.9775},
+{"m": 5, "n": 7, "k": 26, "tile_m": 1, "tile_n": 1, "w": 10, "v": 6, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 81.302},
+{"m": 5, "n": 7, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 4, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 89.0756},
+{"m": 5, "n": 7, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 93.7976},
+{"m": 5, "n": 7, "k": 45, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 98.0821},
+{"m": 5, "n": 8, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 27.2512},
+{"m": 5, "n": 8, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 32.9231},
+{"m": 5, "n": 8, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 39.1691},
+{"m": 5, "n": 8, "k": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 47.0366},
+{"m": 5, "n": 8, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 48.3135},
+{"m": 5, "n": 8, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 59.2125},
+{"m": 5, "n": 8, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 67.8873},
+{"m": 5, "n": 8, "k": 17, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 63.6387},
+{"m": 5, "n": 8, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 85.8051},
+{"m": 5, "n": 8, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 87.9872},
+{"m": 5, "n": 8, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 8, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 84.7498},
+{"m": 5, "n": 8, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 83.6633},
+{"m": 5, "n": 8, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 94.1701},
+{"m": 5, "n": 9, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 30.6314},
+{"m": 5, "n": 9, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 37.6561},
+{"m": 5, "n": 9, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 43.5479},
+{"m": 5, "n": 9, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 49.7157},
+{"m": 5, "n": 9, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 49.4117},
+{"m": 5, "n": 9, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 61.0651},
+{"m": 5, "n": 9, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 71.6433},
+{"m": 5, "n": 9, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 71.2271},
+{"m": 5, "n": 9, "k": 17, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 71.4887},
+{"m": 5, "n": 9, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 85.9047},
+{"m": 5, "n": 9, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 88.2854},
+{"m": 5, "n": 9, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 90.6552},
+{"m": 5, "n": 9, "k": 25, "tile_m": 1, "tile_n": 1, "w": 10, "v": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 98.39},
+{"m": 5, "n": 9, "k": 26, "tile_m": 1, "tile_n": 1, "w": 10, "v": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 99.7839},
+{"m": 5, "n": 9, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 8, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 110.791},
+{"m": 5, "n": 9, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 8, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 114.978},
+{"m": 5, "n": 9, "k": 45, "tile_m": 1, "tile_n": 1, "w": 18, "v": 6, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 117.396},
+{"m": 5, "n": 13, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 43.3144},
+{"m": 5, "n": 13, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 52.3204},
+{"m": 5, "n": 13, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 60.4434},
+{"m": 5, "n": 13, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 69.0831},
+{"m": 5, "n": 13, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 63.9439},
+{"m": 5, "n": 13, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 74.3939},
+{"m": 5, "n": 13, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 93.8869},
+{"m": 5, "n": 13, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 94.5206},
+{"m": 5, "n": 13, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 99.4373},
+{"m": 5, "n": 13, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 110.942},
+{"m": 5, "n": 13, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 110.721},
+{"m": 5, "n": 13, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 113.32},
+{"m": 5, "n": 13, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 114.526},
+{"m": 5, "n": 13, "k": 26, "tile_m": 1, "tile_n": 1, "w": 10, "v": 12, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 115.088},
+{"m": 5, "n": 13, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 12, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 124.415},
+{"m": 5, "n": 13, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 12, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 122.982},
+{"m": 5, "n": 13, "k": 45, "tile_m": 1, "tile_n": 1, "w": 16, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 127.844},
+{"m": 5, "n": 16, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 53.1228},
+{"m": 5, "n": 16, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 63.7683},
+{"m": 5, "n": 16, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 68.1547},
+{"m": 5, "n": 16, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 79.5016},
+{"m": 5, "n": 16, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 83.055},
+{"m": 5, "n": 16, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 101.84},
+{"m": 5, "n": 16, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 116.875},
+{"m": 5, "n": 16, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 121.579},
+{"m": 5, "n": 16, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 135.569},
+{"m": 5, "n": 16, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 129.272},
+{"m": 5, "n": 16, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 131.765},
+{"m": 5, "n": 16, "k": 26, "tile_m": 1, "tile_n": 1, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 128.942},
+{"m": 5, "n": 16, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 139.49},
+{"m": 5, "n": 17, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 54.7705},
+{"m": 5, "n": 17, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 66.6945},
+{"m": 5, "n": 17, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 67.0057},
+{"m": 5, "n": 17, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 77.7652},
+{"m": 5, "n": 17, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 87.0744},
+{"m": 5, "n": 17, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 106.256},
+{"m": 5, "n": 17, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 121.156},
+{"m": 5, "n": 17, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 119.245},
+{"m": 5, "n": 17, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 136.959},
+{"m": 5, "n": 17, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 123.364},
+{"m": 5, "n": 17, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 128.46},
+{"m": 5, "n": 17, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 132.131},
+{"m": 5, "n": 17, "k": 32, "tile_m": 1, "tile_n": 1, "w": 14, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 135.01},
+{"m": 5, "n": 22, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 64.6247},
+{"m": 5, "n": 22, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 71.6059},
+{"m": 5, "n": 22, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 73.2559},
+{"m": 5, "n": 22, "k": 8, "tile_m": 1, "tile_n": 1, "w": 4, "v": 22, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 92.3688},
+{"m": 5, "n": 22, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 98.0181},
+{"m": 5, "n": 22, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 119.94},
+{"m": 5, "n": 22, "k": 16, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 136.353},
+{"m": 5, "n": 22, "k": 17, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 137.955},
+{"m": 5, "n": 22, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 135.568},
+{"m": 5, "n": 22, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 135.879},
+{"m": 5, "n": 22, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 138.483},
+{"m": 5, "n": 22, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 145.469},
+{"m": 5, "n": 22, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 22, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 143.787},
+{"m": 5, "n": 23, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 66.9592},
+{"m": 5, "n": 23, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 74.1593},
+{"m": 5, "n": 23, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 76.2473},
+{"m": 5, "n": 23, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 94.6116},
+{"m": 5, "n": 23, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 102.375},
+{"m": 5, "n": 23, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 123.606},
+{"m": 5, "n": 23, "k": 16, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 140},
+{"m": 5, "n": 23, "k": 17, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 125.344},
+{"m": 5, "n": 23, "k": 22, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 144.101},
+{"m": 5, "n": 23, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 141.081},
+{"m": 5, "n": 23, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 143.882},
+{"m": 5, "n": 23, "k": 26, "tile_m": 1, "tile_n": 1, "w": 10, "v": 22, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 136.154},
+{"m": 5, "n": 23, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 22, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 145.364},
+{"m": 5, "n": 24, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 70.2727},
+{"m": 5, "n": 24, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 79.6991},
+{"m": 5, "n": 24, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 80.5021},
+{"m": 5, "n": 24, "k": 8, "tile_m": 1, "tile_n": 1, "w": 4, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 100.583},
+{"m": 5, "n": 24, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 107.639},
+{"m": 5, "n": 24, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 130.403},
+{"m": 5, "n": 24, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 138.648},
+{"m": 5, "n": 24, "k": 17, "tile_m": 1, "tile_n": 1, "w": 8, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 128.385},
+{"m": 5, "n": 24, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 147.78},
+{"m": 5, "n": 24, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 147.238},
+{"m": 5, "n": 24, "k": 24, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 149.11},
+{"m": 5, "n": 24, "k": 26, "tile_m": 1, "tile_n": 1, "w": 10, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 144.829},
+{"m": 5, "n": 24, "k": 32, "tile_m": 1, "tile_n": 1, "w": 12, "v": 24, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 151.834},
+{"m": 5, "n": 25, "k": 4, "tile_m": 1, "tile_n": 1, "w": 2, "v": 24, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 71.6625},
+{"m": 5, "n": 25, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 80.6391},
+{"m": 5, "n": 25, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 92.0275},
+{"m": 5, "n": 25, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 111.946},
+{"m": 5, "n": 25, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 138.956},
+{"m": 5, "n": 25, "k": 25, "tile_m": 1, "tile_n": 1, "w": 10, "v": 22, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 151.406},
+{"m": 5, "n": 25, "k": 26, "tile_m": 1, "tile_n": 1, "w": 10, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 152.399},
+{"m": 5, "n": 25, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 159.392},
+{"m": 5, "n": 25, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 20, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 164.81},
+{"m": 5, "n": 25, "k": 45, "tile_m": 1, "tile_n": 1, "w": 16, "v": 22, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 167.254},
+{"m": 5, "n": 26, "k": 4, "tile_m": 1, "tile_n": 2, "w": 2, "v": 26, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 73.0565},
+{"m": 5, "n": 26, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 72.8437},
+{"m": 5, "n": 26, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 83.0577},
+{"m": 5, "n": 26, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 92.7505},
+{"m": 5, "n": 26, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 97.7841},
+{"m": 5, "n": 26, "k": 9, "tile_m": 5, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 106.059},
+{"m": 5, "n": 26, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 127.925},
+{"m": 5, "n": 26, "k": 16, "tile_m": 1, "tile_n": 2, "w": 8, "v": 24, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 124.739},
+{"m": 5, "n": 26, "k": 17, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 121.911},
+{"m": 5, "n": 26, "k": 22, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 138.328},
+{"m": 5, "n": 26, "k": 23, "tile_m": 1, "tile_n": 2, "w": 6, "v": 26, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 133.003},
+{"m": 5, "n": 26, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 26, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 142.549},
+{"m": 5, "n": 26, "k": 25, "tile_m": 6, "tile_n": 1, "w": 12, "v": 26, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 150.57},
+{"m": 5, "n": 26, "k": 26, "tile_m": 5, "tile_n": 1, "w": 12, "v": 26, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 152.336},
+{"m": 5, "n": 26, "k": 28, "tile_m": 2, "tile_n": 3, "w": 14, "v": 26, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 161.207},
+{"m": 5, "n": 26, "k": 32, "tile_m": 2, "tile_n": 3, "w": 16, "v": 26, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 165.179},
+{"m": 5, "n": 26, "k": 45, "tile_m": 3, "tile_n": 1, "w": 16, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 163.833},
+{"m": 5, "n": 28, "k": 4, "tile_m": 1, "tile_n": 2, "w": 2, "v": 28, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 78.7832},
+{"m": 5, "n": 28, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 78.538},
+{"m": 5, "n": 28, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 94.7919},
+{"m": 5, "n": 28, "k": 9, "tile_m": 5, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 114.142},
+{"m": 5, "n": 28, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 136.621},
+{"m": 5, "n": 28, "k": 25, "tile_m": 1, "tile_n": 2, "w": 10, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 155.335},
+{"m": 5, "n": 28, "k": 26, "tile_m": 6, "tile_n": 1, "w": 10, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 157.636},
+{"m": 5, "n": 28, "k": 28, "tile_m": 3, "tile_n": 2, "w": 14, "v": 28, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 164.633},
+{"m": 5, "n": 28, "k": 32, "tile_m": 5, "tile_n": 1, "w": 12, "v": 28, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 167.029},
+{"m": 5, "n": 28, "k": 45, "tile_m": 2, "tile_n": 1, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 170.753},
+{"m": 5, "n": 32, "k": 4, "tile_m": 1, "tile_n": 2, "w": 2, "v": 32, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 90.3387},
+{"m": 5, "n": 32, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 90.1318},
+{"m": 5, "n": 32, "k": 6, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 95.4478},
+{"m": 5, "n": 32, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 110.148},
+{"m": 5, "n": 32, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 120.304},
+{"m": 5, "n": 32, "k": 9, "tile_m": 5, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 128.642},
+{"m": 5, "n": 32, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 146.704},
+{"m": 5, "n": 32, "k": 16, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 148.849},
+{"m": 5, "n": 32, "k": 17, "tile_m": 6, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 145.146},
+{"m": 5, "n": 32, "k": 22, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 152.464},
+{"m": 5, "n": 32, "k": 23, "tile_m": 1, "tile_n": 2, "w": 6, "v": 32, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 153.738},
+{"m": 5, "n": 32, "k": 24, "tile_m": 1, "tile_n": 2, "w": 8, "v": 32, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 156.997},
+{"m": 5, "n": 32, "k": 25, "tile_m": 5, "tile_n": 1, "w": 12, "v": 32, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 165.526},
+{"m": 5, "n": 32, "k": 26, "tile_m": 1, "tile_n": 2, "w": 10, "v": 32, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 167.342},
+{"m": 5, "n": 32, "k": 28, "tile_m": 2, "tile_n": 1, "w": 10, "v": 32, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 170.549},
+{"m": 5, "n": 32, "k": 32, "tile_m": 1, "tile_n": 2, "w": 12, "v": 32, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 175.093},
+{"m": 5, "n": 32, "k": 45, "tile_m": 2, "tile_n": 1, "w": 12, "v": 32, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 178.419},
+{"m": 5, "n": 45, "k": 4, "tile_m": 1, "tile_n": 2, "w": 2, "v": 44, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 102.104},
+{"m": 5, "n": 45, "k": 5, "tile_m": 1, "tile_n": 2, "w": 2, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 103.389},
+{"m": 5, "n": 45, "k": 7, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 131.225},
+{"m": 5, "n": 45, "k": 9, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 142.875},
+{"m": 5, "n": 45, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 154.231},
+{"m": 5, "n": 45, "k": 25, "tile_m": 1, "tile_n": 2, "w": 10, "v": 44, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 169.95},
+{"m": 5, "n": 45, "k": 26, "tile_m": 3, "tile_n": 1, "w": 8, "v": 18, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 170.684},
+{"m": 5, "n": 45, "k": 28, "tile_m": 1, "tile_n": 2, "w": 14, "v": 26, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 177.397},
+{"m": 5, "n": 45, "k": 32, "tile_m": 1, "tile_n": 2, "w": 8, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 181.043},
+{"m": 5, "n": 45, "k": 45, "tile_m": 1, "tile_n": 2, "w": 12, "v": 42, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 183.404},
+{"m": 6, "n": 4, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 17.3648},
+{"m": 6, "n": 4, "k": 5, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 20.891},
+{"m": 6, "n": 4, "k": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 25.3088},
+{"m": 6, "n": 4, "k": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 34.4029},
+{"m": 6, "n": 4, "k": 9, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 30.9154},
+{"m": 6, "n": 4, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 40.7212},
+{"m": 6, "n": 4, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 48.547},
+{"m": 6, "n": 4, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 42.7597},
+{"m": 6, "n": 4, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 59.0194},
+{"m": 6, "n": 4, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 62.4159},
+{"m": 6, "n": 4, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 59.3286},
+{"m": 6, "n": 4, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 63.2716},
+{"m": 6, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 71.0281},
+{"m": 6, "n": 5, "k": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 21.0382},
+{"m": 6, "n": 5, "k": 5, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 25.6146},
+{"m": 6, "n": 5, "k": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 30.7386},
+{"m": 6, "n": 5, "k": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 39.7844},
+{"m": 6, "n": 5, "k": 9, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 37.5717},
+{"m": 6, "n": 5, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 49.4221},
+{"m": 6, "n": 5, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 58.085},
+{"m": 6, "n": 5, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 52.5703},
+{"m": 6, "n": 5, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 69.4004},
+{"m": 6, "n": 5, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 71.6165},
+{"m": 6, "n": 5, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 73.8541},
+{"m": 6, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 78.7409},
+{"m": 6, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 87.6399},
+{"m": 6, "n": 6, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 29.0092},
+{"m": 6, "n": 6, "k": 5, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 34.7398},
+{"m": 6, "n": 6, "k": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 41.3431},
+{"m": 6, "n": 6, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 51.4584},
+{"m": 6, "n": 6, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 54.7869},
+{"m": 6, "n": 6, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 65.899},
+{"m": 6, "n": 6, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 74.696},
+{"m": 6, "n": 6, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 73.6249},
+{"m": 6, "n": 6, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 83.3214},
+{"m": 6, "n": 6, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 85.2118},
+{"m": 6, "n": 6, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 87.2119},
+{"m": 6, "n": 6, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 91.5958},
+{"m": 6, "n": 6, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 93.8914},
+{"m": 6, "n": 6, "k": 36, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 90.6049},
+{"m": 6, "n": 8, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 32.8542},
+{"m": 6, "n": 8, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 39.5654},
+{"m": 6, "n": 8, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 46.7754},
+{"m": 6, "n": 8, "k": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 56.4219},
+{"m": 6, "n": 8, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 57.8262},
+{"m": 6, "n": 8, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 70.6689},
+{"m": 6, "n": 8, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 81.6668},
+{"m": 6, "n": 8, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 75.7991},
+{"m": 6, "n": 8, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 102.189},
+{"m": 6, "n": 8, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 104.903},
+{"m": 6, "n": 8, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 8, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 99.5961},
+{"m": 6, "n": 8, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 100.125},
+{"m": 6, "n": 8, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 8, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 110.732},
+{"m": 6, "n": 9, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 35.8024},
+{"m": 6, "n": 9, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 43.8484},
+{"m": 6, "n": 9, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 51.8175},
+{"m": 6, "n": 9, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 58.965},
+{"m": 6, "n": 9, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 63.9309},
+{"m": 6, "n": 9, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 78.5539},
+{"m": 6, "n": 9, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 84.561},
+{"m": 6, "n": 9, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 84.3988},
+{"m": 6, "n": 9, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 100.301},
+{"m": 6, "n": 9, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 103.968},
+{"m": 6, "n": 9, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 106.858},
+{"m": 6, "n": 9, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 110.172},
+{"m": 6, "n": 9, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 117.743},
+{"m": 6, "n": 13, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 50.793},
+{"m": 6, "n": 13, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 61.4172},
+{"m": 6, "n": 13, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 72.3602},
+{"m": 6, "n": 13, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 76.7893},
+{"m": 6, "n": 13, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 82.6919},
+{"m": 6, "n": 13, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 103.505},
+{"m": 6, "n": 13, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 109.832},
+{"m": 6, "n": 13, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 107.414},
+{"m": 6, "n": 13, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 126.399},
+{"m": 6, "n": 13, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 127.16},
+{"m": 6, "n": 13, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 129.224},
+{"m": 6, "n": 13, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 124.698},
+{"m": 6, "n": 13, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 134.667},
+{"m": 6, "n": 16, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 63.5995},
+{"m": 6, "n": 16, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 78.998},
+{"m": 6, "n": 16, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 79.6159},
+{"m": 6, "n": 16, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 94.2819},
+{"m": 6, "n": 16, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 99.4404},
+{"m": 6, "n": 16, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 121.474},
+{"m": 6, "n": 16, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 131.447},
+{"m": 6, "n": 16, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 130.503},
+{"m": 6, "n": 16, "k": 22, "tile_m": 1, "tile_n": 1, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 140.994},
+{"m": 6, "n": 16, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 143.929},
+{"m": 6, "n": 16, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 151.414},
+{"m": 6, "n": 16, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 150.43},
+{"m": 6, "n": 16, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 162.722},
+{"m": 6, "n": 17, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 60.5441},
+{"m": 6, "n": 17, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 68.6498},
+{"m": 6, "n": 17, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 75.0572},
+{"m": 6, "n": 17, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 88.8231},
+{"m": 6, "n": 17, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 96.638},
+{"m": 6, "n": 17, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 115.635},
+{"m": 6, "n": 17, "k": 16, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 122.699},
+{"m": 6, "n": 17, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 122.369},
+{"m": 6, "n": 17, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 138.221},
+{"m": 6, "n": 17, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 137.919},
+{"m": 6, "n": 17, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 141.952},
+{"m": 6, "n": 17, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 145.765},
+{"m": 6, "n": 17, "k": 32, "tile_m": 1, "tile_n": 1, "w": 14, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 147.119},
+{"m": 6, "n": 22, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 68.9181},
+{"m": 6, "n": 22, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 77.9158},
+{"m": 6, "n": 22, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 85.5436},
+{"m": 6, "n": 22, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 107.115},
+{"m": 6, "n": 22, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 107.717},
+{"m": 6, "n": 22, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 130.85},
+{"m": 6, "n": 22, "k": 16, "tile_m": 1, "tile_n": 2, "w": 8, "v": 14, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 143.533},
+{"m": 6, "n": 22, "k": 17, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 147.658},
+{"m": 6, "n": 22, "k": 22, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 142.021},
+{"m": 6, "n": 22, "k": 23, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 144.504},
+{"m": 6, "n": 22, "k": 24, "tile_m": 2, "tile_n": 1, "w": 8, "v": 22, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 150.931},
+{"m": 6, "n": 22, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 151.978},
+{"m": 6, "n": 22, "k": 32, "tile_m": 2, "tile_n": 3, "w": 16, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 160.565},
+{"m": 6, "n": 23, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 70.9369},
+{"m": 6, "n": 23, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 80.8594},
+{"m": 6, "n": 23, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 88.9708},
+{"m": 6, "n": 23, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 111.224},
+{"m": 6, "n": 23, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 111.977},
+{"m": 6, "n": 23, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 138.705},
+{"m": 6, "n": 23, "k": 16, "tile_m": 2, "tile_n": 1, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 145.791},
+{"m": 6, "n": 23, "k": 17, "tile_m": 2, "tile_n": 1, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 130.847},
+{"m": 6, "n": 23, "k": 22, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 145.676},
+{"m": 6, "n": 23, "k": 23, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 147.626},
+{"m": 6, "n": 23, "k": 24, "tile_m": 2, "tile_n": 1, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 153.564},
+{"m": 6, "n": 23, "k": 26, "tile_m": 2, "tile_n": 1, "w": 10, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 149.513},
+{"m": 6, "n": 23, "k": 32, "tile_m": 2, "tile_n": 1, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 163.779},
+{"m": 6, "n": 24, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 77.1222},
+{"m": 6, "n": 24, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 85.3145},
+{"m": 6, "n": 24, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 94.4076},
+{"m": 6, "n": 24, "k": 8, "tile_m": 2, "tile_n": 1, "w": 4, "v": 24, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 110.004},
+{"m": 6, "n": 24, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 118.271},
+{"m": 6, "n": 24, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 142.641},
+{"m": 6, "n": 24, "k": 16, "tile_m": 1, "tile_n": 2, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 155.64},
+{"m": 6, "n": 24, "k": 17, "tile_m": 1, "tile_n": 2, "w": 8, "v": 24, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 140.277},
+{"m": 6, "n": 24, "k": 22, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 154.822},
+{"m": 6, "n": 24, "k": 23, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 156.783},
+{"m": 6, "n": 24, "k": 24, "tile_m": 2, "tile_n": 1, "w": 8, "v": 24, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 163.247},
+{"m": 6, "n": 24, "k": 26, "tile_m": 1, "tile_n": 2, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 158.81},
+{"m": 6, "n": 24, "k": 32, "tile_m": 2, "tile_n": 1, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 171.227},
+{"m": 6, "n": 26, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 72.8888},
+{"m": 6, "n": 26, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 86.2243},
+{"m": 6, "n": 26, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 100.321},
+{"m": 6, "n": 26, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 114.794},
+{"m": 6, "n": 26, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 124.78},
+{"m": 6, "n": 26, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 150.084},
+{"m": 6, "n": 26, "k": 16, "tile_m": 2, "tile_n": 1, "w": 8, "v": 26, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 148.541},
+{"m": 6, "n": 26, "k": 17, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 146.817},
+{"m": 6, "n": 26, "k": 22, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 164.867},
+{"m": 6, "n": 26, "k": 23, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 167.944},
+{"m": 6, "n": 26, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 26, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 167.824},
+{"m": 6, "n": 26, "k": 26, "tile_m": 1, "tile_n": 2, "w": 10, "v": 26, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 160.058},
+{"m": 6, "n": 26, "k": 32, "tile_m": 1, "tile_n": 1, "w": 12, "v": 26, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 172.981},
+{"m": 6, "n": 32, "k": 4, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 88.5988},
+{"m": 6, "n": 32, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 107.109},
+{"m": 6, "n": 32, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 112.623},
+{"m": 6, "n": 32, "k": 8, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 136.523},
+{"m": 6, "n": 32, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 148.067},
+{"m": 6, "n": 32, "k": 13, "tile_m": 1, "tile_n": 2, "w": 6, "v": 16, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 157.238},
+{"m": 6, "n": 32, "k": 16, "tile_m": 2, "tile_n": 1, "w": 8, "v": 32, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 170.847},
+{"m": 6, "n": 32, "k": 17, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 172.856},
+{"m": 6, "n": 32, "k": 22, "tile_m": 2, "tile_n": 1, "w": 8, "v": 32, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 177.946},
+{"m": 6, "n": 32, "k": 23, "tile_m": 2, "tile_n": 1, "w": 8, "v": 32, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 179.578},
+{"m": 6, "n": 32, "k": 24, "tile_m": 2, "tile_n": 1, "w": 8, "v": 32, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 184.552},
+{"m": 6, "n": 32, "k": 26, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 182.386},
+{"m": 6, "n": 32, "k": 32, "tile_m": 2, "tile_n": 1, "w": 8, "v": 18, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 192.489},
+{"m": 6, "n": 36, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 119.79},
+{"m": 7, "n": 4, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 20.321},
+{"m": 7, "n": 4, "k": 5, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 25.1685},
+{"m": 7, "n": 4, "k": 7, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 33.8708},
+{"m": 7, "n": 4, "k": 9, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 41.5372},
+{"m": 7, "n": 4, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 53.8869},
+{"m": 7, "n": 4, "k": 25, "tile_m": 1, "tile_n": 1, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 73.2421},
+{"m": 7, "n": 4, "k": 26, "tile_m": 1, "tile_n": 1, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 75.2431},
+{"m": 7, "n": 4, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 84.3456},
+{"m": 7, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 90.5669},
+{"m": 7, "n": 4, "k": 45, "tile_m": 1, "tile_n": 1, "w": 18, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 89.7354},
+{"m": 7, "n": 5, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 23.648},
+{"m": 7, "n": 5, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 28.8325},
+{"m": 7, "n": 5, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 38.3808},
+{"m": 7, "n": 5, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 47.369},
+{"m": 7, "n": 5, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 62.9693},
+{"m": 7, "n": 5, "k": 25, "tile_m": 1, "tile_n": 1, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 79.6162},
+{"m": 7, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 81.9313},
+{"m": 7, "n": 5, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 88.1174},
+{"m": 7, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 93.4222},
+{"m": 7, "n": 5, "k": 45, "tile_m": 1, "tile_n": 1, "w": 18, "v": 4, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 98.0637},
+{"m": 7, "n": 7, "k": 4, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 40.7019},
+{"m": 7, "n": 7, "k": 5, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 49.7395},
+{"m": 7, "n": 7, "k": 7, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 64.2082},
+{"m": 7, "n": 7, "k": 9, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 74.9724},
+{"m": 7, "n": 7, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 92.3343},
+{"m": 7, "n": 7, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 116.952},
+{"m": 7, "n": 7, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 111.036},
+{"m": 7, "n": 7, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 6, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 119.39},
+{"m": 7, "n": 7, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 126.959},
+{"m": 7, "n": 7, "k": 45, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 128.604},
+{"m": 7, "n": 7, "k": 49, "tile_m": 1, "tile_n": 1, "w": 18, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 120.76},
+{"m": 7, "n": 9, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 42.249},
+{"m": 7, "n": 9, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 50.9731},
+{"m": 7, "n": 9, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 68.4855},
+{"m": 7, "n": 9, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 84.8179},
+{"m": 7, "n": 9, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 101.494},
+{"m": 7, "n": 9, "k": 25, "tile_m": 1, "tile_n": 1, "w": 10, "v": 8, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 127.326},
+{"m": 7, "n": 9, "k": 26, "tile_m": 1, "tile_n": 1, "w": 10, "v": 8, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 129.924},
+{"m": 7, "n": 9, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 8, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 142.345},
+{"m": 7, "n": 9, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 145.13},
+{"m": 7, "n": 9, "k": 45, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 145.375},
+{"m": 7, "n": 13, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 59.6126},
+{"m": 7, "n": 13, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 71.567},
+{"m": 7, "n": 13, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 94.7367},
+{"m": 7, "n": 13, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 104.845},
+{"m": 7, "n": 13, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 131.471},
+{"m": 7, "n": 13, "k": 25, "tile_m": 1, "tile_n": 1, "w": 12, "v": 10, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 152.657},
+{"m": 7, "n": 13, "k": 26, "tile_m": 1, "tile_n": 1, "w": 12, "v": 10, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 154.864},
+{"m": 7, "n": 13, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 6, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 160.679},
+{"m": 7, "n": 13, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 12, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 167.82},
+{"m": 7, "n": 13, "k": 45, "tile_m": 1, "tile_n": 1, "w": 16, "v": 12, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 170.871},
+{"m": 7, "n": 25, "k": 4, "tile_m": 1, "tile_n": 2, "w": 2, "v": 24, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 90.6823},
+{"m": 7, "n": 25, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 96.0502},
+{"m": 7, "n": 25, "k": 7, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 116.201},
+{"m": 7, "n": 25, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 137.027},
+{"m": 7, "n": 25, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 165.715},
+{"m": 7, "n": 25, "k": 25, "tile_m": 1, "tile_n": 2, "w": 12, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 192.888},
+{"m": 7, "n": 25, "k": 26, "tile_m": 1, "tile_n": 2, "w": 12, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 195.055},
+{"m": 7, "n": 25, "k": 28, "tile_m": 2, "tile_n": 2, "w": 14, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 204.588},
+{"m": 7, "n": 25, "k": 32, "tile_m": 1, "tile_n": 2, "w": 16, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 209.44},
+{"m": 7, "n": 25, "k": 45, "tile_m": 1, "tile_n": 2, "w": 12, "v": 24, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 212.537},
+{"m": 7, "n": 26, "k": 4, "tile_m": 1, "tile_n": 2, "w": 2, "v": 26, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 98.6714},
+{"m": 7, "n": 26, "k": 5, "tile_m": 1, "tile_n": 2, "w": 2, "v": 26, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 97.2595},
+{"m": 7, "n": 26, "k": 7, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 120.571},
+{"m": 7, "n": 26, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 142.154},
+{"m": 7, "n": 26, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 171.139},
+{"m": 7, "n": 26, "k": 25, "tile_m": 1, "tile_n": 2, "w": 12, "v": 26, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 197.945},
+{"m": 7, "n": 26, "k": 26, "tile_m": 1, "tile_n": 2, "w": 12, "v": 26, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 200.252},
+{"m": 7, "n": 26, "k": 28, "tile_m": 1, "tile_n": 2, "w": 14, "v": 26, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 208.875},
+{"m": 7, "n": 26, "k": 32, "tile_m": 1, "tile_n": 2, "w": 16, "v": 18, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 213.257},
+{"m": 7, "n": 26, "k": 45, "tile_m": 1, "tile_n": 2, "w": 12, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 219.31},
+{"m": 7, "n": 28, "k": 4, "tile_m": 2, "tile_n": 2, "w": 2, "v": 28, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 101.062},
+{"m": 7, "n": 28, "k": 5, "tile_m": 2, "tile_n": 2, "w": 2, "v": 28, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 99.5538},
+{"m": 7, "n": 28, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 121.608},
+{"m": 7, "n": 28, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 147.435},
+{"m": 7, "n": 28, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 169.528},
+{"m": 7, "n": 28, "k": 25, "tile_m": 2, "tile_n": 2, "w": 12, "v": 28, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 201.753},
+{"m": 7, "n": 28, "k": 26, "tile_m": 2, "tile_n": 2, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 204.712},
+{"m": 7, "n": 28, "k": 28, "tile_m": 2, "tile_n": 2, "w": 14, "v": 28, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 210.808},
+{"m": 7, "n": 28, "k": 32, "tile_m": 2, "tile_n": 2, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 216.209},
+{"m": 7, "n": 28, "k": 45, "tile_m": 2, "tile_n": 2, "w": 12, "v": 28, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 223.329},
+{"m": 7, "n": 32, "k": 4, "tile_m": 2, "tile_n": 2, "w": 2, "v": 32, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 115.233},
+{"m": 7, "n": 32, "k": 5, "tile_m": 2, "tile_n": 2, "w": 2, "v": 32, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 114.267},
+{"m": 7, "n": 32, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 140.19},
+{"m": 7, "n": 32, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 162.426},
+{"m": 7, "n": 32, "k": 13, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 185.749},
+{"m": 7, "n": 32, "k": 25, "tile_m": 2, "tile_n": 2, "w": 12, "v": 32, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 215.554},
+{"m": 7, "n": 32, "k": 26, "tile_m": 2, "tile_n": 2, "w": 12, "v": 32, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 217.184},
+{"m": 7, "n": 32, "k": 28, "tile_m": 2, "tile_n": 2, "w": 10, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 220.896},
+{"m": 7, "n": 32, "k": 32, "tile_m": 2, "tile_n": 2, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 226.677},
+{"m": 7, "n": 32, "k": 45, "tile_m": 2, "tile_n": 2, "w": 12, "v": 32, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 234.276},
+{"m": 7, "n": 45, "k": 4, "tile_m": 2, "tile_n": 2, "w": 2, "v": 32, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 128.485},
+{"m": 7, "n": 45, "k": 5, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 130.706},
+{"m": 7, "n": 45, "k": 7, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 151.354},
+{"m": 7, "n": 45, "k": 9, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 179.007},
+{"m": 7, "n": 45, "k": 13, "tile_m": 2, "tile_n": 2, "w": 6, "v": 28, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 193.014},
+{"m": 7, "n": 45, "k": 25, "tile_m": 2, "tile_n": 2, "w": 8, "v": 32, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 223.056},
+{"m": 7, "n": 45, "k": 26, "tile_m": 2, "tile_n": 2, "w": 8, "v": 36, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 225.941},
+{"m": 7, "n": 45, "k": 28, "tile_m": 2, "tile_n": 2, "w": 14, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 232.072},
+{"m": 7, "n": 45, "k": 32, "tile_m": 2, "tile_n": 3, "w": 8, "v": 38, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 236.673},
+{"m": 7, "n": 45, "k": 45, "tile_m": 2, "tile_n": 2, "w": 12, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 241.311},
+{"m": 7, "n": 49, "k": 7, "tile_m": 2, "tile_n": 3, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 147.937},
+{"m": 8, "n": 4, "k": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 23.9735},
+{"m": 8, "n": 4, "k": 5, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 28.4815},
+{"m": 8, "n": 4, "k": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 34.2353},
+{"m": 8, "n": 4, "k": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 45.8575},
+{"m": 8, "n": 4, "k": 9, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 48.5061},
+{"m": 8, "n": 4, "k": 13, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 55.0971},
+{"m": 8, "n": 4, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 64.3498},
+{"m": 8, "n": 4, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 66.887},
+{"m": 8, "n": 4, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 80.5774},
+{"m": 8, "n": 4, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 83.3154},
+{"m": 8, "n": 4, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 78.1446},
+{"m": 8, "n": 4, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 72.9839},
+{"m": 8, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 84.7409},
+{"m": 8, "n": 5, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 27.0068},
+{"m": 8, "n": 5, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 33.1999},
+{"m": 8, "n": 5, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 38.8056},
+{"m": 8, "n": 5, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 49.3499},
+{"m": 8, "n": 5, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 54.6039},
+{"m": 8, "n": 5, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 64.6405},
+{"m": 8, "n": 5, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 75.6469},
+{"m": 8, "n": 5, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 78.0896},
+{"m": 8, "n": 5, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 86.0905},
+{"m": 8, "n": 5, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 88.5829},
+{"m": 8, "n": 5, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 80.7721},
+{"m": 8, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 83.5916},
+{"m": 8, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 94.7041},
+{"m": 8, "n": 6, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 32.5636},
+{"m": 8, "n": 6, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 39.9008},
+{"m": 8, "n": 6, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 46.2498},
+{"m": 8, "n": 6, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 59.3358},
+{"m": 8, "n": 6, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 65.4188},
+{"m": 8, "n": 6, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 77.8557},
+{"m": 8, "n": 6, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 85.9489},
+{"m": 8, "n": 6, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 87.1602},
+{"m": 8, "n": 6, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 102.308},
+{"m": 8, "n": 6, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 105.056},
+{"m": 8, "n": 6, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 6, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 99.2986},
+{"m": 8, "n": 6, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 100.382},
+{"m": 8, "n": 6, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 112.447},
+{"m": 8, "n": 8, "k": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 52.7483},
+{"m": 8, "n": 8, "k": 5, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 62.8469},
+{"m": 8, "n": 8, "k": 6, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 72.9942},
+{"m": 8, "n": 8, "k": 8, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 90.7763},
+{"m": 8, "n": 8, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 96.8478},
+{"m": 8, "n": 8, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 110.805},
+{"m": 8, "n": 8, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 122.011},
+{"m": 8, "n": 8, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 123.976},
+{"m": 8, "n": 8, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 142.579},
+{"m": 8, "n": 8, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 138.92},
+{"m": 8, "n": 8, "k": 24, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 139.574},
+{"m": 8, "n": 8, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 139.438},
+{"m": 8, "n": 8, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 141.729},
+{"m": 8, "n": 8, "k": 64, "tile_m": 1, "tile_n": 1, "w": 16, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 155.798},
+{"m": 8, "n": 9, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 47.6694},
+{"m": 8, "n": 9, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 57.6518},
+{"m": 8, "n": 9, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 67.1608},
+{"m": 8, "n": 9, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 84.8613},
+{"m": 8, "n": 9, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 92.0394},
+{"m": 8, "n": 9, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 100.035},
+{"m": 8, "n": 9, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 113.671},
+{"m": 8, "n": 9, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 116.819},
+{"m": 8, "n": 9, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 122.26},
+{"m": 8, "n": 9, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 123.944},
+{"m": 8, "n": 9, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 6, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 125.923},
+{"m": 8, "n": 9, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 128.998},
+{"m": 8, "n": 9, "k": 32, "tile_m": 1, "tile_n": 1, "w": 12, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 131.311},
+{"m": 8, "n": 13, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 63.3347},
+{"m": 8, "n": 13, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 75.8181},
+{"m": 8, "n": 13, "k": 6, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 86.1038},
+{"m": 8, "n": 13, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 98.14},
+{"m": 8, "n": 13, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 105.704},
+{"m": 8, "n": 13, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 123.059},
+{"m": 8, "n": 13, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 10, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 135.239},
+{"m": 8, "n": 13, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 137.477},
+{"m": 8, "n": 13, "k": 22, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 162.424},
+{"m": 8, "n": 13, "k": 23, "tile_m": 1, "tile_n": 1, "w": 8, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 145.317},
+{"m": 8, "n": 13, "k": 24, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 151.977},
+{"m": 8, "n": 13, "k": 26, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 152.263},
+{"m": 8, "n": 13, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 10, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 160.083},
+{"m": 8, "n": 16, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 77.4084},
+{"m": 8, "n": 16, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 91.6492},
+{"m": 8, "n": 16, "k": 6, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 102.56},
+{"m": 8, "n": 16, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 121.25},
+{"m": 8, "n": 16, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 120.932},
+{"m": 8, "n": 16, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 150.649},
+{"m": 8, "n": 16, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 165.868},
+{"m": 8, "n": 16, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 166.714},
+{"m": 8, "n": 16, "k": 22, "tile_m": 1, "tile_n": 1, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 174.831},
+{"m": 8, "n": 16, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 177.658},
+{"m": 8, "n": 16, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 183.951},
+{"m": 8, "n": 16, "k": 26, "tile_m": 2, "tile_n": 1, "w": 10, "v": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 180.88},
+{"m": 8, "n": 16, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 16, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 193.463},
+{"m": 8, "n": 17, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 77.1216},
+{"m": 8, "n": 17, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 92.0325},
+{"m": 8, "n": 17, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 91.8413},
+{"m": 8, "n": 17, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 111.233},
+{"m": 8, "n": 17, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 121.218},
+{"m": 8, "n": 17, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 139.461},
+{"m": 8, "n": 17, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 147.572},
+{"m": 8, "n": 17, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 143.132},
+{"m": 8, "n": 17, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 224, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 150.659},
+{"m": 8, "n": 17, "k": 23, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 157.854},
+{"m": 8, "n": 17, "k": 24, "tile_m": 2, "tile_n": 1, "w": 12, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 164.338},
+{"m": 8, "n": 17, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 224, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 155.587},
+{"m": 8, "n": 17, "k": 32, "tile_m": 2, "tile_n": 3, "w": 16, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 172.147},
+{"m": 8, "n": 22, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 98.4831},
+{"m": 8, "n": 22, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 102.251},
+{"m": 8, "n": 22, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 113.706},
+{"m": 8, "n": 22, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 142.267},
+{"m": 8, "n": 22, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 141.743},
+{"m": 8, "n": 22, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 172.127},
+{"m": 8, "n": 22, "k": 16, "tile_m": 2, "tile_n": 1, "w": 8, "v": 22, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 186.548},
+{"m": 8, "n": 22, "k": 17, "tile_m": 2, "tile_n": 1, "w": 8, "v": 10, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 175.381},
+{"m": 8, "n": 22, "k": 22, "tile_m": 2, "tile_n": 1, "w": 8, "v": 22, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 183.582},
+{"m": 8, "n": 22, "k": 23, "tile_m": 2, "tile_n": 1, "w": 8, "v": 22, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 185.959},
+{"m": 8, "n": 22, "k": 24, "tile_m": 2, "tile_n": 1, "w": 8, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 195.033},
+{"m": 8, "n": 22, "k": 26, "tile_m": 2, "tile_n": 1, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 187.132},
+{"m": 8, "n": 22, "k": 32, "tile_m": 2, "tile_n": 1, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 211.83},
+{"m": 8, "n": 23, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 102.42},
+{"m": 8, "n": 23, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 105.176},
+{"m": 8, "n": 23, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 118.044},
+{"m": 8, "n": 23, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 147.212},
+{"m": 8, "n": 23, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 147.697},
+{"m": 8, "n": 23, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 178.045},
+{"m": 8, "n": 23, "k": 16, "tile_m": 2, "tile_n": 1, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 188.608},
+{"m": 8, "n": 23, "k": 17, "tile_m": 2, "tile_n": 1, "w": 8, "v": 10, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 178.959},
+{"m": 8, "n": 23, "k": 22, "tile_m": 2, "tile_n": 1, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 187.535},
+{"m": 8, "n": 23, "k": 23, "tile_m": 2, "tile_n": 1, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 189.238},
+{"m": 8, "n": 23, "k": 24, "tile_m": 2, "tile_n": 1, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 196.5},
+{"m": 8, "n": 23, "k": 26, "tile_m": 2, "tile_n": 1, "w": 10, "v": 22, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 191.916},
+{"m": 8, "n": 23, "k": 32, "tile_m": 2, "tile_n": 1, "w": 8, "v": 10, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 214.467},
+{"m": 8, "n": 24, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 99.7498},
+{"m": 8, "n": 24, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 111.391},
+{"m": 8, "n": 24, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 123.551},
+{"m": 8, "n": 24, "k": 8, "tile_m": 2, "tile_n": 1, "w": 4, "v": 24, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 143.632},
+{"m": 8, "n": 24, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 154.155},
+{"m": 8, "n": 24, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 185.726},
+{"m": 8, "n": 24, "k": 16, "tile_m": 2, "tile_n": 1, "w": 8, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 198.469},
+{"m": 8, "n": 24, "k": 17, "tile_m": 2, "tile_n": 1, "w": 8, "v": 10, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 187.951},
+{"m": 8, "n": 24, "k": 22, "tile_m": 2, "tile_n": 1, "w": 8, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 199.801},
+{"m": 8, "n": 24, "k": 23, "tile_m": 2, "tile_n": 1, "w": 8, "v": 24, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 199.689},
+{"m": 8, "n": 24, "k": 24, "tile_m": 2, "tile_n": 1, "w": 8, "v": 24, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 207.228},
+{"m": 8, "n": 24, "k": 26, "tile_m": 2, "tile_n": 1, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 204.676},
+{"m": 8, "n": 24, "k": 32, "tile_m": 2, "tile_n": 1, "w": 8, "v": 10, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 221.005},
+{"m": 8, "n": 26, "k": 4, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 98.6441},
+{"m": 8, "n": 26, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 103.296},
+{"m": 8, "n": 26, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 117.769},
+{"m": 8, "n": 26, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 147.311},
+{"m": 8, "n": 26, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 157.749},
+{"m": 8, "n": 26, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 183.678},
+{"m": 8, "n": 26, "k": 16, "tile_m": 2, "tile_n": 1, "w": 8, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 184.93},
+{"m": 8, "n": 26, "k": 17, "tile_m": 2, "tile_n": 1, "w": 8, "v": 26, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 174.79},
+{"m": 8, "n": 26, "k": 22, "tile_m": 2, "tile_n": 1, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 190.782},
+{"m": 8, "n": 26, "k": 23, "tile_m": 2, "tile_n": 1, "w": 8, "v": 26, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 192.48},
+{"m": 8, "n": 26, "k": 24, "tile_m": 2, "tile_n": 1, "w": 8, "v": 26, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 201.264},
+{"m": 8, "n": 26, "k": 26, "tile_m": 2, "tile_n": 2, "w": 8, "v": 26, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 200.465},
+{"m": 8, "n": 26, "k": 32, "tile_m": 2, "tile_n": 2, "w": 8, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 213.624},
+{"m": 8, "n": 32, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 120.164},
+{"m": 8, "n": 32, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 126.86},
+{"m": 8, "n": 32, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 143.186},
+{"m": 8, "n": 32, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 175.277},
+{"m": 8, "n": 32, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 183.653},
+{"m": 8, "n": 32, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 193.414},
+{"m": 8, "n": 32, "k": 16, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 216.01},
+{"m": 8, "n": 32, "k": 17, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 213.609},
+{"m": 8, "n": 32, "k": 22, "tile_m": 2, "tile_n": 1, "w": 8, "v": 32, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 222.573},
+{"m": 8, "n": 32, "k": 23, "tile_m": 2, "tile_n": 1, "w": 8, "v": 32, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 224.463},
+{"m": 8, "n": 32, "k": 24, "tile_m": 2, "tile_n": 1, "w": 8, "v": 32, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 231.134},
+{"m": 8, "n": 32, "k": 26, "tile_m": 2, "tile_n": 2, "w": 8, "v": 32, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 230.134},
+{"m": 8, "n": 32, "k": 32, "tile_m": 2, "tile_n": 1, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 238.795},
+{"m": 8, "n": 64, "k": 8, "tile_m": 1, "tile_n": 4, "w": 4, "v": 48, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 205.107},
+{"m": 9, "n": 4, "k": 4, "tile_m": 1, "tile_n": 1, "w": 2, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 25.2097},
+{"m": 9, "n": 4, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 29.9919},
+{"m": 9, "n": 4, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 35.1352},
+{"m": 9, "n": 4, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 40.3827},
+{"m": 9, "n": 4, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 40.9728},
+{"m": 9, "n": 4, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 48.8693},
+{"m": 9, "n": 4, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 57.4295},
+{"m": 9, "n": 4, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 60.1671},
+{"m": 9, "n": 4, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 59.5034},
+{"m": 9, "n": 4, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 80.7153},
+{"m": 9, "n": 4, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 81.9869},
+{"m": 9, "n": 4, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 78.1791},
+{"m": 9, "n": 4, "k": 25, "tile_m": 1, "tile_n": 1, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 82.9701},
+{"m": 9, "n": 4, "k": 26, "tile_m": 1, "tile_n": 1, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 84.3279},
+{"m": 9, "n": 4, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 92.4296},
+{"m": 9, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 97.0899},
+{"m": 9, "n": 4, "k": 45, "tile_m": 1, "tile_n": 1, "w": 18, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 97.9513},
+{"m": 9, "n": 5, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 30.4526},
+{"m": 9, "n": 5, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 37.3908},
+{"m": 9, "n": 5, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 43.6465},
+{"m": 9, "n": 5, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 49.939},
+{"m": 9, "n": 5, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 49.3598},
+{"m": 9, "n": 5, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 60.7052},
+{"m": 9, "n": 5, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 71.4975},
+{"m": 9, "n": 5, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 70.7421},
+{"m": 9, "n": 5, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 73.9933},
+{"m": 9, "n": 5, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 86.1888},
+{"m": 9, "n": 5, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 88.3985},
+{"m": 9, "n": 5, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 91.3193},
+{"m": 9, "n": 5, "k": 25, "tile_m": 1, "tile_n": 1, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 98.0414},
+{"m": 9, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 99.6254},
+{"m": 9, "n": 5, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 110.374},
+{"m": 9, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 115.467},
+{"m": 9, "n": 5, "k": 45, "tile_m": 1, "tile_n": 1, "w": 18, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 117.769},
+{"m": 9, "n": 6, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 35.7692},
+{"m": 9, "n": 6, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 43.884},
+{"m": 9, "n": 6, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 51.8037},
+{"m": 9, "n": 6, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 58.9838},
+{"m": 9, "n": 6, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 63.1913},
+{"m": 9, "n": 6, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 78.6654},
+{"m": 9, "n": 6, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 87.0012},
+{"m": 9, "n": 6, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 84.4738},
+{"m": 9, "n": 6, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 101.406},
+{"m": 9, "n": 6, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 104.769},
+{"m": 9, "n": 6, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 6, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 108.241},
+{"m": 9, "n": 6, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 111.759},
+{"m": 9, "n": 6, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 118.358},
+{"m": 9, "n": 7, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 42.4018},
+{"m": 9, "n": 7, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 51.6611},
+{"m": 9, "n": 7, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 69.256},
+{"m": 9, "n": 7, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 84.5734},
+{"m": 9, "n": 7, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 99.4122},
+{"m": 9, "n": 7, "k": 25, "tile_m": 1, "tile_n": 1, "w": 10, "v": 6, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 127.018},
+{"m": 9, "n": 7, "k": 26, "tile_m": 1, "tile_n": 1, "w": 12, "v": 6, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 128.925},
+{"m": 9, "n": 7, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 6, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 142.303},
+{"m": 9, "n": 7, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 143.679},
+{"m": 9, "n": 7, "k": 45, "tile_m": 1, "tile_n": 1, "w": 16, "v": 6, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 145.789},
+{"m": 9, "n": 8, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 48.1233},
+{"m": 9, "n": 8, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 57.2607},
+{"m": 9, "n": 8, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 67.6162},
+{"m": 9, "n": 8, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 76.9026},
+{"m": 9, "n": 8, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 82.1029},
+{"m": 9, "n": 8, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 99.4363},
+{"m": 9, "n": 8, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 106.792},
+{"m": 9, "n": 8, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 103.155},
+{"m": 9, "n": 8, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 122.251},
+{"m": 9, "n": 8, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 125.713},
+{"m": 9, "n": 8, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 8, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 127.47},
+{"m": 9, "n": 8, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 127.087},
+{"m": 9, "n": 8, "k": 32, "tile_m": 1, "tile_n": 1, "w": 12, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 132.924},
+{"m": 9, "n": 9, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 62.4312},
+{"m": 9, "n": 9, "k": 5, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 74.0588},
+{"m": 9, "n": 9, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 83.6127},
+{"m": 9, "n": 9, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 92.4293},
+{"m": 9, "n": 9, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 97.3911},
+{"m": 9, "n": 9, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 107.815},
+{"m": 9, "n": 9, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 123.717},
+{"m": 9, "n": 9, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 123.42},
+{"m": 9, "n": 9, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 126.933},
+{"m": 9, "n": 9, "k": 22, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 140.116},
+{"m": 9, "n": 9, "k": 23, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 144.441},
+{"m": 9, "n": 9, "k": 24, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 147.669},
+{"m": 9, "n": 9, "k": 25, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 152.349},
+{"m": 9, "n": 9, "k": 26, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 155.592},
+{"m": 9, "n": 9, "k": 28, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 155.64},
+{"m": 9, "n": 9, "k": 32, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 159.535},
+{"m": 9, "n": 9, "k": 45, "tile_m": 1, "tile_n": 1, "w": 16, "v": 8, "threads": 160, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 160.12},
+{"m": 9, "n": 9, "k": 64, "tile_m": 1, "tile_n": 1, "w": 14, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 160.483},
+{"m": 9, "n": 9, "k": 81, "tile_m": 1, "tile_n": 1, "w": 14, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 164.81},
+{"m": 9, "n": 13, "k": 4, "tile_m": 1, "tile_n": 1, "w": 2, "v": 12, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 68.546},
+{"m": 9, "n": 13, "k": 5, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 81.5548},
+{"m": 9, "n": 13, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 86.6047},
+{"m": 9, "n": 13, "k": 7, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 104.773},
+{"m": 9, "n": 13, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 110.269},
+{"m": 9, "n": 13, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 118.614},
+{"m": 9, "n": 13, "k": 13, "tile_m": 1, "tile_n": 2, "w": 6, "v": 10, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 137.421},
+{"m": 9, "n": 13, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 148.198},
+{"m": 9, "n": 13, "k": 17, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 144.57},
+{"m": 9, "n": 13, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 157.619},
+{"m": 9, "n": 13, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 159.911},
+{"m": 9, "n": 13, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 164.48},
+{"m": 9, "n": 13, "k": 25, "tile_m": 1, "tile_n": 2, "w": 10, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 167.537},
+{"m": 9, "n": 13, "k": 26, "tile_m": 1, "tile_n": 2, "w": 10, "v": 6, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 171.427},
+{"m": 9, "n": 13, "k": 28, "tile_m": 1, "tile_n": 2, "w": 14, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 186.17},
+{"m": 9, "n": 13, "k": 32, "tile_m": 1, "tile_n": 2, "w": 16, "v": 8, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 191.308},
+{"m": 9, "n": 13, "k": 45, "tile_m": 1, "tile_n": 2, "w": 18, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 196.238},
+{"m": 9, "n": 16, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 76.4401},
+{"m": 9, "n": 16, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 90.0694},
+{"m": 9, "n": 16, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 101.254},
+{"m": 9, "n": 16, "k": 8, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 114.152},
+{"m": 9, "n": 16, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 125.152},
+{"m": 9, "n": 16, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 138.713},
+{"m": 9, "n": 16, "k": 16, "tile_m": 1, "tile_n": 2, "w": 8, "v": 10, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 161.565},
+{"m": 9, "n": 16, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 162.59},
+{"m": 9, "n": 16, "k": 22, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 167.882},
+{"m": 9, "n": 16, "k": 23, "tile_m": 1, "tile_n": 2, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 166.582},
+{"m": 9, "n": 16, "k": 24, "tile_m": 1, "tile_n": 2, "w": 12, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 170.479},
+{"m": 9, "n": 16, "k": 26, "tile_m": 1, "tile_n": 2, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 173.529},
+{"m": 9, "n": 16, "k": 32, "tile_m": 1, "tile_n": 2, "w": 14, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 179.16},
+{"m": 9, "n": 16, "k": 64, "tile_m": 3, "tile_n": 2, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 207.542},
+{"m": 9, "n": 17, "k": 4, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 77.9597},
+{"m": 9, "n": 17, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 93.47},
+{"m": 9, "n": 17, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 98.6733},
+{"m": 9, "n": 17, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 116.283},
+{"m": 9, "n": 17, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 130.008},
+{"m": 9, "n": 17, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 146.013},
+{"m": 9, "n": 17, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 163.56},
+{"m": 9, "n": 17, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 162.657},
+{"m": 9, "n": 17, "k": 22, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 165.859},
+{"m": 9, "n": 17, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 224, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 162.634},
+{"m": 9, "n": 17, "k": 24, "tile_m": 2, "tile_n": 1, "w": 8, "v": 10, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 166.06},
+{"m": 9, "n": 17, "k": 26, "tile_m": 1, "tile_n": 2, "w": 10, "v": 10, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 167.993},
+{"m": 9, "n": 17, "k": 32, "tile_m": 2, "tile_n": 1, "w": 16, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 180.16},
+{"m": 9, "n": 22, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 90.7465},
+{"m": 9, "n": 22, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 106.972},
+{"m": 9, "n": 22, "k": 6, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 111.035},
+{"m": 9, "n": 22, "k": 8, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 132.298},
+{"m": 9, "n": 22, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 151.642},
+{"m": 9, "n": 22, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 172.574},
+{"m": 9, "n": 22, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 172.49},
+{"m": 9, "n": 22, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 170.487},
+{"m": 9, "n": 22, "k": 22, "tile_m": 2, "tile_n": 2, "w": 10, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 183.705},
+{"m": 9, "n": 22, "k": 23, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 191.689},
+{"m": 9, "n": 22, "k": 24, "tile_m": 2, "tile_n": 2, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 194.866},
+{"m": 9, "n": 22, "k": 26, "tile_m": 2, "tile_n": 2, "w": 10, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 194.953},
+{"m": 9, "n": 22, "k": 32, "tile_m": 2, "tile_n": 2, "w": 10, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 207.422},
+{"m": 9, "n": 22, "k": 64, "tile_m": 2, "tile_n": 2, "w": 12, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 239.402},
+{"m": 9, "n": 23, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 94.256},
+{"m": 9, "n": 23, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 111.899},
+{"m": 9, "n": 23, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 114.731},
+{"m": 9, "n": 23, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 143.712},
+{"m": 9, "n": 23, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 157.699},
+{"m": 9, "n": 23, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 177.746},
+{"m": 9, "n": 23, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 177.57},
+{"m": 9, "n": 23, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 176.836},
+{"m": 9, "n": 23, "k": 22, "tile_m": 2, "tile_n": 2, "w": 10, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 194.385},
+{"m": 9, "n": 23, "k": 23, "tile_m": 2, "tile_n": 2, "w": 10, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 198.019},
+{"m": 9, "n": 23, "k": 24, "tile_m": 2, "tile_n": 2, "w": 10, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 203.27},
+{"m": 9, "n": 23, "k": 26, "tile_m": 2, "tile_n": 1, "w": 10, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 199.492},
+{"m": 9, "n": 23, "k": 32, "tile_m": 1, "tile_n": 2, "w": 14, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 209.275},
+{"m": 9, "n": 24, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 100.426},
+{"m": 9, "n": 24, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 117.722},
+{"m": 9, "n": 24, "k": 6, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 122.677},
+{"m": 9, "n": 24, "k": 8, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 141.521},
+{"m": 9, "n": 24, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 165.569},
+{"m": 9, "n": 24, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 189.324},
+{"m": 9, "n": 24, "k": 16, "tile_m": 1, "tile_n": 2, "w": 8, "v": 14, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 191.231},
+{"m": 9, "n": 24, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 187.441},
+{"m": 9, "n": 24, "k": 22, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 209.101},
+{"m": 9, "n": 24, "k": 23, "tile_m": 2, "tile_n": 2, "w": 10, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 207.575},
+{"m": 9, "n": 24, "k": 24, "tile_m": 2, "tile_n": 2, "w": 8, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 215.864},
+{"m": 9, "n": 24, "k": 26, "tile_m": 1, "tile_n": 2, "w": 10, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 210.582},
+{"m": 9, "n": 24, "k": 32, "tile_m": 2, "tile_n": 2, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 225.901},
+{"m": 9, "n": 25, "k": 4, "tile_m": 2, "tile_n": 1, "w": 2, "v": 14, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 107.355},
+{"m": 9, "n": 25, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 116.291},
+{"m": 9, "n": 25, "k": 7, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 132.632},
+{"m": 9, "n": 25, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 153.698},
+{"m": 9, "n": 25, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 192.195},
+{"m": 9, "n": 25, "k": 25, "tile_m": 2, "tile_n": 1, "w": 10, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 219.162},
+{"m": 9, "n": 25, "k": 26, "tile_m": 2, "tile_n": 1, "w": 12, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 219.784},
+{"m": 9, "n": 25, "k": 28, "tile_m": 2, "tile_n": 3, "w": 14, "v": 18, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 229.143},
+{"m": 9, "n": 25, "k": 32, "tile_m": 2, "tile_n": 3, "w": 16, "v": 18, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 232.091},
+{"m": 9, "n": 25, "k": 45, "tile_m": 1, "tile_n": 4, "w": 14, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 239.491},
+{"m": 9, "n": 26, "k": 4, "tile_m": 1, "tile_n": 2, "w": 2, "v": 26, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 112.616},
+{"m": 9, "n": 26, "k": 5, "tile_m": 3, "tile_n": 1, "w": 2, "v": 26, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 114.528},
+{"m": 9, "n": 26, "k": 6, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 129.406},
+{"m": 9, "n": 26, "k": 7, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 137.992},
+{"m": 9, "n": 26, "k": 8, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 148.898},
+{"m": 9, "n": 26, "k": 9, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 160.328},
+{"m": 9, "n": 26, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 200.731},
+{"m": 9, "n": 26, "k": 16, "tile_m": 1, "tile_n": 2, "w": 8, "v": 14, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 192.481},
+{"m": 9, "n": 26, "k": 17, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 191.617},
+{"m": 9, "n": 26, "k": 22, "tile_m": 1, "tile_n": 2, "w": 10, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 201.724},
+{"m": 9, "n": 26, "k": 23, "tile_m": 1, "tile_n": 2, "w": 10, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 205.283},
+{"m": 9, "n": 26, "k": 24, "tile_m": 1, "tile_n": 2, "w": 8, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 215.418},
+{"m": 9, "n": 26, "k": 25, "tile_m": 1, "tile_n": 2, "w": 12, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 224.702},
+{"m": 9, "n": 26, "k": 26, "tile_m": 1, "tile_n": 2, "w": 12, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 225.99},
+{"m": 9, "n": 26, "k": 28, "tile_m": 1, "tile_n": 4, "w": 14, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 240.33},
+{"m": 9, "n": 26, "k": 32, "tile_m": 1, "tile_n": 4, "w": 16, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 246.812},
+{"m": 9, "n": 26, "k": 45, "tile_m": 1, "tile_n": 4, "w": 16, "v": 26, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 249.034},
+{"m": 9, "n": 28, "k": 4, "tile_m": 1, "tile_n": 2, "w": 2, "v": 28, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 121.338},
+{"m": 9, "n": 28, "k": 5, "tile_m": 3, "tile_n": 1, "w": 2, "v": 28, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 123.294},
+{"m": 9, "n": 28, "k": 7, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 149.096},
+{"m": 9, "n": 28, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 170.708},
+{"m": 9, "n": 28, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 209.922},
+{"m": 9, "n": 28, "k": 25, "tile_m": 1, "tile_n": 2, "w": 12, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 234.576},
+{"m": 9, "n": 28, "k": 26, "tile_m": 1, "tile_n": 2, "w": 10, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 240.981},
+{"m": 9, "n": 28, "k": 28, "tile_m": 1, "tile_n": 2, "w": 14, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 250.549},
+{"m": 9, "n": 28, "k": 32, "tile_m": 1, "tile_n": 2, "w": 16, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 255.13},
+{"m": 9, "n": 28, "k": 45, "tile_m": 1, "tile_n": 4, "w": 12, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 263.838},
+{"m": 9, "n": 32, "k": 4, "tile_m": 3, "tile_n": 1, "w": 2, "v": 32, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 137.267},
+{"m": 9, "n": 32, "k": 5, "tile_m": 3, "tile_n": 1, "w": 2, "v": 32, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 141.586},
+{"m": 9, "n": 32, "k": 6, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 150.539},
+{"m": 9, "n": 32, "k": 7, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 168.582},
+{"m": 9, "n": 32, "k": 8, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 183.327},
+{"m": 9, "n": 32, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 192.731},
+{"m": 9, "n": 32, "k": 13, "tile_m": 3, "tile_n": 1, "w": 6, "v": 30, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 209.298},
+{"m": 9, "n": 32, "k": 16, "tile_m": 3, "tile_n": 1, "w": 8, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 215.364},
+{"m": 9, "n": 32, "k": 17, "tile_m": 2, "tile_n": 2, "w": 6, "v": 32, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 212.232},
+{"m": 9, "n": 32, "k": 22, "tile_m": 3, "tile_n": 1, "w": 8, "v": 20, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 230.249},
+{"m": 9, "n": 32, "k": 23, "tile_m": 3, "tile_n": 1, "w": 8, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 232.646},
+{"m": 9, "n": 32, "k": 24, "tile_m": 3, "tile_n": 1, "w": 8, "v": 20, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 239.302},
+{"m": 9, "n": 32, "k": 25, "tile_m": 2, "tile_n": 3, "w": 10, "v": 32, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 253.788},
+{"m": 9, "n": 32, "k": 26, "tile_m": 3, "tile_n": 2, "w": 10, "v": 30, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 254.099},
+{"m": 9, "n": 32, "k": 28, "tile_m": 3, "tile_n": 2, "w": 14, "v": 32, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 261.58},
+{"m": 9, "n": 32, "k": 32, "tile_m": 3, "tile_n": 2, "w": 16, "v": 32, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 266.524},
+{"m": 9, "n": 32, "k": 45, "tile_m": 2, "tile_n": 2, "w": 10, "v": 32, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 277.488},
+{"m": 9, "n": 45, "k": 4, "tile_m": 5, "tile_n": 1, "w": 2, "v": 42, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 133.76},
+{"m": 9, "n": 45, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 143.893},
+{"m": 9, "n": 45, "k": 7, "tile_m": 2, "tile_n": 3, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 171.55},
+{"m": 9, "n": 45, "k": 9, "tile_m": 2, "tile_n": 2, "w": 4, "v": 44, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 194.717},
+{"m": 9, "n": 45, "k": 13, "tile_m": 3, "tile_n": 2, "w": 6, "v": 32, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 225.041},
+{"m": 9, "n": 45, "k": 25, "tile_m": 3, "tile_n": 2, "w": 10, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 260.831},
+{"m": 9, "n": 45, "k": 26, "tile_m": 3, "tile_n": 2, "w": 10, "v": 38, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 265.9},
+{"m": 9, "n": 45, "k": 28, "tile_m": 2, "tile_n": 2, "w": 14, "v": 16, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 275.862},
+{"m": 9, "n": 45, "k": 32, "tile_m": 2, "tile_n": 4, "w": 12, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 275.89},
+{"m": 9, "n": 45, "k": 45, "tile_m": 2, "tile_n": 3, "w": 8, "v": 18, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 284.511},
+{"m": 9, "n": 64, "k": 9, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 213.899},
+{"m": 9, "n": 64, "k": 16, "tile_m": 3, "tile_n": 2, "w": 6, "v": 48, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 262.958},
+{"m": 9, "n": 64, "k": 22, "tile_m": 3, "tile_n": 2, "w": 6, "v": 32, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 285.617},
+{"m": 9, "n": 64, "k": 64, "tile_m": 3, "tile_n": 2, "w": 10, "v": 64, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 319.273},
+{"m": 9, "n": 81, "k": 9, "tile_m": 5, "tile_n": 2, "w": 2, "v": 52, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 202.245},
+{"m": 10, "n": 4, "k": 4, "tile_m": 1, "tile_n": 1, "w": 2, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 28.1008},
+{"m": 10, "n": 4, "k": 10, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 54.1832},
+{"m": 10, "n": 4, "k": 15, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 70.4501},
+{"m": 10, "n": 10, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 74.7338},
+{"m": 10, "n": 10, "k": 10, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 116.741},
+{"m": 10, "n": 10, "k": 15, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 141.061},
+{"m": 10, "n": 10, "k": 100, "tile_m": 2, "tile_n": 2, "w": 20, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 193.259},
+{"m": 10, "n": 15, "k": 4, "tile_m": 1, "tile_n": 2, "w": 2, "v": 8, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 81.7434},
+{"m": 10, "n": 15, "k": 10, "tile_m": 2, "tile_n": 1, "w": 4, "v": 8, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 137.343},
+{"m": 10, "n": 15, "k": 15, "tile_m": 2, "tile_n": 1, "w": 6, "v": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 168.752},
+{"m": 10, "n": 100, "k": 10, "tile_m": 2, "tile_n": 4, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 250.611},
+{"m": 11, "n": 11, "k": 11, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 148.474},
+{"m": 11, "n": 11, "k": 121, "tile_m": 3, "tile_n": 2, "w": 16, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 206.461},
+{"m": 11, "n": 121, "k": 11, "tile_m": 3, "tile_n": 2, "threads": 256, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 264.615},
+{"m": 12, "n": 12, "k": 12, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 154.228},
+{"m": 12, "n": 12, "k": 144, "tile_m": 3, "tile_n": 2, "w": 16, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 249.09},
+{"m": 12, "n": 144, "k": 12, "tile_m": 3, "tile_n": 3, "w": 6, "v": 80, "threads": 256, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 273.287},
+{"m": 13, "n": 4, "k": 4, "tile_m": 1, "tile_n": 1, "w": 2, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 35.8537},
+{"m": 13, "n": 4, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 43.1223},
+{"m": 13, "n": 4, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 50.5155},
+{"m": 13, "n": 4, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 58.1156},
+{"m": 13, "n": 4, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 56.8225},
+{"m": 13, "n": 4, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 62.7402},
+{"m": 13, "n": 4, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 81.1843},
+{"m": 13, "n": 4, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 82.3205},
+{"m": 13, "n": 4, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 85.3823},
+{"m": 13, "n": 4, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 106.3},
+{"m": 13, "n": 4, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 104.38},
+{"m": 13, "n": 4, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 103.008},
+{"m": 13, "n": 4, "k": 25, "tile_m": 1, "tile_n": 1, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 102.905},
+{"m": 13, "n": 4, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 107.426},
+{"m": 13, "n": 4, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 115.153},
+{"m": 13, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 116.235},
+{"m": 13, "n": 4, "k": 45, "tile_m": 1, "tile_n": 1, "w": 20, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 116.154},
+{"m": 13, "n": 5, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 43.1026},
+{"m": 13, "n": 5, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 52.3569},
+{"m": 13, "n": 5, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 60.9248},
+{"m": 13, "n": 5, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 68.9053},
+{"m": 13, "n": 5, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 64.2414},
+{"m": 13, "n": 5, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 74.1677},
+{"m": 13, "n": 5, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 93.5165},
+{"m": 13, "n": 5, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 94.8452},
+{"m": 13, "n": 5, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 97.5907},
+{"m": 13, "n": 5, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 110.275},
+{"m": 13, "n": 5, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 112.051},
+{"m": 13, "n": 5, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 114.338},
+{"m": 13, "n": 5, "k": 25, "tile_m": 1, "tile_n": 1, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 115.183},
+{"m": 13, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 116.18},
+{"m": 13, "n": 5, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 124.902},
+{"m": 13, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "w": 14, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 124.762},
+{"m": 13, "n": 5, "k": 45, "tile_m": 1, "tile_n": 1, "w": 18, "v": 4, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 128.223},
+{"m": 13, "n": 6, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 50.8013},
+{"m": 13, "n": 6, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 61.8717},
+{"m": 13, "n": 6, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 72.4236},
+{"m": 13, "n": 6, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 77.0262},
+{"m": 13, "n": 6, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 82.5687},
+{"m": 13, "n": 6, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 102.487},
+{"m": 13, "n": 6, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 6, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 112.36},
+{"m": 13, "n": 6, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 105.637},
+{"m": 13, "n": 6, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 126.591},
+{"m": 13, "n": 6, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 127.181},
+{"m": 13, "n": 6, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 131.17},
+{"m": 13, "n": 6, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 129.955},
+{"m": 13, "n": 6, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 138.459},
+{"m": 13, "n": 7, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 59.9957},
+{"m": 13, "n": 7, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 72.1074},
+{"m": 13, "n": 7, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 95.9252},
+{"m": 13, "n": 7, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 103.151},
+{"m": 13, "n": 7, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 129.722},
+{"m": 13, "n": 7, "k": 25, "tile_m": 1, "tile_n": 1, "w": 12, "v": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 153.809},
+{"m": 13, "n": 7, "k": 26, "tile_m": 1, "tile_n": 1, "w": 12, "v": 6, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 155.84},
+{"m": 13, "n": 7, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 6, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 160.527},
+{"m": 13, "n": 7, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 6, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 168.672},
+{"m": 13, "n": 7, "k": 45, "tile_m": 1, "tile_n": 1, "w": 18, "v": 6, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 170.503},
+{"m": 13, "n": 8, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 64.3202},
+{"m": 13, "n": 8, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 71.3921},
+{"m": 13, "n": 8, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 81.3107},
+{"m": 13, "n": 8, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 99.8992},
+{"m": 13, "n": 8, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 106.433},
+{"m": 13, "n": 8, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 117.265},
+{"m": 13, "n": 8, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 138.215},
+{"m": 13, "n": 8, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 139.52},
+{"m": 13, "n": 8, "k": 22, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 163.585},
+{"m": 13, "n": 8, "k": 23, "tile_m": 1, "tile_n": 1, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 147.91},
+{"m": 13, "n": 8, "k": 24, "tile_m": 1, "tile_n": 2, "w": 12, "v": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 151.064},
+{"m": 13, "n": 8, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 151.357},
+{"m": 13, "n": 8, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 157.473},
+{"m": 13, "n": 9, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 68.6834},
+{"m": 13, "n": 9, "k": 5, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 82.6413},
+{"m": 13, "n": 9, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 87.8396},
+{"m": 13, "n": 9, "k": 7, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 105.779},
+{"m": 13, "n": 9, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 109.971},
+{"m": 13, "n": 9, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 118.002},
+{"m": 13, "n": 9, "k": 13, "tile_m": 2, "tile_n": 1, "w": 6, "v": 6, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 137.392},
+{"m": 13, "n": 9, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 147.281},
+{"m": 13, "n": 9, "k": 17, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 143.348},
+{"m": 13, "n": 9, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 158.407},
+{"m": 13, "n": 9, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 160.165},
+{"m": 13, "n": 9, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 163.24},
+{"m": 13, "n": 9, "k": 25, "tile_m": 2, "tile_n": 1, "w": 10, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 172.498},
+{"m": 13, "n": 9, "k": 26, "tile_m": 2, "tile_n": 1, "w": 10, "v": 6, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 175.531},
+{"m": 13, "n": 9, "k": 28, "tile_m": 2, "tile_n": 1, "w": 14, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 187.173},
+{"m": 13, "n": 9, "k": 32, "tile_m": 2, "tile_n": 1, "w": 16, "v": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 190.526},
+{"m": 13, "n": 9, "k": 45, "tile_m": 2, "tile_n": 1, "w": 16, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 195.377},
+{"m": 13, "n": 13, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 100.777},
+{"m": 13, "n": 13, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 116.755},
+{"m": 13, "n": 13, "k": 6, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 128.884},
+{"m": 13, "n": 13, "k": 7, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 143.945},
+{"m": 13, "n": 13, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 141.808},
+{"m": 13, "n": 13, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 155.464},
+{"m": 13, "n": 13, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 174.905},
+{"m": 13, "n": 13, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 188.6},
+{"m": 13, "n": 13, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 196.824},
+{"m": 13, "n": 13, "k": 22, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 200.407},
+{"m": 13, "n": 13, "k": 23, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 192.756},
+{"m": 13, "n": 13, "k": 24, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 194.026},
+{"m": 13, "n": 13, "k": 25, "tile_m": 1, "tile_n": 2, "w": 10, "v": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 204.499},
+{"m": 13, "n": 13, "k": 26, "tile_m": 1, "tile_n": 2, "w": 10, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 205.053},
+{"m": 13, "n": 13, "k": 28, "tile_m": 2, "tile_n": 2, "w": 14, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 218.849},
+{"m": 13, "n": 13, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 223.821},
+{"m": 13, "n": 13, "k": 45, "tile_m": 2, "tile_n": 2, "w": 16, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 232.303},
+{"m": 13, "n": 13, "k": 169, "tile_m": 2, "tile_n": 2, "w": 18, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 258.16},
+{"m": 13, "n": 16, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 100.974},
+{"m": 13, "n": 16, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 114.075},
+{"m": 13, "n": 16, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 131.042},
+{"m": 13, "n": 16, "k": 8, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 148.468},
+{"m": 13, "n": 16, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 153.966},
+{"m": 13, "n": 16, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 175.389},
+{"m": 13, "n": 16, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 210.814},
+{"m": 13, "n": 16, "k": 17, "tile_m": 2, "tile_n": 2, "w": 6, "v": 16, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 185.642},
+{"m": 13, "n": 16, "k": 22, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 212.052},
+{"m": 13, "n": 16, "k": 23, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 217.955},
+{"m": 13, "n": 16, "k": 24, "tile_m": 2, "tile_n": 2, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 214.166},
+{"m": 13, "n": 16, "k": 26, "tile_m": 2, "tile_n": 2, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 210.017},
+{"m": 13, "n": 16, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 232.99},
+{"m": 13, "n": 17, "k": 4, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 99.2194},
+{"m": 13, "n": 17, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 118.252},
+{"m": 13, "n": 17, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 135.183},
+{"m": 13, "n": 17, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 144.56},
+{"m": 13, "n": 17, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 156.989},
+{"m": 13, "n": 17, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 195.592},
+{"m": 13, "n": 17, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 218.026},
+{"m": 13, "n": 17, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 187.859},
+{"m": 13, "n": 17, "k": 22, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 222.018},
+{"m": 13, "n": 17, "k": 23, "tile_m": 2, "tile_n": 2, "w": 6, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 216.451},
+{"m": 13, "n": 17, "k": 24, "tile_m": 2, "tile_n": 2, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 214.46},
+{"m": 13, "n": 17, "k": 26, "tile_m": 2, "tile_n": 2, "w": 12, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 211.202},
+{"m": 13, "n": 17, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 237.799},
+{"m": 13, "n": 22, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 117.05},
+{"m": 13, "n": 22, "k": 5, "tile_m": 3, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 132.674},
+{"m": 13, "n": 22, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 147.212},
+{"m": 13, "n": 22, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 172.205},
+{"m": 13, "n": 22, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 181.465},
+{"m": 13, "n": 22, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 207.061},
+{"m": 13, "n": 22, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 206.302},
+{"m": 13, "n": 22, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 204.952},
+{"m": 13, "n": 22, "k": 22, "tile_m": 3, "tile_n": 2, "w": 10, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 225.453},
+{"m": 13, "n": 22, "k": 23, "tile_m": 2, "tile_n": 2, "w": 8, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 227.833},
+{"m": 13, "n": 22, "k": 24, "tile_m": 3, "tile_n": 2, "w": 12, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 239.227},
+{"m": 13, "n": 22, "k": 26, "tile_m": 3, "tile_n": 2, "w": 10, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 241.066},
+{"m": 13, "n": 22, "k": 32, "tile_m": 3, "tile_n": 2, "w": 12, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 252.527},
+{"m": 13, "n": 23, "k": 4, "tile_m": 3, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 118.375},
+{"m": 13, "n": 23, "k": 5, "tile_m": 3, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 136.973},
+{"m": 13, "n": 23, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 148.462},
+{"m": 13, "n": 23, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 174.284},
+{"m": 13, "n": 23, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 185.07},
+{"m": 13, "n": 23, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 214.408},
+{"m": 13, "n": 23, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 22, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 215.76},
+{"m": 13, "n": 23, "k": 17, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 217.951},
+{"m": 13, "n": 23, "k": 22, "tile_m": 2, "tile_n": 2, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 227.875},
+{"m": 13, "n": 23, "k": 23, "tile_m": 2, "tile_n": 3, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 233.26},
+{"m": 13, "n": 23, "k": 24, "tile_m": 2, "tile_n": 3, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 243.006},
+{"m": 13, "n": 23, "k": 26, "tile_m": 2, "tile_n": 2, "w": 12, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 235.319},
+{"m": 13, "n": 23, "k": 32, "tile_m": 3, "tile_n": 2, "w": 12, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 256.302},
+{"m": 13, "n": 24, "k": 4, "tile_m": 3, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 126.462},
+{"m": 13, "n": 24, "k": 5, "tile_m": 3, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 145.967},
+{"m": 13, "n": 24, "k": 6, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 158.896},
+{"m": 13, "n": 24, "k": 8, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 182.54},
+{"m": 13, "n": 24, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 195.482},
+{"m": 13, "n": 24, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 203.566},
+{"m": 13, "n": 24, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 223.93},
+{"m": 13, "n": 24, "k": 17, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 228.962},
+{"m": 13, "n": 24, "k": 22, "tile_m": 2, "tile_n": 3, "w": 6, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 243.549},
+{"m": 13, "n": 24, "k": 23, "tile_m": 2, "tile_n": 2, "w": 8, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 244.933},
+{"m": 13, "n": 24, "k": 24, "tile_m": 3, "tile_n": 2, "w": 12, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 256.27},
+{"m": 13, "n": 24, "k": 26, "tile_m": 3, "tile_n": 2, "w": 10, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 253.677},
+{"m": 13, "n": 24, "k": 32, "tile_m": 3, "tile_n": 2, "w": 12, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 272.912},
+{"m": 13, "n": 24, "k": 45, "tile_m": 2, "tile_n": 3, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 323.835},
+{"m": 13, "n": 25, "k": 4, "tile_m": 2, "tile_n": 2, "w": 2, "v": 18, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 139.434},
+{"m": 13, "n": 25, "k": 5, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 146.157},
+{"m": 13, "n": 25, "k": 7, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 169.341},
+{"m": 13, "n": 25, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 199.087},
+{"m": 13, "n": 25, "k": 13, "tile_m": 2, "tile_n": 2, "w": 6, "v": 18, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 222.344},
+{"m": 13, "n": 25, "k": 25, "tile_m": 2, "tile_n": 3, "w": 12, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 283.473},
+{"m": 13, "n": 25, "k": 26, "tile_m": 2, "tile_n": 3, "w": 12, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 286.294},
+{"m": 13, "n": 25, "k": 28, "tile_m": 2, "tile_n": 3, "w": 14, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 298.297},
+{"m": 13, "n": 25, "k": 32, "tile_m": 2, "tile_n": 3, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 300.302},
+{"m": 13, "n": 25, "k": 45, "tile_m": 2, "tile_n": 3, "w": 12, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 322.398},
+{"m": 13, "n": 26, "k": 4, "tile_m": 2, "tile_n": 2, "w": 2, "v": 22, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 142.206},
+{"m": 13, "n": 26, "k": 5, "tile_m": 2, "tile_n": 2, "w": 2, "v": 26, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 153.192},
+{"m": 13, "n": 26, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 165.607},
+{"m": 13, "n": 26, "k": 7, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 175.539},
+{"m": 13, "n": 26, "k": 8, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 191.191},
+{"m": 13, "n": 26, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 206.218},
+{"m": 13, "n": 26, "k": 13, "tile_m": 2, "tile_n": 3, "w": 6, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 236.552},
+{"m": 13, "n": 26, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 225.673},
+{"m": 13, "n": 26, "k": 17, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 241.87},
+{"m": 13, "n": 26, "k": 22, "tile_m": 2, "tile_n": 2, "w": 6, "v": 26, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 251.077},
+{"m": 13, "n": 26, "k": 23, "tile_m": 2, "tile_n": 2, "w": 6, "v": 26, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 255.001},
+{"m": 13, "n": 26, "k": 24, "tile_m": 2, "tile_n": 3, "w": 12, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 262.921},
+{"m": 13, "n": 26, "k": 25, "tile_m": 2, "tile_n": 3, "w": 12, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 290.699},
+{"m": 13, "n": 26, "k": 26, "tile_m": 2, "tile_n": 3, "w": 12, "v": 26, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 296.294},
+{"m": 13, "n": 26, "k": 28, "tile_m": 2, "tile_n": 2, "w": 14, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 306.437},
+{"m": 13, "n": 26, "k": 32, "tile_m": 2, "tile_n": 3, "w": 12, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 312.2},
+{"m": 13, "n": 26, "k": 45, "tile_m": 2, "tile_n": 3, "w": 12, "v": 26, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 333.855},
+{"m": 13, "n": 28, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 136.696},
+{"m": 13, "n": 28, "k": 5, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 147.311},
+{"m": 13, "n": 28, "k": 7, "tile_m": 5, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 165.948},
+{"m": 13, "n": 28, "k": 9, "tile_m": 2, "tile_n": 2, "w": 4, "v": 28, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 197.709},
+{"m": 13, "n": 28, "k": 13, "tile_m": 4, "tile_n": 2, "w": 6, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 230.774},
+{"m": 13, "n": 28, "k": 25, "tile_m": 1, "tile_n": 4, "w": 10, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 277.441},
+{"m": 13, "n": 28, "k": 26, "tile_m": 1, "tile_n": 4, "w": 12, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 282.085},
+{"m": 13, "n": 28, "k": 28, "tile_m": 1, "tile_n": 4, "w": 10, "v": 26, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 286.256},
+{"m": 13, "n": 28, "k": 32, "tile_m": 1, "tile_n": 4, "w": 12, "v": 28, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 294.744},
+{"m": 13, "n": 28, "k": 45, "tile_m": 4, "tile_n": 2, "w": 12, "v": 28, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 301.413},
+{"m": 13, "n": 32, "k": 4, "tile_m": 4, "tile_n": 2, "w": 2, "v": 32, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 147.822},
+{"m": 13, "n": 32, "k": 5, "tile_m": 3, "tile_n": 2, "w": 2, "v": 32, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 156.628},
+{"m": 13, "n": 32, "k": 6, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 181.813},
+{"m": 13, "n": 32, "k": 7, "tile_m": 5, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 188.684},
+{"m": 13, "n": 32, "k": 8, "tile_m": 2, "tile_n": 2, "w": 4, "v": 32, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 200.207},
+{"m": 13, "n": 32, "k": 9, "tile_m": 2, "tile_n": 2, "w": 4, "v": 32, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 223.308},
+{"m": 13, "n": 32, "k": 13, "tile_m": 4, "tile_n": 2, "w": 6, "v": 26, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 263.806},
+{"m": 13, "n": 32, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 260.668},
+{"m": 13, "n": 32, "k": 17, "tile_m": 2, "tile_n": 3, "w": 6, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 247.911},
+{"m": 13, "n": 32, "k": 22, "tile_m": 2, "tile_n": 3, "w": 6, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 271.196},
+{"m": 13, "n": 32, "k": 23, "tile_m": 2, "tile_n": 3, "w": 6, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 275.98},
+{"m": 13, "n": 32, "k": 24, "tile_m": 2, "tile_n": 2, "w": 12, "v": 24, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 283.245},
+{"m": 13, "n": 32, "k": 25, "tile_m": 2, "tile_n": 4, "w": 6, "v": 26, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 302.793},
+{"m": 13, "n": 32, "k": 26, "tile_m": 2, "tile_n": 4, "w": 12, "v": 32, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 303.713},
+{"m": 13, "n": 32, "k": 28, "tile_m": 2, "tile_n": 4, "w": 8, "v": 26, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 314.111},
+{"m": 13, "n": 32, "k": 32, "tile_m": 2, "tile_n": 4, "w": 16, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 330.971},
+{"m": 13, "n": 32, "k": 45, "tile_m": 2, "tile_n": 4, "w": 12, "v": 32, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 336.419},
+{"m": 13, "n": 45, "k": 4, "tile_m": 4, "tile_n": 2, "w": 2, "v": 36, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 161.891},
+{"m": 13, "n": 45, "k": 5, "tile_m": 3, "tile_n": 2, "w": 2, "v": 36, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 174.168},
+{"m": 13, "n": 45, "k": 7, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 203.007},
+{"m": 13, "n": 45, "k": 9, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 235.887},
+{"m": 13, "n": 45, "k": 13, "tile_m": 2, "tile_n": 3, "w": 6, "v": 36, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 260.83},
+{"m": 13, "n": 45, "k": 24, "tile_m": 2, "tile_n": 5, "w": 12, "v": 40, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 328.273},
+{"m": 13, "n": 45, "k": 25, "tile_m": 2, "tile_n": 3, "w": 12, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 318.496},
+{"m": 13, "n": 45, "k": 26, "tile_m": 2, "tile_n": 3, "w": 12, "v": 36, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 323.253},
+{"m": 13, "n": 45, "k": 28, "tile_m": 2, "tile_n": 3, "w": 14, "v": 36, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 338.61},
+{"m": 13, "n": 45, "k": 32, "tile_m": 2, "tile_n": 5, "w": 12, "v": 38, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 342.906},
+{"m": 13, "n": 45, "k": 45, "tile_m": 2, "tile_n": 5, "w": 12, "v": 44, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 366.795},
+{"m": 13, "n": 169, "k": 13, "tile_m": 4, "tile_n": 3, "w": 6, "v": 96, "threads": 256, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 241.485},
+{"m": 14, "n": 14, "k": 14, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 197.885},
+{"m": 14, "n": 14, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 216.145},
+{"m": 14, "n": 14, "k": 29, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 218.838},
+{"m": 14, "n": 14, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 224.281},
+{"m": 14, "n": 14, "k": 196, "tile_m": 2, "tile_n": 2, "w": 16, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 289.084},
+{"m": 14, "n": 16, "k": 14, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 213.982},
+{"m": 14, "n": 16, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 230.421},
+{"m": 14, "n": 16, "k": 29, "tile_m": 2, "tile_n": 2, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 232.968},
+{"m": 14, "n": 29, "k": 14, "tile_m": 2, "tile_n": 2, "w": 4, "v": 20, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 231.308},
+{"m": 14, "n": 29, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 267.108},
+{"m": 14, "n": 29, "k": 29, "tile_m": 2, "tile_n": 2, "w": 10, "v": 20, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 272.491},
+{"m": 14, "n": 29, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 20, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 292.149},
+{"m": 14, "n": 32, "k": 14, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 258.209},
+{"m": 14, "n": 32, "k": 29, "tile_m": 2, "tile_n": 2, "w": 10, "v": 32, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 311.422},
+{"m": 14, "n": 32, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 32, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 326.197},
+{"m": 14, "n": 196, "k": 14, "tile_m": 2, "tile_n": 6, "threads": 256, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 278.411},
+{"m": 15, "n": 4, "k": 4, "tile_m": 1, "tile_n": 1, "w": 2, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 41.0244},
+{"m": 15, "n": 4, "k": 10, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 76.5643},
+{"m": 15, "n": 4, "k": 15, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 101.102},
+{"m": 15, "n": 10, "k": 4, "tile_m": 2, "tile_n": 1, "w": 2, "v": 10, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 85.363},
+{"m": 15, "n": 10, "k": 10, "tile_m": 1, "tile_n": 2, "w": 4, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 138.924},
+{"m": 15, "n": 10, "k": 15, "tile_m": 1, "tile_n": 2, "w": 6, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 168.55},
+{"m": 15, "n": 15, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 119.369},
+{"m": 15, "n": 15, "k": 10, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 184.444},
+{"m": 15, "n": 15, "k": 15, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 226.439},
+{"m": 15, "n": 15, "k": 225, "tile_m": 2, "tile_n": 2, "w": 16, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 311.643},
+{"m": 15, "n": 225, "k": 15, "tile_m": 3, "tile_n": 3, "w": 4, "v": 150, "threads": 384, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 258.751},
+{"m": 16, "n": 4, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 43.2513},
+{"m": 16, "n": 4, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 52.8509},
+{"m": 16, "n": 4, "k": 6, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 56.0623},
+{"m": 16, "n": 4, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 70.6265},
+{"m": 16, "n": 4, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 76.3591},
+{"m": 16, "n": 4, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 90.3877},
+{"m": 16, "n": 4, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 104.947},
+{"m": 16, "n": 4, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 108.128},
+{"m": 16, "n": 4, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 117.022},
+{"m": 16, "n": 4, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 118.619},
+{"m": 16, "n": 4, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 118.972},
+{"m": 16, "n": 4, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 116.617},
+{"m": 16, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 119.202},
+{"m": 16, "n": 5, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 53.2937},
+{"m": 16, "n": 5, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 64.8851},
+{"m": 16, "n": 5, "k": 6, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 68.9342},
+{"m": 16, "n": 5, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 84.6639},
+{"m": 16, "n": 5, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 91.9906},
+{"m": 16, "n": 5, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 107.42},
+{"m": 16, "n": 5, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 121.912},
+{"m": 16, "n": 5, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 125.062},
+{"m": 16, "n": 5, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 134.168},
+{"m": 16, "n": 5, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 127.673},
+{"m": 16, "n": 5, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 129.534},
+{"m": 16, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 127.182},
+{"m": 16, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 138.029},
+{"m": 16, "n": 6, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 63.7826},
+{"m": 16, "n": 6, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 77.3562},
+{"m": 16, "n": 6, "k": 6, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 81.9641},
+{"m": 16, "n": 6, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 99.2729},
+{"m": 16, "n": 6, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 108.16},
+{"m": 16, "n": 6, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 128.018},
+{"m": 16, "n": 6, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 6, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 134.069},
+{"m": 16, "n": 6, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 141.119},
+{"m": 16, "n": 6, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 147.402},
+{"m": 16, "n": 6, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 147.837},
+{"m": 16, "n": 6, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 6, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 151.996},
+{"m": 16, "n": 6, "k": 26, "tile_m": 1, "tile_n": 1, "w": 10, "v": 6, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 149.231},
+{"m": 16, "n": 6, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 163.734},
+{"m": 16, "n": 8, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 78.0533},
+{"m": 16, "n": 8, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 91.3267},
+{"m": 16, "n": 8, "k": 6, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 105.373},
+{"m": 16, "n": 8, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 124.195},
+{"m": 16, "n": 8, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 121.754},
+{"m": 16, "n": 8, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 150.445},
+{"m": 16, "n": 8, "k": 16, "tile_m": 1, "tile_n": 1, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 166.502},
+{"m": 16, "n": 8, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 167.3},
+{"m": 16, "n": 8, "k": 22, "tile_m": 1, "tile_n": 1, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 175.569},
+{"m": 16, "n": 8, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 178.527},
+{"m": 16, "n": 8, "k": 24, "tile_m": 2, "tile_n": 1, "w": 12, "v": 8, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 185.133},
+{"m": 16, "n": 8, "k": 26, "tile_m": 1, "tile_n": 1, "w": 12, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 178.92},
+{"m": 16, "n": 8, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 8, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 194.196},
+{"m": 16, "n": 9, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 82.0886},
+{"m": 16, "n": 9, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 98.1233},
+{"m": 16, "n": 9, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 102.023},
+{"m": 16, "n": 9, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 120.113},
+{"m": 16, "n": 9, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 128.209},
+{"m": 16, "n": 9, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 149.02},
+{"m": 16, "n": 9, "k": 16, "tile_m": 2, "tile_n": 1, "w": 8, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 161.845},
+{"m": 16, "n": 9, "k": 17, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 166.142},
+{"m": 16, "n": 9, "k": 22, "tile_m": 2, "tile_n": 1, "w": 8, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 171.029},
+{"m": 16, "n": 9, "k": 23, "tile_m": 2, "tile_n": 1, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 173.179},
+{"m": 16, "n": 9, "k": 24, "tile_m": 2, "tile_n": 1, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 175.852},
+{"m": 16, "n": 9, "k": 26, "tile_m": 2, "tile_n": 1, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 180.319},
+{"m": 16, "n": 9, "k": 32, "tile_m": 2, "tile_n": 1, "w": 6, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 179.384},
+{"m": 16, "n": 9, "k": 64, "tile_m": 3, "tile_n": 2, "w": 16, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 213.459},
+{"m": 16, "n": 13, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 101.905},
+{"m": 16, "n": 13, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 116.398},
+{"m": 16, "n": 13, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 127.421},
+{"m": 16, "n": 13, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 146.46},
+{"m": 16, "n": 13, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 156.829},
+{"m": 16, "n": 13, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 189.636},
+{"m": 16, "n": 13, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 214.841},
+{"m": 16, "n": 13, "k": 17, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 191.644},
+{"m": 16, "n": 13, "k": 22, "tile_m": 2, "tile_n": 2, "w": 8, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 210.521},
+{"m": 16, "n": 13, "k": 23, "tile_m": 2, "tile_n": 2, "w": 8, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 214.991},
+{"m": 16, "n": 13, "k": 24, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 212.921},
+{"m": 16, "n": 13, "k": 26, "tile_m": 2, "tile_n": 1, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 210.224},
+{"m": 16, "n": 13, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 234.974},
+{"m": 16, "n": 14, "k": 14, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 215.62},
+{"m": 16, "n": 14, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 230.5},
+{"m": 16, "n": 14, "k": 29, "tile_m": 2, "tile_n": 1, "w": 8, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 231.585},
+{"m": 16, "n": 16, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 142.372},
+{"m": 16, "n": 16, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 161.476},
+{"m": 16, "n": 16, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 180.677},
+{"m": 16, "n": 16, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 205.549},
+{"m": 16, "n": 16, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 205.186},
+{"m": 16, "n": 16, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 240.903},
+{"m": 16, "n": 16, "k": 14, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 253.252},
+{"m": 16, "n": 16, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 267.825},
+{"m": 16, "n": 16, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 247.453},
+{"m": 16, "n": 16, "k": 22, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 268.121},
+{"m": 16, "n": 16, "k": 23, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 272.615},
+{"m": 16, "n": 16, "k": 24, "tile_m": 2, "tile_n": 2, "w": 12, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 265.276},
+{"m": 16, "n": 16, "k": 26, "tile_m": 2, "tile_n": 2, "w": 10, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 263.235},
+{"m": 16, "n": 16, "k": 29, "tile_m": 2, "tile_n": 2, "w": 14, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 270.638},
+{"m": 16, "n": 16, "k": 32, "tile_m": 2, "tile_n": 2, "w": 14, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 276.949},
+{"m": 16, "n": 16, "k": 55, "tile_m": 2, "tile_n": 2, "w": 14, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 303.184},
+{"m": 16, "n": 16, "k": 64, "tile_m": 2, "tile_n": 2, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 312.221},
+{"m": 16, "n": 16, "k": 256, "tile_m": 2, "tile_n": 2, "w": 14, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 341.89},
+{"m": 16, "n": 17, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 113.047},
+{"m": 16, "n": 17, "k": 5, "tile_m": 1, "tile_n": 3, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 135.825},
+{"m": 16, "n": 17, "k": 6, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 152.914},
+{"m": 16, "n": 17, "k": 8, "tile_m": 2, "tile_n": 3, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 165.821},
+{"m": 16, "n": 17, "k": 9, "tile_m": 1, "tile_n": 3, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 179.436},
+{"m": 16, "n": 17, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 215.752},
+{"m": 16, "n": 17, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 202.68},
+{"m": 16, "n": 17, "k": 17, "tile_m": 3, "tile_n": 2, "w": 6, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 210.423},
+{"m": 16, "n": 17, "k": 22, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 234.804},
+{"m": 16, "n": 17, "k": 23, "tile_m": 1, "tile_n": 3, "w": 6, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 235.716},
+{"m": 16, "n": 17, "k": 24, "tile_m": 2, "tile_n": 3, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 241.704},
+{"m": 16, "n": 17, "k": 26, "tile_m": 2, "tile_n": 3, "w": 10, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 235.825},
+{"m": 16, "n": 17, "k": 32, "tile_m": 2, "tile_n": 3, "w": 12, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 255.137},
+{"m": 16, "n": 22, "k": 4, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 138.141},
+{"m": 16, "n": 22, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 161.969},
+{"m": 16, "n": 22, "k": 6, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 169.805},
+{"m": 16, "n": 22, "k": 8, "tile_m": 2, "tile_n": 3, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 205.457},
+{"m": 16, "n": 22, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 217.014},
+{"m": 16, "n": 22, "k": 13, "tile_m": 2, "tile_n": 2, "w": 4, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 223.224},
+{"m": 16, "n": 22, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 253.21},
+{"m": 16, "n": 22, "k": 17, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 260.436},
+{"m": 16, "n": 22, "k": 22, "tile_m": 2, "tile_n": 3, "w": 10, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 273.938},
+{"m": 16, "n": 22, "k": 23, "tile_m": 2, "tile_n": 3, "w": 10, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 277.81},
+{"m": 16, "n": 22, "k": 24, "tile_m": 2, "tile_n": 3, "w": 12, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 291.318},
+{"m": 16, "n": 22, "k": 26, "tile_m": 2, "tile_n": 3, "w": 10, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 289.631},
+{"m": 16, "n": 22, "k": 32, "tile_m": 2, "tile_n": 3, "w": 12, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 305.311},
+{"m": 16, "n": 22, "k": 64, "tile_m": 2, "tile_n": 2, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 349.601},
+{"m": 16, "n": 23, "k": 4, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 143.468},
+{"m": 16, "n": 23, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 167.762},
+{"m": 16, "n": 23, "k": 6, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 176.832},
+{"m": 16, "n": 23, "k": 8, "tile_m": 2, "tile_n": 3, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 213.06},
+{"m": 16, "n": 23, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 226.28},
+{"m": 16, "n": 23, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 230.437},
+{"m": 16, "n": 23, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 263.178},
+{"m": 16, "n": 23, "k": 17, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 264.544},
+{"m": 16, "n": 23, "k": 22, "tile_m": 2, "tile_n": 3, "w": 10, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 279.549},
+{"m": 16, "n": 23, "k": 23, "tile_m": 2, "tile_n": 2, "w": 10, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 282.297},
+{"m": 16, "n": 23, "k": 24, "tile_m": 2, "tile_n": 3, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 295.553},
+{"m": 16, "n": 23, "k": 26, "tile_m": 2, "tile_n": 2, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 291.977},
+{"m": 16, "n": 23, "k": 32, "tile_m": 2, "tile_n": 3, "w": 12, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 313.606},
+{"m": 16, "n": 24, "k": 4, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 150.444},
+{"m": 16, "n": 24, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 174.489},
+{"m": 16, "n": 24, "k": 6, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 184.054},
+{"m": 16, "n": 24, "k": 8, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 207.226},
+{"m": 16, "n": 24, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 235.336},
+{"m": 16, "n": 24, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 239.748},
+{"m": 16, "n": 24, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 283.218},
+{"m": 16, "n": 24, "k": 17, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 275.019},
+{"m": 16, "n": 24, "k": 22, "tile_m": 2, "tile_n": 3, "w": 8, "v": 18, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 298.156},
+{"m": 16, "n": 24, "k": 23, "tile_m": 2, "tile_n": 3, "w": 8, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 302.868},
+{"m": 16, "n": 24, "k": 24, "tile_m": 2, "tile_n": 2, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 313.429},
+{"m": 16, "n": 24, "k": 26, "tile_m": 2, "tile_n": 3, "w": 10, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 309.598},
+{"m": 16, "n": 24, "k": 32, "tile_m": 2, "tile_n": 3, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 328.287},
+{"m": 16, "n": 26, "k": 4, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 145.64},
+{"m": 16, "n": 26, "k": 5, "tile_m": 2, "tile_n": 3, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 161.73},
+{"m": 16, "n": 26, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 166.297},
+{"m": 16, "n": 26, "k": 8, "tile_m": 2, "tile_n": 3, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 203.682},
+{"m": 16, "n": 26, "k": 9, "tile_m": 2, "tile_n": 3, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 211.795},
+{"m": 16, "n": 26, "k": 13, "tile_m": 2, "tile_n": 2, "w": 6, "v": 26, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 235.299},
+{"m": 16, "n": 26, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 18, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 273.171},
+{"m": 16, "n": 26, "k": 17, "tile_m": 2, "tile_n": 2, "w": 8, "v": 18, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 265.788},
+{"m": 16, "n": 26, "k": 22, "tile_m": 2, "tile_n": 4, "w": 10, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 285.563},
+{"m": 16, "n": 26, "k": 23, "tile_m": 2, "tile_n": 2, "w": 6, "v": 18, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 284.848},
+{"m": 16, "n": 26, "k": 24, "tile_m": 2, "tile_n": 2, "w": 8, "v": 18, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 301.847},
+{"m": 16, "n": 26, "k": 26, "tile_m": 2, "tile_n": 4, "w": 10, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 298.512},
+{"m": 16, "n": 26, "k": 32, "tile_m": 2, "tile_n": 4, "w": 10, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 308.645},
+{"m": 16, "n": 29, "k": 14, "tile_m": 2, "tile_n": 2, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 264.624},
+{"m": 16, "n": 29, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 294.66},
+{"m": 16, "n": 29, "k": 29, "tile_m": 2, "tile_n": 2, "w": 6, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 312.556},
+{"m": 16, "n": 29, "k": 55, "tile_m": 2, "tile_n": 4, "w": 6, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 360.672},
+{"m": 16, "n": 32, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 149.795},
+{"m": 16, "n": 32, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 166.138},
+{"m": 16, "n": 32, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 189.982},
+{"m": 16, "n": 32, "k": 8, "tile_m": 2, "tile_n": 2, "w": 4, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 234.188},
+{"m": 16, "n": 32, "k": 9, "tile_m": 2, "tile_n": 2, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 239.327},
+{"m": 16, "n": 32, "k": 13, "tile_m": 2, "tile_n": 2, "w": 6, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 290.526},
+{"m": 16, "n": 32, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 326.65},
+{"m": 16, "n": 32, "k": 17, "tile_m": 2, "tile_n": 2, "w": 8, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 322.698},
+{"m": 16, "n": 32, "k": 22, "tile_m": 2, "tile_n": 4, "w": 6, "v": 28, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 328.078},
+{"m": 16, "n": 32, "k": 23, "tile_m": 2, "tile_n": 2, "w": 6, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 344.677},
+{"m": 16, "n": 32, "k": 24, "tile_m": 2, "tile_n": 2, "w": 8, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 358.185},
+{"m": 16, "n": 32, "k": 26, "tile_m": 2, "tile_n": 2, "w": 6, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 342.564},
+{"m": 16, "n": 32, "k": 32, "tile_m": 2, "tile_n": 4, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 360.103},
+{"m": 16, "n": 55, "k": 16, "tile_m": 2, "tile_n": 4, "w": 8, "v": 32, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 331.33},
+{"m": 16, "n": 55, "k": 29, "tile_m": 2, "tile_n": 4, "w": 8, "v": 40, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 387.674},
+{"m": 16, "n": 55, "k": 55, "tile_m": 2, "tile_n": 4, "w": 8, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 430.218},
+{"m": 16, "n": 64, "k": 9, "tile_m": 2, "tile_n": 4, "w": 4, "v": 40, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 281.238},
+{"m": 16, "n": 64, "k": 16, "tile_m": 2, "tile_n": 4, "w": 8, "v": 40, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 374.147},
+{"m": 16, "n": 64, "k": 22, "tile_m": 2, "tile_n": 4, "w": 8, "v": 40, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 409.267},
+{"m": 16, "n": 64, "k": 64, "tile_m": 2, "tile_n": 4, "w": 8, "v": 44, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 500.346},
+{"m": 16, "n": 256, "k": 16, "tile_m": 2, "tile_n": 6, "w": 6, "v": 168, "threads": 384, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 309.179},
+{"m": 17, "n": 4, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 44.4021},
+{"m": 17, "n": 4, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 54.1312},
+{"m": 17, "n": 4, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 55.1151},
+{"m": 17, "n": 4, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 64.4064},
+{"m": 17, "n": 4, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 69.4042},
+{"m": 17, "n": 4, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 86.341},
+{"m": 17, "n": 4, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 99.1383},
+{"m": 17, "n": 4, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 98.4389},
+{"m": 17, "n": 4, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 113.713},
+{"m": 17, "n": 4, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 109.504},
+{"m": 17, "n": 4, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 109.247},
+{"m": 17, "n": 4, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 112.934},
+{"m": 17, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 116.496},
+{"m": 17, "n": 5, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 55.1226},
+{"m": 17, "n": 5, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 67.2537},
+{"m": 17, "n": 5, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 67.5261},
+{"m": 17, "n": 5, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 78.5404},
+{"m": 17, "n": 5, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 86.2825},
+{"m": 17, "n": 5, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 106.81},
+{"m": 17, "n": 5, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 121.92},
+{"m": 17, "n": 5, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 122.006},
+{"m": 17, "n": 5, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 136.463},
+{"m": 17, "n": 5, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 132.002},
+{"m": 17, "n": 5, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 135.055},
+{"m": 17, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 131.777},
+{"m": 17, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 138.231},
+{"m": 17, "n": 6, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 60.0659},
+{"m": 17, "n": 6, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 69.3811},
+{"m": 17, "n": 6, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 76.6485},
+{"m": 17, "n": 6, "k": 8, "tile_m": 1, "tile_n": 1, "w": 4, "v": 6, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 87.7851},
+{"m": 17, "n": 6, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 93.856},
+{"m": 17, "n": 6, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 121.148},
+{"m": 17, "n": 6, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 129.192},
+{"m": 17, "n": 6, "k": 17, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 129.614},
+{"m": 17, "n": 6, "k": 22, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 140.116},
+{"m": 17, "n": 6, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 138.103},
+{"m": 17, "n": 6, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 142.037},
+{"m": 17, "n": 6, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 145.376},
+{"m": 17, "n": 6, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 150.065},
+{"m": 17, "n": 8, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 73.5398},
+{"m": 17, "n": 8, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 84.7969},
+{"m": 17, "n": 8, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 90.287},
+{"m": 17, "n": 8, "k": 8, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 110.66},
+{"m": 17, "n": 8, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 117.865},
+{"m": 17, "n": 8, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 136.931},
+{"m": 17, "n": 8, "k": 16, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 151.999},
+{"m": 17, "n": 8, "k": 17, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 153.384},
+{"m": 17, "n": 8, "k": 22, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 157.352},
+{"m": 17, "n": 8, "k": 23, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 157.04},
+{"m": 17, "n": 8, "k": 24, "tile_m": 2, "tile_n": 3, "w": 12, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 158.743},
+{"m": 17, "n": 8, "k": 26, "tile_m": 2, "tile_n": 3, "w": 12, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 158.262},
+{"m": 17, "n": 8, "k": 32, "tile_m": 3, "tile_n": 2, "w": 16, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 178.979},
+{"m": 17, "n": 9, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 77.9497},
+{"m": 17, "n": 9, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 93.1439},
+{"m": 17, "n": 9, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 98.5145},
+{"m": 17, "n": 9, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 115.668},
+{"m": 17, "n": 9, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 130.249},
+{"m": 17, "n": 9, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 150.565},
+{"m": 17, "n": 9, "k": 16, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 163.688},
+{"m": 17, "n": 9, "k": 17, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 167.344},
+{"m": 17, "n": 9, "k": 22, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 171.276},
+{"m": 17, "n": 9, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 224, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 166.022},
+{"m": 17, "n": 9, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 224, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 168.798},
+{"m": 17, "n": 9, "k": 26, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 168.829},
+{"m": 17, "n": 9, "k": 32, "tile_m": 2, "tile_n": 3, "w": 16, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 184.866},
+{"m": 17, "n": 13, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 100.145},
+{"m": 17, "n": 13, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 118.278},
+{"m": 17, "n": 13, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 131.89},
+{"m": 17, "n": 13, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 149.14},
+{"m": 17, "n": 13, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 161.29},
+{"m": 17, "n": 13, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 199.157},
+{"m": 17, "n": 13, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 215.17},
+{"m": 17, "n": 13, "k": 17, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 193.774},
+{"m": 17, "n": 13, "k": 22, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 220.321},
+{"m": 17, "n": 13, "k": 23, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 220.147},
+{"m": 17, "n": 13, "k": 24, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 222.453},
+{"m": 17, "n": 13, "k": 26, "tile_m": 2, "tile_n": 2, "w": 12, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 213.018},
+{"m": 17, "n": 13, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 238.862},
+{"m": 17, "n": 16, "k": 4, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 116.716},
+{"m": 17, "n": 16, "k": 5, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 136.165},
+{"m": 17, "n": 16, "k": 6, "tile_m": 3, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 154.74},
+{"m": 17, "n": 16, "k": 8, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 169.907},
+{"m": 17, "n": 16, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 177.331},
+{"m": 17, "n": 16, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 203.746},
+{"m": 17, "n": 16, "k": 16, "tile_m": 3, "tile_n": 1, "w": 4, "v": 10, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 206.356},
+{"m": 17, "n": 16, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 207.944},
+{"m": 17, "n": 16, "k": 22, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 235.476},
+{"m": 17, "n": 16, "k": 23, "tile_m": 3, "tile_n": 1, "w": 6, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 235.699},
+{"m": 17, "n": 16, "k": 24, "tile_m": 3, "tile_n": 2, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 245.438},
+{"m": 17, "n": 16, "k": 26, "tile_m": 3, "tile_n": 2, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 240.279},
+{"m": 17, "n": 16, "k": 32, "tile_m": 3, "tile_n": 2, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 257.664},
+{"m": 17, "n": 17, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 123.512},
+{"m": 17, "n": 17, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 144.444},
+{"m": 17, "n": 17, "k": 6, "tile_m": 3, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 153.953},
+{"m": 17, "n": 17, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 179.063},
+{"m": 17, "n": 17, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 194.247},
+{"m": 17, "n": 17, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 227.787},
+{"m": 17, "n": 17, "k": 16, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 228.835},
+{"m": 17, "n": 17, "k": 17, "tile_m": 2, "tile_n": 2, "w": 6, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 239.722},
+{"m": 17, "n": 17, "k": 22, "tile_m": 2, "tile_n": 2, "w": 6, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 235.625},
+{"m": 17, "n": 17, "k": 23, "tile_m": 2, "tile_n": 2, "w": 6, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 237.176},
+{"m": 17, "n": 17, "k": 24, "tile_m": 2, "tile_n": 3, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 240.597},
+{"m": 17, "n": 17, "k": 26, "tile_m": 3, "tile_n": 2, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 240.047},
+{"m": 17, "n": 17, "k": 32, "tile_m": 3, "tile_n": 2, "w": 14, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 260.215},
+{"m": 17, "n": 22, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 138.391},
+{"m": 17, "n": 22, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 148.4},
+{"m": 17, "n": 22, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 150.275},
+{"m": 17, "n": 22, "k": 8, "tile_m": 2, "tile_n": 2, "w": 4, "v": 22, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 182.307},
+{"m": 17, "n": 22, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 187.291},
+{"m": 17, "n": 22, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 214.624},
+{"m": 17, "n": 22, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 246.559},
+{"m": 17, "n": 22, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 251.891},
+{"m": 17, "n": 22, "k": 22, "tile_m": 3, "tile_n": 2, "w": 10, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 245.288},
+{"m": 17, "n": 22, "k": 23, "tile_m": 3, "tile_n": 2, "w": 8, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 245.432},
+{"m": 17, "n": 22, "k": 24, "tile_m": 3, "tile_n": 2, "w": 12, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 262.797},
+{"m": 17, "n": 22, "k": 26, "tile_m": 3, "tile_n": 2, "w": 12, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 257.52},
+{"m": 17, "n": 22, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 22, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 279.426},
+{"m": 17, "n": 23, "k": 4, "tile_m": 5, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 131.562},
+{"m": 17, "n": 23, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 153.614},
+{"m": 17, "n": 23, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 153.311},
+{"m": 17, "n": 23, "k": 8, "tile_m": 2, "tile_n": 2, "w": 4, "v": 22, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 183.993},
+{"m": 17, "n": 23, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 192.159},
+{"m": 17, "n": 23, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 227.532},
+{"m": 17, "n": 23, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 253.516},
+{"m": 17, "n": 23, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 253.057},
+{"m": 17, "n": 23, "k": 22, "tile_m": 2, "tile_n": 2, "w": 10, "v": 22, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 263.902},
+{"m": 17, "n": 23, "k": 23, "tile_m": 3, "tile_n": 2, "w": 10, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 257.187},
+{"m": 17, "n": 23, "k": 24, "tile_m": 2, "tile_n": 2, "w": 10, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 274.723},
+{"m": 17, "n": 23, "k": 26, "tile_m": 3, "tile_n": 2, "w": 10, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 264.933},
+{"m": 17, "n": 23, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 16, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 282.093},
+{"m": 17, "n": 24, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 149.438},
+{"m": 17, "n": 24, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 160.205},
+{"m": 17, "n": 24, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 165.872},
+{"m": 17, "n": 24, "k": 8, "tile_m": 2, "tile_n": 2, "w": 4, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 196.795},
+{"m": 17, "n": 24, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 203.363},
+{"m": 17, "n": 24, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 236.192},
+{"m": 17, "n": 24, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 24, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 260.019},
+{"m": 17, "n": 24, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 260.23},
+{"m": 17, "n": 24, "k": 22, "tile_m": 3, "tile_n": 2, "w": 10, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 265.399},
+{"m": 17, "n": 24, "k": 23, "tile_m": 3, "tile_n": 2, "w": 8, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 267.658},
+{"m": 17, "n": 24, "k": 24, "tile_m": 2, "tile_n": 2, "w": 12, "v": 24, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 276.151},
+{"m": 17, "n": 24, "k": 26, "tile_m": 3, "tile_n": 2, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 280.206},
+{"m": 17, "n": 24, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 301.526},
+{"m": 17, "n": 26, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 155.546},
+{"m": 17, "n": 26, "k": 5, "tile_m": 1, "tile_n": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 155.547},
+{"m": 17, "n": 26, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 174.528},
+{"m": 17, "n": 26, "k": 8, "tile_m": 2, "tile_n": 2, "w": 4, "v": 26, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 205.713},
+{"m": 17, "n": 26, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 205.14},
+{"m": 17, "n": 26, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 243.482},
+{"m": 17, "n": 26, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 272.907},
+{"m": 17, "n": 26, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 275.819},
+{"m": 17, "n": 26, "k": 22, "tile_m": 2, "tile_n": 3, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 277.137},
+{"m": 17, "n": 26, "k": 23, "tile_m": 3, "tile_n": 2, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 285.309},
+{"m": 17, "n": 26, "k": 24, "tile_m": 3, "tile_n": 2, "w": 8, "v": 26, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 292.828},
+{"m": 17, "n": 26, "k": 26, "tile_m": 3, "tile_n": 2, "w": 10, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 288.933},
+{"m": 17, "n": 26, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 18, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 317.652},
+{"m": 17, "n": 32, "k": 4, "tile_m": 3, "tile_n": 2, "w": 2, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 148.299},
+{"m": 17, "n": 32, "k": 5, "tile_m": 3, "tile_n": 1, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 168.196},
+{"m": 17, "n": 32, "k": 6, "tile_m": 3, "tile_n": 2, "w": 2, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 182.522},
+{"m": 17, "n": 32, "k": 8, "tile_m": 3, "tile_n": 2, "w": 4, "v": 28, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 230.442},
+{"m": 17, "n": 32, "k": 9, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 233.382},
+{"m": 17, "n": 32, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 261.656},
+{"m": 17, "n": 32, "k": 16, "tile_m": 3, "tile_n": 2, "w": 4, "v": 26, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 304.612},
+{"m": 17, "n": 32, "k": 17, "tile_m": 3, "tile_n": 2, "w": 8, "v": 28, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 292.771},
+{"m": 17, "n": 32, "k": 22, "tile_m": 3, "tile_n": 2, "w": 6, "v": 32, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 305.08},
+{"m": 17, "n": 32, "k": 23, "tile_m": 3, "tile_n": 2, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 328.197},
+{"m": 17, "n": 32, "k": 24, "tile_m": 3, "tile_n": 2, "w": 8, "v": 28, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 335.43},
+{"m": 17, "n": 32, "k": 26, "tile_m": 3, "tile_n": 2, "w": 8, "v": 28, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 337.328},
+{"m": 17, "n": 32, "k": 32, "tile_m": 3, "tile_n": 2, "w": 8, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 356.942},
+{"m": 22, "n": 4, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 57.5751},
+{"m": 22, "n": 4, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 61.4088},
+{"m": 22, "n": 4, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 66.0702},
+{"m": 22, "n": 4, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 83.1265},
+{"m": 22, "n": 4, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 90.0009},
+{"m": 22, "n": 4, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 109.711},
+{"m": 22, "n": 4, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 119.067},
+{"m": 22, "n": 4, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 119.067},
+{"m": 22, "n": 4, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 126.35},
+{"m": 22, "n": 4, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 125.232},
+{"m": 22, "n": 4, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 126.365},
+{"m": 22, "n": 4, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 123.866},
+{"m": 22, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "w": 8, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 128.16},
+{"m": 22, "n": 5, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 64.238},
+{"m": 22, "n": 5, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 73.3009},
+{"m": 22, "n": 5, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 74.4677},
+{"m": 22, "n": 5, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 93.8793},
+{"m": 22, "n": 5, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 97.9858},
+{"m": 22, "n": 5, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 125.068},
+{"m": 22, "n": 5, "k": 16, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 136.417},
+{"m": 22, "n": 5, "k": 17, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 138.949},
+{"m": 22, "n": 5, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 145.653},
+{"m": 22, "n": 5, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 147.827},
+{"m": 22, "n": 5, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 141.609},
+{"m": 22, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 144.189},
+{"m": 22, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 146.023},
+{"m": 22, "n": 6, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 69.8662},
+{"m": 22, "n": 6, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 77.9372},
+{"m": 22, "n": 6, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 84.6147},
+{"m": 22, "n": 6, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 106.018},
+{"m": 22, "n": 6, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 109.232},
+{"m": 22, "n": 6, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 137.639},
+{"m": 22, "n": 6, "k": 16, "tile_m": 2, "tile_n": 1, "w": 8, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 143.963},
+{"m": 22, "n": 6, "k": 17, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 147.12},
+{"m": 22, "n": 6, "k": 22, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 147.34},
+{"m": 22, "n": 6, "k": 23, "tile_m": 2, "tile_n": 1, "w": 8, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 144.445},
+{"m": 22, "n": 6, "k": 24, "tile_m": 2, "tile_n": 1, "w": 8, "v": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 152.082},
+{"m": 22, "n": 6, "k": 26, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 150.145},
+{"m": 22, "n": 6, "k": 32, "tile_m": 3, "tile_n": 2, "w": 16, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 163.029},
+{"m": 22, "n": 8, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 94.6278},
+{"m": 22, "n": 8, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 101.742},
+{"m": 22, "n": 8, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 113.174},
+{"m": 22, "n": 8, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 142.411},
+{"m": 22, "n": 8, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 145.287},
+{"m": 22, "n": 8, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 172.352},
+{"m": 22, "n": 8, "k": 16, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 187.276},
+{"m": 22, "n": 8, "k": 17, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 184.837},
+{"m": 22, "n": 8, "k": 22, "tile_m": 2, "tile_n": 1, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 185.428},
+{"m": 22, "n": 8, "k": 23, "tile_m": 1, "tile_n": 2, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 187.194},
+{"m": 22, "n": 8, "k": 24, "tile_m": 2, "tile_n": 1, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 197.07},
+{"m": 22, "n": 8, "k": 26, "tile_m": 1, "tile_n": 2, "w": 8, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 190.52},
+{"m": 22, "n": 8, "k": 32, "tile_m": 3, "tile_n": 2, "w": 16, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 205.185},
+{"m": 22, "n": 9, "k": 4, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 89.3747},
+{"m": 22, "n": 9, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 106.787},
+{"m": 22, "n": 9, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 112.692},
+{"m": 22, "n": 9, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 139.231},
+{"m": 22, "n": 9, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 150.647},
+{"m": 22, "n": 9, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 176.971},
+{"m": 22, "n": 9, "k": 16, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 172.625},
+{"m": 22, "n": 9, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 179.675},
+{"m": 22, "n": 9, "k": 22, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 198.116},
+{"m": 22, "n": 9, "k": 23, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 201.354},
+{"m": 22, "n": 9, "k": 24, "tile_m": 2, "tile_n": 2, "w": 12, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 200.245},
+{"m": 22, "n": 9, "k": 26, "tile_m": 2, "tile_n": 2, "w": 10, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 197.52},
+{"m": 22, "n": 9, "k": 32, "tile_m": 2, "tile_n": 2, "w": 10, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 207.544},
+{"m": 22, "n": 9, "k": 64, "tile_m": 2, "tile_n": 2, "w": 12, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 239.452},
+{"m": 22, "n": 13, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 116.442},
+{"m": 22, "n": 13, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 133.637},
+{"m": 22, "n": 13, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 146.616},
+{"m": 22, "n": 13, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 171.063},
+{"m": 22, "n": 13, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 183.073},
+{"m": 22, "n": 13, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 223.261},
+{"m": 22, "n": 13, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 214.711},
+{"m": 22, "n": 13, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 224.809},
+{"m": 22, "n": 13, "k": 22, "tile_m": 3, "tile_n": 2, "w": 10, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 221.172},
+{"m": 22, "n": 13, "k": 23, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 228.978},
+{"m": 22, "n": 13, "k": 24, "tile_m": 2, "tile_n": 3, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 233.378},
+{"m": 22, "n": 13, "k": 26, "tile_m": 3, "tile_n": 2, "w": 10, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 236.465},
+{"m": 22, "n": 13, "k": 32, "tile_m": 2, "tile_n": 3, "w": 12, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 250.128},
+{"m": 22, "n": 16, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 141.362},
+{"m": 22, "n": 16, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 165.072},
+{"m": 22, "n": 16, "k": 6, "tile_m": 3, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 168.045},
+{"m": 22, "n": 16, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 208.282},
+{"m": 22, "n": 16, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 221.618},
+{"m": 22, "n": 16, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 242.184},
+{"m": 22, "n": 16, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 254.265},
+{"m": 22, "n": 16, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 270.21},
+{"m": 22, "n": 16, "k": 22, "tile_m": 2, "tile_n": 2, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 275.664},
+{"m": 22, "n": 16, "k": 23, "tile_m": 2, "tile_n": 2, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 279.173},
+{"m": 22, "n": 16, "k": 24, "tile_m": 3, "tile_n": 2, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 292.083},
+{"m": 22, "n": 16, "k": 26, "tile_m": 2, "tile_n": 2, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 290.449},
+{"m": 22, "n": 16, "k": 32, "tile_m": 2, "tile_n": 2, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 308.173},
+{"m": 22, "n": 16, "k": 64, "tile_m": 3, "tile_n": 2, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 357.117},
+{"m": 22, "n": 17, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 139.051},
+{"m": 22, "n": 17, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 159.925},
+{"m": 22, "n": 17, "k": 6, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 158.152},
+{"m": 22, "n": 17, "k": 8, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 188.223},
+{"m": 22, "n": 17, "k": 9, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 202.404},
+{"m": 22, "n": 17, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 224.16},
+{"m": 22, "n": 17, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 245.41},
+{"m": 22, "n": 17, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 257.375},
+{"m": 22, "n": 17, "k": 22, "tile_m": 2, "tile_n": 4, "w": 10, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 256.316},
+{"m": 22, "n": 17, "k": 23, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 255.027},
+{"m": 22, "n": 17, "k": 24, "tile_m": 2, "tile_n": 2, "w": 6, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 259.941},
+{"m": 22, "n": 17, "k": 26, "tile_m": 3, "tile_n": 2, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 256.136},
+{"m": 22, "n": 17, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 275.263},
+{"m": 22, "n": 22, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 163.707},
+{"m": 22, "n": 22, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 187.588},
+{"m": 22, "n": 22, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 192.65},
+{"m": 22, "n": 22, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 227.684},
+{"m": 22, "n": 22, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 241.517},
+{"m": 22, "n": 22, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 290.16},
+{"m": 22, "n": 22, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 316.266},
+{"m": 22, "n": 22, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 317.077},
+{"m": 22, "n": 22, "k": 22, "tile_m": 3, "tile_n": 2, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 330.052},
+{"m": 22, "n": 22, "k": 23, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 308.901},
+{"m": 22, "n": 22, "k": 24, "tile_m": 2, "tile_n": 2, "w": 8, "v": 22, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 310.483},
+{"m": 22, "n": 22, "k": 26, "tile_m": 2, "tile_n": 2, "w": 8, "v": 14, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 317.329},
+{"m": 22, "n": 22, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 22, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 345.889},
+{"m": 22, "n": 22, "k": 64, "tile_m": 3, "tile_n": 3, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 397.616},
+{"m": 22, "n": 23, "k": 4, "tile_m": 2, "tile_n": 3, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 147.314},
+{"m": 22, "n": 23, "k": 5, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 165.555},
+{"m": 22, "n": 23, "k": 6, "tile_m": 3, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 177.922},
+{"m": 22, "n": 23, "k": 8, "tile_m": 3, "tile_n": 2, "w": 4, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 217.558},
+{"m": 22, "n": 23, "k": 9, "tile_m": 3, "tile_n": 2, "w": 4, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 220.434},
+{"m": 22, "n": 23, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 270.773},
+{"m": 22, "n": 23, "k": 16, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 295.869},
+{"m": 22, "n": 23, "k": 17, "tile_m": 3, "tile_n": 2, "w": 4, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 281.315},
+{"m": 22, "n": 23, "k": 22, "tile_m": 3, "tile_n": 2, "w": 10, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 301.99},
+{"m": 22, "n": 23, "k": 23, "tile_m": 2, "tile_n": 3, "w": 10, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 311.315},
+{"m": 22, "n": 23, "k": 24, "tile_m": 2, "tile_n": 3, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 311.437},
+{"m": 22, "n": 23, "k": 26, "tile_m": 2, "tile_n": 3, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 325.286},
+{"m": 22, "n": 23, "k": 32, "tile_m": 2, "tile_n": 3, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 332.066},
+{"m": 22, "n": 24, "k": 4, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 146.658},
+{"m": 22, "n": 24, "k": 5, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 172.584},
+{"m": 22, "n": 24, "k": 6, "tile_m": 3, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 190.547},
+{"m": 22, "n": 24, "k": 8, "tile_m": 3, "tile_n": 2, "w": 4, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 231.867},
+{"m": 22, "n": 24, "k": 9, "tile_m": 2, "tile_n": 3, "w": 4, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 230.841},
+{"m": 22, "n": 24, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 283.717},
+{"m": 22, "n": 24, "k": 16, "tile_m": 2, "tile_n": 3, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 305.622},
+{"m": 22, "n": 24, "k": 17, "tile_m": 2, "tile_n": 3, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 300.284},
+{"m": 22, "n": 24, "k": 22, "tile_m": 3, "tile_n": 2, "w": 4, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 321.992},
+{"m": 22, "n": 24, "k": 23, "tile_m": 2, "tile_n": 3, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 330.118},
+{"m": 22, "n": 24, "k": 24, "tile_m": 2, "tile_n": 3, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 337.228},
+{"m": 22, "n": 24, "k": 26, "tile_m": 2, "tile_n": 3, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 342.548},
+{"m": 22, "n": 24, "k": 32, "tile_m": 3, "tile_n": 2, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 356.369},
+{"m": 22, "n": 26, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 150.577},
+{"m": 22, "n": 26, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 174.989},
+{"m": 22, "n": 26, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 196.805},
+{"m": 22, "n": 26, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 217.596},
+{"m": 22, "n": 26, "k": 9, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 231.7},
+{"m": 22, "n": 26, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 276.614},
+{"m": 22, "n": 26, "k": 16, "tile_m": 3, "tile_n": 2, "w": 6, "v": 26, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 268.495},
+{"m": 22, "n": 26, "k": 17, "tile_m": 2, "tile_n": 3, "w": 6, "v": 14, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 274.845},
+{"m": 22, "n": 26, "k": 22, "tile_m": 2, "tile_n": 3, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 305.508},
+{"m": 22, "n": 26, "k": 23, "tile_m": 2, "tile_n": 2, "w": 6, "v": 26, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 307.774},
+{"m": 22, "n": 26, "k": 24, "tile_m": 2, "tile_n": 3, "w": 12, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 312.05},
+{"m": 22, "n": 26, "k": 26, "tile_m": 2, "tile_n": 3, "w": 4, "v": 18, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 314.535},
+{"m": 22, "n": 26, "k": 32, "tile_m": 2, "tile_n": 3, "w": 14, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 328.943},
+{"m": 22, "n": 32, "k": 4, "tile_m": 3, "tile_n": 2, "w": 2, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 173.713},
+{"m": 22, "n": 32, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 199.383},
+{"m": 22, "n": 32, "k": 6, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 213.238},
+{"m": 22, "n": 32, "k": 8, "tile_m": 3, "tile_n": 2, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 279.051},
+{"m": 22, "n": 32, "k": 9, "tile_m": 3, "tile_n": 2, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 280.794},
+{"m": 22, "n": 32, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 317.355},
+{"m": 22, "n": 32, "k": 16, "tile_m": 3, "tile_n": 2, "w": 8, "v": 32, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 321.452},
+{"m": 22, "n": 32, "k": 17, "tile_m": 3, "tile_n": 3, "w": 4, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 322.465},
+{"m": 22, "n": 32, "k": 22, "tile_m": 2, "tile_n": 3, "w": 4, "v": 20, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 368.406},
+{"m": 22, "n": 32, "k": 23, "tile_m": 2, "tile_n": 3, "w": 6, "v": 32, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 359.94},
+{"m": 22, "n": 32, "k": 24, "tile_m": 2, "tile_n": 3, "w": 12, "v": 32, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 374.035},
+{"m": 22, "n": 32, "k": 26, "tile_m": 2, "tile_n": 3, "w": 4, "v": 20, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 379.484},
+{"m": 22, "n": 32, "k": 32, "tile_m": 2, "tile_n": 3, "w": 12, "v": 32, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 392.581},
+{"m": 22, "n": 64, "k": 9, "tile_m": 3, "tile_n": 4, "w": 4, "v": 40, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 278.224},
+{"m": 22, "n": 64, "k": 16, "tile_m": 3, "tile_n": 4, "w": 4, "v": 40, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 364.597},
+{"m": 22, "n": 64, "k": 22, "tile_m": 6, "tile_n": 2, "w": 4, "v": 32, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 383.067},
+{"m": 22, "n": 64, "k": 64, "tile_m": 3, "tile_n": 4, "w": 8, "v": 24, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 504.56},
+{"m": 23, "n": 4, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 59.6814},
+{"m": 23, "n": 4, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 63.3487},
+{"m": 23, "n": 4, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 68.454},
+{"m": 23, "n": 4, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 86.3208},
+{"m": 23, "n": 4, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 93.3249},
+{"m": 23, "n": 4, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 111.101},
+{"m": 23, "n": 4, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 121.134},
+{"m": 23, "n": 4, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 121.05},
+{"m": 23, "n": 4, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 126.088},
+{"m": 23, "n": 4, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 125.969},
+{"m": 23, "n": 4, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 122.921},
+{"m": 23, "n": 4, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 127.127},
+{"m": 23, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "w": 8, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 128.586},
+{"m": 23, "n": 5, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 66.3956},
+{"m": 23, "n": 5, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 76.0417},
+{"m": 23, "n": 5, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 76.9185},
+{"m": 23, "n": 5, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 94.7903},
+{"m": 23, "n": 5, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 102.173},
+{"m": 23, "n": 5, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 124.782},
+{"m": 23, "n": 5, "k": 16, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 138.278},
+{"m": 23, "n": 5, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 140.85},
+{"m": 23, "n": 5, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 149.521},
+{"m": 23, "n": 5, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 144.145},
+{"m": 23, "n": 5, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 146.774},
+{"m": 23, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 149.841},
+{"m": 23, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 148.711},
+{"m": 23, "n": 6, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 71.0708},
+{"m": 23, "n": 6, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 79.8984},
+{"m": 23, "n": 6, "k": 6, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 88.3131},
+{"m": 23, "n": 6, "k": 8, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 109.787},
+{"m": 23, "n": 6, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 112.176},
+{"m": 23, "n": 6, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 137.164},
+{"m": 23, "n": 6, "k": 16, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 149.132},
+{"m": 23, "n": 6, "k": 17, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 136.359},
+{"m": 23, "n": 6, "k": 22, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 153.003},
+{"m": 23, "n": 6, "k": 23, "tile_m": 1, "tile_n": 2, "w": 8, "v": 6, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 148.475},
+{"m": 23, "n": 6, "k": 24, "tile_m": 1, "tile_n": 2, "w": 8, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 154.711},
+{"m": 23, "n": 6, "k": 26, "tile_m": 1, "tile_n": 2, "w": 8, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 151.108},
+{"m": 23, "n": 6, "k": 32, "tile_m": 2, "tile_n": 3, "w": 16, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 164.982},
+{"m": 23, "n": 8, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 96.1136},
+{"m": 23, "n": 8, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 104.824},
+{"m": 23, "n": 8, "k": 6, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 117.471},
+{"m": 23, "n": 8, "k": 8, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 147.094},
+{"m": 23, "n": 8, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 148.553},
+{"m": 23, "n": 8, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 178.719},
+{"m": 23, "n": 8, "k": 16, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 188.882},
+{"m": 23, "n": 8, "k": 17, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 180.998},
+{"m": 23, "n": 8, "k": 22, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 190.243},
+{"m": 23, "n": 8, "k": 23, "tile_m": 1, "tile_n": 2, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 192.208},
+{"m": 23, "n": 8, "k": 24, "tile_m": 1, "tile_n": 2, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 198.683},
+{"m": 23, "n": 8, "k": 26, "tile_m": 1, "tile_n": 2, "w": 10, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 196.116},
+{"m": 23, "n": 8, "k": 32, "tile_m": 1, "tile_n": 2, "w": 12, "v": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 208.86},
+{"m": 23, "n": 9, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 94.4818},
+{"m": 23, "n": 9, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 111.971},
+{"m": 23, "n": 9, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 115.643},
+{"m": 23, "n": 9, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 144.455},
+{"m": 23, "n": 9, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 157.597},
+{"m": 23, "n": 9, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 184.356},
+{"m": 23, "n": 9, "k": 16, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 177.395},
+{"m": 23, "n": 9, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 180.861},
+{"m": 23, "n": 9, "k": 22, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 204.892},
+{"m": 23, "n": 9, "k": 23, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 205.862},
+{"m": 23, "n": 9, "k": 24, "tile_m": 2, "tile_n": 2, "w": 12, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 205.963},
+{"m": 23, "n": 9, "k": 26, "tile_m": 2, "tile_n": 2, "w": 10, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 201.066},
+{"m": 23, "n": 9, "k": 32, "tile_m": 2, "tile_n": 2, "w": 10, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 210.534},
+{"m": 23, "n": 13, "k": 4, "tile_m": 4, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 116.674},
+{"m": 23, "n": 13, "k": 5, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 136.278},
+{"m": 23, "n": 13, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 148.585},
+{"m": 23, "n": 13, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 173.078},
+{"m": 23, "n": 13, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 185.538},
+{"m": 23, "n": 13, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 226.085},
+{"m": 23, "n": 13, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 216.852},
+{"m": 23, "n": 13, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 219.365},
+{"m": 23, "n": 13, "k": 22, "tile_m": 2, "tile_n": 2, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 226.737},
+{"m": 23, "n": 13, "k": 23, "tile_m": 3, "tile_n": 2, "w": 6, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 232.991},
+{"m": 23, "n": 13, "k": 24, "tile_m": 2, "tile_n": 3, "w": 12, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 241.459},
+{"m": 23, "n": 13, "k": 26, "tile_m": 3, "tile_n": 2, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 239.493},
+{"m": 23, "n": 13, "k": 32, "tile_m": 3, "tile_n": 2, "w": 12, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 258.236},
+{"m": 23, "n": 16, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 147.182},
+{"m": 23, "n": 16, "k": 5, "tile_m": 3, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 165.435},
+{"m": 23, "n": 16, "k": 6, "tile_m": 3, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 175.112},
+{"m": 23, "n": 16, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 216.799},
+{"m": 23, "n": 16, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 227.299},
+{"m": 23, "n": 16, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 234.514},
+{"m": 23, "n": 16, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 260.11},
+{"m": 23, "n": 16, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 266.036},
+{"m": 23, "n": 16, "k": 22, "tile_m": 3, "tile_n": 2, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 279.926},
+{"m": 23, "n": 16, "k": 23, "tile_m": 3, "tile_n": 2, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 284.497},
+{"m": 23, "n": 16, "k": 24, "tile_m": 2, "tile_n": 2, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 297.891},
+{"m": 23, "n": 16, "k": 26, "tile_m": 3, "tile_n": 2, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 297.501},
+{"m": 23, "n": 16, "k": 32, "tile_m": 3, "tile_n": 2, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 317.92},
+{"m": 23, "n": 17, "k": 4, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 133.402},
+{"m": 23, "n": 17, "k": 5, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 155.289},
+{"m": 23, "n": 17, "k": 6, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 160.956},
+{"m": 23, "n": 17, "k": 8, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 192.178},
+{"m": 23, "n": 17, "k": 9, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 207.496},
+{"m": 23, "n": 17, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 228.053},
+{"m": 23, "n": 17, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 253.335},
+{"m": 23, "n": 17, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 255.563},
+{"m": 23, "n": 17, "k": 22, "tile_m": 2, "tile_n": 2, "w": 10, "v": 10, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 265.383},
+{"m": 23, "n": 17, "k": 23, "tile_m": 3, "tile_n": 2, "w": 10, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 252.781},
+{"m": 23, "n": 17, "k": 24, "tile_m": 2, "tile_n": 2, "w": 10, "v": 10, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 274.855},
+{"m": 23, "n": 17, "k": 26, "tile_m": 3, "tile_n": 2, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 264.804},
+{"m": 23, "n": 17, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 14, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 281.666},
+{"m": 23, "n": 22, "k": 4, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 146.324},
+{"m": 23, "n": 22, "k": 5, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 165.527},
+{"m": 23, "n": 22, "k": 6, "tile_m": 3, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 177.939},
+{"m": 23, "n": 22, "k": 8, "tile_m": 3, "tile_n": 2, "w": 4, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 218.859},
+{"m": 23, "n": 22, "k": 9, "tile_m": 2, "tile_n": 3, "w": 4, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 222.676},
+{"m": 23, "n": 22, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 270.777},
+{"m": 23, "n": 22, "k": 16, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 286.218},
+{"m": 23, "n": 22, "k": 17, "tile_m": 2, "tile_n": 3, "w": 4, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 282.016},
+{"m": 23, "n": 22, "k": 22, "tile_m": 2, "tile_n": 3, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 307.973},
+{"m": 23, "n": 22, "k": 23, "tile_m": 2, "tile_n": 3, "w": 10, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 314.138},
+{"m": 23, "n": 22, "k": 24, "tile_m": 2, "tile_n": 3, "w": 4, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 321.113},
+{"m": 23, "n": 22, "k": 26, "tile_m": 2, "tile_n": 3, "w": 10, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 323.835},
+{"m": 23, "n": 22, "k": 32, "tile_m": 2, "tile_n": 3, "w": 4, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 340.251},
+{"m": 23, "n": 23, "k": 4, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 160.698},
+{"m": 23, "n": 23, "k": 5, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 179.196},
+{"m": 23, "n": 23, "k": 6, "tile_m": 3, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 200.307},
+{"m": 23, "n": 23, "k": 8, "tile_m": 3, "tile_n": 2, "w": 4, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 225.962},
+{"m": 23, "n": 23, "k": 9, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 239.666},
+{"m": 23, "n": 23, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 286.552},
+{"m": 23, "n": 23, "k": 16, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 319.963},
+{"m": 23, "n": 23, "k": 17, "tile_m": 3, "tile_n": 2, "w": 4, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 292.211},
+{"m": 23, "n": 23, "k": 22, "tile_m": 2, "tile_n": 3, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 317.15},
+{"m": 23, "n": 23, "k": 23, "tile_m": 3, "tile_n": 2, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 362.853},
+{"m": 23, "n": 23, "k": 24, "tile_m": 2, "tile_n": 3, "w": 4, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 331.615},
+{"m": 23, "n": 23, "k": 26, "tile_m": 2, "tile_n": 3, "w": 10, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 333.812},
+{"m": 23, "n": 23, "k": 32, "tile_m": 2, "tile_n": 3, "w": 4, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 352.432},
+{"m": 23, "n": 24, "k": 4, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 151.249},
+{"m": 23, "n": 24, "k": 5, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 176.59},
+{"m": 23, "n": 24, "k": 6, "tile_m": 3, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 196.262},
+{"m": 23, "n": 24, "k": 8, "tile_m": 3, "tile_n": 2, "w": 4, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 239.385},
+{"m": 23, "n": 24, "k": 9, "tile_m": 2, "tile_n": 3, "w": 4, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 239.724},
+{"m": 23, "n": 24, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 291.1},
+{"m": 23, "n": 24, "k": 16, "tile_m": 2, "tile_n": 3, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 312.142},
+{"m": 23, "n": 24, "k": 17, "tile_m": 3, "tile_n": 3, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 309.544},
+{"m": 23, "n": 24, "k": 22, "tile_m": 2, "tile_n": 3, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 332.21},
+{"m": 23, "n": 24, "k": 23, "tile_m": 2, "tile_n": 3, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 337.924},
+{"m": 23, "n": 24, "k": 24, "tile_m": 3, "tile_n": 2, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 345.783},
+{"m": 23, "n": 24, "k": 26, "tile_m": 2, "tile_n": 3, "w": 10, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 348.405},
+{"m": 23, "n": 24, "k": 32, "tile_m": 2, "tile_n": 3, "w": 8, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 366.046},
+{"m": 23, "n": 26, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 153.591},
+{"m": 23, "n": 26, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 177.384},
+{"m": 23, "n": 26, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 202.501},
+{"m": 23, "n": 26, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 223.371},
+{"m": 23, "n": 26, "k": 9, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 239.736},
+{"m": 23, "n": 26, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 286.414},
+{"m": 23, "n": 26, "k": 16, "tile_m": 2, "tile_n": 3, "w": 6, "v": 20, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 278.305},
+{"m": 23, "n": 26, "k": 17, "tile_m": 2, "tile_n": 3, "w": 6, "v": 20, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 285.804},
+{"m": 23, "n": 26, "k": 22, "tile_m": 2, "tile_n": 3, "w": 6, "v": 20, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 308.631},
+{"m": 23, "n": 26, "k": 23, "tile_m": 3, "tile_n": 2, "w": 6, "v": 26, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 313.656},
+{"m": 23, "n": 26, "k": 24, "tile_m": 2, "tile_n": 3, "w": 12, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 321.263},
+{"m": 23, "n": 26, "k": 26, "tile_m": 3, "tile_n": 2, "w": 10, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 317.704},
+{"m": 23, "n": 26, "k": 32, "tile_m": 2, "tile_n": 3, "w": 14, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 340.048},
+{"m": 23, "n": 32, "k": 4, "tile_m": 3, "tile_n": 2, "w": 2, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 180.711},
+{"m": 23, "n": 32, "k": 5, "tile_m": 3, "tile_n": 2, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 200.317},
+{"m": 23, "n": 32, "k": 6, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 221.286},
+{"m": 23, "n": 32, "k": 8, "tile_m": 3, "tile_n": 2, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 289.124},
+{"m": 23, "n": 32, "k": 9, "tile_m": 3, "tile_n": 2, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 290.689},
+{"m": 23, "n": 32, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 327.89},
+{"m": 23, "n": 32, "k": 16, "tile_m": 3, "tile_n": 2, "w": 8, "v": 32, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 332.643},
+{"m": 23, "n": 32, "k": 17, "tile_m": 3, "tile_n": 3, "w": 4, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 334.409},
+{"m": 23, "n": 32, "k": 22, "tile_m": 3, "tile_n": 2, "w": 10, "v": 32, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 360.996},
+{"m": 23, "n": 32, "k": 23, "tile_m": 3, "tile_n": 2, "w": 10, "v": 32, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 369.126},
+{"m": 23, "n": 32, "k": 24, "tile_m": 3, "tile_n": 2, "w": 12, "v": 32, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 384.75},
+{"m": 23, "n": 32, "k": 26, "tile_m": 3, "tile_n": 2, "w": 10, "v": 32, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 381.494},
+{"m": 23, "n": 32, "k": 32, "tile_m": 3, "tile_n": 2, "w": 12, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 398.604},
+{"m": 24, "n": 4, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 58.8119},
+{"m": 24, "n": 4, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 67.0164},
+{"m": 24, "n": 4, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 72.194},
+{"m": 24, "n": 4, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 89.6464},
+{"m": 24, "n": 4, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 98.0009},
+{"m": 24, "n": 4, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 115.513},
+{"m": 24, "n": 4, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 123.069},
+{"m": 24, "n": 4, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 124.559},
+{"m": 24, "n": 4, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 128.978},
+{"m": 24, "n": 4, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 125.42},
+{"m": 24, "n": 4, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 128.156},
+{"m": 24, "n": 4, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 131.844},
+{"m": 24, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "w": 8, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 132.646},
+{"m": 24, "n": 5, "k": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 70.448},
+{"m": 24, "n": 5, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 80.4972},
+{"m": 24, "n": 5, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 81.0577},
+{"m": 24, "n": 5, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 101.258},
+{"m": 24, "n": 5, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 107.347},
+{"m": 24, "n": 5, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 131.211},
+{"m": 24, "n": 5, "k": 16, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 143.808},
+{"m": 24, "n": 5, "k": 17, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 142.699},
+{"m": 24, "n": 5, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 153.077},
+{"m": 24, "n": 5, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 150.001},
+{"m": 24, "n": 5, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 152.933},
+{"m": 24, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 147.417},
+{"m": 24, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 153.309},
+{"m": 24, "n": 6, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 76.9814},
+{"m": 24, "n": 6, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 85.2808},
+{"m": 24, "n": 6, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 93.5526},
+{"m": 24, "n": 6, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 115.359},
+{"m": 24, "n": 6, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 120.439},
+{"m": 24, "n": 6, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 144.87},
+{"m": 24, "n": 6, "k": 16, "tile_m": 1, "tile_n": 2, "w": 8, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 155.633},
+{"m": 24, "n": 6, "k": 17, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 148.725},
+{"m": 24, "n": 6, "k": 22, "tile_m": 1, "tile_n": 2, "w": 8, "v": 6, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 154.487},
+{"m": 24, "n": 6, "k": 23, "tile_m": 2, "tile_n": 1, "w": 8, "v": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 156.025},
+{"m": 24, "n": 6, "k": 24, "tile_m": 2, "tile_n": 1, "w": 8, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 163.99},
+{"m": 24, "n": 6, "k": 26, "tile_m": 2, "tile_n": 1, "w": 8, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 159.791},
+{"m": 24, "n": 6, "k": 32, "tile_m": 2, "tile_n": 1, "w": 16, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 171.985},
+{"m": 24, "n": 8, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 102.382},
+{"m": 24, "n": 8, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 110.447},
+{"m": 24, "n": 8, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 123.269},
+{"m": 24, "n": 8, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 152.162},
+{"m": 24, "n": 8, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 157.455},
+{"m": 24, "n": 8, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 185.221},
+{"m": 24, "n": 8, "k": 16, "tile_m": 1, "tile_n": 2, "w": 8, "v": 6, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 196.938},
+{"m": 24, "n": 8, "k": 17, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 189.416},
+{"m": 24, "n": 8, "k": 22, "tile_m": 1, "tile_n": 2, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 199.914},
+{"m": 24, "n": 8, "k": 23, "tile_m": 1, "tile_n": 2, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 200.887},
+{"m": 24, "n": 8, "k": 24, "tile_m": 2, "tile_n": 1, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 209.127},
+{"m": 24, "n": 8, "k": 26, "tile_m": 2, "tile_n": 1, "w": 10, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 205.917},
+{"m": 24, "n": 8, "k": 32, "tile_m": 2, "tile_n": 1, "w": 8, "v": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 218.41},
+{"m": 24, "n": 9, "k": 4, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 98.6797},
+{"m": 24, "n": 9, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 118.095},
+{"m": 24, "n": 9, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 123.841},
+{"m": 24, "n": 9, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 150.841},
+{"m": 24, "n": 9, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 164.779},
+{"m": 24, "n": 9, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 192.82},
+{"m": 24, "n": 9, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 192.434},
+{"m": 24, "n": 9, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 191.25},
+{"m": 24, "n": 9, "k": 22, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 209.088},
+{"m": 24, "n": 9, "k": 23, "tile_m": 2, "tile_n": 1, "w": 10, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 204.604},
+{"m": 24, "n": 9, "k": 24, "tile_m": 2, "tile_n": 2, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 216.095},
+{"m": 24, "n": 9, "k": 26, "tile_m": 2, "tile_n": 2, "w": 8, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 211.244},
+{"m": 24, "n": 9, "k": 32, "tile_m": 2, "tile_n": 2, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 227.824},
+{"m": 24, "n": 13, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 125.487},
+{"m": 24, "n": 13, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 146.004},
+{"m": 24, "n": 13, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 160.137},
+{"m": 24, "n": 13, "k": 8, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 183.429},
+{"m": 24, "n": 13, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 196.169},
+{"m": 24, "n": 13, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 210.09},
+{"m": 24, "n": 13, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 243.961},
+{"m": 24, "n": 13, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 233.808},
+{"m": 24, "n": 13, "k": 22, "tile_m": 2, "tile_n": 3, "w": 6, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 244.295},
+{"m": 24, "n": 13, "k": 23, "tile_m": 2, "tile_n": 3, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 245.584},
+{"m": 24, "n": 13, "k": 24, "tile_m": 3, "tile_n": 2, "w": 12, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 253.032},
+{"m": 24, "n": 13, "k": 26, "tile_m": 3, "tile_n": 2, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 252.69},
+{"m": 24, "n": 13, "k": 32, "tile_m": 2, "tile_n": 3, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 271.274},
+{"m": 24, "n": 16, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 151.035},
+{"m": 24, "n": 16, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 177.041},
+{"m": 24, "n": 16, "k": 6, "tile_m": 3, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 183.2},
+{"m": 24, "n": 16, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 220.011},
+{"m": 24, "n": 16, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 237.976},
+{"m": 24, "n": 16, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 255.121},
+{"m": 24, "n": 16, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 283.257},
+{"m": 24, "n": 16, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 282.576},
+{"m": 24, "n": 16, "k": 22, "tile_m": 2, "tile_n": 2, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 305.434},
+{"m": 24, "n": 16, "k": 23, "tile_m": 2, "tile_n": 2, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 305.948},
+{"m": 24, "n": 16, "k": 24, "tile_m": 2, "tile_n": 2, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 312.346},
+{"m": 24, "n": 16, "k": 26, "tile_m": 2, "tile_n": 2, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 311.766},
+{"m": 24, "n": 16, "k": 32, "tile_m": 2, "tile_n": 2, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 330.08},
+{"m": 24, "n": 17, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 148.753},
+{"m": 24, "n": 17, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 172.254},
+{"m": 24, "n": 17, "k": 6, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 170.444},
+{"m": 24, "n": 17, "k": 8, "tile_m": 2, "tile_n": 3, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 202.085},
+{"m": 24, "n": 17, "k": 9, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 220.336},
+{"m": 24, "n": 17, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 241.006},
+{"m": 24, "n": 17, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 267.336},
+{"m": 24, "n": 17, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 269.754},
+{"m": 24, "n": 17, "k": 22, "tile_m": 2, "tile_n": 4, "w": 10, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 278.395},
+{"m": 24, "n": 17, "k": 23, "tile_m": 2, "tile_n": 3, "w": 10, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 270.301},
+{"m": 24, "n": 17, "k": 24, "tile_m": 2, "tile_n": 2, "w": 6, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 282.786},
+{"m": 24, "n": 17, "k": 26, "tile_m": 3, "tile_n": 2, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 278.266},
+{"m": 24, "n": 17, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 16, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 299.296},
+{"m": 24, "n": 22, "k": 4, "tile_m": 3, "tile_n": 2, "w": 2, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 146.407},
+{"m": 24, "n": 22, "k": 5, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 171.925},
+{"m": 24, "n": 22, "k": 6, "tile_m": 3, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 190.105},
+{"m": 24, "n": 22, "k": 8, "tile_m": 3, "tile_n": 2, "w": 4, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 231.681},
+{"m": 24, "n": 22, "k": 9, "tile_m": 3, "tile_n": 2, "w": 4, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 233.468},
+{"m": 24, "n": 22, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 284.038},
+{"m": 24, "n": 22, "k": 16, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 308.103},
+{"m": 24, "n": 22, "k": 17, "tile_m": 2, "tile_n": 3, "w": 8, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 301.954},
+{"m": 24, "n": 22, "k": 22, "tile_m": 2, "tile_n": 3, "w": 8, "v": 18, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 325.781},
+{"m": 24, "n": 22, "k": 23, "tile_m": 2, "tile_n": 3, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 331.261},
+{"m": 24, "n": 22, "k": 24, "tile_m": 2, "tile_n": 3, "w": 8, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 338.308},
+{"m": 24, "n": 22, "k": 26, "tile_m": 2, "tile_n": 3, "w": 10, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 343.473},
+{"m": 24, "n": 22, "k": 32, "tile_m": 2, "tile_n": 3, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 356.001},
+{"m": 24, "n": 23, "k": 4, "tile_m": 3, "tile_n": 2, "w": 2, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 151.001},
+{"m": 24, "n": 23, "k": 5, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 176.59},
+{"m": 24, "n": 23, "k": 6, "tile_m": 3, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 196.204},
+{"m": 24, "n": 23, "k": 8, "tile_m": 3, "tile_n": 2, "w": 4, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 239.901},
+{"m": 24, "n": 23, "k": 9, "tile_m": 2, "tile_n": 3, "w": 4, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 239.093},
+{"m": 24, "n": 23, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 292.274},
+{"m": 24, "n": 23, "k": 16, "tile_m": 2, "tile_n": 3, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 315.493},
+{"m": 24, "n": 23, "k": 17, "tile_m": 2, "tile_n": 3, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 311.324},
+{"m": 24, "n": 23, "k": 22, "tile_m": 2, "tile_n": 3, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 335.112},
+{"m": 24, "n": 23, "k": 23, "tile_m": 3, "tile_n": 2, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 341.553},
+{"m": 24, "n": 23, "k": 24, "tile_m": 3, "tile_n": 2, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 347.719},
+{"m": 24, "n": 23, "k": 26, "tile_m": 2, "tile_n": 3, "w": 10, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 351.889},
+{"m": 24, "n": 23, "k": 32, "tile_m": 3, "tile_n": 2, "w": 8, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 367.949},
+{"m": 24, "n": 24, "k": 4, "tile_m": 2, "tile_n": 3, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 171.861},
+{"m": 24, "n": 24, "k": 5, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 199.591},
+{"m": 24, "n": 24, "k": 6, "tile_m": 3, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 223.508},
+{"m": 24, "n": 24, "k": 8, "tile_m": 3, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 252.144},
+{"m": 24, "n": 24, "k": 9, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 270.155},
+{"m": 24, "n": 24, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 316.953},
+{"m": 24, "n": 24, "k": 16, "tile_m": 3, "tile_n": 3, "w": 8, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 346.718},
+{"m": 24, "n": 24, "k": 17, "tile_m": 2, "tile_n": 3, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 331.579},
+{"m": 24, "n": 24, "k": 22, "tile_m": 2, "tile_n": 3, "w": 8, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 362.792},
+{"m": 24, "n": 24, "k": 23, "tile_m": 2, "tile_n": 3, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 369.879},
+{"m": 24, "n": 24, "k": 24, "tile_m": 2, "tile_n": 3, "w": 12, "v": 24, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 411.88},
+{"m": 24, "n": 24, "k": 26, "tile_m": 3, "tile_n": 2, "w": 8, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 372.117},
+{"m": 24, "n": 24, "k": 32, "tile_m": 3, "tile_n": 3, "w": 8, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 401.738},
+{"m": 24, "n": 24, "k": 45, "tile_m": 3, "tile_n": 3, "w": 12, "v": 24, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 443.769},
+{"m": 24, "n": 26, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 165.895},
+{"m": 24, "n": 26, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 192.911},
+{"m": 24, "n": 26, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 216.881},
+{"m": 24, "n": 26, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 240.006},
+{"m": 24, "n": 26, "k": 9, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 255.794},
+{"m": 24, "n": 26, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 304.306},
+{"m": 24, "n": 26, "k": 16, "tile_m": 3, "tile_n": 2, "w": 8, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 296.427},
+{"m": 24, "n": 26, "k": 17, "tile_m": 2, "tile_n": 3, "w": 6, "v": 20, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 300.411},
+{"m": 24, "n": 26, "k": 22, "tile_m": 2, "tile_n": 3, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 335.764},
+{"m": 24, "n": 26, "k": 23, "tile_m": 2, "tile_n": 2, "w": 6, "v": 26, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 332.247},
+{"m": 24, "n": 26, "k": 24, "tile_m": 2, "tile_n": 3, "w": 12, "v": 20, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 341.77},
+{"m": 24, "n": 26, "k": 26, "tile_m": 2, "tile_n": 3, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 345.182},
+{"m": 24, "n": 26, "k": 32, "tile_m": 2, "tile_n": 3, "w": 14, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 358.776},
+{"m": 24, "n": 32, "k": 4, "tile_m": 3, "tile_n": 2, "w": 2, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 188.795},
+{"m": 24, "n": 32, "k": 5, "tile_m": 3, "tile_n": 2, "w": 2, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 202.909},
+{"m": 24, "n": 32, "k": 6, "tile_m": 4, "tile_n": 2, "w": 2, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 216.291},
+{"m": 24, "n": 32, "k": 8, "tile_m": 3, "tile_n": 2, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 301.015},
+{"m": 24, "n": 32, "k": 9, "tile_m": 3, "tile_n": 2, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 301.38},
+{"m": 24, "n": 32, "k": 13, "tile_m": 3, "tile_n": 2, "w": 6, "v": 20, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 306.849},
+{"m": 24, "n": 32, "k": 16, "tile_m": 3, "tile_n": 2, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 358.411},
+{"m": 24, "n": 32, "k": 17, "tile_m": 3, "tile_n": 2, "w": 8, "v": 22, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 348.821},
+{"m": 24, "n": 32, "k": 22, "tile_m": 3, "tile_n": 2, "w": 8, "v": 28, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 382.529},
+{"m": 24, "n": 32, "k": 23, "tile_m": 3, "tile_n": 2, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 388.857},
+{"m": 24, "n": 32, "k": 24, "tile_m": 3, "tile_n": 2, "w": 12, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 396.116},
+{"m": 24, "n": 32, "k": 26, "tile_m": 3, "tile_n": 3, "w": 6, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 397.018},
+{"m": 24, "n": 32, "k": 32, "tile_m": 3, "tile_n": 2, "w": 8, "v": 28, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 417.571},
+{"m": 24, "n": 32, "k": 45, "tile_m": 2, "tile_n": 4, "w": 12, "v": 30, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 482.675},
+{"m": 25, "n": 4, "k": 4, "tile_m": 1, "tile_n": 1, "w": 2, "v": 4, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 61.5545},
+{"m": 25, "n": 4, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 69.6079},
+{"m": 25, "n": 4, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 75.6721},
+{"m": 25, "n": 4, "k": 9, "tile_m": 1, "tile_n": 1, "w": 4, "v": 4, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 91.7531},
+{"m": 25, "n": 4, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 113.536},
+{"m": 25, "n": 4, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 127.9},
+{"m": 25, "n": 4, "k": 26, "tile_m": 1, "tile_n": 1, "w": 10, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 127.537},
+{"m": 25, "n": 4, "k": 28, "tile_m": 2, "tile_n": 1, "w": 14, "v": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 134.943},
+{"m": 25, "n": 4, "k": 32, "tile_m": 1, "tile_n": 2, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 139.857},
+{"m": 25, "n": 4, "k": 45, "tile_m": 2, "tile_n": 1, "w": 16, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 139.994},
+{"m": 25, "n": 5, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 72.4794},
+{"m": 25, "n": 5, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 84.872},
+{"m": 25, "n": 5, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 92.8771},
+{"m": 25, "n": 5, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 112.844},
+{"m": 25, "n": 5, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 137.821},
+{"m": 25, "n": 5, "k": 25, "tile_m": 1, "tile_n": 1, "w": 10, "v": 4, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 152.264},
+{"m": 25, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "w": 10, "v": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 152.747},
+{"m": 25, "n": 5, "k": 28, "tile_m": 2, "tile_n": 3, "w": 14, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 159.29},
+{"m": 25, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 164.744},
+{"m": 25, "n": 5, "k": 45, "tile_m": 1, "tile_n": 1, "w": 16, "v": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 167.914},
+{"m": 25, "n": 7, "k": 4, "tile_m": 2, "tile_n": 1, "w": 2, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 90.9178},
+{"m": 25, "n": 7, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 97.037},
+{"m": 25, "n": 7, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 121.779},
+{"m": 25, "n": 7, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 138.286},
+{"m": 25, "n": 7, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 166.702},
+{"m": 25, "n": 7, "k": 25, "tile_m": 2, "tile_n": 1, "w": 10, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 194.814},
+{"m": 25, "n": 7, "k": 26, "tile_m": 2, "tile_n": 1, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 193.702},
+{"m": 25, "n": 7, "k": 28, "tile_m": 3, "tile_n": 1, "w": 14, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 204.432},
+{"m": 25, "n": 7, "k": 32, "tile_m": 2, "tile_n": 1, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 210.429},
+{"m": 25, "n": 7, "k": 45, "tile_m": 2, "tile_n": 1, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 212.74},
+{"m": 25, "n": 9, "k": 4, "tile_m": 3, "tile_n": 1, "w": 2, "v": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 105.945},
+{"m": 25, "n": 9, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 117.846},
+{"m": 25, "n": 9, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 138.732},
+{"m": 25, "n": 9, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 162.802},
+{"m": 25, "n": 9, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 191.872},
+{"m": 25, "n": 9, "k": 25, "tile_m": 2, "tile_n": 1, "w": 10, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 220.007},
+{"m": 25, "n": 9, "k": 26, "tile_m": 2, "tile_n": 1, "w": 12, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 217.621},
+{"m": 25, "n": 9, "k": 28, "tile_m": 1, "tile_n": 2, "w": 14, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 231.076},
+{"m": 25, "n": 9, "k": 32, "tile_m": 2, "tile_n": 3, "w": 16, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 231.658},
+{"m": 25, "n": 9, "k": 45, "tile_m": 3, "tile_n": 3, "w": 16, "v": 6, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 234.791},
+{"m": 25, "n": 13, "k": 4, "tile_m": 2, "tile_n": 2, "w": 2, "v": 10, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 136.976},
+{"m": 25, "n": 13, "k": 5, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 145.977},
+{"m": 25, "n": 13, "k": 7, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 170.376},
+{"m": 25, "n": 13, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 195.465},
+{"m": 25, "n": 13, "k": 13, "tile_m": 2, "tile_n": 2, "w": 6, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 223.713},
+{"m": 25, "n": 13, "k": 25, "tile_m": 3, "tile_n": 2, "w": 12, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 281.301},
+{"m": 25, "n": 13, "k": 26, "tile_m": 3, "tile_n": 2, "w": 12, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 285.113},
+{"m": 25, "n": 13, "k": 28, "tile_m": 3, "tile_n": 2, "w": 10, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 292.875},
+{"m": 25, "n": 13, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 293.811},
+{"m": 25, "n": 13, "k": 45, "tile_m": 3, "tile_n": 2, "w": 16, "v": 8, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 308.806},
+{"m": 25, "n": 25, "k": 4, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 167.314},
+{"m": 25, "n": 25, "k": 5, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 197.231},
+{"m": 25, "n": 25, "k": 7, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 226.575},
+{"m": 25, "n": 25, "k": 9, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 266.2},
+{"m": 25, "n": 25, "k": 13, "tile_m": 3, "tile_n": 2, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 287.179},
+{"m": 25, "n": 25, "k": 25, "tile_m": 3, "tile_n": 2, "w": 10, "v": 20, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 355.515},
+{"m": 25, "n": 25, "k": 26, "tile_m": 2, "tile_n": 4, "w": 10, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 353.566},
+{"m": 25, "n": 25, "k": 28, "tile_m": 3, "tile_n": 2, "w": 14, "v": 10, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 367.79},
+{"m": 25, "n": 25, "k": 32, "tile_m": 2, "tile_n": 3, "w": 14, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 369.423},
+{"m": 25, "n": 25, "k": 45, "tile_m": 2, "tile_n": 4, "w": 10, "v": 24, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 388.688},
+{"m": 25, "n": 26, "k": 4, "tile_m": 4, "tile_n": 2, "w": 2, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 167.072},
+{"m": 25, "n": 26, "k": 5, "tile_m": 4, "tile_n": 2, "w": 2, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 182.501},
+{"m": 25, "n": 26, "k": 7, "tile_m": 3, "tile_n": 2, "w": 2, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 222.916},
+{"m": 25, "n": 26, "k": 9, "tile_m": 3, "tile_n": 2, "w": 4, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 246.76},
+{"m": 25, "n": 26, "k": 13, "tile_m": 3, "tile_n": 3, "w": 6, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 295.802},
+{"m": 25, "n": 26, "k": 25, "tile_m": 2, "tile_n": 3, "w": 12, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 359.971},
+{"m": 25, "n": 26, "k": 26, "tile_m": 2, "tile_n": 3, "w": 12, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 366.555},
+{"m": 25, "n": 26, "k": 28, "tile_m": 3, "tile_n": 2, "w": 14, "v": 10, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 378.99},
+{"m": 25, "n": 26, "k": 32, "tile_m": 2, "tile_n": 3, "w": 14, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 387.081},
+{"m": 25, "n": 26, "k": 45, "tile_m": 3, "tile_n": 2, "w": 12, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 407.931},
+{"m": 25, "n": 28, "k": 4, "tile_m": 3, "tile_n": 2, "w": 2, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 166.646},
+{"m": 25, "n": 28, "k": 5, "tile_m": 3, "tile_n": 2, "w": 2, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 191.501},
+{"m": 25, "n": 28, "k": 7, "tile_m": 3, "tile_n": 2, "w": 2, "v": 18, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 235.127},
+{"m": 25, "n": 28, "k": 9, "tile_m": 3, "tile_n": 2, "w": 4, "v": 28, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 263.105},
+{"m": 25, "n": 28, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 315.323},
+{"m": 25, "n": 28, "k": 25, "tile_m": 2, "tile_n": 4, "w": 10, "v": 28, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 381.239},
+{"m": 25, "n": 28, "k": 26, "tile_m": 2, "tile_n": 4, "w": 10, "v": 28, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 385.88},
+{"m": 25, "n": 28, "k": 28, "tile_m": 3, "tile_n": 2, "w": 14, "v": 28, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 395.875},
+{"m": 25, "n": 28, "k": 32, "tile_m": 3, "tile_n": 2, "w": 14, "v": 10, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 398.113},
+{"m": 25, "n": 28, "k": 45, "tile_m": 3, "tile_n": 2, "w": 12, "v": 28, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 434.445},
+{"m": 25, "n": 32, "k": 4, "tile_m": 5, "tile_n": 2, "w": 2, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 171.986},
+{"m": 25, "n": 32, "k": 5, "tile_m": 5, "tile_n": 2, "w": 2, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 206.566},
+{"m": 25, "n": 32, "k": 7, "tile_m": 5, "tile_n": 2, "w": 2, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 241.952},
+{"m": 25, "n": 32, "k": 9, "tile_m": 2, "tile_n": 4, "w": 4, "v": 28, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 267.123},
+{"m": 25, "n": 32, "k": 13, "tile_m": 2, "tile_n": 4, "w": 6, "v": 28, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 303.399},
+{"m": 25, "n": 32, "k": 25, "tile_m": 2, "tile_n": 4, "w": 10, "v": 28, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 376.527},
+{"m": 25, "n": 32, "k": 26, "tile_m": 4, "tile_n": 2, "w": 12, "v": 22, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 388.829},
+{"m": 25, "n": 32, "k": 28, "tile_m": 4, "tile_n": 2, "w": 12, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 396.268},
+{"m": 25, "n": 32, "k": 32, "tile_m": 2, "tile_n": 4, "w": 16, "v": 30, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 402.903},
+{"m": 25, "n": 32, "k": 45, "tile_m": 5, "tile_n": 2, "w": 12, "v": 16, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 426.505},
+{"m": 25, "n": 45, "k": 4, "tile_m": 5, "tile_n": 2, "w": 2, "v": 30, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 179.84},
+{"m": 25, "n": 45, "k": 5, "tile_m": 5, "tile_n": 2, "w": 2, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 207.379},
+{"m": 25, "n": 45, "k": 7, "tile_m": 5, "tile_n": 2, "w": 2, "v": 30, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 230.203},
+{"m": 25, "n": 45, "k": 9, "tile_m": 5, "tile_n": 2, "w": 4, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 275.085},
+{"m": 25, "n": 45, "k": 13, "tile_m": 2, "tile_n": 5, "w": 6, "v": 30, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 310.536},
+{"m": 25, "n": 45, "k": 25, "tile_m": 3, "tile_n": 4, "w": 10, "v": 40, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 383.964},
+{"m": 25, "n": 45, "k": 26, "tile_m": 2, "tile_n": 5, "w": 10, "v": 20, "threads": 256, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 382.733},
+{"m": 25, "n": 45, "k": 28, "tile_m": 3, "tile_n": 4, "w": 14, "v": 44, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 405.725},
+{"m": 25, "n": 45, "k": 32, "tile_m": 3, "tile_n": 4, "w": 16, "v": 44, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 416.094},
+{"m": 25, "n": 45, "k": 45, "tile_m": 2, "tile_n": 5, "w": 20, "v": 30, "threads": 192, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 435.914},
+{"m": 26, "n": 4, "k": 4, "tile_m": 1, "tile_n": 1, "w": 2, "v": 4, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 64.5163},
+{"m": 26, "n": 4, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 61.4003},
+{"m": 26, "n": 4, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 71.0928},
+{"m": 26, "n": 4, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 81.2663},
+{"m": 26, "n": 4, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 87.9086},
+{"m": 26, "n": 4, "k": 9, "tile_m": 1, "tile_n": 1, "w": 4, "v": 4, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 95.039},
+{"m": 26, "n": 4, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 117.469},
+{"m": 26, "n": 4, "k": 16, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 125.593},
+{"m": 26, "n": 4, "k": 17, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 123.868},
+{"m": 26, "n": 4, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 126.451},
+{"m": 26, "n": 4, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 128.35},
+{"m": 26, "n": 4, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 131.294},
+{"m": 26, "n": 4, "k": 25, "tile_m": 1, "tile_n": 2, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 128.096},
+{"m": 26, "n": 4, "k": 26, "tile_m": 1, "tile_n": 2, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 130.166},
+{"m": 26, "n": 4, "k": 28, "tile_m": 2, "tile_n": 1, "w": 14, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 136.84},
+{"m": 26, "n": 4, "k": 32, "tile_m": 1, "tile_n": 2, "w": 16, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 140.687},
+{"m": 26, "n": 4, "k": 45, "tile_m": 1, "tile_n": 2, "w": 16, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 141.608},
+{"m": 26, "n": 5, "k": 4, "tile_m": 1, "tile_n": 2, "w": 2, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 69.7487},
+{"m": 26, "n": 5, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 74.0129},
+{"m": 26, "n": 5, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 83.8041},
+{"m": 26, "n": 5, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 93.9083},
+{"m": 26, "n": 5, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 98.7557},
+{"m": 26, "n": 5, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 106.652},
+{"m": 26, "n": 5, "k": 13, "tile_m": 1, "tile_n": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 130.365},
+{"m": 26, "n": 5, "k": 16, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 135.751},
+{"m": 26, "n": 5, "k": 17, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 135.026},
+{"m": 26, "n": 5, "k": 22, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 140.428},
+{"m": 26, "n": 5, "k": 23, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 142.897},
+{"m": 26, "n": 5, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 4, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 141.37},
+{"m": 26, "n": 5, "k": 25, "tile_m": 3, "tile_n": 2, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 148.961},
+{"m": 26, "n": 5, "k": 26, "tile_m": 3, "tile_n": 2, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 150.882},
+{"m": 26, "n": 5, "k": 28, "tile_m": 3, "tile_n": 2, "w": 14, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 160.591},
+{"m": 26, "n": 5, "k": 32, "tile_m": 2, "tile_n": 3, "w": 16, "v": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 163.472},
+{"m": 26, "n": 5, "k": 45, "tile_m": 2, "tile_n": 1, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 163.834},
+{"m": 26, "n": 6, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 72.6709},
+{"m": 26, "n": 6, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 87.4288},
+{"m": 26, "n": 6, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 99.3344},
+{"m": 26, "n": 6, "k": 8, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 118.582},
+{"m": 26, "n": 6, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 126.842},
+{"m": 26, "n": 6, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 153.58},
+{"m": 26, "n": 6, "k": 16, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 159.739},
+{"m": 26, "n": 6, "k": 17, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 157.425},
+{"m": 26, "n": 6, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 163.987},
+{"m": 26, "n": 6, "k": 23, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 166.214},
+{"m": 26, "n": 6, "k": 24, "tile_m": 1, "tile_n": 1, "w": 12, "v": 6, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 167.712},
+{"m": 26, "n": 6, "k": 26, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 165.846},
+{"m": 26, "n": 6, "k": 32, "tile_m": 1, "tile_n": 1, "w": 12, "v": 6, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 174.271},
+{"m": 26, "n": 7, "k": 4, "tile_m": 2, "tile_n": 1, "w": 2, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 93.3904},
+{"m": 26, "n": 7, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 98.4269},
+{"m": 26, "n": 7, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 129.184},
+{"m": 26, "n": 7, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 146.313},
+{"m": 26, "n": 7, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 174.525},
+{"m": 26, "n": 7, "k": 25, "tile_m": 2, "tile_n": 1, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 196.272},
+{"m": 26, "n": 7, "k": 26, "tile_m": 2, "tile_n": 1, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 199.207},
+{"m": 26, "n": 7, "k": 28, "tile_m": 3, "tile_n": 1, "w": 14, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 208.391},
+{"m": 26, "n": 7, "k": 32, "tile_m": 2, "tile_n": 1, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 213.658},
+{"m": 26, "n": 7, "k": 45, "tile_m": 2, "tile_n": 1, "w": 12, "v": 6, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 218.996},
+{"m": 26, "n": 8, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 94.6073},
+{"m": 26, "n": 8, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 104.199},
+{"m": 26, "n": 8, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 120.103},
+{"m": 26, "n": 8, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 147.207},
+{"m": 26, "n": 8, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 158.986},
+{"m": 26, "n": 8, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 184.007},
+{"m": 26, "n": 8, "k": 16, "tile_m": 2, "tile_n": 1, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 185.8},
+{"m": 26, "n": 8, "k": 17, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 184.285},
+{"m": 26, "n": 8, "k": 22, "tile_m": 2, "tile_n": 1, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 191.661},
+{"m": 26, "n": 8, "k": 23, "tile_m": 2, "tile_n": 2, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 194.119},
+{"m": 26, "n": 8, "k": 24, "tile_m": 2, "tile_n": 1, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 203.357},
+{"m": 26, "n": 8, "k": 26, "tile_m": 2, "tile_n": 2, "w": 10, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 201.388},
+{"m": 26, "n": 8, "k": 32, "tile_m": 2, "tile_n": 2, "w": 14, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 214.072},
+{"m": 26, "n": 9, "k": 4, "tile_m": 3, "tile_n": 1, "w": 2, "v": 6, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 109.036},
+{"m": 26, "n": 9, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 114.163},
+{"m": 26, "n": 9, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 131.35},
+{"m": 26, "n": 9, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 144.626},
+{"m": 26, "n": 9, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 157.793},
+{"m": 26, "n": 9, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 169.191},
+{"m": 26, "n": 9, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 189.564},
+{"m": 26, "n": 9, "k": 16, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 197.735},
+{"m": 26, "n": 9, "k": 17, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 202.974},
+{"m": 26, "n": 9, "k": 22, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 205.221},
+{"m": 26, "n": 9, "k": 23, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 209.048},
+{"m": 26, "n": 9, "k": 24, "tile_m": 2, "tile_n": 1, "w": 12, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 218.442},
+{"m": 26, "n": 9, "k": 25, "tile_m": 2, "tile_n": 1, "w": 12, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 224.446},
+{"m": 26, "n": 9, "k": 26, "tile_m": 2, "tile_n": 1, "w": 12, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 226.888},
+{"m": 26, "n": 9, "k": 28, "tile_m": 2, "tile_n": 1, "w": 14, "v": 8, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 238.998},
+{"m": 26, "n": 9, "k": 32, "tile_m": 2, "tile_n": 1, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 238.306},
+{"m": 26, "n": 9, "k": 45, "tile_m": 2, "tile_n": 1, "w": 18, "v": 8, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 247.183},
+{"m": 26, "n": 13, "k": 4, "tile_m": 2, "tile_n": 2, "w": 2, "v": 10, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 141.329},
+{"m": 26, "n": 13, "k": 5, "tile_m": 2, "tile_n": 2, "w": 2, "v": 10, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 147.765},
+{"m": 26, "n": 13, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 164.444},
+{"m": 26, "n": 13, "k": 7, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 180.199},
+{"m": 26, "n": 13, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 189.61},
+{"m": 26, "n": 13, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 206.587},
+{"m": 26, "n": 13, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 243.394},
+{"m": 26, "n": 13, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 244.889},
+{"m": 26, "n": 13, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 248.672},
+{"m": 26, "n": 13, "k": 22, "tile_m": 2, "tile_n": 2, "w": 6, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 250.837},
+{"m": 26, "n": 13, "k": 23, "tile_m": 3, "tile_n": 2, "w": 10, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 251.925},
+{"m": 26, "n": 13, "k": 24, "tile_m": 2, "tile_n": 2, "w": 12, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 262.097},
+{"m": 26, "n": 13, "k": 25, "tile_m": 3, "tile_n": 2, "w": 12, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 287.926},
+{"m": 26, "n": 13, "k": 26, "tile_m": 2, "tile_n": 2, "w": 12, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 292.748},
+{"m": 26, "n": 13, "k": 28, "tile_m": 2, "tile_n": 2, "w": 14, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 305.399},
+{"m": 26, "n": 13, "k": 32, "tile_m": 2, "tile_n": 2, "w": 12, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 307.713},
+{"m": 26, "n": 13, "k": 45, "tile_m": 2, "tile_n": 2, "w": 10, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 321.334},
+{"m": 26, "n": 16, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 152.877},
+{"m": 26, "n": 16, "k": 5, "tile_m": 5, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 155.57},
+{"m": 26, "n": 16, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 170.247},
+{"m": 26, "n": 16, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 201.911},
+{"m": 26, "n": 16, "k": 9, "tile_m": 2, "tile_n": 3, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 223.126},
+{"m": 26, "n": 16, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 248.219},
+{"m": 26, "n": 16, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 272.563},
+{"m": 26, "n": 16, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 278.933},
+{"m": 26, "n": 16, "k": 22, "tile_m": 2, "tile_n": 4, "w": 10, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 283.175},
+{"m": 26, "n": 16, "k": 23, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 283.731},
+{"m": 26, "n": 16, "k": 24, "tile_m": 2, "tile_n": 2, "w": 12, "v": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 283.395},
+{"m": 26, "n": 16, "k": 26, "tile_m": 3, "tile_n": 2, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 289.704},
+{"m": 26, "n": 16, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 312.21},
+{"m": 26, "n": 17, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 155.536},
+{"m": 26, "n": 17, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 152.251},
+{"m": 26, "n": 17, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 174.981},
+{"m": 26, "n": 17, "k": 8, "tile_m": 2, "tile_n": 2, "w": 4, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 203.653},
+{"m": 26, "n": 17, "k": 9, "tile_m": 2, "tile_n": 3, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 229.052},
+{"m": 26, "n": 17, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 254.23},
+{"m": 26, "n": 17, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 281.091},
+{"m": 26, "n": 17, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 285.713},
+{"m": 26, "n": 17, "k": 22, "tile_m": 3, "tile_n": 2, "w": 8, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 275.4},
+{"m": 26, "n": 17, "k": 23, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 284.987},
+{"m": 26, "n": 17, "k": 24, "tile_m": 2, "tile_n": 2, "w": 6, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 298.462},
+{"m": 26, "n": 17, "k": 26, "tile_m": 2, "tile_n": 2, "w": 6, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 287.445},
+{"m": 26, "n": 17, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 12, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 314.433},
+{"m": 26, "n": 22, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 149.972},
+{"m": 26, "n": 22, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 176.08},
+{"m": 26, "n": 22, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 196.809},
+{"m": 26, "n": 22, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 217.745},
+{"m": 26, "n": 22, "k": 9, "tile_m": 4, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 220.047},
+{"m": 26, "n": 22, "k": 13, "tile_m": 2, "tile_n": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 262.523},
+{"m": 26, "n": 22, "k": 16, "tile_m": 3, "tile_n": 2, "w": 4, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 289.65},
+{"m": 26, "n": 22, "k": 17, "tile_m": 2, "tile_n": 3, "w": 6, "v": 12, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 275.462},
+{"m": 26, "n": 22, "k": 22, "tile_m": 2, "tile_n": 3, "w": 4, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 306.524},
+{"m": 26, "n": 22, "k": 23, "tile_m": 2, "tile_n": 2, "w": 6, "v": 22, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 306.629},
+{"m": 26, "n": 22, "k": 24, "tile_m": 2, "tile_n": 3, "w": 12, "v": 22, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 312.951},
+{"m": 26, "n": 22, "k": 26, "tile_m": 2, "tile_n": 3, "w": 4, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 316.347},
+{"m": 26, "n": 22, "k": 32, "tile_m": 3, "tile_n": 2, "w": 14, "v": 22, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 331.192},
+{"m": 26, "n": 23, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 154.026},
+{"m": 26, "n": 23, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 179.309},
+{"m": 26, "n": 23, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 202.375},
+{"m": 26, "n": 23, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 222.858},
+{"m": 26, "n": 23, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 221.968},
+{"m": 26, "n": 23, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 273.966},
+{"m": 26, "n": 23, "k": 16, "tile_m": 3, "tile_n": 2, "w": 6, "v": 12, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 276.664},
+{"m": 26, "n": 23, "k": 17, "tile_m": 2, "tile_n": 3, "w": 6, "v": 12, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 285.445},
+{"m": 26, "n": 23, "k": 22, "tile_m": 2, "tile_n": 3, "w": 4, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 317.821},
+{"m": 26, "n": 23, "k": 23, "tile_m": 2, "tile_n": 2, "w": 6, "v": 12, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 307.93},
+{"m": 26, "n": 23, "k": 24, "tile_m": 2, "tile_n": 3, "w": 12, "v": 12, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 320.822},
+{"m": 26, "n": 23, "k": 26, "tile_m": 2, "tile_n": 3, "w": 4, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 327.373},
+{"m": 26, "n": 23, "k": 32, "tile_m": 2, "tile_n": 3, "w": 14, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 341.076},
+{"m": 26, "n": 24, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 166.334},
+{"m": 26, "n": 24, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 194.858},
+{"m": 26, "n": 24, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 217.359},
+{"m": 26, "n": 24, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 240.36},
+{"m": 26, "n": 24, "k": 9, "tile_m": 4, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 240.63},
+{"m": 26, "n": 24, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 284.219},
+{"m": 26, "n": 24, "k": 16, "tile_m": 3, "tile_n": 2, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 317.599},
+{"m": 26, "n": 24, "k": 17, "tile_m": 3, "tile_n": 2, "w": 6, "v": 24, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 300.196},
+{"m": 26, "n": 24, "k": 22, "tile_m": 2, "tile_n": 3, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 333.184},
+{"m": 26, "n": 24, "k": 23, "tile_m": 2, "tile_n": 2, "w": 6, "v": 24, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 332.175},
+{"m": 26, "n": 24, "k": 24, "tile_m": 2, "tile_n": 3, "w": 12, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 342.541},
+{"m": 26, "n": 24, "k": 26, "tile_m": 2, "tile_n": 3, "w": 4, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 342.458},
+{"m": 26, "n": 24, "k": 32, "tile_m": 3, "tile_n": 2, "w": 14, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 360.604},
+{"m": 26, "n": 25, "k": 4, "tile_m": 4, "tile_n": 2, "w": 2, "v": 18, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 167.244},
+{"m": 26, "n": 25, "k": 5, "tile_m": 3, "tile_n": 2, "w": 2, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 188.512},
+{"m": 26, "n": 25, "k": 7, "tile_m": 3, "tile_n": 2, "w": 2, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 217.789},
+{"m": 26, "n": 25, "k": 9, "tile_m": 2, "tile_n": 3, "w": 4, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 242.956},
+{"m": 26, "n": 25, "k": 13, "tile_m": 2, "tile_n": 4, "w": 6, "v": 18, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 304.863},
+{"m": 26, "n": 25, "k": 25, "tile_m": 2, "tile_n": 3, "w": 12, "v": 22, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 357.372},
+{"m": 26, "n": 25, "k": 26, "tile_m": 3, "tile_n": 2, "w": 10, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 362.44},
+{"m": 26, "n": 25, "k": 28, "tile_m": 2, "tile_n": 3, "w": 14, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 380.957},
+{"m": 26, "n": 25, "k": 32, "tile_m": 2, "tile_n": 3, "w": 12, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 388.464},
+{"m": 26, "n": 25, "k": 45, "tile_m": 2, "tile_n": 4, "w": 12, "v": 22, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 405.487},
+{"m": 26, "n": 26, "k": 4, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 175.533},
+{"m": 26, "n": 26, "k": 5, "tile_m": 3, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 195.723},
+{"m": 26, "n": 26, "k": 6, "tile_m": 3, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 223.837},
+{"m": 26, "n": 26, "k": 7, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 238.031},
+{"m": 26, "n": 26, "k": 8, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 260.398},
+{"m": 26, "n": 26, "k": 9, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 281.056},
+{"m": 26, "n": 26, "k": 13, "tile_m": 2, "tile_n": 4, "w": 6, "v": 18, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 317.738},
+{"m": 26, "n": 26, "k": 16, "tile_m": 3, "tile_n": 2, "w": 4, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 332.873},
+{"m": 26, "n": 26, "k": 17, "tile_m": 2, "tile_n": 3, "w": 6, "v": 16, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 315.978},
+{"m": 26, "n": 26, "k": 22, "tile_m": 2, "tile_n": 3, "w": 4, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 350.804},
+{"m": 26, "n": 26, "k": 23, "tile_m": 2, "tile_n": 3, "w": 6, "v": 26, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 348.123},
+{"m": 26, "n": 26, "k": 24, "tile_m": 2, "tile_n": 3, "w": 12, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 356.594},
+{"m": 26, "n": 26, "k": 25, "tile_m": 2, "tile_n": 4, "w": 12, "v": 24, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 375.765},
+{"m": 26, "n": 26, "k": 26, "tile_m": 2, "tile_n": 3, "w": 12, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 381.742},
+{"m": 26, "n": 26, "k": 28, "tile_m": 2, "tile_n": 4, "w": 14, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 396.724},
+{"m": 26, "n": 26, "k": 32, "tile_m": 2, "tile_n": 3, "w": 14, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 401.65},
+{"m": 26, "n": 26, "k": 45, "tile_m": 2, "tile_n": 4, "w": 12, "v": 24, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 425.671},
+{"m": 26, "n": 28, "k": 4, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 174.838},
+{"m": 26, "n": 28, "k": 5, "tile_m": 3, "tile_n": 2, "w": 2, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 200.558},
+{"m": 26, "n": 28, "k": 7, "tile_m": 3, "tile_n": 2, "w": 2, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 246.118},
+{"m": 26, "n": 28, "k": 9, "tile_m": 3, "tile_n": 2, "w": 4, "v": 28, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 273.477},
+{"m": 26, "n": 28, "k": 13, "tile_m": 2, "tile_n": 4, "w": 6, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 332.816},
+{"m": 26, "n": 28, "k": 25, "tile_m": 2, "tile_n": 4, "w": 10, "v": 28, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 397.022},
+{"m": 26, "n": 28, "k": 26, "tile_m": 2, "tile_n": 4, "w": 10, "v": 28, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 404.741},
+{"m": 26, "n": 28, "k": 28, "tile_m": 3, "tile_n": 2, "w": 10, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 414.939},
+{"m": 26, "n": 28, "k": 32, "tile_m": 3, "tile_n": 2, "w": 12, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 426.043},
+{"m": 26, "n": 28, "k": 45, "tile_m": 2, "tile_n": 4, "w": 12, "v": 28, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 457.514},
+{"m": 26, "n": 32, "k": 4, "tile_m": 5, "tile_n": 2, "w": 2, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 176.504},
+{"m": 26, "n": 32, "k": 5, "tile_m": 5, "tile_n": 2, "w": 2, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 212.767},
+{"m": 26, "n": 32, "k": 6, "tile_m": 5, "tile_n": 2, "w": 2, "v": 18, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 222.341},
+{"m": 26, "n": 32, "k": 7, "tile_m": 5, "tile_n": 2, "w": 2, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 247.293},
+{"m": 26, "n": 32, "k": 8, "tile_m": 3, "tile_n": 3, "w": 4, "v": 28, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 245.658},
+{"m": 26, "n": 32, "k": 9, "tile_m": 2, "tile_n": 4, "w": 4, "v": 28, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 280.034},
+{"m": 26, "n": 32, "k": 13, "tile_m": 2, "tile_n": 4, "w": 6, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 316.971},
+{"m": 26, "n": 32, "k": 16, "tile_m": 2, "tile_n": 4, "w": 8, "v": 28, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 335.651},
+{"m": 26, "n": 32, "k": 17, "tile_m": 2, "tile_n": 4, "w": 8, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 325.543},
+{"m": 26, "n": 32, "k": 22, "tile_m": 2, "tile_n": 4, "w": 8, "v": 28, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 358.85},
+{"m": 26, "n": 32, "k": 23, "tile_m": 2, "tile_n": 4, "w": 8, "v": 28, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 365.224},
+{"m": 26, "n": 32, "k": 24, "tile_m": 2, "tile_n": 4, "w": 12, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 382.529},
+{"m": 26, "n": 32, "k": 25, "tile_m": 2, "tile_n": 4, "w": 12, "v": 32, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 399.183},
+{"m": 26, "n": 32, "k": 26, "tile_m": 2, "tile_n": 4, "w": 12, "v": 32, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 404.75},
+{"m": 26, "n": 32, "k": 28, "tile_m": 2, "tile_n": 4, "w": 10, "v": 32, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 409.577},
+{"m": 26, "n": 32, "k": 32, "tile_m": 4, "tile_n": 2, "w": 16, "v": 32, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 426.515},
+{"m": 26, "n": 32, "k": 45, "tile_m": 5, "tile_n": 2, "w": 12, "v": 24, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 442.282},
+{"m": 26, "n": 45, "k": 4, "tile_m": 3, "tile_n": 2, "w": 2, "v": 16, "threads": 224, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 155.312},
+{"m": 26, "n": 45, "k": 5, "tile_m": 6, "tile_n": 2, "w": 2, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 204.843},
+{"m": 26, "n": 45, "k": 7, "tile_m": 6, "tile_n": 2, "w": 2, "v": 18, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 233.548},
+{"m": 26, "n": 45, "k": 9, "tile_m": 5, "tile_n": 3, "w": 4, "v": 24, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 262.492},
+{"m": 26, "n": 45, "k": 13, "tile_m": 2, "tile_n": 5, "w": 6, "v": 36, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 318.4},
+{"m": 26, "n": 45, "k": 25, "tile_m": 2, "tile_n": 5, "w": 10, "v": 44, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 393.097},
+{"m": 26, "n": 45, "k": 26, "tile_m": 2, "tile_n": 5, "w": 10, "v": 44, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 399.976},
+{"m": 26, "n": 45, "k": 28, "tile_m": 3, "tile_n": 4, "w": 14, "v": 44, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 422.791},
+{"m": 26, "n": 45, "k": 32, "tile_m": 3, "tile_n": 4, "w": 16, "v": 44, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 436.141},
+{"m": 26, "n": 45, "k": 45, "tile_m": 2, "tile_n": 5, "w": 16, "v": 44, "threads": 192, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 455.227},
+{"m": 28, "n": 4, "k": 4, "tile_m": 1, "tile_n": 1, "w": 2, "v": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 69.7132},
+{"m": 28, "n": 4, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 66.2641},
+{"m": 28, "n": 4, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 84.8842},
+{"m": 28, "n": 4, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 102.249},
+{"m": 28, "n": 4, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 122.511},
+{"m": 28, "n": 4, "k": 25, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 131.812},
+{"m": 28, "n": 4, "k": 26, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 133.779},
+{"m": 28, "n": 4, "k": 28, "tile_m": 1, "tile_n": 2, "w": 14, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 139.798},
+{"m": 28, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 141.831},
+{"m": 28, "n": 4, "k": 45, "tile_m": 2, "tile_n": 1, "w": 18, "v": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 141.966},
+{"m": 28, "n": 5, "k": 4, "tile_m": 1, "tile_n": 2, "w": 2, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 74.4649},
+{"m": 28, "n": 5, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 79.7849},
+{"m": 28, "n": 5, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 94.6668},
+{"m": 28, "n": 5, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 113.375},
+{"m": 28, "n": 5, "k": 13, "tile_m": 1, "tile_n": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 137.689},
+{"m": 28, "n": 5, "k": 25, "tile_m": 2, "tile_n": 1, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 154.897},
+{"m": 28, "n": 5, "k": 26, "tile_m": 2, "tile_n": 1, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 157.88},
+{"m": 28, "n": 5, "k": 28, "tile_m": 1, "tile_n": 2, "w": 14, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 163.76},
+{"m": 28, "n": 5, "k": 32, "tile_m": 1, "tile_n": 2, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 166.725},
+{"m": 28, "n": 5, "k": 45, "tile_m": 2, "tile_n": 1, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 170.449},
+{"m": 28, "n": 7, "k": 4, "tile_m": 2, "tile_n": 2, "w": 2, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 96.7805},
+{"m": 28, "n": 7, "k": 5, "tile_m": 2, "tile_n": 2, "w": 2, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 97.3331},
+{"m": 28, "n": 7, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 123.661},
+{"m": 28, "n": 7, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 145.578},
+{"m": 28, "n": 7, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 178.204},
+{"m": 28, "n": 7, "k": 25, "tile_m": 2, "tile_n": 2, "w": 12, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 199.125},
+{"m": 28, "n": 7, "k": 26, "tile_m": 2, "tile_n": 2, "w": 12, "v": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 201.107},
+{"m": 28, "n": 7, "k": 28, "tile_m": 2, "tile_n": 2, "w": 14, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 211.525},
+{"m": 28, "n": 7, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 215.029},
+{"m": 28, "n": 7, "k": 45, "tile_m": 2, "tile_n": 2, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 222.228},
+{"m": 28, "n": 9, "k": 4, "tile_m": 3, "tile_n": 1, "w": 2, "v": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 117.282},
+{"m": 28, "n": 9, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 122.678},
+{"m": 28, "n": 9, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 156.349},
+{"m": 28, "n": 9, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 183.005},
+{"m": 28, "n": 9, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 200.618},
+{"m": 28, "n": 9, "k": 25, "tile_m": 2, "tile_n": 1, "w": 12, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 238.125},
+{"m": 28, "n": 9, "k": 26, "tile_m": 2, "tile_n": 1, "w": 12, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 240.037},
+{"m": 28, "n": 9, "k": 28, "tile_m": 2, "tile_n": 1, "w": 14, "v": 8, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 249.198},
+{"m": 28, "n": 9, "k": 32, "tile_m": 2, "tile_n": 1, "w": 16, "v": 8, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 254.885},
+{"m": 28, "n": 9, "k": 45, "tile_m": 2, "tile_n": 1, "w": 16, "v": 8, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 260.931},
+{"m": 28, "n": 13, "k": 4, "tile_m": 4, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 135.514},
+{"m": 28, "n": 13, "k": 5, "tile_m": 4, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 148.634},
+{"m": 28, "n": 13, "k": 7, "tile_m": 4, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 181.031},
+{"m": 28, "n": 13, "k": 9, "tile_m": 4, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 204.184},
+{"m": 28, "n": 13, "k": 13, "tile_m": 4, "tile_n": 2, "w": 6, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 231.477},
+{"m": 28, "n": 13, "k": 25, "tile_m": 4, "tile_n": 1, "w": 12, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 276.693},
+{"m": 28, "n": 13, "k": 26, "tile_m": 4, "tile_n": 1, "w": 12, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 280.226},
+{"m": 28, "n": 13, "k": 28, "tile_m": 4, "tile_n": 1, "w": 14, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 287.948},
+{"m": 28, "n": 13, "k": 32, "tile_m": 4, "tile_n": 1, "w": 12, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 293.103},
+{"m": 28, "n": 13, "k": 45, "tile_m": 4, "tile_n": 1, "w": 12, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 304.228},
+{"m": 28, "n": 25, "k": 4, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 168.069},
+{"m": 28, "n": 25, "k": 5, "tile_m": 4, "tile_n": 2, "w": 2, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 193.423},
+{"m": 28, "n": 25, "k": 7, "tile_m": 4, "tile_n": 2, "w": 2, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 225.794},
+{"m": 28, "n": 25, "k": 9, "tile_m": 2, "tile_n": 3, "w": 4, "v": 22, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 258.556},
+{"m": 28, "n": 25, "k": 13, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 320.669},
+{"m": 28, "n": 25, "k": 25, "tile_m": 2, "tile_n": 3, "w": 12, "v": 18, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 381.261},
+{"m": 28, "n": 25, "k": 26, "tile_m": 2, "tile_n": 3, "w": 10, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 384.478},
+{"m": 28, "n": 25, "k": 28, "tile_m": 2, "tile_n": 3, "w": 10, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 396.377},
+{"m": 28, "n": 25, "k": 32, "tile_m": 2, "tile_n": 3, "w": 12, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 412.267},
+{"m": 28, "n": 25, "k": 45, "tile_m": 2, "tile_n": 3, "w": 12, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 427.011},
+{"m": 28, "n": 26, "k": 4, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 176.915},
+{"m": 28, "n": 26, "k": 5, "tile_m": 4, "tile_n": 2, "w": 2, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 202.981},
+{"m": 28, "n": 26, "k": 7, "tile_m": 4, "tile_n": 2, "w": 2, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 237.458},
+{"m": 28, "n": 26, "k": 9, "tile_m": 2, "tile_n": 3, "w": 4, "v": 26, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 271.994},
+{"m": 28, "n": 26, "k": 13, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 334.498},
+{"m": 28, "n": 26, "k": 25, "tile_m": 2, "tile_n": 3, "w": 12, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 400.225},
+{"m": 28, "n": 26, "k": 26, "tile_m": 2, "tile_n": 3, "w": 12, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 410.723},
+{"m": 28, "n": 26, "k": 28, "tile_m": 2, "tile_n": 3, "w": 14, "v": 18, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 417.684},
+{"m": 28, "n": 26, "k": 32, "tile_m": 2, "tile_n": 3, "w": 12, "v": 22, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 431.942},
+{"m": 28, "n": 26, "k": 45, "tile_m": 4, "tile_n": 2, "w": 12, "v": 26, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 456.463},
+{"m": 28, "n": 28, "k": 4, "tile_m": 5, "tile_n": 2, "w": 2, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 179.862},
+{"m": 28, "n": 28, "k": 5, "tile_m": 5, "tile_n": 2, "w": 2, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 210.103},
+{"m": 28, "n": 28, "k": 7, "tile_m": 5, "tile_n": 2, "w": 2, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 242.486},
+{"m": 28, "n": 28, "k": 9, "tile_m": 5, "tile_n": 2, "w": 2, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 266.488},
+{"m": 28, "n": 28, "k": 13, "tile_m": 2, "tile_n": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 311.697},
+{"m": 28, "n": 28, "k": 25, "tile_m": 2, "tile_n": 4, "w": 12, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 374.666},
+{"m": 28, "n": 28, "k": 26, "tile_m": 2, "tile_n": 5, "w": 10, "v": 26, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 379.954},
+{"m": 28, "n": 28, "k": 28, "tile_m": 2, "tile_n": 4, "w": 14, "v": 28, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 385.627},
+{"m": 28, "n": 28, "k": 32, "tile_m": 2, "tile_n": 4, "w": 16, "v": 28, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 399.675},
+{"m": 28, "n": 28, "k": 45, "tile_m": 2, "tile_n": 5, "w": 10, "v": 14, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 419.193},
+{"m": 28, "n": 32, "k": 4, "tile_m": 5, "tile_n": 2, "w": 2, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 190.475},
+{"m": 28, "n": 32, "k": 5, "tile_m": 5, "tile_n": 2, "w": 2, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 226.849},
+{"m": 28, "n": 32, "k": 7, "tile_m": 5, "tile_n": 2, "w": 2, "v": 16, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 265.598},
+{"m": 28, "n": 32, "k": 9, "tile_m": 2, "tile_n": 4, "w": 4, "v": 24, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 294.248},
+{"m": 28, "n": 32, "k": 13, "tile_m": 4, "tile_n": 2, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 336.212},
+{"m": 28, "n": 32, "k": 25, "tile_m": 2, "tile_n": 4, "w": 12, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 425.078},
+{"m": 28, "n": 32, "k": 26, "tile_m": 2, "tile_n": 4, "w": 12, "v": 20, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 430.851},
+{"m": 28, "n": 32, "k": 28, "tile_m": 2, "tile_n": 4, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 436.482},
+{"m": 28, "n": 32, "k": 32, "tile_m": 2, "tile_n": 4, "w": 16, "v": 32, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 454.724},
+{"m": 28, "n": 32, "k": 45, "tile_m": 5, "tile_n": 2, "w": 12, "v": 24, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 470.523},
+{"m": 28, "n": 45, "k": 4, "tile_m": 6, "tile_n": 2, "w": 2, "v": 32, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 162.232},
+{"m": 28, "n": 45, "k": 5, "tile_m": 6, "tile_n": 2, "w": 2, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 213.556},
+{"m": 28, "n": 45, "k": 7, "tile_m": 6, "tile_n": 2, "w": 2, "v": 18, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 248.9},
+{"m": 28, "n": 45, "k": 9, "tile_m": 3, "tile_n": 4, "w": 4, "v": 22, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 278.037},
+{"m": 28, "n": 45, "k": 13, "tile_m": 2, "tile_n": 5, "w": 6, "v": 32, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 339.473},
+{"m": 28, "n": 45, "k": 25, "tile_m": 2, "tile_n": 5, "w": 10, "v": 36, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 421.292},
+{"m": 28, "n": 45, "k": 26, "tile_m": 2, "tile_n": 5, "w": 10, "v": 36, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 425.013},
+{"m": 28, "n": 45, "k": 28, "tile_m": 3, "tile_n": 4, "w": 14, "v": 42, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 443.193},
+{"m": 28, "n": 45, "k": 32, "tile_m": 2, "tile_n": 5, "w": 16, "v": 40, "threads": 224, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 462.217},
+{"m": 28, "n": 45, "k": 45, "tile_m": 2, "tile_n": 5, "w": 16, "v": 40, "threads": 192, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 490.812},
+{"m": 29, "n": 14, "k": 14, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 242.078},
+{"m": 29, "n": 14, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 258.248},
+{"m": 29, "n": 14, "k": 29, "tile_m": 2, "tile_n": 2, "w": 8, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 274.397},
+{"m": 29, "n": 14, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 10, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 293.429},
+{"m": 29, "n": 16, "k": 14, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 277.48},
+{"m": 29, "n": 16, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 295.779},
+{"m": 29, "n": 16, "k": 29, "tile_m": 2, "tile_n": 2, "w": 12, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 310.193},
+{"m": 29, "n": 16, "k": 55, "tile_m": 2, "tile_n": 4, "w": 6, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 360.532},
+{"m": 29, "n": 29, "k": 14, "tile_m": 2, "tile_n": 4, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 309.036},
+{"m": 29, "n": 29, "k": 16, "tile_m": 4, "tile_n": 2, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 321.264},
+{"m": 29, "n": 29, "k": 29, "tile_m": 2, "tile_n": 5, "w": 10, "v": 22, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 397.654},
+{"m": 29, "n": 29, "k": 32, "tile_m": 2, "tile_n": 4, "w": 12, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 395.307},
+{"m": 29, "n": 29, "k": 55, "tile_m": 2, "tile_n": 4, "w": 8, "v": 22, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 431.556},
+{"m": 29, "n": 32, "k": 14, "tile_m": 3, "tile_n": 3, "w": 4, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 331.383},
+{"m": 29, "n": 32, "k": 29, "tile_m": 4, "tile_n": 2, "w": 10, "v": 24, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 423.499},
+{"m": 29, "n": 32, "k": 32, "tile_m": 2, "tile_n": 4, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 433.652},
+{"m": 29, "n": 32, "k": 55, "tile_m": 2, "tile_n": 4, "w": 8, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 478.124},
+{"m": 29, "n": 55, "k": 16, "tile_m": 4, "tile_n": 4, "w": 8, "v": 38, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 326.811},
+{"m": 29, "n": 55, "k": 29, "tile_m": 5, "tile_n": 3, "w": 10, "v": 44, "threads": 160, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 384.341},
+{"m": 29, "n": 55, "k": 32, "tile_m": 4, "tile_n": 4, "w": 8, "v": 34, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 424.502},
+{"m": 29, "n": 55, "k": 55, "tile_m": 3, "tile_n": 5, "w": 6, "v": 30, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 465.271},
+{"m": 32, "n": 4, "k": 4, "tile_m": 1, "tile_n": 1, "w": 2, "v": 4, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 78.1605},
+{"m": 32, "n": 4, "k": 5, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 75.2026},
+{"m": 32, "n": 4, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 84.3077},
+{"m": 32, "n": 4, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 95.6134},
+{"m": 32, "n": 4, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 107.39},
+{"m": 32, "n": 4, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 112.586},
+{"m": 32, "n": 4, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 129.333},
+{"m": 32, "n": 4, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 132.816},
+{"m": 32, "n": 4, "k": 17, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 132.452},
+{"m": 32, "n": 4, "k": 22, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 135.963},
+{"m": 32, "n": 4, "k": 23, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 136.381},
+{"m": 32, "n": 4, "k": 24, "tile_m": 1, "tile_n": 1, "w": 8, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 137.282},
+{"m": 32, "n": 4, "k": 25, "tile_m": 1, "tile_n": 1, "w": 8, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 139.087},
+{"m": 32, "n": 4, "k": 26, "tile_m": 1, "tile_n": 1, "w": 12, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 140.533},
+{"m": 32, "n": 4, "k": 28, "tile_m": 2, "tile_n": 1, "w": 14, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 143.079},
+{"m": 32, "n": 4, "k": 32, "tile_m": 2, "tile_n": 1, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 146.474},
+{"m": 32, "n": 4, "k": 45, "tile_m": 2, "tile_n": 1, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 148.211},
+{"m": 32, "n": 5, "k": 4, "tile_m": 2, "tile_n": 1, "w": 2, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 86.8186},
+{"m": 32, "n": 5, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 89.287},
+{"m": 32, "n": 5, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 101.216},
+{"m": 32, "n": 5, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 114.046},
+{"m": 32, "n": 5, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 125.677},
+{"m": 32, "n": 5, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 130.748},
+{"m": 32, "n": 5, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 148.413},
+{"m": 32, "n": 5, "k": 16, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 153.149},
+{"m": 32, "n": 5, "k": 17, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 156.458},
+{"m": 32, "n": 5, "k": 22, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 158.723},
+{"m": 32, "n": 5, "k": 23, "tile_m": 2, "tile_n": 1, "w": 6, "v": 2, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 154.957},
+{"m": 32, "n": 5, "k": 24, "tile_m": 2, "tile_n": 1, "w": 8, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 157.474},
+{"m": 32, "n": 5, "k": 25, "tile_m": 2, "tile_n": 1, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 164.898},
+{"m": 32, "n": 5, "k": 26, "tile_m": 2, "tile_n": 1, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 166.861},
+{"m": 32, "n": 5, "k": 28, "tile_m": 2, "tile_n": 1, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 169.47},
+{"m": 32, "n": 5, "k": 32, "tile_m": 2, "tile_n": 1, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 174.113},
+{"m": 32, "n": 5, "k": 45, "tile_m": 2, "tile_n": 1, "w": 16, "v": 4, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 177.946},
+{"m": 32, "n": 6, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 97.4182},
+{"m": 32, "n": 6, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 106.15},
+{"m": 32, "n": 6, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 119.531},
+{"m": 32, "n": 6, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 148.581},
+{"m": 32, "n": 6, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 153.276},
+{"m": 32, "n": 6, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 172.995},
+{"m": 32, "n": 6, "k": 16, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 179.544},
+{"m": 32, "n": 6, "k": 17, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 177.212},
+{"m": 32, "n": 6, "k": 22, "tile_m": 2, "tile_n": 1, "w": 8, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 177.592},
+{"m": 32, "n": 6, "k": 23, "tile_m": 2, "tile_n": 1, "w": 8, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 179.563},
+{"m": 32, "n": 6, "k": 24, "tile_m": 2, "tile_n": 1, "w": 8, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 184.834},
+{"m": 32, "n": 6, "k": 26, "tile_m": 2, "tile_n": 1, "w": 6, "v": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 181.915},
+{"m": 32, "n": 6, "k": 32, "tile_m": 2, "tile_n": 1, "w": 8, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 191.164},
+{"m": 32, "n": 7, "k": 4, "tile_m": 2, "tile_n": 2, "w": 2, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 113.424},
+{"m": 32, "n": 7, "k": 5, "tile_m": 2, "tile_n": 2, "w": 2, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 112.889},
+{"m": 32, "n": 7, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 139.831},
+{"m": 32, "n": 7, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 162.492},
+{"m": 32, "n": 7, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 191.194},
+{"m": 32, "n": 7, "k": 25, "tile_m": 2, "tile_n": 2, "w": 12, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 216.084},
+{"m": 32, "n": 7, "k": 26, "tile_m": 2, "tile_n": 2, "w": 10, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 218.187},
+{"m": 32, "n": 7, "k": 28, "tile_m": 2, "tile_n": 2, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 222.478},
+{"m": 32, "n": 7, "k": 32, "tile_m": 2, "tile_n": 2, "w": 12, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 228.388},
+{"m": 32, "n": 7, "k": 45, "tile_m": 2, "tile_n": 2, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 233.435},
+{"m": 32, "n": 8, "k": 4, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 125.786},
+{"m": 32, "n": 8, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 129.29},
+{"m": 32, "n": 8, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "small", "perf": 143.901},
+{"m": 32, "n": 8, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 174.913},
+{"m": 32, "n": 8, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 185.745},
+{"m": 32, "n": 8, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 206.098},
+{"m": 32, "n": 8, "k": 16, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 214.735},
+{"m": 32, "n": 8, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 213.369},
+{"m": 32, "n": 8, "k": 22, "tile_m": 2, "tile_n": 1, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 222.523},
+{"m": 32, "n": 8, "k": 23, "tile_m": 2, "tile_n": 1, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 223.88},
+{"m": 32, "n": 8, "k": 24, "tile_m": 2, "tile_n": 1, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 231.024},
+{"m": 32, "n": 8, "k": 26, "tile_m": 2, "tile_n": 2, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 229.882},
+{"m": 32, "n": 8, "k": 32, "tile_m": 2, "tile_n": 2, "w": 12, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 239.979},
+{"m": 32, "n": 9, "k": 4, "tile_m": 2, "tile_n": 2, "w": 2, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 132.73},
+{"m": 32, "n": 9, "k": 5, "tile_m": 2, "tile_n": 2, "w": 2, "v": 6, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 135.487},
+{"m": 32, "n": 9, "k": 6, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 145.86},
+{"m": 32, "n": 9, "k": 7, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 164.668},
+{"m": 32, "n": 9, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 182.062},
+{"m": 32, "n": 9, "k": 9, "tile_m": 2, "tile_n": 3, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 189.732},
+{"m": 32, "n": 9, "k": 13, "tile_m": 1, "tile_n": 3, "w": 6, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 213.509},
+{"m": 32, "n": 9, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 219.794},
+{"m": 32, "n": 9, "k": 17, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 215.226},
+{"m": 32, "n": 9, "k": 22, "tile_m": 1, "tile_n": 3, "w": 6, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 226.772},
+{"m": 32, "n": 9, "k": 23, "tile_m": 2, "tile_n": 3, "w": 6, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 230.82},
+{"m": 32, "n": 9, "k": 24, "tile_m": 1, "tile_n": 3, "w": 8, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 239.49},
+{"m": 32, "n": 9, "k": 25, "tile_m": 2, "tile_n": 2, "w": 10, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 252.716},
+{"m": 32, "n": 9, "k": 26, "tile_m": 2, "tile_n": 3, "w": 10, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 257.379},
+{"m": 32, "n": 9, "k": 28, "tile_m": 1, "tile_n": 3, "w": 14, "v": 6, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 260.597},
+{"m": 32, "n": 9, "k": 32, "tile_m": 2, "tile_n": 3, "w": 16, "v": 8, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 267.55},
+{"m": 32, "n": 9, "k": 45, "tile_m": 1, "tile_n": 3, "w": 10, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 273.232},
+{"m": 32, "n": 13, "k": 4, "tile_m": 2, "tile_n": 2, "w": 2, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 150.16},
+{"m": 32, "n": 13, "k": 5, "tile_m": 2, "tile_n": 3, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 162.28},
+{"m": 32, "n": 13, "k": 6, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 181.421},
+{"m": 32, "n": 13, "k": 7, "tile_m": 2, "tile_n": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 200.411},
+{"m": 32, "n": 13, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 218.093},
+{"m": 32, "n": 13, "k": 9, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 222.138},
+{"m": 32, "n": 13, "k": 13, "tile_m": 2, "tile_n": 4, "w": 6, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 265.867},
+{"m": 32, "n": 13, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 281.835},
+{"m": 32, "n": 13, "k": 17, "tile_m": 2, "tile_n": 4, "w": 6, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 263.517},
+{"m": 32, "n": 13, "k": 22, "tile_m": 2, "tile_n": 2, "w": 8, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 273.854},
+{"m": 32, "n": 13, "k": 23, "tile_m": 2, "tile_n": 2, "w": 6, "v": 10, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 288.889},
+{"m": 32, "n": 13, "k": 24, "tile_m": 2, "tile_n": 2, "w": 6, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 292.866},
+{"m": 32, "n": 13, "k": 25, "tile_m": 4, "tile_n": 2, "w": 12, "v": 6, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 299.633},
+{"m": 32, "n": 13, "k": 26, "tile_m": 2, "tile_n": 2, "w": 8, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 305.955},
+{"m": 32, "n": 13, "k": 28, "tile_m": 2, "tile_n": 4, "w": 14, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 315.29},
+{"m": 32, "n": 13, "k": 32, "tile_m": 4, "tile_n": 2, "w": 16, "v": 10, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 339.092},
+{"m": 32, "n": 13, "k": 45, "tile_m": 2, "tile_n": 4, "w": 16, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 341.117},
+{"m": 32, "n": 14, "k": 14, "tile_m": 2, "tile_n": 2, "w": 6, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 271.737},
+{"m": 32, "n": 14, "k": 29, "tile_m": 2, "tile_n": 2, "w": 6, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 313.057},
+{"m": 32, "n": 14, "k": 32, "tile_m": 2, "tile_n": 2, "w": 8, "v": 10, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 340.64},
+{"m": 32, "n": 16, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 151.321},
+{"m": 32, "n": 16, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 166.987},
+{"m": 32, "n": 16, "k": 6, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 189.814},
+{"m": 32, "n": 16, "k": 8, "tile_m": 2, "tile_n": 2, "w": 4, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 237.248},
+{"m": 32, "n": 16, "k": 9, "tile_m": 2, "tile_n": 2, "w": 4, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 241.881},
+{"m": 32, "n": 16, "k": 13, "tile_m": 2, "tile_n": 2, "w": 6, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 292.252},
+{"m": 32, "n": 16, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 329.973},
+{"m": 32, "n": 16, "k": 17, "tile_m": 2, "tile_n": 2, "w": 8, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 324.51},
+{"m": 32, "n": 16, "k": 22, "tile_m": 2, "tile_n": 4, "w": 6, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 333.461},
+{"m": 32, "n": 16, "k": 23, "tile_m": 2, "tile_n": 2, "w": 6, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 344.66},
+{"m": 32, "n": 16, "k": 24, "tile_m": 2, "tile_n": 2, "w": 8, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 358.655},
+{"m": 32, "n": 16, "k": 26, "tile_m": 2, "tile_n": 2, "w": 6, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 347.137},
+{"m": 32, "n": 16, "k": 32, "tile_m": 2, "tile_n": 4, "w": 8, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 362.722},
+{"m": 32, "n": 17, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 144.864},
+{"m": 32, "n": 17, "k": 5, "tile_m": 2, "tile_n": 3, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 169.7},
+{"m": 32, "n": 17, "k": 6, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 186.207},
+{"m": 32, "n": 17, "k": 8, "tile_m": 2, "tile_n": 3, "w": 4, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 231.895},
+{"m": 32, "n": 17, "k": 9, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 237.103},
+{"m": 32, "n": 17, "k": 13, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 285.362},
+{"m": 32, "n": 17, "k": 16, "tile_m": 2, "tile_n": 3, "w": 4, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 298.281},
+{"m": 32, "n": 17, "k": 17, "tile_m": 2, "tile_n": 3, "w": 8, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 294.427},
+{"m": 32, "n": 17, "k": 22, "tile_m": 2, "tile_n": 3, "w": 8, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 321.363},
+{"m": 32, "n": 17, "k": 23, "tile_m": 2, "tile_n": 3, "w": 4, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 314.354},
+{"m": 32, "n": 17, "k": 24, "tile_m": 2, "tile_n": 3, "w": 6, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 333.041},
+{"m": 32, "n": 17, "k": 26, "tile_m": 2, "tile_n": 3, "w": 6, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 323.24},
+{"m": 32, "n": 17, "k": 32, "tile_m": 2, "tile_n": 3, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 351.318},
+{"m": 32, "n": 22, "k": 4, "tile_m": 3, "tile_n": 2, "w": 2, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 174.057},
+{"m": 32, "n": 22, "k": 5, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 195.309},
+{"m": 32, "n": 22, "k": 6, "tile_m": 3, "tile_n": 2, "w": 2, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 213.72},
+{"m": 32, "n": 22, "k": 8, "tile_m": 4, "tile_n": 2, "w": 4, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 264.277},
+{"m": 32, "n": 22, "k": 9, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 280.289},
+{"m": 32, "n": 22, "k": 13, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 325.002},
+{"m": 32, "n": 22, "k": 16, "tile_m": 3, "tile_n": 2, "w": 4, "v": 14, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 348.283},
+{"m": 32, "n": 22, "k": 17, "tile_m": 2, "tile_n": 4, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 337.15},
+{"m": 32, "n": 22, "k": 22, "tile_m": 3, "tile_n": 2, "w": 10, "v": 20, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 351.551},
+{"m": 32, "n": 22, "k": 23, "tile_m": 4, "tile_n": 2, "w": 4, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 363.288},
+{"m": 32, "n": 22, "k": 24, "tile_m": 2, "tile_n": 4, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 385.833},
+{"m": 32, "n": 22, "k": 26, "tile_m": 2, "tile_n": 4, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 378.454},
+{"m": 32, "n": 22, "k": 32, "tile_m": 2, "tile_n": 4, "w": 8, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 407.594},
+{"m": 32, "n": 23, "k": 4, "tile_m": 3, "tile_n": 2, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 170.118},
+{"m": 32, "n": 23, "k": 5, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 202.087},
+{"m": 32, "n": 23, "k": 6, "tile_m": 2, "tile_n": 3, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 219.29},
+{"m": 32, "n": 23, "k": 8, "tile_m": 4, "tile_n": 2, "w": 4, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 272.379},
+{"m": 32, "n": 23, "k": 9, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 291.61},
+{"m": 32, "n": 23, "k": 13, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 337.911},
+{"m": 32, "n": 23, "k": 16, "tile_m": 2, "tile_n": 4, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 358.681},
+{"m": 32, "n": 23, "k": 17, "tile_m": 2, "tile_n": 4, "w": 8, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 349.834},
+{"m": 32, "n": 23, "k": 22, "tile_m": 2, "tile_n": 3, "w": 10, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 361.851},
+{"m": 32, "n": 23, "k": 23, "tile_m": 4, "tile_n": 2, "w": 4, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 374.412},
+{"m": 32, "n": 23, "k": 24, "tile_m": 2, "tile_n": 4, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 395.474},
+{"m": 32, "n": 23, "k": 26, "tile_m": 2, "tile_n": 4, "w": 8, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 392.455},
+{"m": 32, "n": 23, "k": 32, "tile_m": 2, "tile_n": 4, "w": 8, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 419.821},
+{"m": 32, "n": 24, "k": 4, "tile_m": 4, "tile_n": 2, "w": 2, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 168.649},
+{"m": 32, "n": 24, "k": 5, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 192.606},
+{"m": 32, "n": 24, "k": 6, "tile_m": 4, "tile_n": 2, "w": 2, "v": 12, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 218.903},
+{"m": 32, "n": 24, "k": 8, "tile_m": 2, "tile_n": 4, "w": 4, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 279.775},
+{"m": 32, "n": 24, "k": 9, "tile_m": 3, "tile_n": 3, "w": 4, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 275.596},
+{"m": 32, "n": 24, "k": 13, "tile_m": 2, "tile_n": 4, "w": 6, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 328.765},
+{"m": 32, "n": 24, "k": 16, "tile_m": 2, "tile_n": 4, "w": 8, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 373.707},
+{"m": 32, "n": 24, "k": 17, "tile_m": 2, "tile_n": 4, "w": 8, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 364.783},
+{"m": 32, "n": 24, "k": 22, "tile_m": 2, "tile_n": 3, "w": 8, "v": 20, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 383.032},
+{"m": 32, "n": 24, "k": 23, "tile_m": 2, "tile_n": 3, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 390.4},
+{"m": 32, "n": 24, "k": 24, "tile_m": 2, "tile_n": 4, "w": 8, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 411.108},
+{"m": 32, "n": 24, "k": 26, "tile_m": 2, "tile_n": 4, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 409.018},
+{"m": 32, "n": 24, "k": 32, "tile_m": 2, "tile_n": 4, "w": 8, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 438.697},
+{"m": 32, "n": 24, "k": 45, "tile_m": 2, "tile_n": 4, "w": 12, "v": 18, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 478.687},
+{"m": 32, "n": 25, "k": 4, "tile_m": 4, "tile_n": 2, "w": 2, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 184.135},
+{"m": 32, "n": 25, "k": 5, "tile_m": 5, "tile_n": 2, "w": 2, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 204.72},
+{"m": 32, "n": 25, "k": 7, "tile_m": 5, "tile_n": 2, "w": 2, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 239.808},
+{"m": 32, "n": 25, "k": 9, "tile_m": 2, "tile_n": 4, "w": 4, "v": 22, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 271.023},
+{"m": 32, "n": 25, "k": 13, "tile_m": 2, "tile_n": 5, "w": 6, "v": 22, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 313.779},
+{"m": 32, "n": 25, "k": 25, "tile_m": 4, "tile_n": 2, "w": 12, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 386.311},
+{"m": 32, "n": 25, "k": 26, "tile_m": 2, "tile_n": 4, "w": 10, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 389.664},
+{"m": 32, "n": 25, "k": 28, "tile_m": 2, "tile_n": 5, "w": 14, "v": 24, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 397.586},
+{"m": 32, "n": 25, "k": 32, "tile_m": 4, "tile_n": 2, "w": 16, "v": 24, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 409.68},
+{"m": 32, "n": 25, "k": 45, "tile_m": 2, "tile_n": 5, "w": 12, "v": 10, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 426.761},
+{"m": 32, "n": 26, "k": 4, "tile_m": 4, "tile_n": 2, "w": 2, "v": 18, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 190.663},
+{"m": 32, "n": 26, "k": 5, "tile_m": 5, "tile_n": 2, "w": 2, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 211.617},
+{"m": 32, "n": 26, "k": 6, "tile_m": 5, "tile_n": 2, "w": 2, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 220.557},
+{"m": 32, "n": 26, "k": 7, "tile_m": 5, "tile_n": 2, "w": 2, "v": 14, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 246.023},
+{"m": 32, "n": 26, "k": 8, "tile_m": 3, "tile_n": 3, "w": 4, "v": 22, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 246.38},
+{"m": 32, "n": 26, "k": 9, "tile_m": 2, "tile_n": 4, "w": 4, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 280.415},
+{"m": 32, "n": 26, "k": 13, "tile_m": 2, "tile_n": 4, "w": 4, "v": 22, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 323.047},
+{"m": 32, "n": 26, "k": 16, "tile_m": 2, "tile_n": 4, "w": 8, "v": 22, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 336.964},
+{"m": 32, "n": 26, "k": 17, "tile_m": 4, "tile_n": 2, "w": 6, "v": 22, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 335.578},
+{"m": 32, "n": 26, "k": 22, "tile_m": 2, "tile_n": 4, "w": 8, "v": 22, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 363.449},
+{"m": 32, "n": 26, "k": 23, "tile_m": 2, "tile_n": 4, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 370.605},
+{"m": 32, "n": 26, "k": 24, "tile_m": 4, "tile_n": 2, "w": 12, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 386.132},
+{"m": 32, "n": 26, "k": 25, "tile_m": 2, "tile_n": 4, "w": 12, "v": 18, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 398.053},
+{"m": 32, "n": 26, "k": 26, "tile_m": 4, "tile_n": 2, "w": 12, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 399.369},
+{"m": 32, "n": 26, "k": 28, "tile_m": 4, "tile_n": 2, "w": 12, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 407.816},
+{"m": 32, "n": 26, "k": 32, "tile_m": 4, "tile_n": 2, "w": 16, "v": 26, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 425.774},
+{"m": 32, "n": 26, "k": 45, "tile_m": 2, "tile_n": 5, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 446.509},
+{"m": 32, "n": 28, "k": 4, "tile_m": 4, "tile_n": 2, "w": 2, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 201.528},
+{"m": 32, "n": 28, "k": 5, "tile_m": 4, "tile_n": 2, "w": 2, "v": 20, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 209.83},
+{"m": 32, "n": 28, "k": 7, "tile_m": 4, "tile_n": 2, "w": 2, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 243.583},
+{"m": 32, "n": 28, "k": 9, "tile_m": 2, "tile_n": 4, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 296.73},
+{"m": 32, "n": 28, "k": 13, "tile_m": 2, "tile_n": 4, "w": 4, "v": 20, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 340.313},
+{"m": 32, "n": 28, "k": 25, "tile_m": 2, "tile_n": 4, "w": 12, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 425.713},
+{"m": 32, "n": 28, "k": 26, "tile_m": 4, "tile_n": 2, "w": 12, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 426.391},
+{"m": 32, "n": 28, "k": 28, "tile_m": 4, "tile_n": 2, "w": 12, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 434.061},
+{"m": 32, "n": 28, "k": 32, "tile_m": 4, "tile_n": 2, "w": 16, "v": 28, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 453.918},
+{"m": 32, "n": 28, "k": 45, "tile_m": 2, "tile_n": 5, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 474.442},
+{"m": 32, "n": 29, "k": 14, "tile_m": 2, "tile_n": 4, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 343.714},
+{"m": 32, "n": 29, "k": 29, "tile_m": 2, "tile_n": 4, "w": 10, "v": 18, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 425.393},
+{"m": 32, "n": 29, "k": 32, "tile_m": 2, "tile_n": 4, "w": 12, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 439.946},
+{"m": 32, "n": 29, "k": 55, "tile_m": 2, "tile_n": 4, "w": 12, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 487.985},
+{"m": 32, "n": 32, "k": 4, "tile_m": 4, "tile_n": 2, "w": 2, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 220.256},
+{"m": 32, "n": 32, "k": 5, "tile_m": 4, "tile_n": 2, "w": 2, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 233.012},
+{"m": 32, "n": 32, "k": 6, "tile_m": 4, "tile_n": 2, "w": 2, "v": 20, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 233.277},
+{"m": 32, "n": 32, "k": 7, "tile_m": 4, "tile_n": 2, "w": 2, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 269.642},
+{"m": 32, "n": 32, "k": 8, "tile_m": 3, "tile_n": 3, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 288.605},
+{"m": 32, "n": 32, "k": 9, "tile_m": 2, "tile_n": 4, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 330.576},
+{"m": 32, "n": 32, "k": 13, "tile_m": 2, "tile_n": 4, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 378.511},
+{"m": 32, "n": 32, "k": 14, "tile_m": 2, "tile_n": 4, "w": 6, "v": 20, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 370.201},
+{"m": 32, "n": 32, "k": 16, "tile_m": 2, "tile_n": 4, "w": 8, "v": 20, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 415.932},
+{"m": 32, "n": 32, "k": 17, "tile_m": 2, "tile_n": 4, "w": 8, "v": 20, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 408.083},
+{"m": 32, "n": 32, "k": 22, "tile_m": 2, "tile_n": 4, "w": 8, "v": 20, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 439.077},
+{"m": 32, "n": 32, "k": 23, "tile_m": 2, "tile_n": 4, "w": 8, "v": 20, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 450.644},
+{"m": 32, "n": 32, "k": 24, "tile_m": 2, "tile_n": 4, "w": 8, "v": 20, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 457.257},
+{"m": 32, "n": 32, "k": 25, "tile_m": 4, "tile_n": 2, "w": 12, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 471.97},
+{"m": 32, "n": 32, "k": 26, "tile_m": 2, "tile_n": 4, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 482.604},
+{"m": 32, "n": 32, "k": 28, "tile_m": 2, "tile_n": 4, "w": 10, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 485.43},
+{"m": 32, "n": 32, "k": 29, "tile_m": 2, "tile_n": 4, "w": 10, "v": 20, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 470.358},
+{"m": 32, "n": 32, "k": 32, "tile_m": 2, "tile_n": 4, "w": 12, "v": 20, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 509.322},
+{"m": 32, "n": 32, "k": 45, "tile_m": 2, "tile_n": 4, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 526.52},
+{"m": 32, "n": 32, "k": 55, "tile_m": 2, "tile_n": 4, "w": 8, "v": 20, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 531.47},
+{"m": 32, "n": 45, "k": 4, "tile_m": 4, "tile_n": 2, "w": 2, "v": 34, "threads": 192, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 193.676},
+{"m": 32, "n": 45, "k": 5, "tile_m": 4, "tile_n": 2, "w": 2, "v": 24, "threads": 192, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 201.497},
+{"m": 32, "n": 45, "k": 7, "tile_m": 2, "tile_n": 3, "threads": 256, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 238.295},
+{"m": 32, "n": 45, "k": 9, "tile_m": 4, "tile_n": 3, "w": 4, "v": 28, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 315.514},
+{"m": 32, "n": 45, "k": 13, "tile_m": 4, "tile_n": 3, "w": 6, "v": 24, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 372.936},
+{"m": 32, "n": 45, "k": 25, "tile_m": 4, "tile_n": 3, "w": 8, "v": 20, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 481.689},
+{"m": 32, "n": 45, "k": 26, "tile_m": 4, "tile_n": 3, "w": 12, "v": 24, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 483.916},
+{"m": 32, "n": 45, "k": 28, "tile_m": 4, "tile_n": 3, "w": 14, "v": 28, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 503.765},
+{"m": 32, "n": 45, "k": 32, "tile_m": 4, "tile_n": 3, "w": 8, "v": 28, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 523.025},
+{"m": 32, "n": 45, "k": 45, "tile_m": 4, "tile_n": 3, "w": 12, "v": 32, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 536.898},
+{"m": 32, "n": 55, "k": 29, "tile_m": 4, "tile_n": 4, "w": 8, "v": 36, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 447.064},
+{"m": 32, "n": 55, "k": 32, "tile_m": 4, "tile_n": 4, "w": 4, "v": 26, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 477.495},
+{"m": 32, "n": 55, "k": 55, "tile_m": 3, "tile_n": 5, "w": 6, "v": 24, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 518.157},
+{"m": 36, "n": 6, "k": 6, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 113.312},
+{"m": 45, "n": 4, "k": 4, "tile_m": 1, "tile_n": 2, "w": 2, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 90.7503},
+{"m": 45, "n": 4, "k": 5, "tile_m": 1, "tile_n": 2, "w": 2, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 88.8845},
+{"m": 45, "n": 4, "k": 7, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 109.043},
+{"m": 45, "n": 4, "k": 9, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 119.668},
+{"m": 45, "n": 4, "k": 13, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 126.187},
+{"m": 45, "n": 4, "k": 25, "tile_m": 1, "tile_n": 2, "w": 10, "v": 2, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 142.394},
+{"m": 45, "n": 4, "k": 26, "tile_m": 1, "tile_n": 2, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 143.612},
+{"m": 45, "n": 4, "k": 28, "tile_m": 3, "tile_n": 1, "w": 14, "v": 4, "threads": 192, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 147.113},
+{"m": 45, "n": 4, "k": 32, "tile_m": 1, "tile_n": 2, "w": 8, "v": 4, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 149.4},
+{"m": 45, "n": 4, "k": 45, "tile_m": 1, "tile_n": 2, "w": 12, "v": 4, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 150.684},
+{"m": 45, "n": 5, "k": 4, "tile_m": 3, "tile_n": 1, "w": 2, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 101.474},
+{"m": 45, "n": 5, "k": 5, "tile_m": 3, "tile_n": 1, "w": 2, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 101.829},
+{"m": 45, "n": 5, "k": 7, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 124.597},
+{"m": 45, "n": 5, "k": 9, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 138.834},
+{"m": 45, "n": 5, "k": 13, "tile_m": 3, "tile_n": 1, "w": 6, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 148.846},
+{"m": 45, "n": 5, "k": 25, "tile_m": 3, "tile_n": 1, "w": 8, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 168.184},
+{"m": 45, "n": 5, "k": 26, "tile_m": 3, "tile_n": 1, "w": 8, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 171.306},
+{"m": 45, "n": 5, "k": 28, "tile_m": 3, "tile_n": 2, "w": 14, "v": 4, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 173.248},
+{"m": 45, "n": 5, "k": 32, "tile_m": 1, "tile_n": 3, "w": 8, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 179.706},
+{"m": 45, "n": 5, "k": 45, "tile_m": 3, "tile_n": 1, "w": 12, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 180.372},
+{"m": 45, "n": 7, "k": 4, "tile_m": 2, "tile_n": 2, "w": 2, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 120.397},
+{"m": 45, "n": 7, "k": 5, "tile_m": 2, "tile_n": 2, "w": 2, "v": 6, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 130.96},
+{"m": 45, "n": 7, "k": 7, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 150.737},
+{"m": 45, "n": 7, "k": 9, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 173.029},
+{"m": 45, "n": 7, "k": 13, "tile_m": 3, "tile_n": 2, "w": 6, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 191.272},
+{"m": 45, "n": 7, "k": 25, "tile_m": 3, "tile_n": 2, "w": 8, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 222.433},
+{"m": 45, "n": 7, "k": 26, "tile_m": 3, "tile_n": 2, "w": 8, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 220.248},
+{"m": 45, "n": 7, "k": 28, "tile_m": 3, "tile_n": 2, "w": 14, "v": 6, "threads": 160, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 229.232},
+{"m": 45, "n": 7, "k": 32, "tile_m": 3, "tile_n": 2, "w": 16, "v": 6, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 232.684},
+{"m": 45, "n": 7, "k": 45, "tile_m": 5, "tile_n": 1, "w": 8, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 240.56},
+{"m": 45, "n": 9, "k": 4, "tile_m": 3, "tile_n": 2, "w": 2, "v": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 130.378},
+{"m": 45, "n": 9, "k": 5, "tile_m": 5, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 142.506},
+{"m": 45, "n": 9, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 167.682},
+{"m": 45, "n": 9, "k": 9, "tile_m": 3, "tile_n": 2, "w": 4, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 190.947},
+{"m": 45, "n": 9, "k": 13, "tile_m": 3, "tile_n": 2, "w": 6, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 223.144},
+{"m": 45, "n": 9, "k": 25, "tile_m": 3, "tile_n": 2, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 258.374},
+{"m": 45, "n": 9, "k": 26, "tile_m": 3, "tile_n": 2, "w": 10, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 260.559},
+{"m": 45, "n": 9, "k": 28, "tile_m": 3, "tile_n": 2, "w": 10, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 266.255},
+{"m": 45, "n": 9, "k": 32, "tile_m": 3, "tile_n": 2, "w": 12, "v": 6, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 271.239},
+{"m": 45, "n": 9, "k": 45, "tile_m": 3, "tile_n": 2, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 288.261},
+{"m": 45, "n": 13, "k": 4, "tile_m": 5, "tile_n": 1, "w": 2, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 161.582},
+{"m": 45, "n": 13, "k": 5, "tile_m": 3, "tile_n": 2, "w": 2, "v": 8, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 174.113},
+{"m": 45, "n": 13, "k": 7, "tile_m": 5, "tile_n": 2, "w": 2, "v": 10, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 201.625},
+{"m": 45, "n": 13, "k": 9, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 234.915},
+{"m": 45, "n": 13, "k": 13, "tile_m": 3, "tile_n": 2, "w": 6, "v": 8, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 255.57},
+{"m": 45, "n": 13, "k": 24, "tile_m": 5, "tile_n": 2, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 327.987},
+{"m": 45, "n": 13, "k": 25, "tile_m": 3, "tile_n": 2, "w": 12, "v": 6, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 314.759},
+{"m": 45, "n": 13, "k": 26, "tile_m": 3, "tile_n": 2, "w": 12, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 320.527},
+{"m": 45, "n": 13, "k": 28, "tile_m": 5, "tile_n": 2, "w": 10, "v": 10, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 333.834},
+{"m": 45, "n": 13, "k": 32, "tile_m": 5, "tile_n": 2, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 346.121},
+{"m": 45, "n": 13, "k": 45, "tile_m": 5, "tile_n": 2, "w": 12, "v": 12, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 371.646},
+{"m": 45, "n": 24, "k": 13, "tile_m": 3, "tile_n": 3, "w": 6, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 369.651},
+{"m": 45, "n": 24, "k": 24, "tile_m": 3, "tile_n": 3, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 456.36},
+{"m": 45, "n": 24, "k": 32, "tile_m": 3, "tile_n": 3, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 476.863},
+{"m": 45, "n": 24, "k": 45, "tile_m": 3, "tile_n": 4, "w": 8, "v": 16, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 507.03},
+{"m": 45, "n": 25, "k": 4, "tile_m": 6, "tile_n": 2, "w": 2, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 181.279},
+{"m": 45, "n": 25, "k": 5, "tile_m": 5, "tile_n": 2, "w": 2, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 210.509},
+{"m": 45, "n": 25, "k": 7, "tile_m": 5, "tile_n": 2, "w": 2, "v": 14, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 229.999},
+{"m": 45, "n": 25, "k": 9, "tile_m": 5, "tile_n": 2, "w": 4, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 293.374},
+{"m": 45, "n": 25, "k": 13, "tile_m": 5, "tile_n": 2, "w": 4, "v": 14, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 304.438},
+{"m": 45, "n": 25, "k": 25, "tile_m": 3, "tile_n": 4, "w": 10, "v": 22, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 377.937},
+{"m": 45, "n": 25, "k": 26, "tile_m": 3, "tile_n": 4, "w": 10, "v": 24, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 376.764},
+{"m": 45, "n": 25, "k": 28, "tile_m": 5, "tile_n": 2, "w": 14, "v": 24, "threads": 192, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 394.568},
+{"m": 45, "n": 25, "k": 32, "tile_m": 3, "tile_n": 4, "w": 16, "v": 24, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 419.218},
+{"m": 45, "n": 25, "k": 45, "tile_m": 5, "tile_n": 2, "w": 16, "v": 24, "threads": 192, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 435.39},
+{"m": 45, "n": 26, "k": 4, "tile_m": 6, "tile_n": 2, "w": 2, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 184.281},
+{"m": 45, "n": 26, "k": 5, "tile_m": 5, "tile_n": 2, "w": 2, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 211.405},
+{"m": 45, "n": 26, "k": 7, "tile_m": 5, "tile_n": 2, "w": 2, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 242.135},
+{"m": 45, "n": 26, "k": 9, "tile_m": 5, "tile_n": 2, "w": 2, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 277.095},
+{"m": 45, "n": 26, "k": 13, "tile_m": 5, "tile_n": 2, "w": 4, "v": 22, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 322.208},
+{"m": 45, "n": 26, "k": 25, "tile_m": 5, "tile_n": 2, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 394.731},
+{"m": 45, "n": 26, "k": 26, "tile_m": 5, "tile_n": 2, "w": 4, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 401.24},
+{"m": 45, "n": 26, "k": 28, "tile_m": 5, "tile_n": 2, "w": 4, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 436.355},
+{"m": 45, "n": 26, "k": 32, "tile_m": 5, "tile_n": 2, "w": 4, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 444.707},
+{"m": 45, "n": 26, "k": 45, "tile_m": 5, "tile_n": 2, "w": 4, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 470.147},
+{"m": 45, "n": 28, "k": 4, "tile_m": 6, "tile_n": 2, "w": 2, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 196.839},
+{"m": 45, "n": 28, "k": 5, "tile_m": 5, "tile_n": 2, "w": 2, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 224.568},
+{"m": 45, "n": 28, "k": 7, "tile_m": 5, "tile_n": 2, "w": 2, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 263.736},
+{"m": 45, "n": 28, "k": 9, "tile_m": 5, "tile_n": 2, "w": 2, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 293.355},
+{"m": 45, "n": 28, "k": 13, "tile_m": 5, "tile_n": 2, "w": 4, "v": 14, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 340.659},
+{"m": 45, "n": 28, "k": 25, "tile_m": 5, "tile_n": 2, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 422.701},
+{"m": 45, "n": 28, "k": 26, "tile_m": 5, "tile_n": 2, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 427.927},
+{"m": 45, "n": 28, "k": 28, "tile_m": 5, "tile_n": 2, "w": 4, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 465.948},
+{"m": 45, "n": 28, "k": 32, "tile_m": 5, "tile_n": 2, "w": 4, "v": 10, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 474.663},
+{"m": 45, "n": 28, "k": 45, "tile_m": 5, "tile_n": 2, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 500.869},
+{"m": 45, "n": 32, "k": 4, "tile_m": 6, "tile_n": 2, "w": 2, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 218.515},
+{"m": 45, "n": 32, "k": 5, "tile_m": 6, "tile_n": 2, "w": 2, "v": 16, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 224.185},
+{"m": 45, "n": 32, "k": 7, "tile_m": 6, "tile_n": 2, "w": 2, "v": 10, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 257.346},
+{"m": 45, "n": 32, "k": 9, "tile_m": 6, "tile_n": 2, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 300.997},
+{"m": 45, "n": 32, "k": 13, "tile_m": 3, "tile_n": 4, "w": 6, "v": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 370.865},
+{"m": 45, "n": 32, "k": 24, "tile_m": 3, "tile_n": 4, "w": 12, "v": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 474.921},
+{"m": 45, "n": 32, "k": 25, "tile_m": 3, "tile_n": 4, "w": 12, "v": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 459.048},
+{"m": 45, "n": 32, "k": 26, "tile_m": 3, "tile_n": 4, "w": 12, "v": 16, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 472.758},
+{"m": 45, "n": 32, "k": 28, "tile_m": 3, "tile_n": 4, "w": 14, "v": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 494.885},
+{"m": 45, "n": 32, "k": 32, "tile_m": 3, "tile_n": 4, "w": 12, "v": 16, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 504.584},
+{"m": 45, "n": 32, "k": 45, "tile_m": 3, "tile_n": 4, "w": 12, "v": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 536.655},
+{"m": 45, "n": 45, "k": 4, "tile_m": 6, "tile_n": 2, "w": 2, "v": 28, "threads": 256, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 178.318},
+{"m": 45, "n": 45, "k": 5, "tile_m": 5, "tile_n": 2, "w": 2, "v": 28, "threads": 256, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 199.013},
+{"m": 45, "n": 45, "k": 7, "tile_m": 3, "tile_n": 2, "w": 2, "v": 30, "threads": 352, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 229.112},
+{"m": 45, "n": 45, "k": 9, "tile_m": 3, "tile_n": 3, "w": 4, "v": 28, "threads": 256, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 291.982},
+{"m": 45, "n": 45, "k": 13, "tile_m": 3, "tile_n": 6, "w": 6, "v": 24, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 360.044},
+{"m": 45, "n": 45, "k": 24, "tile_m": 6, "tile_n": 3, "w": 12, "v": 28, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 456.144},
+{"m": 45, "n": 45, "k": 25, "tile_m": 6, "tile_n": 3, "w": 10, "v": 28, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 450.391},
+{"m": 45, "n": 45, "k": 26, "tile_m": 3, "tile_n": 6, "w": 10, "v": 28, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 457.692},
+{"m": 45, "n": 45, "k": 28, "tile_m": 3, "tile_n": 6, "w": 14, "v": 22, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 480.917},
+{"m": 45, "n": 45, "k": 32, "tile_m": 3, "tile_n": 6, "w": 16, "v": 28, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 511.25},
+{"m": 45, "n": 45, "k": 45, "tile_m": 3, "tile_n": 6, "w": 16, "v": 28, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 534.417},
+{"m": 49, "n": 7, "k": 7, "tile_m": 3, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 145.44},
+{"m": 55, "n": 16, "k": 16, "tile_m": 3, "tile_n": 3, "w": 8, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 322.352},
+{"m": 55, "n": 16, "k": 29, "tile_m": 3, "tile_n": 3, "w": 6, "v": 8, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 369.726},
+{"m": 55, "n": 16, "k": 55, "tile_m": 5, "tile_n": 2, "w": 6, "v": 12, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 426.451},
+{"m": 55, "n": 29, "k": 16, "tile_m": 3, "tile_n": 5, "w": 8, "v": 20, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 339.155},
+{"m": 55, "n": 29, "k": 29, "tile_m": 3, "tile_n": 5, "w": 10, "v": 26, "threads": 160, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 383.513},
+{"m": 55, "n": 29, "k": 32, "tile_m": 3, "tile_n": 5, "w": 8, "v": 20, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 427.971},
+{"m": 55, "n": 29, "k": 55, "tile_m": 3, "tile_n": 5, "w": 6, "v": 20, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 466.603},
+{"m": 55, "n": 32, "k": 29, "tile_m": 5, "tile_n": 3, "w": 4, "v": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 421.352},
+{"m": 55, "n": 32, "k": 32, "tile_m": 5, "tile_n": 3, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 461.927},
+{"m": 55, "n": 32, "k": 55, "tile_m": 5, "tile_n": 3, "w": 6, "v": 20, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 500.36},
+{"m": 55, "n": 55, "k": 16, "tile_m": 5, "tile_n": 5, "w": 6, "v": 26, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 361.626},
+{"m": 55, "n": 55, "k": 29, "tile_m": 5, "tile_n": 5, "w": 10, "v": 30, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 408.729},
+{"m": 55, "n": 55, "k": 32, "tile_m": 5, "tile_n": 5, "w": 6, "v": 26, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 501.123},
+{"m": 55, "n": 55, "k": 55, "tile_m": 5, "tile_n": 5, "w": 6, "v": 26, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 588.05},
+{"m": 64, "n": 8, "k": 8, "tile_m": 2, "tile_n": 2, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 213.145},
+{"m": 64, "n": 9, "k": 9, "tile_m": 2, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 240.201},
+{"m": 64, "n": 9, "k": 16, "tile_m": 2, "tile_n": 3, "w": 4, "v": 6, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 263.151},
+{"m": 64, "n": 9, "k": 22, "tile_m": 2, "tile_n": 3, "w": 6, "v": 4, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB1", "perf": 286.988},
+{"m": 64, "n": 9, "k": 64, "tile_m": 2, "tile_n": 3, "w": 10, "v": 8, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 319.492},
+{"m": 64, "n": 16, "k": 9, "tile_m": 2, "tile_n": 4, "w": 4, "v": 10, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 283.571},
+{"m": 64, "n": 16, "k": 16, "tile_m": 2, "tile_n": 4, "w": 8, "v": 10, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 379.404},
+{"m": 64, "n": 16, "k": 22, "tile_m": 2, "tile_n": 4, "w": 8, "v": 8, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 408.89},
+{"m": 64, "n": 16, "k": 64, "tile_m": 2, "tile_n": 4, "w": 8, "v": 10, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 501.245},
+{"m": 64, "n": 22, "k": 9, "tile_m": 6, "tile_n": 2, "w": 4, "v": 12, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 271.107},
+{"m": 64, "n": 22, "k": 16, "tile_m": 2, "tile_n": 6, "w": 8, "v": 14, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 369.789},
+{"m": 64, "n": 22, "k": 22, "tile_m": 6, "tile_n": 2, "w": 4, "v": 12, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 383.088},
+{"m": 64, "n": 22, "k": 64, "tile_m": 2, "tile_n": 6, "w": 8, "v": 2, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 507.361},
+{"m": 64, "n": 64, "k": 9, "tile_m": 4, "tile_n": 4, "w": 4, "v": 16, "threads": 256, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 271.502},
+{"m": 64, "n": 64, "k": 16, "tile_m": 4, "tile_n": 4, "w": 6, "v": 16, "threads": 256, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 363.539},
+{"m": 64, "n": 64, "k": 22, "tile_m": 4, "tile_n": 4, "w": 8, "v": 16, "threads": 256, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 410.791},
+{"m": 64, "n": 64, "k": 64, "tile_m": 3, "tile_n": 6, "w": 16, "v": 32, "threads": 256, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 563.614},
+{"m": 78, "n": 78, "k": 78, "tile_m": 5, "tile_n": 5, "w": 8, "v": 26, "threads": 256, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 589.26},
+{"m": 81, "n": 9, "k": 9, "tile_m": 3, "tile_n": 3, "w": 4, "v": 6, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB1", "perf": 189.642},
+{"m": 96, "n": 96, "k": 96, "tile_m": 6, "tile_n": 3, "w": 14, "v": 48, "threads": 512, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 614.588},
+{"m": 100, "n": 10, "k": 10, "tile_m": 2, "tile_n": 2, "threads": 256, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 226.917},
+{"m": 121, "n": 11, "k": 11, "tile_m": 5, "tile_n": 3, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 233.211},
+{"m": 144, "n": 12, "k": 12, "tile_m": 2, "tile_n": 4, "w": 6, "v": 8, "threads": 288, "grouping": 16, "minblocks": 4, "algorithm": "largeDB1", "perf": 268.209},
+{"m": 169, "n": 13, "k": 13, "tile_m": 3, "tile_n": 4, "w": 6, "v": 10, "threads": 256, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 221.427},
+{"m": 196, "n": 14, "k": 14, "tile_m": 6, "tile_n": 2, "threads": 256, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 243.838},
+{"m": 225, "n": 15, "k": 15, "tile_m": 3, "tile_n": 3, "w": 4, "v": 12, "threads": 384, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 248.307},
+{"m": 256, "n": 16, "k": 16, "tile_m": 2, "tile_n": 6, "w": 6, "v": 10, "threads": 384, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 309.19}
 ]
-
-#EOF

--- a/src/acc/libsmm_acc/libcusmm/parameters_K40.txt
+++ b/src/acc/libsmm_acc/libcusmm/parameters_K40.txt
@@ -1,28 +1,21 @@
-# *****************************************************************************
-# * CP2K: A general program to perform molecular dynamics simulations         *
-# * Copyright (C) 2000 - 2018  CP2K developers group                          *
-# *****************************************************************************
-
 [
-  Kernel_dnt_largeDB2(m=12, n=12, k=12, tile_m=1, tile_n=2, w=6, v=8, threads=96, grouping=16, minblocks=4) , # 174.853 GFlop/s
-  Kernel_dnt_largeDB2(m=16, n=16, k=16, tile_m=2, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=12) , # 279.888 GFlop/s
-  Kernel_dnt_largeDB2(m=17, n=17, k=17, tile_m=2, tile_n=2, w=6, v=12, threads=128, grouping=16, minblocks=12) , # 248.155 GFlop/s
-  Kernel_dnt_largeDB2(m=22, n=22, k=22, tile_m=3, tile_n=2, w=8, v=22, threads=96, grouping=16, minblocks=12) , # 354.045 GFlop/s
-  Kernel_dnt_largeDB2(m=23, n=23, k=23, tile_m=3, tile_n=2, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 384.495 GFlop/s
-  Kernel_dnt_largeDB2(m=24, n=24, k=24, tile_m=3, tile_n=2, w=8, v=20, threads=96, grouping=16, minblocks=12) , # 439.977 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=26, k=26, tile_m=2, tile_n=3, w=12, v=26, threads=128, grouping=16, minblocks=8) , # 405.2 GFlop/s
-  Kernel_dnt_largeDB2(m=29, n=29, k=29, tile_m=2, tile_n=5, w=10, v=16, threads=96, grouping=16, minblocks=8) , # 426.072 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=32, k=32, tile_m=2, tile_n=4, w=12, v=20, threads=128, grouping=16, minblocks=8) , # 530.707 GFlop/s
-  Kernel_dnt_medium(m=14, n=14, k=14, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 205.751 GFlop/s
-  Kernel_dnt_medium(m=15, n=15, k=15, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 221.72 GFlop/s
-  Kernel_dnt_small(m=10, n=10, k=10, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 132.089 GFlop/s
-  Kernel_dnt_small(m=11, n=11, k=11, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=4) , # 162.566 GFlop/s
-  Kernel_dnt_small(m=13, n=13, k=13, tile_m=2, tile_n=1, threads=96, grouping=16, minblocks=12) , # 184.195 GFlop/s
-  Kernel_dnt_small(m=8, n=8, k=8, tile_m=1, tile_n=1, threads=64, grouping=16, minblocks=4) , # 95.1028 GFlop/s
-  Kernel_dnt_small(m=9, n=9, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 111.384 GFlop/s
-  Kernel_dnt_tiny(m=5, n=5, k=5, threads=64, grouping=16, minblocks=1) , # 30.4899 GFlop/s
-  Kernel_dnt_tiny(m=6, n=6, k=6, threads=128, grouping=16, minblocks=1) , # 44.1711 GFlop/s
-  Kernel_dnt_tiny(m=7, n=7, k=7, threads=96, grouping=16, minblocks=1) , # 64.2483 GFlop/s
+{"m": 12, "n": 12, "k": 12, "tile_m": 1, "tile_n": 2, "w": 6, "v": 8, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 174.853},
+{"m": 16, "n": 16, "k": 16, "tile_m": 2, "tile_n": 2, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 279.888},
+{"m": 17, "n": 17, "k": 17, "tile_m": 2, "tile_n": 2, "w": 6, "v": 12, "threads": 128, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 248.155},
+{"m": 22, "n": 22, "k": 22, "tile_m": 3, "tile_n": 2, "w": 8, "v": 22, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 354.045},
+{"m": 23, "n": 23, "k": 23, "tile_m": 3, "tile_n": 2, "w": 8, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 384.495},
+{"m": 24, "n": 24, "k": 24, "tile_m": 3, "tile_n": 2, "w": 8, "v": 20, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 439.977},
+{"m": 26, "n": 26, "k": 26, "tile_m": 2, "tile_n": 3, "w": 12, "v": 26, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 405.2},
+{"m": 29, "n": 29, "k": 29, "tile_m": 2, "tile_n": 5, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 426.072},
+{"m": 32, "n": 32, "k": 32, "tile_m": 2, "tile_n": 4, "w": 12, "v": 20, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 530.707},
+{"m": 14, "n": 14, "k": 14, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 205.751},
+{"m": 15, "n": 15, "k": 15, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 221.72},
+{"m": 10, "n": 10, "k": 10, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 132.089},
+{"m": 11, "n": 11, "k": 11, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 162.566},
+{"m": 13, "n": 13, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "small", "perf": 184.195},
+{"m": 8, "n": 8, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 95.1028},
+{"m": 9, "n": 9, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 111.384},
+{"m": 5, "n": 5, "k": 5, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 30.4899},
+{"m": 6, "n": 6, "k": 6, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 44.1711},
+{"m": 7, "n": 7, "k": 7, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 64.2483}
 ]
-
-#EOF

--- a/src/acc/libsmm_acc/libcusmm/parameters_K80.txt
+++ b/src/acc/libsmm_acc/libcusmm/parameters_K80.txt
@@ -1,28 +1,21 @@
-# *****************************************************************************
-# * CP2K: A general program to perform molecular dynamics simulations         *
-# * Copyright (C) 2000 - 2018  CP2K developers group                          *
-# *****************************************************************************
-
 [
-  Kernel_dnt_largeDB2(m=10, n=10, k=10, tile_m=2, tile_n=1, w=4, v=10, threads=96, grouping=16, minblocks=4) , # 115.19 GFlop/s
-  Kernel_dnt_largeDB2(m=12, n=12, k=12, tile_m=3, tile_n=2, w=6, v=12, threads=96, grouping=16, minblocks=4) , # 193.79 GFlop/s
-  Kernel_dnt_largeDB2(m=16, n=16, k=16, tile_m=4, tile_n=2, w=8, v=16, threads=128, grouping=16, minblocks=1) , # 322.824 GFlop/s
-  Kernel_dnt_largeDB2(m=17, n=17, k=17, tile_m=2, tile_n=3, w=6, v=14, threads=128, grouping=16, minblocks=8) , # 279.903 GFlop/s
-  Kernel_dnt_largeDB2(m=22, n=22, k=22, tile_m=3, tile_n=3, w=8, v=22, threads=96, grouping=16, minblocks=8) , # 405.672 GFlop/s
-  Kernel_dnt_largeDB2(m=23, n=23, k=23, tile_m=3, tile_n=3, w=8, v=12, threads=96, grouping=16, minblocks=8) , # 439.289 GFlop/s
-  Kernel_dnt_largeDB2(m=24, n=24, k=24, tile_m=6, tile_n=3, w=12, v=24, threads=96, grouping=16, minblocks=4) , # 506.39 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=26, k=26, tile_m=3, tile_n=4, w=10, v=26, threads=96, grouping=16, minblocks=4) , # 464.067 GFlop/s
-  Kernel_dnt_largeDB2(m=29, n=29, k=29, tile_m=3, tile_n=5, w=12, v=28, threads=96, grouping=16, minblocks=1) , # 491.026 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=32, k=32, tile_m=4, tile_n=4, w=8, v=26, threads=128, grouping=16, minblocks=1) , # 594.053 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=13, tile_m=2, tile_n=2, threads=96, grouping=16, minblocks=12) , # 204.17 GFlop/s
-  Kernel_dnt_medium(m=14, n=14, k=14, tile_m=4, tile_n=2, threads=96, grouping=16, minblocks=1) , # 239.224 GFlop/s
-  Kernel_dnt_medium(m=15, n=15, k=15, tile_m=4, tile_n=2, threads=96, grouping=16, minblocks=8) , # 275.724 GFlop/s
-  Kernel_dnt_small(m=11, n=11, k=11, tile_m=1, tile_n=1, threads=128, grouping=16, minblocks=1) , # 168.009 GFlop/s
-  Kernel_dnt_small(m=9, n=9, k=9, tile_m=1, tile_n=1, threads=96, grouping=16, minblocks=4) , # 117.001 GFlop/s
-  Kernel_dnt_tiny(m=5, n=5, k=5, threads=64, grouping=16, minblocks=1) , # 33.4544 GFlop/s
-  Kernel_dnt_tiny(m=6, n=6, k=6, threads=96, grouping=16, minblocks=1) , # 47.3645 GFlop/s
-  Kernel_dnt_tiny(m=7, n=7, k=7, threads=96, grouping=16, minblocks=1) , # 70.7194 GFlop/s
-  Kernel_dnt_tiny(m=8, n=8, k=8, threads=96, grouping=16, minblocks=1) , # 103.662 GFlop/s
+{"m": 10, "n": 10, "k": 10, "tile_m": 2, "tile_n": 1, "w": 4, "v": 10, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 115.19},
+{"m": 12, "n": 12, "k": 12, "tile_m": 3, "tile_n": 2, "w": 6, "v": 12, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 193.79},
+{"m": 16, "n": 16, "k": 16, "tile_m": 4, "tile_n": 2, "w": 8, "v": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 322.824},
+{"m": 17, "n": 17, "k": 17, "tile_m": 2, "tile_n": 3, "w": 6, "v": 14, "threads": 128, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 279.903},
+{"m": 22, "n": 22, "k": 22, "tile_m": 3, "tile_n": 3, "w": 8, "v": 22, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 405.672},
+{"m": 23, "n": 23, "k": 23, "tile_m": 3, "tile_n": 3, "w": 8, "v": 12, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 439.289},
+{"m": 24, "n": 24, "k": 24, "tile_m": 6, "tile_n": 3, "w": 12, "v": 24, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 506.39},
+{"m": 26, "n": 26, "k": 26, "tile_m": 3, "tile_n": 4, "w": 10, "v": 26, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 464.067},
+{"m": 29, "n": 29, "k": 29, "tile_m": 3, "tile_n": 5, "w": 12, "v": 28, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 491.026},
+{"m": 32, "n": 32, "k": 32, "tile_m": 4, "tile_n": 4, "w": 8, "v": 26, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 594.053},
+{"m": 13, "n": 13, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 204.17},
+{"m": 14, "n": 14, "k": 14, "tile_m": 4, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 239.224},
+{"m": 15, "n": 15, "k": 15, "tile_m": 4, "tile_n": 2, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 275.724},
+{"m": 11, "n": 11, "k": 11, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "small", "perf": 168.009},
+{"m": 9, "n": 9, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "small", "perf": 117.001},
+{"m": 5, "n": 5, "k": 5, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 33.4544},
+{"m": 6, "n": 6, "k": 6, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 47.3645},
+{"m": 7, "n": 7, "k": 7, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 70.7194},
+{"m": 8, "n": 8, "k": 8, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "tiny", "perf": 103.662}
 ]
-
-#EOF

--- a/src/acc/libsmm_acc/libcusmm/parameters_P100.txt
+++ b/src/acc/libsmm_acc/libcusmm/parameters_P100.txt
@@ -1,1675 +1,1668 @@
-# *****************************************************************************
-# * CP2K: A general program to perform molecular dynamics simulations         *
-# * Copyright (C) 2000 - 2018  CP2K developers group                          *
-# *****************************************************************************
-
 [
-  Kernel_dnt_medium(m=4, n=4, k=4, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=9) , # 146.542 GFlop/s
-  Kernel_dnt_medium(m=4, n=4, k=5, tile_m=1, tile_n=1, threads=32, grouping=18, minblocks=10) , # 177.041 GFlop/s
-  Kernel_dnt_medium(m=4, n=4, k=6, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=16) , # 206.475 GFlop/s
-  Kernel_dnt_medium(m=4, n=4, k=7, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=9) , # 219.254 GFlop/s
-  Kernel_dnt_tiny(m=4, n=4, k=8, threads=32, grouping=12, minblocks=28) , # 224.843 GFlop/s
-  Kernel_dnt_medium(m=4, n=4, k=9, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=2) , # 212.125 GFlop/s
-  Kernel_dnt_medium(m=4, n=4, k=10, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=23) , # 230.568 GFlop/s
-  Kernel_dnt_medium(m=4, n=4, k=13, tile_m=1, tile_n=1, threads=32, grouping=12, minblocks=26) , # 277.241 GFlop/s
-  Kernel_dnt_medium(m=4, n=4, k=15, tile_m=1, tile_n=1, threads=32, grouping=12, minblocks=18) , # 306.278 GFlop/s
-  Kernel_dnt_medium(m=4, n=4, k=25, tile_m=1, tile_n=1, threads=32, grouping=18, minblocks=17) , # 296.162 GFlop/s
-  Kernel_dnt_medium(m=4, n=4, k=26, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=18) , # 298.901 GFlop/s
-  Kernel_dnt_medium(m=4, n=4, k=28, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=11) , # 299.878 GFlop/s
-  Kernel_dnt_small(m=4, n=4, k=32, tile_m=1, tile_n=1, threads=32, grouping=3, minblocks=14) , # 303.953 GFlop/s
-  Kernel_dnt_medium(m=4, n=4, k=45, tile_m=1, tile_n=1, threads=64, grouping=3, minblocks=2) , # 294.358 GFlop/s
-  Kernel_dnt_medium(m=4, n=5, k=4, tile_m=1, tile_n=1, threads=32, grouping=18, minblocks=11) , # 177.692 GFlop/s
-  Kernel_dnt_medium(m=4, n=5, k=5, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=11) , # 217.191 GFlop/s
-  Kernel_dnt_medium(m=4, n=5, k=6, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=22) , # 236.563 GFlop/s
-  Kernel_dnt_medium(m=4, n=5, k=7, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=21) , # 211.342 GFlop/s
-  Kernel_dnt_medium(m=4, n=5, k=8, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=1) , # 221.036 GFlop/s
-  Kernel_dnt_medium(m=4, n=5, k=9, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=4) , # 229.753 GFlop/s
-  Kernel_dnt_medium(m=4, n=5, k=13, tile_m=1, tile_n=1, threads=32, grouping=13, minblocks=9) , # 289.348 GFlop/s
-  Kernel_dnt_medium(m=4, n=5, k=25, tile_m=1, tile_n=1, threads=32, grouping=3, minblocks=13) , # 321.429 GFlop/s
-  Kernel_dnt_medium(m=4, n=5, k=26, tile_m=1, tile_n=1, threads=32, grouping=3, minblocks=10) , # 314.511 GFlop/s
-  Kernel_dnt_medium(m=4, n=5, k=28, tile_m=1, tile_n=1, threads=32, grouping=4, minblocks=1) , # 320.416 GFlop/s
-  Kernel_dnt_medium(m=4, n=5, k=32, tile_m=1, tile_n=1, threads=64, grouping=3, minblocks=21) , # 329.232 GFlop/s
-  Kernel_dnt_medium(m=4, n=5, k=45, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=9) , # 321.273 GFlop/s
-  Kernel_dnt_medium(m=4, n=6, k=4, tile_m=1, tile_n=1, threads=32, grouping=18, minblocks=15) , # 212.803 GFlop/s
-  Kernel_dnt_medium(m=4, n=6, k=5, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=5) , # 249.115 GFlop/s
-  Kernel_dnt_medium(m=4, n=6, k=6, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=7) , # 220.182 GFlop/s
-  Kernel_dnt_medium(m=4, n=6, k=7, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=25) , # 249.712 GFlop/s
-  Kernel_dnt_medium(m=4, n=6, k=8, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=11) , # 261.366 GFlop/s
-  Kernel_dnt_medium(m=4, n=6, k=9, tile_m=1, tile_n=1, threads=32, grouping=13, minblocks=7) , # 270.512 GFlop/s
-  Kernel_dnt_medium(m=4, n=7, k=4, tile_m=1, tile_n=1, threads=32, grouping=18, minblocks=3) , # 247.865 GFlop/s
-  Kernel_dnt_medium(m=4, n=7, k=5, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=10) , # 221.348 GFlop/s
-  Kernel_dnt_medium(m=4, n=7, k=6, tile_m=1, tile_n=1, threads=32, grouping=15, minblocks=21) , # 253.675 GFlop/s
-  Kernel_dnt_medium(m=4, n=7, k=7, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=26) , # 283.879 GFlop/s
-  Kernel_dnt_medium(m=4, n=7, k=8, tile_m=1, tile_n=1, threads=32, grouping=13, minblocks=27) , # 296.012 GFlop/s
-  Kernel_dnt_medium(m=4, n=7, k=9, tile_m=1, tile_n=1, threads=32, grouping=13, minblocks=1) , # 308.449 GFlop/s
-  Kernel_dnt_medium(m=4, n=7, k=13, tile_m=1, tile_n=1, threads=32, grouping=11, minblocks=20) , # 367.159 GFlop/s
-  Kernel_dnt_medium(m=4, n=7, k=25, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=3) , # 359.977 GFlop/s
-  Kernel_dnt_medium(m=4, n=7, k=26, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=18) , # 366.138 GFlop/s
-  Kernel_dnt_medium(m=4, n=7, k=28, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=9) , # 366.881 GFlop/s
-  Kernel_dnt_medium(m=4, n=7, k=32, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=17) , # 372.257 GFlop/s
-  Kernel_dnt_medium(m=4, n=7, k=45, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=1) , # 364.346 GFlop/s
-  Kernel_dnt_medium(m=4, n=8, k=4, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=27) , # 238.702 GFlop/s
-  Kernel_dnt_medium(m=4, n=8, k=5, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=2) , # 250.59 GFlop/s
-  Kernel_dnt_medium(m=4, n=8, k=6, tile_m=1, tile_n=1, threads=32, grouping=15, minblocks=19) , # 289.589 GFlop/s
-  Kernel_dnt_medium(m=4, n=8, k=7, tile_m=1, tile_n=1, threads=32, grouping=13, minblocks=13) , # 321.553 GFlop/s
-  Kernel_dnt_medium(m=4, n=8, k=8, tile_m=1, tile_n=1, threads=32, grouping=11, minblocks=25) , # 316.767 GFlop/s
-  Kernel_dnt_medium(m=4, n=8, k=9, tile_m=1, tile_n=1, threads=32, grouping=13, minblocks=27) , # 338.79 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=4, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=2) , # 227.781 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=5, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=7) , # 266.956 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=6, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=7) , # 312.537 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=7, tile_m=2, tile_n=1, threads=32, grouping=12, minblocks=8) , # 337.427 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=8, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=19) , # 339.161 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=9, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=21) , # 345.165 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=13, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=5) , # 387.107 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=25, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=6) , # 386.259 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=26, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=17) , # 388.032 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=28, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=16) , # 393.694 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=32, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=8) , # 394.752 GFlop/s
-  Kernel_dnt_medium(m=4, n=9, k=45, tile_m=1, tile_n=1, threads=128, grouping=4, minblocks=4) , # 391.427 GFlop/s
-  Kernel_dnt_medium(m=4, n=10, k=4, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=2) , # 250.088 GFlop/s
-  Kernel_dnt_medium(m=4, n=10, k=10, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=11) , # 391.438 GFlop/s
-  Kernel_dnt_medium(m=4, n=10, k=15, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=12) , # 397.304 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=4, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=6) , # 311.366 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=5, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=10) , # 351.076 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=7, tile_m=1, tile_n=2, threads=32, grouping=12, minblocks=17) , # 428.77 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=9, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=19) , # 418.275 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=13, tile_m=1, tile_n=1, threads=64, grouping=6, minblocks=5) , # 420.747 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=25, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=13) , # 427.859 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=26, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=9) , # 434.909 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=28, tile_m=1, tile_n=1, threads=128, grouping=4, minblocks=2) , # 436.522 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=32, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=8) , # 438.394 GFlop/s
-  Kernel_dnt_medium(m=4, n=13, k=45, tile_m=1, tile_n=1, threads=128, grouping=4, minblocks=2) , # 436.72 GFlop/s
-  Kernel_dnt_medium(m=4, n=15, k=4, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=5) , # 354.445 GFlop/s
-  Kernel_dnt_medium(m=4, n=15, k=10, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=14) , # 431.464 GFlop/s
-  Kernel_dnt_medium(m=4, n=15, k=15, tile_m=1, tile_n=1, threads=64, grouping=26, minblocks=12) , # 442.867 GFlop/s
-  Kernel_dnt_medium(m=4, n=25, k=4, tile_m=5, tile_n=1, threads=32, grouping=13, minblocks=7) , # 445.525 GFlop/s
-  Kernel_dnt_medium(m=4, n=25, k=5, tile_m=6, tile_n=1, threads=32, grouping=13, minblocks=2) , # 455.615 GFlop/s
-  Kernel_dnt_medium(m=4, n=25, k=7, tile_m=4, tile_n=1, threads=32, grouping=16, minblocks=8) , # 454.983 GFlop/s
-  Kernel_dnt_medium(m=4, n=25, k=9, tile_m=2, tile_n=1, threads=64, grouping=24, minblocks=7) , # 458.769 GFlop/s
-  Kernel_dnt_medium(m=4, n=25, k=13, tile_m=2, tile_n=1, threads=64, grouping=4, minblocks=13) , # 471.674 GFlop/s
-  Kernel_dnt_medium(m=4, n=25, k=25, tile_m=2, tile_n=1, threads=128, grouping=3, minblocks=5) , # 481.216 GFlop/s
-  Kernel_dnt_medium(m=4, n=25, k=26, tile_m=2, tile_n=1, threads=128, grouping=4, minblocks=6) , # 484.075 GFlop/s
-  Kernel_dnt_medium(m=4, n=25, k=28, tile_m=1, tile_n=1, threads=128, grouping=3, minblocks=2) , # 486.834 GFlop/s
-  Kernel_dnt_medium(m=4, n=25, k=32, tile_m=1, tile_n=2, threads=128, grouping=3, minblocks=2) , # 492.058 GFlop/s
-  Kernel_dnt_medium(m=4, n=25, k=45, tile_m=1, tile_n=1, threads=192, grouping=3, minblocks=3) , # 490.296 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=4, tile_m=4, tile_n=1, threads=32, grouping=12, minblocks=2) , # 450.52 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=5, tile_m=4, tile_n=1, threads=32, grouping=13, minblocks=3) , # 452.479 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=7, tile_m=2, tile_n=2, threads=32, grouping=18, minblocks=4) , # 462.349 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=9, tile_m=2, tile_n=1, threads=64, grouping=26, minblocks=1) , # 458.638 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=13, tile_m=1, tile_n=2, threads=64, grouping=26, minblocks=7) , # 475.833 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=25, tile_m=1, tile_n=1, threads=128, grouping=3, minblocks=5) , # 485.815 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=26, tile_m=2, tile_n=1, threads=128, grouping=3, minblocks=6) , # 486.965 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=28, tile_m=1, tile_n=1, threads=128, grouping=3, minblocks=5) , # 488.784 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=32, tile_m=1, tile_n=1, threads=160, grouping=2, minblocks=3) , # 494.485 GFlop/s
-  Kernel_dnt_medium(m=4, n=26, k=45, tile_m=1, tile_n=1, threads=192, grouping=3, minblocks=1) , # 494.086 GFlop/s
-  Kernel_dnt_medium(m=4, n=28, k=4, tile_m=1, tile_n=5, threads=32, grouping=13, minblocks=6) , # 442.777 GFlop/s
-  Kernel_dnt_medium(m=4, n=28, k=5, tile_m=6, tile_n=1, threads=32, grouping=13, minblocks=23) , # 450.581 GFlop/s
-  Kernel_dnt_medium(m=4, n=28, k=7, tile_m=4, tile_n=1, threads=64, grouping=22, minblocks=8) , # 462.427 GFlop/s
-  Kernel_dnt_medium(m=4, n=28, k=9, tile_m=2, tile_n=1, threads=64, grouping=26, minblocks=17) , # 474.408 GFlop/s
-  Kernel_dnt_medium(m=4, n=28, k=13, tile_m=2, tile_n=1, threads=64, grouping=32, minblocks=7) , # 484.113 GFlop/s
-  Kernel_dnt_medium(m=4, n=28, k=25, tile_m=1, tile_n=1, threads=128, grouping=5, minblocks=7) , # 487.596 GFlop/s
-  Kernel_dnt_medium(m=4, n=28, k=26, tile_m=2, tile_n=1, threads=128, grouping=4, minblocks=3) , # 487.843 GFlop/s
-  Kernel_dnt_medium(m=4, n=28, k=28, tile_m=1, tile_n=1, threads=128, grouping=4, minblocks=5) , # 489.847 GFlop/s
-  Kernel_dnt_medium(m=4, n=28, k=32, tile_m=2, tile_n=1, threads=192, grouping=4, minblocks=3) , # 497.128 GFlop/s
-  Kernel_dnt_medium(m=4, n=28, k=45, tile_m=1, tile_n=1, threads=192, grouping=3, minblocks=2) , # 502.934 GFlop/s
-  Kernel_dnt_medium(m=4, n=32, k=4, tile_m=4, tile_n=1, threads=32, grouping=13, minblocks=2) , # 460.973 GFlop/s
-  Kernel_dnt_medium(m=4, n=32, k=5, tile_m=5, tile_n=1, threads=32, grouping=17, minblocks=5) , # 463.913 GFlop/s
-  Kernel_dnt_medium(m=4, n=32, k=7, tile_m=2, tile_n=1, threads=64, grouping=4, minblocks=21) , # 475.538 GFlop/s
-  Kernel_dnt_medium(m=4, n=32, k=9, tile_m=1, tile_n=2, threads=64, grouping=4, minblocks=8) , # 481.514 GFlop/s
-  Kernel_dnt_medium(m=4, n=32, k=13, tile_m=1, tile_n=2, threads=64, grouping=32, minblocks=5) , # 491.05 GFlop/s
-  Kernel_dnt_medium(m=4, n=32, k=25, tile_m=1, tile_n=1, threads=128, grouping=5, minblocks=6) , # 495.767 GFlop/s
-  Kernel_dnt_largeDB2(m=4, n=32, k=26, tile_m=1, tile_n=2, w=8, v=16, threads=64, grouping=16, minblocks=1) , # 500.984 GFlop/s
-  Kernel_dnt_medium(m=4, n=32, k=28, tile_m=1, tile_n=1, threads=256, grouping=5, minblocks=6) , # 501.158 GFlop/s
-  Kernel_dnt_medium(m=4, n=32, k=32, tile_m=1, tile_n=1, threads=256, grouping=4, minblocks=1) , # 508.453 GFlop/s
-  Kernel_dnt_medium(m=4, n=32, k=45, tile_m=1, tile_n=1, threads=192, grouping=3, minblocks=3) , # 513.575 GFlop/s
-  Kernel_dnt_medium(m=4, n=45, k=4, tile_m=1, tile_n=3, threads=64, grouping=19, minblocks=2) , # 451.602 GFlop/s
-  Kernel_dnt_medium(m=4, n=45, k=5, tile_m=1, tile_n=6, threads=64, grouping=26, minblocks=12) , # 455.413 GFlop/s
-  Kernel_dnt_medium(m=4, n=45, k=7, tile_m=4, tile_n=1, threads=64, grouping=26, minblocks=4) , # 473.951 GFlop/s
-  Kernel_dnt_medium(m=4, n=45, k=9, tile_m=1, tile_n=2, threads=96, grouping=29, minblocks=12) , # 476.94 GFlop/s
-  Kernel_dnt_medium(m=4, n=45, k=13, tile_m=2, tile_n=2, threads=64, grouping=26, minblocks=5) , # 489.857 GFlop/s
-  Kernel_dnt_medium(m=4, n=45, k=25, tile_m=2, tile_n=1, threads=128, grouping=3, minblocks=2) , # 508.404 GFlop/s
-  Kernel_dnt_medium(m=4, n=45, k=26, tile_m=1, tile_n=1, threads=192, grouping=4, minblocks=4) , # 512.756 GFlop/s
-  Kernel_dnt_medium(m=4, n=45, k=28, tile_m=2, tile_n=1, threads=128, grouping=3, minblocks=4) , # 516.097 GFlop/s
-  Kernel_dnt_medium(m=4, n=45, k=32, tile_m=1, tile_n=2, threads=192, grouping=3, minblocks=2) , # 523.467 GFlop/s
-  Kernel_dnt_medium(m=4, n=45, k=45, tile_m=1, tile_n=1, threads=256, grouping=3, minblocks=1) , # 529.993 GFlop/s
-  Kernel_dnt_medium(m=5, n=4, k=4, tile_m=1, tile_n=1, threads=32, grouping=18, minblocks=15) , # 177.029 GFlop/s
-  Kernel_dnt_medium(m=5, n=4, k=5, tile_m=1, tile_n=1, threads=32, grouping=18, minblocks=3) , # 214.145 GFlop/s
-  Kernel_dnt_medium(m=5, n=4, k=6, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=1) , # 233.353 GFlop/s
-  Kernel_dnt_medium(m=5, n=4, k=7, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=24) , # 211.838 GFlop/s
-  Kernel_dnt_medium(m=5, n=4, k=8, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=4) , # 220.845 GFlop/s
-  Kernel_dnt_medium(m=5, n=4, k=9, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=14) , # 228.292 GFlop/s
-  Kernel_dnt_medium(m=5, n=4, k=13, tile_m=1, tile_n=1, threads=32, grouping=13, minblocks=20) , # 276.437 GFlop/s
-  Kernel_dnt_medium(m=5, n=4, k=25, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=8) , # 312.504 GFlop/s
-  Kernel_dnt_medium(m=5, n=4, k=26, tile_m=1, tile_n=1, threads=32, grouping=9, minblocks=17) , # 310.699 GFlop/s
-  Kernel_dnt_medium(m=5, n=4, k=28, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=23) , # 314.448 GFlop/s
-  Kernel_dnt_medium(m=5, n=4, k=32, tile_m=1, tile_n=1, threads=64, grouping=3, minblocks=21) , # 327.177 GFlop/s
-  Kernel_dnt_medium(m=5, n=4, k=45, tile_m=1, tile_n=1, threads=64, grouping=3, minblocks=5) , # 314.251 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=4, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=1) , # 225.089 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=5, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=15) , # 260.59 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=6, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=10) , # 285.889 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=7, tile_m=1, tile_n=1, threads=32, grouping=13, minblocks=17) , # 262.967 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=8, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=14) , # 288.785 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=9, tile_m=1, tile_n=1, threads=32, grouping=13, minblocks=17) , # 311.74 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=12, tile_m=1, tile_n=1, threads=32, grouping=12, minblocks=3) , # 375.736 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=13, tile_m=1, tile_n=1, threads=32, grouping=13, minblocks=17) , # 363.798 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=16, tile_m=1, tile_n=1, threads=32, grouping=13, minblocks=13) , # 384.724 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=24, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=22) , # 372.44 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=25, tile_m=1, tile_n=1, threads=64, grouping=3, minblocks=23) , # 364.992 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=26, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=4) , # 358.249 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=28, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=12) , # 359.923 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=32, tile_m=1, tile_n=1, threads=32, grouping=2, minblocks=17) , # 370.681 GFlop/s
-  Kernel_dnt_medium(m=5, n=5, k=45, tile_m=1, tile_n=1, threads=64, grouping=3, minblocks=12) , # 356.319 GFlop/s
-  Kernel_dnt_medium(m=5, n=6, k=4, tile_m=1, tile_n=1, threads=32, grouping=18, minblocks=23) , # 264.288 GFlop/s
-  Kernel_dnt_medium(m=5, n=6, k=5, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=6) , # 293.115 GFlop/s
-  Kernel_dnt_medium(m=5, n=6, k=6, tile_m=1, tile_n=1, threads=32, grouping=15, minblocks=7) , # 274.264 GFlop/s
-  Kernel_dnt_medium(m=5, n=6, k=7, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=20) , # 273.457 GFlop/s
-  Kernel_dnt_medium(m=5, n=6, k=8, tile_m=1, tile_n=1, threads=32, grouping=13, minblocks=7) , # 305.918 GFlop/s
-  Kernel_dnt_medium(m=5, n=6, k=9, tile_m=1, tile_n=1, threads=32, grouping=13, minblocks=16) , # 328.197 GFlop/s
-  Kernel_dnt_medium(m=5, n=7, k=4, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=20) , # 262.885 GFlop/s
-  Kernel_dnt_medium(m=5, n=7, k=5, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=2) , # 256.737 GFlop/s
-  Kernel_dnt_medium(m=5, n=7, k=6, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=20) , # 291.538 GFlop/s
-  Kernel_dnt_medium(m=5, n=7, k=7, tile_m=1, tile_n=2, threads=32, grouping=16, minblocks=10) , # 295.189 GFlop/s
-  Kernel_dnt_medium(m=5, n=7, k=8, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=25) , # 327.718 GFlop/s
-  Kernel_dnt_medium(m=5, n=7, k=9, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=16) , # 349.89 GFlop/s
-  Kernel_dnt_medium(m=5, n=7, k=13, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=18) , # 396.99 GFlop/s
-  Kernel_dnt_medium(m=5, n=7, k=25, tile_m=1, tile_n=1, threads=64, grouping=26, minblocks=10) , # 395.03 GFlop/s
-  Kernel_dnt_medium(m=5, n=7, k=26, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=3) , # 400.328 GFlop/s
-  Kernel_dnt_medium(m=5, n=7, k=28, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=4) , # 400.111 GFlop/s
-  Kernel_dnt_medium(m=5, n=7, k=32, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=4) , # 408.48 GFlop/s
-  Kernel_dnt_medium(m=5, n=7, k=45, tile_m=1, tile_n=1, threads=96, grouping=3, minblocks=7) , # 402.851 GFlop/s
-  Kernel_dnt_medium(m=5, n=8, k=4, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=9) , # 260.853 GFlop/s
-  Kernel_dnt_medium(m=5, n=8, k=5, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=20) , # 290.836 GFlop/s
-  Kernel_dnt_medium(m=5, n=8, k=6, tile_m=1, tile_n=2, threads=32, grouping=16, minblocks=3) , # 332.611 GFlop/s
-  Kernel_dnt_medium(m=5, n=8, k=7, tile_m=1, tile_n=2, threads=32, grouping=16, minblocks=14) , # 332.852 GFlop/s
-  Kernel_dnt_medium(m=5, n=8, k=8, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=14) , # 364.813 GFlop/s
-  Kernel_dnt_medium(m=5, n=8, k=9, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=14) , # 383.158 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=4, tile_m=1, tile_n=2, threads=32, grouping=16, minblocks=16) , # 273.232 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=5, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=7) , # 321.78 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=6, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=5) , # 370.575 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=7, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=21) , # 372.988 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=8, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=2) , # 397.604 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=9, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=24) , # 420.547 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=13, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=26) , # 428.436 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=25, tile_m=1, tile_n=1, threads=64, grouping=26, minblocks=7) , # 437.524 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=26, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=12) , # 442.884 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=28, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=11) , # 446.122 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=32, tile_m=1, tile_n=1, threads=96, grouping=4, minblocks=2) , # 451.393 GFlop/s
-  Kernel_dnt_medium(m=5, n=9, k=45, tile_m=1, tile_n=1, threads=128, grouping=4, minblocks=4) , # 448.595 GFlop/s
-  Kernel_dnt_medium(m=5, n=12, k=5, tile_m=1, tile_n=2, threads=32, grouping=12, minblocks=12) , # 403.762 GFlop/s
-  Kernel_dnt_medium(m=5, n=12, k=12, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=2) , # 482.763 GFlop/s
-  Kernel_dnt_medium(m=5, n=12, k=13, tile_m=1, tile_n=2, threads=32, grouping=4, minblocks=9) , # 472.41 GFlop/s
-  Kernel_dnt_medium(m=5, n=12, k=26, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=5) , # 493.318 GFlop/s
-  Kernel_dnt_medium(m=5, n=12, k=32, tile_m=1, tile_n=1, threads=96, grouping=3, minblocks=2) , # 499.203 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=4, tile_m=3, tile_n=1, threads=32, grouping=13, minblocks=14) , # 371.523 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=5, tile_m=3, tile_n=1, threads=32, grouping=12, minblocks=3) , # 420.528 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=7, tile_m=3, tile_n=1, threads=32, grouping=13, minblocks=15) , # 463.048 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=9, tile_m=3, tile_n=1, threads=32, grouping=16, minblocks=15) , # 476.293 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=12, tile_m=1, tile_n=3, threads=64, grouping=22, minblocks=17) , # 487.729 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=13, tile_m=1, tile_n=3, threads=32, grouping=5, minblocks=1) , # 469.163 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=16, tile_m=1, tile_n=3, threads=96, grouping=29, minblocks=8) , # 486.36 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=24, tile_m=3, tile_n=1, threads=64, grouping=3, minblocks=4) , # 491.279 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=25, tile_m=1, tile_n=1, threads=128, grouping=5, minblocks=12) , # 485.413 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=26, tile_m=3, tile_n=1, threads=64, grouping=4, minblocks=5) , # 487.003 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=28, tile_m=1, tile_n=1, threads=96, grouping=4, minblocks=8) , # 491.337 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=32, tile_m=1, tile_n=1, threads=128, grouping=5, minblocks=2) , # 504.563 GFlop/s
-  Kernel_dnt_medium(m=5, n=13, k=45, tile_m=1, tile_n=1, threads=128, grouping=3, minblocks=3) , # 499.154 GFlop/s
-  Kernel_dnt_medium(m=5, n=16, k=5, tile_m=3, tile_n=1, threads=32, grouping=11, minblocks=16) , # 500.621 GFlop/s
-  Kernel_dnt_medium(m=5, n=16, k=13, tile_m=1, tile_n=3, threads=64, grouping=4, minblocks=20) , # 504.808 GFlop/s
-  Kernel_dnt_medium(m=5, n=16, k=16, tile_m=1, tile_n=1, threads=96, grouping=6, minblocks=14) , # 518.964 GFlop/s
-  Kernel_dnt_medium(m=5, n=16, k=32, tile_m=1, tile_n=1, threads=128, grouping=4, minblocks=1) , # 532.529 GFlop/s
-  Kernel_dnt_medium(m=5, n=24, k=5, tile_m=1, tile_n=4, threads=32, grouping=13, minblocks=19) , # 529.873 GFlop/s
-  Kernel_dnt_medium(m=5, n=24, k=13, tile_m=1, tile_n=2, threads=96, grouping=32, minblocks=12) , # 547.828 GFlop/s
-  Kernel_dnt_largeDB2(m=5, n=24, k=24, tile_m=1, tile_n=2, w=8, v=24, threads=64, grouping=16, minblocks=4) , # 573.313 GFlop/s
-  Kernel_dnt_medium(m=5, n=24, k=26, tile_m=1, tile_n=2, threads=160, grouping=3, minblocks=8) , # 570.406 GFlop/s
-  Kernel_dnt_medium(m=5, n=24, k=32, tile_m=1, tile_n=1, threads=192, grouping=2, minblocks=5) , # 579.512 GFlop/s
-  Kernel_dnt_medium(m=5, n=25, k=4, tile_m=5, tile_n=1, threads=32, grouping=13, minblocks=1) , # 498.541 GFlop/s
-  Kernel_dnt_medium(m=5, n=25, k=5, tile_m=6, tile_n=1, threads=32, grouping=15, minblocks=8) , # 512.665 GFlop/s
-  Kernel_dnt_medium(m=5, n=25, k=7, tile_m=4, tile_n=1, threads=64, grouping=22, minblocks=3) , # 511.578 GFlop/s
-  Kernel_dnt_medium(m=5, n=25, k=9, tile_m=3, tile_n=1, threads=64, grouping=26, minblocks=10) , # 542.861 GFlop/s
-  Kernel_dnt_medium(m=5, n=25, k=13, tile_m=1, tile_n=1, threads=128, grouping=6, minblocks=12) , # 540.652 GFlop/s
-  Kernel_dnt_medium(m=5, n=25, k=25, tile_m=1, tile_n=1, threads=128, grouping=3, minblocks=5) , # 567.148 GFlop/s
-  Kernel_dnt_medium(m=5, n=25, k=26, tile_m=1, tile_n=1, threads=160, grouping=5, minblocks=1) , # 571.256 GFlop/s
-  Kernel_dnt_medium(m=5, n=25, k=28, tile_m=1, tile_n=1, threads=192, grouping=4, minblocks=7) , # 571.421 GFlop/s
-  Kernel_dnt_medium(m=5, n=25, k=32, tile_m=1, tile_n=1, threads=224, grouping=3, minblocks=6) , # 584.779 GFlop/s
-  Kernel_dnt_medium(m=5, n=25, k=45, tile_m=1, tile_n=1, threads=256, grouping=3, minblocks=2) , # 583.507 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=4, tile_m=5, tile_n=1, threads=32, grouping=13, minblocks=11) , # 507.889 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=5, tile_m=5, tile_n=1, threads=32, grouping=16, minblocks=1) , # 520.031 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=7, tile_m=3, tile_n=1, threads=64, grouping=22, minblocks=15) , # 521.285 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=9, tile_m=3, tile_n=1, threads=64, grouping=26, minblocks=9) , # 549.571 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=12, tile_m=3, tile_n=1, threads=64, grouping=32, minblocks=2) , # 554.52 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=13, tile_m=1, tile_n=3, threads=96, grouping=32, minblocks=12) , # 549.535 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=24, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=6) , # 571.163 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=25, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=7) , # 568.459 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=26, tile_m=1, tile_n=2, threads=160, grouping=4, minblocks=2) , # 572.317 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=28, tile_m=1, tile_n=2, threads=160, grouping=5, minblocks=7) , # 573.92 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=32, tile_m=1, tile_n=2, threads=224, grouping=3, minblocks=6) , # 584.452 GFlop/s
-  Kernel_dnt_medium(m=5, n=26, k=45, tile_m=1, tile_n=1, threads=256, grouping=3, minblocks=4) , # 587.258 GFlop/s
-  Kernel_dnt_medium(m=5, n=28, k=4, tile_m=1, tile_n=5, threads=32, grouping=16, minblocks=21) , # 507.593 GFlop/s
-  Kernel_dnt_medium(m=5, n=28, k=5, tile_m=5, tile_n=1, threads=32, grouping=19, minblocks=10) , # 526.317 GFlop/s
-  Kernel_dnt_medium(m=5, n=28, k=7, tile_m=3, tile_n=1, threads=64, grouping=26, minblocks=13) , # 538.63 GFlop/s
-  Kernel_dnt_medium(m=5, n=28, k=9, tile_m=3, tile_n=1, threads=64, grouping=26, minblocks=2) , # 561.006 GFlop/s
-  Kernel_dnt_medium(m=5, n=28, k=13, tile_m=1, tile_n=3, threads=96, grouping=32, minblocks=11) , # 561.153 GFlop/s
-  Kernel_dnt_medium(m=5, n=28, k=25, tile_m=3, tile_n=1, threads=128, grouping=4, minblocks=6) , # 577.262 GFlop/s
-  Kernel_dnt_medium(m=5, n=28, k=26, tile_m=1, tile_n=1, threads=160, grouping=4, minblocks=5) , # 578.939 GFlop/s
-  Kernel_dnt_medium(m=5, n=28, k=28, tile_m=2, tile_n=1, threads=160, grouping=4, minblocks=5) , # 581.324 GFlop/s
-  Kernel_dnt_medium(m=5, n=28, k=32, tile_m=3, tile_n=1, threads=128, grouping=3, minblocks=2) , # 589.399 GFlop/s
-  Kernel_dnt_medium(m=5, n=28, k=45, tile_m=1, tile_n=1, threads=256, grouping=3, minblocks=3) , # 595.274 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=4, tile_m=6, tile_n=1, threads=32, grouping=16, minblocks=20) , # 523.602 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=5, tile_m=6, tile_n=1, threads=32, grouping=16, minblocks=15) , # 535.714 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=7, tile_m=3, tile_n=1, threads=64, grouping=26, minblocks=4) , # 554.629 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=9, tile_m=3, tile_n=1, threads=64, grouping=30, minblocks=1) , # 565.992 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=12, tile_m=2, tile_n=1, threads=96, grouping=32, minblocks=10) , # 574.485 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=13, tile_m=1, tile_n=3, threads=96, grouping=32, minblocks=10) , # 572.183 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=16, tile_m=2, tile_n=1, threads=128, grouping=5, minblocks=4) , # 583.958 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=24, tile_m=2, tile_n=1, threads=160, grouping=4, minblocks=4) , # 593.51 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=25, tile_m=3, tile_n=1, threads=128, grouping=5, minblocks=1) , # 593.335 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=26, tile_m=1, tile_n=1, threads=256, grouping=4, minblocks=6) , # 593.116 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=28, tile_m=3, tile_n=1, threads=128, grouping=4, minblocks=3) , # 596.857 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=32, tile_m=1, tile_n=1, threads=256, grouping=4, minblocks=5) , # 610.053 GFlop/s
-  Kernel_dnt_medium(m=5, n=32, k=45, tile_m=1, tile_n=1, threads=256, grouping=3, minblocks=2) , # 612.697 GFlop/s
-  Kernel_dnt_medium(m=5, n=45, k=4, tile_m=5, tile_n=1, threads=64, grouping=22, minblocks=15) , # 510.03 GFlop/s
-  Kernel_dnt_medium(m=5, n=45, k=5, tile_m=1, tile_n=4, threads=64, grouping=26, minblocks=15) , # 528.041 GFlop/s
-  Kernel_dnt_medium(m=5, n=45, k=7, tile_m=1, tile_n=4, threads=64, grouping=26, minblocks=4) , # 553.915 GFlop/s
-  Kernel_dnt_medium(m=5, n=45, k=9, tile_m=3, tile_n=1, threads=96, grouping=29, minblocks=3) , # 564.82 GFlop/s
-  Kernel_dnt_medium(m=5, n=45, k=13, tile_m=1, tile_n=2, threads=128, grouping=5, minblocks=8) , # 579.618 GFlop/s
-  Kernel_dnt_medium(m=5, n=45, k=25, tile_m=3, tile_n=1, threads=128, grouping=4, minblocks=2) , # 612.003 GFlop/s
-  Kernel_dnt_medium(m=5, n=45, k=26, tile_m=1, tile_n=2, threads=192, grouping=3, minblocks=4) , # 612.137 GFlop/s
-  Kernel_dnt_medium(m=5, n=45, k=28, tile_m=3, tile_n=1, threads=160, grouping=3, minblocks=1) , # 623.505 GFlop/s
-  Kernel_dnt_medium(m=5, n=45, k=32, tile_m=3, tile_n=1, threads=192, grouping=4, minblocks=2) , # 630.854 GFlop/s
-  Kernel_dnt_medium(m=5, n=45, k=45, tile_m=1, tile_n=1, threads=256, grouping=3, minblocks=1) , # 635.739 GFlop/s
-  Kernel_dnt_medium(m=6, n=4, k=4, tile_m=1, tile_n=1, threads=32, grouping=18, minblocks=3) , # 212.84 GFlop/s
-  Kernel_dnt_medium(m=6, n=4, k=5, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=25) , # 250.003 GFlop/s
-  Kernel_dnt_medium(m=6, n=4, k=6, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=24) , # 227.238 GFlop/s
-  Kernel_dnt_medium(m=6, n=4, k=7, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=5) , # 253.726 GFlop/s
-  Kernel_dnt_medium(m=6, n=4, k=8, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=13) , # 260.467 GFlop/s
-  Kernel_dnt_medium(m=6, n=4, k=9, tile_m=1, tile_n=1, threads=32, grouping=13, minblocks=12) , # 268.788 GFlop/s
-  Kernel_dnt_medium(m=6, n=5, k=4, tile_m=1, tile_n=1, threads=32, grouping=18, minblocks=25) , # 265.113 GFlop/s
-  Kernel_dnt_medium(m=6, n=5, k=5, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=4) , # 292.379 GFlop/s
-  Kernel_dnt_medium(m=6, n=5, k=6, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=20) , # 278.719 GFlop/s
-  Kernel_dnt_medium(m=6, n=5, k=7, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=13) , # 273.867 GFlop/s
-  Kernel_dnt_medium(m=6, n=5, k=8, tile_m=1, tile_n=1, threads=32, grouping=13, minblocks=13) , # 306.256 GFlop/s
-  Kernel_dnt_medium(m=6, n=5, k=9, tile_m=1, tile_n=1, threads=32, grouping=12, minblocks=2) , # 330.458 GFlop/s
-  Kernel_dnt_medium(m=6, n=6, k=4, tile_m=1, tile_n=2, threads=32, grouping=16, minblocks=20) , # 279.038 GFlop/s
-  Kernel_dnt_medium(m=6, n=6, k=5, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=13) , # 324.604 GFlop/s
-  Kernel_dnt_medium(m=6, n=6, k=6, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=26) , # 309.661 GFlop/s
-  Kernel_dnt_medium(m=6, n=6, k=7, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=11) , # 347.979 GFlop/s
-  Kernel_dnt_medium(m=6, n=6, k=8, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=4) , # 388.615 GFlop/s
-  Kernel_dnt_medium(m=6, n=6, k=9, tile_m=1, tile_n=2, threads=32, grouping=11, minblocks=15) , # 414.229 GFlop/s
-  Kernel_dnt_medium(m=6, n=7, k=4, tile_m=1, tile_n=2, threads=32, grouping=16, minblocks=22) , # 310.207 GFlop/s
-  Kernel_dnt_medium(m=6, n=7, k=5, tile_m=1, tile_n=2, threads=32, grouping=16, minblocks=2) , # 307.915 GFlop/s
-  Kernel_dnt_medium(m=6, n=7, k=6, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=27) , # 311.923 GFlop/s
-  Kernel_dnt_medium(m=6, n=7, k=7, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=18) , # 348.666 GFlop/s
-  Kernel_dnt_medium(m=6, n=7, k=8, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=3) , # 391.768 GFlop/s
-  Kernel_dnt_medium(m=6, n=7, k=9, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=16) , # 421.422 GFlop/s
-  Kernel_dnt_medium(m=6, n=8, k=4, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=13) , # 306.933 GFlop/s
-  Kernel_dnt_medium(m=6, n=8, k=5, tile_m=1, tile_n=2, threads=32, grouping=16, minblocks=27) , # 346.794 GFlop/s
-  Kernel_dnt_medium(m=6, n=8, k=6, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=2) , # 356.722 GFlop/s
-  Kernel_dnt_medium(m=6, n=8, k=7, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=1) , # 397.923 GFlop/s
-  Kernel_dnt_medium(m=6, n=8, k=8, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=2) , # 434.94 GFlop/s
-  Kernel_dnt_medium(m=6, n=8, k=9, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=19) , # 449.288 GFlop/s
-  Kernel_dnt_medium(m=6, n=9, k=4, tile_m=1, tile_n=2, threads=32, grouping=16, minblocks=26) , # 326.343 GFlop/s
-  Kernel_dnt_medium(m=6, n=9, k=5, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=17) , # 387.121 GFlop/s
-  Kernel_dnt_medium(m=6, n=9, k=6, tile_m=1, tile_n=2, threads=32, grouping=12, minblocks=13) , # 390.83 GFlop/s
-  Kernel_dnt_medium(m=6, n=9, k=7, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=4) , # 440.029 GFlop/s
-  Kernel_dnt_medium(m=6, n=9, k=8, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=27) , # 468.53 GFlop/s
-  Kernel_dnt_medium(m=6, n=9, k=9, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=13) , # 476.022 GFlop/s
-  Kernel_dnt_medium(m=7, n=4, k=4, tile_m=1, tile_n=1, threads=32, grouping=18, minblocks=9) , # 247.91 GFlop/s
-  Kernel_dnt_medium(m=7, n=4, k=5, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=11) , # 222.094 GFlop/s
-  Kernel_dnt_medium(m=7, n=4, k=6, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=3) , # 256.908 GFlop/s
-  Kernel_dnt_medium(m=7, n=4, k=7, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=20) , # 286.148 GFlop/s
-  Kernel_dnt_medium(m=7, n=4, k=8, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=15) , # 296.218 GFlop/s
-  Kernel_dnt_medium(m=7, n=4, k=9, tile_m=1, tile_n=1, threads=32, grouping=13, minblocks=8) , # 306.346 GFlop/s
-  Kernel_dnt_medium(m=7, n=4, k=13, tile_m=1, tile_n=1, threads=32, grouping=12, minblocks=25) , # 361.319 GFlop/s
-  Kernel_dnt_medium(m=7, n=4, k=25, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=21) , # 356.58 GFlop/s
-  Kernel_dnt_medium(m=7, n=4, k=26, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=21) , # 362.674 GFlop/s
-  Kernel_dnt_medium(m=7, n=4, k=28, tile_m=1, tile_n=1, threads=64, grouping=6, minblocks=5) , # 363.829 GFlop/s
-  Kernel_dnt_medium(m=7, n=4, k=32, tile_m=1, tile_n=1, threads=64, grouping=3, minblocks=8) , # 371.107 GFlop/s
-  Kernel_dnt_medium(m=7, n=4, k=45, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=9) , # 363.482 GFlop/s
-  Kernel_dnt_medium(m=7, n=5, k=4, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=19) , # 270.919 GFlop/s
-  Kernel_dnt_medium(m=7, n=5, k=5, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=27) , # 263.9 GFlop/s
-  Kernel_dnt_medium(m=7, n=5, k=6, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=23) , # 304.548 GFlop/s
-  Kernel_dnt_medium(m=7, n=5, k=7, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=20) , # 302.41 GFlop/s
-  Kernel_dnt_medium(m=7, n=5, k=8, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=14) , # 332.161 GFlop/s
-  Kernel_dnt_medium(m=7, n=5, k=9, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=25) , # 349.89 GFlop/s
-  Kernel_dnt_medium(m=7, n=5, k=13, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=21) , # 397.427 GFlop/s
-  Kernel_dnt_medium(m=7, n=5, k=25, tile_m=2, tile_n=1, threads=64, grouping=4, minblocks=20) , # 400.125 GFlop/s
-  Kernel_dnt_medium(m=7, n=5, k=26, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=12) , # 397.999 GFlop/s
-  Kernel_dnt_medium(m=7, n=5, k=28, tile_m=2, tile_n=1, threads=64, grouping=4, minblocks=7) , # 402.797 GFlop/s
-  Kernel_dnt_medium(m=7, n=5, k=32, tile_m=1, tile_n=1, threads=64, grouping=3, minblocks=11) , # 409.525 GFlop/s
-  Kernel_dnt_medium(m=7, n=5, k=45, tile_m=1, tile_n=1, threads=96, grouping=3, minblocks=5) , # 401.97 GFlop/s
-  Kernel_dnt_medium(m=7, n=6, k=4, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=24) , # 313.286 GFlop/s
-  Kernel_dnt_medium(m=7, n=6, k=5, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=19) , # 312.621 GFlop/s
-  Kernel_dnt_medium(m=7, n=6, k=6, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=3) , # 321.111 GFlop/s
-  Kernel_dnt_medium(m=7, n=6, k=7, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=12) , # 350.795 GFlop/s
-  Kernel_dnt_medium(m=7, n=6, k=8, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=13) , # 385.441 GFlop/s
-  Kernel_dnt_medium(m=7, n=6, k=9, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=15) , # 418.272 GFlop/s
-  Kernel_dnt_medium(m=7, n=7, k=4, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=1) , # 364.566 GFlop/s
-  Kernel_dnt_medium(m=7, n=7, k=5, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=11) , # 358.669 GFlop/s
-  Kernel_dnt_medium(m=7, n=7, k=6, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=3) , # 406.525 GFlop/s
-  Kernel_dnt_medium(m=7, n=7, k=7, tile_m=2, tile_n=1, threads=32, grouping=11, minblocks=27) , # 449.927 GFlop/s
-  Kernel_dnt_medium(m=7, n=7, k=8, tile_m=2, tile_n=1, threads=32, grouping=11, minblocks=12) , # 495.144 GFlop/s
-  Kernel_dnt_medium(m=7, n=7, k=9, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=5) , # 495.72 GFlop/s
-  Kernel_dnt_medium(m=7, n=7, k=13, tile_m=2, tile_n=1, threads=32, grouping=18, minblocks=27) , # 488.334 GFlop/s
-  Kernel_dnt_medium(m=7, n=7, k=25, tile_m=2, tile_n=1, threads=64, grouping=4, minblocks=10) , # 489.312 GFlop/s
-  Kernel_dnt_medium(m=7, n=7, k=26, tile_m=2, tile_n=1, threads=64, grouping=4, minblocks=1) , # 490.132 GFlop/s
-  Kernel_dnt_medium(m=7, n=7, k=28, tile_m=2, tile_n=1, threads=64, grouping=4, minblocks=9) , # 490.192 GFlop/s
-  Kernel_dnt_medium(m=7, n=7, k=32, tile_m=1, tile_n=1, threads=128, grouping=4, minblocks=11) , # 499.565 GFlop/s
-  Kernel_dnt_medium(m=7, n=7, k=45, tile_m=1, tile_n=1, threads=160, grouping=3, minblocks=7) , # 491.99 GFlop/s
-  Kernel_dnt_medium(m=7, n=8, k=4, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=12) , # 354.633 GFlop/s
-  Kernel_dnt_medium(m=7, n=8, k=5, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=9) , # 359.16 GFlop/s
-  Kernel_dnt_medium(m=7, n=8, k=6, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=19) , # 411.24 GFlop/s
-  Kernel_dnt_medium(m=7, n=8, k=7, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=18) , # 455.7 GFlop/s
-  Kernel_dnt_medium(m=7, n=8, k=8, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=23) , # 500.053 GFlop/s
-  Kernel_dnt_medium(m=7, n=8, k=9, tile_m=1, tile_n=2, threads=32, grouping=11, minblocks=3) , # 501.545 GFlop/s
-  Kernel_dnt_medium(m=7, n=9, k=4, tile_m=3, tile_n=1, threads=32, grouping=16, minblocks=25) , # 357.248 GFlop/s
-  Kernel_dnt_medium(m=7, n=9, k=5, tile_m=3, tile_n=1, threads=32, grouping=16, minblocks=5) , # 380.106 GFlop/s
-  Kernel_dnt_medium(m=7, n=9, k=6, tile_m=1, tile_n=3, threads=32, grouping=13, minblocks=1) , # 421.294 GFlop/s
-  Kernel_dnt_medium(m=7, n=9, k=7, tile_m=3, tile_n=1, threads=32, grouping=13, minblocks=26) , # 474.232 GFlop/s
-  Kernel_dnt_medium(m=7, n=9, k=8, tile_m=3, tile_n=1, threads=32, grouping=13, minblocks=25) , # 498.036 GFlop/s
-  Kernel_dnt_medium(m=7, n=9, k=9, tile_m=1, tile_n=3, threads=32, grouping=13, minblocks=19) , # 512.04 GFlop/s
-  Kernel_dnt_medium(m=7, n=9, k=13, tile_m=1, tile_n=1, threads=64, grouping=5, minblocks=22) , # 509.15 GFlop/s
-  Kernel_dnt_medium(m=7, n=9, k=25, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=9) , # 538.393 GFlop/s
-  Kernel_dnt_medium(m=7, n=9, k=26, tile_m=1, tile_n=1, threads=64, grouping=32, minblocks=2) , # 539.44 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=9, k=28, tile_m=1, tile_n=1, w=14, v=8, threads=64, grouping=16, minblocks=8) , # 544.807 GFlop/s
-  Kernel_dnt_medium(m=7, n=9, k=32, tile_m=1, tile_n=1, threads=64, grouping=3, minblocks=10) , # 550.841 GFlop/s
-  Kernel_dnt_medium(m=7, n=9, k=45, tile_m=1, tile_n=1, threads=128, grouping=3, minblocks=8) , # 548.66 GFlop/s
-  Kernel_dnt_medium(m=7, n=13, k=4, tile_m=4, tile_n=1, threads=32, grouping=15, minblocks=24) , # 473.871 GFlop/s
-  Kernel_dnt_medium(m=7, n=13, k=5, tile_m=2, tile_n=2, threads=32, grouping=13, minblocks=20) , # 484.652 GFlop/s
-  Kernel_dnt_medium(m=7, n=13, k=7, tile_m=4, tile_n=1, threads=32, grouping=14, minblocks=22) , # 568.233 GFlop/s
-  Kernel_dnt_medium(m=7, n=13, k=9, tile_m=2, tile_n=2, threads=32, grouping=12, minblocks=25) , # 575.698 GFlop/s
-  Kernel_dnt_medium(m=7, n=13, k=13, tile_m=2, tile_n=1, threads=64, grouping=26, minblocks=17) , # 576.55 GFlop/s
-  Kernel_dnt_medium(m=7, n=13, k=25, tile_m=2, tile_n=1, threads=64, grouping=6, minblocks=2) , # 602.965 GFlop/s
-  Kernel_dnt_medium(m=7, n=13, k=26, tile_m=2, tile_n=1, threads=96, grouping=5, minblocks=1) , # 607.199 GFlop/s
-  Kernel_dnt_medium(m=7, n=13, k=28, tile_m=2, tile_n=1, threads=96, grouping=4, minblocks=8) , # 615.391 GFlop/s
-  Kernel_dnt_medium(m=7, n=13, k=32, tile_m=1, tile_n=1, threads=96, grouping=4, minblocks=2) , # 622.982 GFlop/s
-  Kernel_dnt_medium(m=7, n=13, k=45, tile_m=1, tile_n=1, threads=128, grouping=3, minblocks=2) , # 626.534 GFlop/s
-  Kernel_dnt_medium(m=7, n=25, k=4, tile_m=4, tile_n=2, threads=32, grouping=16, minblocks=10) , # 580.16 GFlop/s
-  Kernel_dnt_medium(m=7, n=25, k=5, tile_m=4, tile_n=1, threads=64, grouping=22, minblocks=18) , # 597.952 GFlop/s
-  Kernel_dnt_medium(m=7, n=25, k=7, tile_m=4, tile_n=1, threads=64, grouping=22, minblocks=12) , # 658.065 GFlop/s
-  Kernel_dnt_medium(m=7, n=25, k=9, tile_m=1, tile_n=3, threads=64, grouping=22, minblocks=2) , # 683.511 GFlop/s
-  Kernel_dnt_medium(m=7, n=25, k=13, tile_m=1, tile_n=3, threads=96, grouping=29, minblocks=11) , # 697.002 GFlop/s
-  Kernel_dnt_medium(m=7, n=25, k=25, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=3) , # 721.815 GFlop/s
-  Kernel_dnt_medium(m=7, n=25, k=26, tile_m=1, tile_n=2, threads=192, grouping=5, minblocks=3) , # 726.291 GFlop/s
-  Kernel_dnt_medium(m=7, n=25, k=28, tile_m=1, tile_n=2, threads=224, grouping=4, minblocks=6) , # 733.469 GFlop/s
-  Kernel_dnt_medium(m=7, n=25, k=32, tile_m=1, tile_n=3, threads=128, grouping=3, minblocks=4) , # 738.173 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=25, k=45, tile_m=1, tile_n=2, w=22, v=24, threads=96, grouping=16, minblocks=4) , # 744.304 GFlop/s
-  Kernel_dnt_medium(m=7, n=26, k=4, tile_m=4, tile_n=2, threads=32, grouping=16, minblocks=7) , # 597.715 GFlop/s
-  Kernel_dnt_medium(m=7, n=26, k=5, tile_m=4, tile_n=2, threads=64, grouping=22, minblocks=14) , # 612.13 GFlop/s
-  Kernel_dnt_medium(m=7, n=26, k=7, tile_m=4, tile_n=1, threads=64, grouping=22, minblocks=9) , # 669.6 GFlop/s
-  Kernel_dnt_medium(m=7, n=26, k=9, tile_m=1, tile_n=3, threads=64, grouping=26, minblocks=14) , # 695 GFlop/s
-  Kernel_dnt_medium(m=7, n=26, k=13, tile_m=1, tile_n=3, threads=96, grouping=32, minblocks=10) , # 708.859 GFlop/s
-  Kernel_dnt_medium(m=7, n=26, k=25, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=7) , # 732.407 GFlop/s
-  Kernel_dnt_medium(m=7, n=26, k=26, tile_m=1, tile_n=2, threads=192, grouping=5, minblocks=2) , # 739.029 GFlop/s
-  Kernel_dnt_medium(m=7, n=26, k=28, tile_m=1, tile_n=2, threads=224, grouping=4, minblocks=6) , # 743.234 GFlop/s
-  Kernel_dnt_medium(m=7, n=26, k=32, tile_m=1, tile_n=2, threads=256, grouping=4, minblocks=5) , # 753.794 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=26, k=45, tile_m=2, tile_n=2, w=16, v=26, threads=64, grouping=16, minblocks=8) , # 753.616 GFlop/s
-  Kernel_dnt_medium(m=7, n=28, k=4, tile_m=4, tile_n=2, threads=32, grouping=16, minblocks=16) , # 621.956 GFlop/s
-  Kernel_dnt_medium(m=7, n=28, k=5, tile_m=4, tile_n=1, threads=64, grouping=22, minblocks=12) , # 630.557 GFlop/s
-  Kernel_dnt_medium(m=7, n=28, k=7, tile_m=4, tile_n=1, threads=64, grouping=26, minblocks=8) , # 687.436 GFlop/s
-  Kernel_dnt_medium(m=7, n=28, k=9, tile_m=2, tile_n=2, threads=64, grouping=26, minblocks=11) , # 709.918 GFlop/s
-  Kernel_dnt_medium(m=7, n=28, k=13, tile_m=2, tile_n=2, threads=96, grouping=12, minblocks=7) , # 710.614 GFlop/s
-  Kernel_dnt_medium(m=7, n=28, k=25, tile_m=1, tile_n=2, threads=192, grouping=5, minblocks=3) , # 746.919 GFlop/s
-  Kernel_dnt_medium(m=7, n=28, k=26, tile_m=2, tile_n=1, threads=192, grouping=4, minblocks=6) , # 752.82 GFlop/s
-  Kernel_dnt_medium(m=7, n=28, k=28, tile_m=2, tile_n=1, threads=224, grouping=4, minblocks=6) , # 754.704 GFlop/s
-  Kernel_dnt_medium(m=7, n=28, k=32, tile_m=2, tile_n=1, threads=128, grouping=4, minblocks=1) , # 766.488 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=28, k=45, tile_m=2, tile_n=1, w=12, v=24, threads=128, grouping=16, minblocks=2) , # 770.322 GFlop/s
-  Kernel_dnt_medium(m=7, n=32, k=4, tile_m=4, tile_n=2, threads=32, grouping=19, minblocks=15) , # 627.174 GFlop/s
-  Kernel_dnt_medium(m=7, n=32, k=5, tile_m=4, tile_n=1, threads=64, grouping=21, minblocks=3) , # 656.782 GFlop/s
-  Kernel_dnt_medium(m=7, n=32, k=7, tile_m=2, tile_n=2, threads=64, grouping=22, minblocks=11) , # 701.471 GFlop/s
-  Kernel_dnt_medium(m=7, n=32, k=9, tile_m=4, tile_n=1, threads=64, grouping=32, minblocks=2) , # 721.47 GFlop/s
-  Kernel_dnt_medium(m=7, n=32, k=13, tile_m=4, tile_n=1, threads=96, grouping=6, minblocks=10) , # 736.094 GFlop/s
-  Kernel_dnt_medium(m=7, n=32, k=25, tile_m=2, tile_n=1, threads=192, grouping=4, minblocks=1) , # 769.295 GFlop/s
-  Kernel_dnt_medium(m=7, n=32, k=26, tile_m=2, tile_n=1, threads=192, grouping=4, minblocks=1) , # 776.776 GFlop/s
-  Kernel_dnt_medium(m=7, n=32, k=28, tile_m=2, tile_n=1, threads=256, grouping=4, minblocks=5) , # 778.504 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=32, k=32, tile_m=2, tile_n=2, w=16, v=32, threads=64, grouping=16, minblocks=2) , # 790.893 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=32, k=45, tile_m=2, tile_n=1, w=12, v=32, threads=128, grouping=16, minblocks=2) , # 802.202 GFlop/s
-  Kernel_dnt_medium(m=7, n=45, k=4, tile_m=2, tile_n=3, threads=64, grouping=28, minblocks=2) , # 631.988 GFlop/s
-  Kernel_dnt_medium(m=7, n=45, k=5, tile_m=1, tile_n=5, threads=64, grouping=27, minblocks=5) , # 663.525 GFlop/s
-  Kernel_dnt_medium(m=7, n=45, k=7, tile_m=1, tile_n=5, threads=64, grouping=32, minblocks=7) , # 709.225 GFlop/s
-  Kernel_dnt_medium(m=7, n=45, k=9, tile_m=4, tile_n=1, threads=128, grouping=32, minblocks=10) , # 727.897 GFlop/s
-  Kernel_dnt_medium(m=7, n=45, k=13, tile_m=4, tile_n=1, threads=128, grouping=29, minblocks=3) , # 755.771 GFlop/s
-  Kernel_dnt_medium(m=7, n=45, k=25, tile_m=2, tile_n=1, threads=192, grouping=4, minblocks=1) , # 801.315 GFlop/s
-  Kernel_dnt_medium(m=7, n=45, k=26, tile_m=2, tile_n=1, threads=224, grouping=3, minblocks=3) , # 810.209 GFlop/s
-  Kernel_dnt_medium(m=7, n=45, k=28, tile_m=2, tile_n=1, threads=256, grouping=3, minblocks=4) , # 818.919 GFlop/s
-  Kernel_dnt_medium(m=7, n=45, k=32, tile_m=2, tile_n=1, threads=256, grouping=3, minblocks=3) , # 832.676 GFlop/s
-  Kernel_dnt_largeDB2(m=7, n=45, k=45, tile_m=4, tile_n=1, w=12, v=32, threads=96, grouping=16, minblocks=2) , # 841.043 GFlop/s
-  Kernel_dnt_medium(m=8, n=4, k=4, tile_m=1, tile_n=1, threads=32, grouping=18, minblocks=27) , # 241.107 GFlop/s
-  Kernel_dnt_medium(m=8, n=4, k=5, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=12) , # 253.28 GFlop/s
-  Kernel_dnt_medium(m=8, n=4, k=6, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=8) , # 292.754 GFlop/s
-  Kernel_dnt_medium(m=8, n=4, k=7, tile_m=1, tile_n=1, threads=32, grouping=16, minblocks=5) , # 322.969 GFlop/s
-  Kernel_dnt_small(m=8, n=4, k=8, tile_m=1, tile_n=1, threads=32, grouping=9, minblocks=7) , # 312.182 GFlop/s
-  Kernel_dnt_medium(m=8, n=4, k=9, tile_m=1, tile_n=1, threads=32, grouping=13, minblocks=25) , # 336.929 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=4, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=27) , # 261.066 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=5, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=25) , # 297.369 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=6, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=25) , # 344.888 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=7, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=21) , # 335.855 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=8, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=4) , # 362.704 GFlop/s
-  Kernel_dnt_medium(m=8, n=5, k=9, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=27) , # 388.028 GFlop/s
-  Kernel_dnt_medium(m=8, n=6, k=4, tile_m=1, tile_n=2, threads=32, grouping=15, minblocks=24) , # 306.873 GFlop/s
-  Kernel_dnt_medium(m=8, n=6, k=5, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=19) , # 351.046 GFlop/s
-  Kernel_dnt_medium(m=8, n=6, k=6, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=20) , # 357.061 GFlop/s
-  Kernel_dnt_medium(m=8, n=6, k=7, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=25) , # 398.063 GFlop/s
-  Kernel_dnt_medium(m=8, n=6, k=8, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=27) , # 432.142 GFlop/s
-  Kernel_dnt_medium(m=8, n=6, k=9, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=2) , # 451.4 GFlop/s
-  Kernel_dnt_medium(m=8, n=7, k=4, tile_m=1, tile_n=2, threads=32, grouping=15, minblocks=11) , # 354.317 GFlop/s
-  Kernel_dnt_medium(m=8, n=7, k=5, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=6) , # 358.106 GFlop/s
-  Kernel_dnt_medium(m=8, n=7, k=6, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=17) , # 412.399 GFlop/s
-  Kernel_dnt_medium(m=8, n=7, k=7, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=11) , # 463.962 GFlop/s
-  Kernel_dnt_medium(m=8, n=7, k=8, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=25) , # 495.994 GFlop/s
-  Kernel_dnt_medium(m=8, n=7, k=9, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=26) , # 501.068 GFlop/s
-  Kernel_dnt_medium(m=8, n=8, k=4, tile_m=1, tile_n=2, threads=32, grouping=16, minblocks=11) , # 423.915 GFlop/s
-  Kernel_dnt_medium(m=8, n=8, k=5, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=12) , # 468.053 GFlop/s
-  Kernel_dnt_medium(m=8, n=8, k=6, tile_m=2, tile_n=1, threads=32, grouping=11, minblocks=17) , # 531.999 GFlop/s
-  Kernel_dnt_medium(m=8, n=8, k=7, tile_m=2, tile_n=1, threads=32, grouping=11, minblocks=1) , # 571.337 GFlop/s
-  Kernel_dnt_medium(m=8, n=8, k=8, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=25) , # 605.152 GFlop/s
-  Kernel_dnt_medium(m=8, n=8, k=9, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=5) , # 571.958 GFlop/s
-  Kernel_dnt_medium(m=8, n=9, k=4, tile_m=1, tile_n=3, threads=32, grouping=15, minblocks=25) , # 378.51 GFlop/s
-  Kernel_dnt_medium(m=8, n=9, k=5, tile_m=1, tile_n=3, threads=32, grouping=16, minblocks=12) , # 433.932 GFlop/s
-  Kernel_dnt_medium(m=8, n=9, k=6, tile_m=1, tile_n=3, threads=32, grouping=13, minblocks=12) , # 500.839 GFlop/s
-  Kernel_dnt_medium(m=8, n=9, k=7, tile_m=1, tile_n=3, threads=32, grouping=11, minblocks=25) , # 544.839 GFlop/s
-  Kernel_dnt_medium(m=8, n=9, k=8, tile_m=1, tile_n=3, threads=32, grouping=13, minblocks=9) , # 572.229 GFlop/s
-  Kernel_dnt_medium(m=8, n=9, k=9, tile_m=1, tile_n=3, threads=32, grouping=16, minblocks=20) , # 567.681 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=4, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=27) , # 223.697 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=5, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=12) , # 264.552 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=6, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=12) , # 305.331 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=7, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=25) , # 335.175 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=8, tile_m=1, tile_n=2, threads=32, grouping=16, minblocks=26) , # 321.571 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=9, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=6) , # 341.86 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=13, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=5) , # 381.012 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=25, tile_m=1, tile_n=1, threads=64, grouping=5, minblocks=4) , # 380.088 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=26, tile_m=1, tile_n=1, threads=64, grouping=29, minblocks=1) , # 384.187 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=28, tile_m=1, tile_n=1, threads=64, grouping=7, minblocks=5) , # 389.01 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=32, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=11) , # 391.946 GFlop/s
-  Kernel_dnt_medium(m=9, n=4, k=45, tile_m=1, tile_n=1, threads=96, grouping=3, minblocks=9) , # 387.535 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=4, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=2) , # 274.355 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=5, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=7) , # 325.528 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=6, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=3) , # 371.15 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=7, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=1) , # 371.567 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=8, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=19) , # 394.72 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=9, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=2) , # 417.155 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=13, tile_m=1, tile_n=2, threads=32, grouping=16, minblocks=13) , # 424.207 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=25, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=15) , # 441.803 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=26, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=3) , # 441.181 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=28, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=13) , # 447.972 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=32, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=5) , # 455.083 GFlop/s
-  Kernel_dnt_medium(m=9, n=5, k=45, tile_m=1, tile_n=1, threads=128, grouping=5, minblocks=2) , # 447.72 GFlop/s
-  Kernel_dnt_medium(m=9, n=6, k=4, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=16) , # 324.725 GFlop/s
-  Kernel_dnt_medium(m=9, n=6, k=5, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=2) , # 383.299 GFlop/s
-  Kernel_dnt_medium(m=9, n=6, k=6, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=9) , # 384.354 GFlop/s
-  Kernel_dnt_medium(m=9, n=6, k=7, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=15) , # 435.21 GFlop/s
-  Kernel_dnt_medium(m=9, n=6, k=8, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=14) , # 469.311 GFlop/s
-  Kernel_dnt_medium(m=9, n=6, k=9, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=9) , # 476.433 GFlop/s
-  Kernel_dnt_medium(m=9, n=7, k=4, tile_m=3, tile_n=1, threads=32, grouping=16, minblocks=3) , # 360.754 GFlop/s
-  Kernel_dnt_medium(m=9, n=7, k=5, tile_m=3, tile_n=1, threads=32, grouping=16, minblocks=5) , # 379.473 GFlop/s
-  Kernel_dnt_medium(m=9, n=7, k=6, tile_m=1, tile_n=3, threads=32, grouping=13, minblocks=20) , # 420.882 GFlop/s
-  Kernel_dnt_medium(m=9, n=7, k=7, tile_m=3, tile_n=1, threads=32, grouping=13, minblocks=27) , # 478.365 GFlop/s
-  Kernel_dnt_medium(m=9, n=7, k=8, tile_m=3, tile_n=1, threads=32, grouping=13, minblocks=1) , # 493.848 GFlop/s
-  Kernel_dnt_medium(m=9, n=7, k=9, tile_m=3, tile_n=1, threads=32, grouping=13, minblocks=2) , # 516.64 GFlop/s
-  Kernel_dnt_medium(m=9, n=7, k=13, tile_m=1, tile_n=3, threads=32, grouping=13, minblocks=1) , # 510.27 GFlop/s
-  Kernel_dnt_medium(m=9, n=7, k=25, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=12) , # 537.082 GFlop/s
-  Kernel_dnt_medium(m=9, n=7, k=26, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=2) , # 540.279 GFlop/s
-  Kernel_dnt_medium(m=9, n=7, k=28, tile_m=1, tile_n=1, threads=96, grouping=4, minblocks=11) , # 545.866 GFlop/s
-  Kernel_dnt_medium(m=9, n=7, k=32, tile_m=1, tile_n=1, threads=128, grouping=4, minblocks=11) , # 551.821 GFlop/s
-  Kernel_dnt_medium(m=9, n=7, k=45, tile_m=1, tile_n=1, threads=128, grouping=4, minblocks=3) , # 550.203 GFlop/s
-  Kernel_dnt_medium(m=9, n=8, k=4, tile_m=3, tile_n=1, threads=32, grouping=15, minblocks=3) , # 375.31 GFlop/s
-  Kernel_dnt_medium(m=9, n=8, k=5, tile_m=3, tile_n=1, threads=32, grouping=16, minblocks=26) , # 428.946 GFlop/s
-  Kernel_dnt_medium(m=9, n=8, k=6, tile_m=1, tile_n=3, threads=32, grouping=13, minblocks=22) , # 484.981 GFlop/s
-  Kernel_dnt_medium(m=9, n=8, k=7, tile_m=3, tile_n=1, threads=32, grouping=13, minblocks=9) , # 540.555 GFlop/s
-  Kernel_dnt_medium(m=9, n=8, k=8, tile_m=3, tile_n=1, threads=32, grouping=13, minblocks=2) , # 563.409 GFlop/s
-  Kernel_dnt_medium(m=9, n=8, k=9, tile_m=1, tile_n=3, threads=32, grouping=16, minblocks=20) , # 561.368 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=4, tile_m=3, tile_n=1, threads=32, grouping=13, minblocks=16) , # 449.812 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=5, tile_m=3, tile_n=1, threads=32, grouping=12, minblocks=25) , # 520.817 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=6, tile_m=3, tile_n=1, threads=32, grouping=12, minblocks=11) , # 584.233 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=7, tile_m=3, tile_n=1, threads=32, grouping=13, minblocks=25) , # 593.141 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=8, tile_m=3, tile_n=1, threads=32, grouping=16, minblocks=2) , # 609.153 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=9, tile_m=1, tile_n=3, threads=32, grouping=13, minblocks=20) , # 596.262 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=12, tile_m=3, tile_n=1, threads=32, grouping=18, minblocks=16) , # 608.863 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=13, tile_m=1, tile_n=3, threads=32, grouping=21, minblocks=3) , # 598.854 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=22, tile_m=1, tile_n=2, threads=64, grouping=26, minblocks=2) , # 602.914 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=25, tile_m=1, tile_n=1, threads=128, grouping=5, minblocks=11) , # 604.486 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=26, tile_m=1, tile_n=1, threads=128, grouping=5, minblocks=9) , # 606.896 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=28, tile_m=1, tile_n=1, threads=128, grouping=4, minblocks=12) , # 623.854 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=32, tile_m=1, tile_n=1, threads=96, grouping=4, minblocks=2) , # 619.696 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=45, tile_m=1, tile_n=1, threads=224, grouping=4, minblocks=6) , # 621.925 GFlop/s
-  Kernel_dnt_medium(m=9, n=12, k=9, tile_m=1, tile_n=4, threads=32, grouping=13, minblocks=25) , # 636.186 GFlop/s
-  Kernel_dnt_medium(m=9, n=12, k=12, tile_m=1, tile_n=2, threads=64, grouping=22, minblocks=15) , # 653.32 GFlop/s
-  Kernel_dnt_medium(m=9, n=13, k=4, tile_m=5, tile_n=1, threads=32, grouping=12, minblocks=8) , # 520.652 GFlop/s
-  Kernel_dnt_medium(m=9, n=13, k=5, tile_m=5, tile_n=1, threads=32, grouping=13, minblocks=13) , # 570.99 GFlop/s
-  Kernel_dnt_medium(m=9, n=13, k=7, tile_m=1, tile_n=5, threads=32, grouping=16, minblocks=2) , # 619.584 GFlop/s
-  Kernel_dnt_medium(m=9, n=13, k=9, tile_m=5, tile_n=1, threads=32, grouping=12, minblocks=21) , # 635.789 GFlop/s
-  Kernel_dnt_medium(m=9, n=13, k=13, tile_m=1, tile_n=2, threads=64, grouping=26, minblocks=18) , # 675.011 GFlop/s
-  Kernel_dnt_medium(m=9, n=13, k=25, tile_m=1, tile_n=2, threads=64, grouping=26, minblocks=6) , # 695.157 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=13, k=26, tile_m=1, tile_n=2, w=12, v=12, threads=64, grouping=16, minblocks=2) , # 706.349 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=13, k=28, tile_m=1, tile_n=2, w=12, v=8, threads=64, grouping=16, minblocks=2) , # 709.773 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=13, k=32, tile_m=1, tile_n=2, w=14, v=8, threads=64, grouping=16, minblocks=1) , # 720.317 GFlop/s
-  Kernel_dnt_medium(m=9, n=13, k=45, tile_m=1, tile_n=1, threads=160, grouping=3, minblocks=6) , # 722.283 GFlop/s
-  Kernel_dnt_medium(m=9, n=22, k=9, tile_m=2, tile_n=2, threads=96, grouping=32, minblocks=5) , # 751.681 GFlop/s
-  Kernel_dnt_medium(m=9, n=22, k=22, tile_m=1, tile_n=2, threads=128, grouping=5, minblocks=7) , # 814.968 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=22, k=32, tile_m=2, tile_n=2, w=16, v=22, threads=64, grouping=16, minblocks=1) , # 851.65 GFlop/s
-  Kernel_dnt_medium(m=9, n=25, k=4, tile_m=1, tile_n=4, threads=64, grouping=22, minblocks=19) , # 627.071 GFlop/s
-  Kernel_dnt_medium(m=9, n=25, k=5, tile_m=1, tile_n=4, threads=64, grouping=22, minblocks=11) , # 697.048 GFlop/s
-  Kernel_dnt_medium(m=9, n=25, k=7, tile_m=1, tile_n=4, threads=64, grouping=27, minblocks=11) , # 759.221 GFlop/s
-  Kernel_dnt_medium(m=9, n=25, k=9, tile_m=1, tile_n=4, threads=96, grouping=29, minblocks=10) , # 780.691 GFlop/s
-  Kernel_dnt_medium(m=9, n=25, k=13, tile_m=1, tile_n=4, threads=128, grouping=9, minblocks=9) , # 806.204 GFlop/s
-  Kernel_dnt_medium(m=9, n=25, k=25, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=5) , # 850.306 GFlop/s
-  Kernel_dnt_medium(m=9, n=25, k=26, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=5) , # 860.479 GFlop/s
-  Kernel_dnt_medium(m=9, n=25, k=28, tile_m=2, tile_n=1, threads=160, grouping=4, minblocks=6) , # 868.917 GFlop/s
-  Kernel_dnt_medium(m=9, n=25, k=32, tile_m=2, tile_n=1, threads=160, grouping=4, minblocks=4) , # 876.897 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=25, k=45, tile_m=1, tile_n=2, w=14, v=14, threads=128, grouping=16, minblocks=2) , # 889.424 GFlop/s
-  Kernel_dnt_medium(m=9, n=26, k=4, tile_m=1, tile_n=4, threads=64, grouping=22, minblocks=20) , # 651.805 GFlop/s
-  Kernel_dnt_medium(m=9, n=26, k=5, tile_m=1, tile_n=4, threads=64, grouping=26, minblocks=19) , # 709.356 GFlop/s
-  Kernel_dnt_medium(m=9, n=26, k=7, tile_m=1, tile_n=4, threads=64, grouping=26, minblocks=11) , # 779.501 GFlop/s
-  Kernel_dnt_medium(m=9, n=26, k=9, tile_m=1, tile_n=4, threads=96, grouping=26, minblocks=11) , # 790.313 GFlop/s
-  Kernel_dnt_medium(m=9, n=26, k=13, tile_m=1, tile_n=4, threads=128, grouping=32, minblocks=9) , # 820.423 GFlop/s
-  Kernel_dnt_medium(m=9, n=26, k=25, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=1) , # 859.973 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=26, k=26, tile_m=1, tile_n=5, w=10, v=26, threads=64, grouping=16, minblocks=1) , # 873.449 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=26, k=28, tile_m=1, tile_n=3, w=10, v=14, threads=96, grouping=16, minblocks=2) , # 879.817 GFlop/s
-  Kernel_dnt_medium(m=9, n=26, k=32, tile_m=1, tile_n=2, threads=128, grouping=3, minblocks=3) , # 884.616 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=26, k=45, tile_m=1, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=1) , # 907.729 GFlop/s
-  Kernel_dnt_medium(m=9, n=28, k=4, tile_m=1, tile_n=4, threads=64, grouping=22, minblocks=14) , # 687.488 GFlop/s
-  Kernel_dnt_medium(m=9, n=28, k=5, tile_m=1, tile_n=4, threads=64, grouping=21, minblocks=10) , # 735.829 GFlop/s
-  Kernel_dnt_medium(m=9, n=28, k=7, tile_m=1, tile_n=4, threads=64, grouping=26, minblocks=14) , # 806.204 GFlop/s
-  Kernel_dnt_medium(m=9, n=28, k=9, tile_m=3, tile_n=1, threads=96, grouping=26, minblocks=11) , # 821.996 GFlop/s
-  Kernel_dnt_medium(m=9, n=28, k=13, tile_m=1, tile_n=4, threads=128, grouping=21, minblocks=7) , # 840.047 GFlop/s
-  Kernel_dnt_medium(m=9, n=28, k=25, tile_m=1, tile_n=2, threads=128, grouping=5, minblocks=1) , # 890.192 GFlop/s
-  Kernel_dnt_medium(m=9, n=28, k=26, tile_m=1, tile_n=2, threads=256, grouping=4, minblocks=6) , # 897.077 GFlop/s
-  Kernel_dnt_medium(m=9, n=28, k=28, tile_m=1, tile_n=2, threads=256, grouping=4, minblocks=5) , # 904.627 GFlop/s
-  Kernel_dnt_medium(m=9, n=28, k=32, tile_m=1, tile_n=2, threads=160, grouping=3, minblocks=4) , # 915.991 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=28, k=45, tile_m=1, tile_n=2, w=10, v=28, threads=128, grouping=16, minblocks=2) , # 927.821 GFlop/s
-  Kernel_dnt_medium(m=9, n=32, k=4, tile_m=5, tile_n=1, threads=64, grouping=22, minblocks=14) , # 721.352 GFlop/s
-  Kernel_dnt_medium(m=9, n=32, k=5, tile_m=3, tile_n=2, threads=64, grouping=26, minblocks=3) , # 765.332 GFlop/s
-  Kernel_dnt_medium(m=9, n=32, k=7, tile_m=1, tile_n=5, threads=64, grouping=26, minblocks=6) , # 832 GFlop/s
-  Kernel_dnt_medium(m=9, n=32, k=9, tile_m=2, tile_n=2, threads=96, grouping=32, minblocks=3) , # 851.008 GFlop/s
-  Kernel_dnt_medium(m=9, n=32, k=13, tile_m=5, tile_n=1, threads=128, grouping=5, minblocks=10) , # 869.42 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=32, k=22, tile_m=3, tile_n=2, w=8, v=32, threads=64, grouping=16, minblocks=1) , # 910.237 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=32, k=25, tile_m=3, tile_n=1, w=10, v=26, threads=96, grouping=16, minblocks=2) , # 918.498 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=32, k=26, tile_m=3, tile_n=1, w=10, v=18, threads=96, grouping=16, minblocks=2) , # 925 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=32, k=28, tile_m=3, tile_n=1, w=10, v=26, threads=96, grouping=16, minblocks=1) , # 928.218 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=32, k=32, tile_m=1, tile_n=5, w=12, v=32, threads=64, grouping=16, minblocks=4) , # 944.428 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=32, k=45, tile_m=3, tile_n=1, w=10, v=28, threads=96, grouping=16, minblocks=4) , # 965.569 GFlop/s
-  Kernel_dnt_medium(m=9, n=45, k=4, tile_m=6, tile_n=2, threads=64, grouping=30, minblocks=10) , # 732.692 GFlop/s
-  Kernel_dnt_medium(m=9, n=45, k=5, tile_m=5, tile_n=2, threads=64, grouping=30, minblocks=11) , # 771.67 GFlop/s
-  Kernel_dnt_medium(m=9, n=45, k=7, tile_m=1, tile_n=5, threads=96, grouping=29, minblocks=10) , # 833.778 GFlop/s
-  Kernel_dnt_medium(m=9, n=45, k=9, tile_m=1, tile_n=5, threads=128, grouping=32, minblocks=9) , # 859.465 GFlop/s
-  Kernel_dnt_medium(m=9, n=45, k=13, tile_m=1, tile_n=3, threads=160, grouping=5, minblocks=7) , # 903.628 GFlop/s
-  Kernel_dnt_medium(m=9, n=45, k=25, tile_m=5, tile_n=1, threads=256, grouping=24, minblocks=4) , # 967.166 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=45, k=26, tile_m=5, tile_n=1, w=10, v=18, threads=96, grouping=16, minblocks=4) , # 977.295 GFlop/s
-  Kernel_dnt_medium(m=9, n=45, k=28, tile_m=5, tile_n=1, threads=256, grouping=4, minblocks=4) , # 990.414 GFlop/s
-  Kernel_dnt_medium(m=9, n=45, k=32, tile_m=5, tile_n=1, threads=128, grouping=3, minblocks=3) , # 1004.63 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=45, k=45, tile_m=2, tile_n=2, w=12, v=16, threads=128, grouping=16, minblocks=1) , # 1022.05 GFlop/s
-  Kernel_dnt_medium(m=10, n=4, k=4, tile_m=1, tile_n=2, threads=32, grouping=16, minblocks=1) , # 247.284 GFlop/s
-  Kernel_dnt_medium(m=10, n=4, k=10, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=22) , # 389.557 GFlop/s
-  Kernel_dnt_medium(m=10, n=4, k=15, tile_m=1, tile_n=1, threads=64, grouping=6, minblocks=27) , # 396.818 GFlop/s
-  Kernel_dnt_medium(m=10, n=10, k=4, tile_m=2, tile_n=2, threads=32, grouping=13, minblocks=22) , # 526.19 GFlop/s
-  Kernel_dnt_medium(m=10, n=10, k=10, tile_m=1, tile_n=4, threads=32, grouping=18, minblocks=22) , # 663.631 GFlop/s
-  Kernel_dnt_medium(m=10, n=10, k=15, tile_m=1, tile_n=2, threads=64, grouping=24, minblocks=4) , # 666.283 GFlop/s
-  Kernel_dnt_medium(m=10, n=15, k=4, tile_m=5, tile_n=1, threads=32, grouping=13, minblocks=7) , # 610.102 GFlop/s
-  Kernel_dnt_medium(m=10, n=15, k=10, tile_m=1, tile_n=3, threads=64, grouping=24, minblocks=17) , # 729.268 GFlop/s
-  Kernel_dnt_medium(m=10, n=15, k=15, tile_m=1, tile_n=3, threads=64, grouping=22, minblocks=6) , # 749.635 GFlop/s
-  Kernel_dnt_medium(m=11, n=11, k=11, tile_m=2, tile_n=2, threads=64, grouping=26, minblocks=5) , # 702.059 GFlop/s
-  Kernel_dnt_medium(m=12, n=5, k=5, tile_m=2, tile_n=1, threads=32, grouping=11, minblocks=6) , # 414.313 GFlop/s
-  Kernel_dnt_medium(m=12, n=5, k=12, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=1) , # 489.381 GFlop/s
-  Kernel_dnt_medium(m=12, n=5, k=13, tile_m=2, tile_n=1, threads=32, grouping=4, minblocks=8) , # 472.929 GFlop/s
-  Kernel_dnt_medium(m=12, n=5, k=26, tile_m=1, tile_n=1, threads=96, grouping=5, minblocks=6) , # 492.364 GFlop/s
-  Kernel_dnt_medium(m=12, n=5, k=32, tile_m=1, tile_n=1, threads=64, grouping=3, minblocks=1) , # 501.048 GFlop/s
-  Kernel_dnt_medium(m=12, n=9, k=9, tile_m=4, tile_n=1, threads=32, grouping=13, minblocks=25) , # 630.854 GFlop/s
-  Kernel_dnt_medium(m=12, n=9, k=12, tile_m=1, tile_n=2, threads=64, grouping=22, minblocks=5) , # 663.387 GFlop/s
-  Kernel_dnt_medium(m=12, n=12, k=5, tile_m=6, tile_n=1, threads=32, grouping=15, minblocks=3) , # 704.113 GFlop/s
-  Kernel_dnt_medium(m=12, n=12, k=9, tile_m=1, tile_n=3, threads=64, grouping=22, minblocks=10) , # 766.851 GFlop/s
-  Kernel_dnt_medium(m=12, n=12, k=12, tile_m=1, tile_n=3, threads=64, grouping=26, minblocks=1) , # 787.849 GFlop/s
-  Kernel_dnt_medium(m=12, n=12, k=13, tile_m=1, tile_n=3, threads=64, grouping=32, minblocks=1) , # 783.946 GFlop/s
-  Kernel_dnt_medium(m=12, n=12, k=25, tile_m=1, tile_n=2, threads=128, grouping=6, minblocks=5) , # 798.948 GFlop/s
-  Kernel_dnt_medium(m=12, n=12, k=26, tile_m=1, tile_n=3, threads=160, grouping=5, minblocks=8) , # 794.647 GFlop/s
-  Kernel_dnt_medium(m=12, n=12, k=32, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=5) , # 821.891 GFlop/s
-  Kernel_dnt_medium(m=12, n=13, k=5, tile_m=3, tile_n=2, threads=32, grouping=14, minblocks=12) , # 671.755 GFlop/s
-  Kernel_dnt_medium(m=12, n=13, k=12, tile_m=1, tile_n=3, threads=64, grouping=24, minblocks=17) , # 785.316 GFlop/s
-  Kernel_dnt_medium(m=12, n=13, k=13, tile_m=2, tile_n=2, threads=64, grouping=26, minblocks=12) , # 777.453 GFlop/s
-  Kernel_dnt_medium(m=12, n=13, k=26, tile_m=1, tile_n=2, threads=96, grouping=5, minblocks=3) , # 821.309 GFlop/s
-  Kernel_dnt_medium(m=12, n=13, k=32, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=6) , # 841.375 GFlop/s
-  Kernel_dnt_medium(m=12, n=25, k=12, tile_m=1, tile_n=5, threads=96, grouping=32, minblocks=10) , # 953.604 GFlop/s
-  Kernel_dnt_medium(m=12, n=25, k=25, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=6) , # 1042.81 GFlop/s
-  Kernel_dnt_medium(m=12, n=26, k=5, tile_m=1, tile_n=6, threads=64, grouping=26, minblocks=12) , # 857.411 GFlop/s
-  Kernel_dnt_medium(m=12, n=26, k=12, tile_m=1, tile_n=2, threads=160, grouping=9, minblocks=3) , # 961.121 GFlop/s
-  Kernel_dnt_medium(m=12, n=26, k=13, tile_m=1, tile_n=6, threads=96, grouping=5, minblocks=11) , # 975.617 GFlop/s
-  Kernel_dnt_medium(m=12, n=26, k=26, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=1) , # 1066.53 GFlop/s
-  Kernel_dnt_medium(m=12, n=26, k=32, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=1) , # 1099.3 GFlop/s
-  Kernel_dnt_medium(m=12, n=32, k=5, tile_m=6, tile_n=1, threads=64, grouping=29, minblocks=12) , # 905.659 GFlop/s
-  Kernel_dnt_medium(m=12, n=32, k=12, tile_m=1, tile_n=4, threads=96, grouping=4, minblocks=11) , # 1037.69 GFlop/s
-  Kernel_dnt_medium(m=12, n=32, k=13, tile_m=1, tile_n=4, threads=160, grouping=5, minblocks=8) , # 1052.61 GFlop/s
-  Kernel_dnt_medium(m=12, n=32, k=26, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=3) , # 1139.65 GFlop/s
-  Kernel_dnt_medium(m=12, n=32, k=32, tile_m=1, tile_n=2, threads=192, grouping=3, minblocks=4) , # 1180.17 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=4, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=6) , # 309.329 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=5, tile_m=1, tile_n=2, threads=32, grouping=16, minblocks=19) , # 351.076 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=7, tile_m=2, tile_n=1, threads=32, grouping=11, minblocks=12) , # 430.38 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=9, tile_m=1, tile_n=2, threads=32, grouping=13, minblocks=7) , # 412.394 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=13, tile_m=1, tile_n=1, threads=64, grouping=4, minblocks=27) , # 421.461 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=25, tile_m=1, tile_n=1, threads=128, grouping=4, minblocks=1) , # 422.942 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=26, tile_m=1, tile_n=1, threads=128, grouping=4, minblocks=10) , # 428.057 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=28, tile_m=1, tile_n=1, threads=128, grouping=4, minblocks=2) , # 436.195 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=32, tile_m=1, tile_n=1, threads=160, grouping=4, minblocks=5) , # 440.449 GFlop/s
-  Kernel_dnt_medium(m=13, n=4, k=45, tile_m=1, tile_n=1, threads=192, grouping=3, minblocks=5) , # 436.899 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=4, tile_m=1, tile_n=3, threads=32, grouping=16, minblocks=13) , # 362.493 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=5, tile_m=1, tile_n=3, threads=32, grouping=13, minblocks=1) , # 414.824 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=7, tile_m=1, tile_n=3, threads=32, grouping=13, minblocks=16) , # 451.746 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=9, tile_m=3, tile_n=1, threads=32, grouping=13, minblocks=18) , # 474.015 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=12, tile_m=1, tile_n=3, threads=64, grouping=18, minblocks=16) , # 489.219 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=13, tile_m=1, tile_n=3, threads=32, grouping=6, minblocks=12) , # 460.079 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=16, tile_m=1, tile_n=3, threads=96, grouping=30, minblocks=3) , # 482.507 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=24, tile_m=1, tile_n=2, threads=64, grouping=5, minblocks=1) , # 491.453 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=25, tile_m=1, tile_n=2, threads=128, grouping=5, minblocks=11) , # 487.722 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=26, tile_m=1, tile_n=2, threads=64, grouping=4, minblocks=1) , # 485.067 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=28, tile_m=1, tile_n=1, threads=96, grouping=3, minblocks=7) , # 493.982 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=32, tile_m=1, tile_n=1, threads=96, grouping=3, minblocks=4) , # 501.16 GFlop/s
-  Kernel_dnt_medium(m=13, n=5, k=45, tile_m=1, tile_n=1, threads=128, grouping=4, minblocks=5) , # 501.227 GFlop/s
-  Kernel_dnt_medium(m=13, n=7, k=4, tile_m=1, tile_n=4, threads=32, grouping=13, minblocks=12) , # 476.167 GFlop/s
-  Kernel_dnt_medium(m=13, n=7, k=5, tile_m=2, tile_n=2, threads=32, grouping=13, minblocks=13) , # 472.557 GFlop/s
-  Kernel_dnt_medium(m=13, n=7, k=7, tile_m=4, tile_n=1, threads=32, grouping=13, minblocks=22) , # 566.505 GFlop/s
-  Kernel_dnt_medium(m=13, n=7, k=9, tile_m=2, tile_n=2, threads=32, grouping=16, minblocks=23) , # 562.908 GFlop/s
-  Kernel_dnt_medium(m=13, n=7, k=13, tile_m=1, tile_n=2, threads=64, grouping=6, minblocks=9) , # 575.653 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=7, k=25, tile_m=1, tile_n=2, w=12, v=6, threads=64, grouping=16, minblocks=2) , # 598.682 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=7, k=26, tile_m=1, tile_n=2, w=12, v=4, threads=64, grouping=16, minblocks=2) , # 609.262 GFlop/s
-  Kernel_dnt_medium(m=13, n=7, k=28, tile_m=1, tile_n=1, threads=128, grouping=5, minblocks=4) , # 611.772 GFlop/s
-  Kernel_dnt_medium(m=13, n=7, k=32, tile_m=1, tile_n=1, threads=128, grouping=6, minblocks=5) , # 622.583 GFlop/s
-  Kernel_dnt_medium(m=13, n=7, k=45, tile_m=1, tile_n=1, threads=128, grouping=3, minblocks=6) , # 627.27 GFlop/s
-  Kernel_dnt_medium(m=13, n=9, k=4, tile_m=5, tile_n=1, threads=32, grouping=13, minblocks=27) , # 500.98 GFlop/s
-  Kernel_dnt_medium(m=13, n=9, k=5, tile_m=1, tile_n=5, threads=32, grouping=13, minblocks=12) , # 558.304 GFlop/s
-  Kernel_dnt_medium(m=13, n=9, k=7, tile_m=1, tile_n=5, threads=32, grouping=14, minblocks=25) , # 614.166 GFlop/s
-  Kernel_dnt_medium(m=13, n=9, k=9, tile_m=2, tile_n=1, threads=64, grouping=26, minblocks=19) , # 633.01 GFlop/s
-  Kernel_dnt_medium(m=13, n=9, k=13, tile_m=2, tile_n=1, threads=64, grouping=22, minblocks=3) , # 674.039 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=9, k=25, tile_m=2, tile_n=1, w=12, v=8, threads=64, grouping=16, minblocks=2) , # 696.232 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=9, k=26, tile_m=2, tile_n=1, w=10, v=8, threads=64, grouping=16, minblocks=12) , # 700.495 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=9, k=28, tile_m=2, tile_n=1, w=14, v=6, threads=64, grouping=16, minblocks=2) , # 716.029 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=9, k=32, tile_m=2, tile_n=1, w=14, v=8, threads=64, grouping=16, minblocks=2) , # 717.374 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=9, k=45, tile_m=2, tile_n=1, w=14, v=6, threads=64, grouping=16, minblocks=12) , # 720.997 GFlop/s
-  Kernel_dnt_medium(m=13, n=12, k=5, tile_m=1, tile_n=6, threads=32, grouping=13, minblocks=23) , # 669.522 GFlop/s
-  Kernel_dnt_medium(m=13, n=12, k=12, tile_m=1, tile_n=3, threads=64, grouping=26, minblocks=17) , # 782.744 GFlop/s
-  Kernel_dnt_medium(m=13, n=12, k=13, tile_m=3, tile_n=1, threads=64, grouping=22, minblocks=6) , # 773.206 GFlop/s
-  Kernel_dnt_medium(m=13, n=12, k=26, tile_m=1, tile_n=3, threads=128, grouping=5, minblocks=9) , # 802.307 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=12, k=32, tile_m=4, tile_n=1, w=16, v=12, threads=64, grouping=16, minblocks=2) , # 828.44 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=4, tile_m=4, tile_n=2, threads=32, grouping=15, minblocks=15) , # 645.445 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=5, tile_m=3, tile_n=3, threads=32, grouping=17, minblocks=13) , # 687.167 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=7, tile_m=4, tile_n=2, threads=32, grouping=20, minblocks=14) , # 753.739 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=9, tile_m=4, tile_n=1, threads=64, grouping=26, minblocks=5) , # 798.832 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=12, tile_m=2, tile_n=2, threads=64, grouping=26, minblocks=4) , # 819.816 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=13, tile_m=4, tile_n=1, threads=64, grouping=32, minblocks=6) , # 808.211 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=14, tile_m=2, tile_n=2, threads=96, grouping=32, minblocks=10) , # 828.516 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=16, tile_m=2, tile_n=2, threads=64, grouping=32, minblocks=7) , # 829.325 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=24, tile_m=1, tile_n=2, threads=128, grouping=5, minblocks=4) , # 846.028 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=25, tile_m=2, tile_n=1, threads=128, grouping=5, minblocks=5) , # 843.072 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=26, tile_m=2, tile_n=1, threads=128, grouping=4, minblocks=1) , # 847.219 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=28, tile_m=2, tile_n=1, threads=128, grouping=4, minblocks=7) , # 855.86 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=32, tile_m=2, tile_n=1, threads=160, grouping=5, minblocks=2) , # 869.632 GFlop/s
-  Kernel_dnt_medium(m=13, n=13, k=45, tile_m=2, tile_n=1, threads=128, grouping=3, minblocks=3) , # 862.482 GFlop/s
-  Kernel_dnt_medium(m=13, n=14, k=13, tile_m=2, tile_n=2, threads=64, grouping=26, minblocks=3) , # 818.092 GFlop/s
-  Kernel_dnt_medium(m=13, n=14, k=14, tile_m=1, tile_n=2, threads=96, grouping=32, minblocks=6) , # 824.853 GFlop/s
-  Kernel_dnt_medium(m=13, n=14, k=25, tile_m=1, tile_n=2, threads=128, grouping=6, minblocks=1) , # 867.323 GFlop/s
-  Kernel_dnt_medium(m=13, n=14, k=26, tile_m=1, tile_n=2, threads=128, grouping=5, minblocks=7) , # 875.867 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=14, k=32, tile_m=2, tile_n=2, w=16, v=14, threads=64, grouping=16, minblocks=4) , # 894.079 GFlop/s
-  Kernel_dnt_medium(m=13, n=16, k=5, tile_m=4, tile_n=2, threads=32, grouping=17, minblocks=14) , # 721.863 GFlop/s
-  Kernel_dnt_medium(m=13, n=16, k=13, tile_m=2, tile_n=2, threads=64, grouping=26, minblocks=1) , # 866.035 GFlop/s
-  Kernel_dnt_medium(m=13, n=16, k=16, tile_m=4, tile_n=1, threads=96, grouping=4, minblocks=13) , # 894.502 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=16, k=32, tile_m=4, tile_n=1, w=16, v=16, threads=64, grouping=16, minblocks=4) , # 942.893 GFlop/s
-  Kernel_dnt_medium(m=13, n=24, k=5, tile_m=2, tile_n=3, threads=64, grouping=26, minblocks=10) , # 834.262 GFlop/s
-  Kernel_dnt_medium(m=13, n=24, k=13, tile_m=4, tile_n=1, threads=96, grouping=5, minblocks=12) , # 976.165 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=24, k=24, tile_m=3, tile_n=2, w=12, v=20, threads=64, grouping=16, minblocks=1) , # 1079.09 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=24, k=26, tile_m=2, tile_n=3, w=10, v=22, threads=64, grouping=16, minblocks=8) , # 1075.11 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=24, k=32, tile_m=2, tile_n=3, w=16, v=22, threads=64, grouping=16, minblocks=4) , # 1104.28 GFlop/s
-  Kernel_dnt_medium(m=13, n=25, k=4, tile_m=2, tile_n=3, threads=64, grouping=25, minblocks=9) , # 775.128 GFlop/s
-  Kernel_dnt_medium(m=13, n=25, k=5, tile_m=2, tile_n=3, threads=64, grouping=27, minblocks=5) , # 818.248 GFlop/s
-  Kernel_dnt_medium(m=13, n=25, k=7, tile_m=2, tile_n=2, threads=96, grouping=32, minblocks=10) , # 895.315 GFlop/s
-  Kernel_dnt_medium(m=13, n=25, k=9, tile_m=2, tile_n=2, threads=96, grouping=32, minblocks=9) , # 937.417 GFlop/s
-  Kernel_dnt_medium(m=13, n=25, k=13, tile_m=1, tile_n=3, threads=128, grouping=7, minblocks=9) , # 972.388 GFlop/s
-  Kernel_dnt_medium(m=13, n=25, k=14, tile_m=1, tile_n=4, threads=96, grouping=32, minblocks=9) , # 993.182 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=25, k=25, tile_m=2, tile_n=3, w=10, v=14, threads=64, grouping=16, minblocks=2) , # 1071.67 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=25, k=26, tile_m=2, tile_n=3, w=10, v=22, threads=64, grouping=16, minblocks=8) , # 1087.2 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=25, k=28, tile_m=2, tile_n=3, w=14, v=14, threads=64, grouping=16, minblocks=4) , # 1098.76 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=25, k=32, tile_m=2, tile_n=3, w=16, v=20, threads=64, grouping=16, minblocks=8) , # 1113.24 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=25, k=45, tile_m=2, tile_n=3, w=10, v=14, threads=64, grouping=16, minblocks=1) , # 1134.6 GFlop/s
-  Kernel_dnt_medium(m=13, n=26, k=4, tile_m=2, tile_n=3, threads=64, grouping=24, minblocks=3) , # 796.636 GFlop/s
-  Kernel_dnt_medium(m=13, n=26, k=5, tile_m=2, tile_n=3, threads=64, grouping=26, minblocks=10) , # 799.952 GFlop/s
-  Kernel_dnt_medium(m=13, n=26, k=7, tile_m=2, tile_n=2, threads=96, grouping=32, minblocks=9) , # 916.63 GFlop/s
-  Kernel_dnt_medium(m=13, n=26, k=9, tile_m=1, tile_n=3, threads=128, grouping=32, minblocks=12) , # 954.576 GFlop/s
-  Kernel_dnt_medium(m=13, n=26, k=12, tile_m=1, tile_n=3, threads=160, grouping=6, minblocks=9) , # 999.327 GFlop/s
-  Kernel_dnt_medium(m=13, n=26, k=13, tile_m=1, tile_n=4, threads=96, grouping=32, minblocks=10) , # 1007.42 GFlop/s
-  Kernel_dnt_medium(m=13, n=26, k=14, tile_m=1, tile_n=3, threads=128, grouping=5, minblocks=10) , # 1015.55 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=26, k=24, tile_m=2, tile_n=2, w=8, v=26, threads=96, grouping=16, minblocks=1) , # 1094.14 GFlop/s
-  Kernel_dnt_medium(m=13, n=26, k=25, tile_m=1, tile_n=3, threads=128, grouping=4, minblocks=4) , # 1087.67 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=26, k=26, tile_m=2, tile_n=2, w=10, v=10, threads=96, grouping=16, minblocks=1) , # 1091.97 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=26, k=28, tile_m=2, tile_n=2, w=14, v=26, threads=96, grouping=16, minblocks=1) , # 1110.06 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=26, k=32, tile_m=2, tile_n=2, w=16, v=26, threads=96, grouping=16, minblocks=1) , # 1133.28 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=26, k=45, tile_m=2, tile_n=3, w=12, v=26, threads=64, grouping=16, minblocks=8) , # 1150.11 GFlop/s
-  Kernel_dnt_medium(m=13, n=28, k=4, tile_m=4, tile_n=4, threads=64, grouping=24, minblocks=12) , # 824.545 GFlop/s
-  Kernel_dnt_medium(m=13, n=28, k=5, tile_m=1, tile_n=4, threads=96, grouping=9, minblocks=14) , # 835.315 GFlop/s
-  Kernel_dnt_medium(m=13, n=28, k=7, tile_m=1, tile_n=4, threads=96, grouping=32, minblocks=9) , # 942.428 GFlop/s
-  Kernel_dnt_medium(m=13, n=28, k=9, tile_m=1, tile_n=4, threads=128, grouping=29, minblocks=10) , # 986.164 GFlop/s
-  Kernel_dnt_medium(m=13, n=28, k=13, tile_m=1, tile_n=4, threads=96, grouping=32, minblocks=9) , # 1028.12 GFlop/s
-  Kernel_dnt_medium(m=13, n=28, k=25, tile_m=4, tile_n=2, threads=64, grouping=4, minblocks=2) , # 1096.2 GFlop/s
-  Kernel_dnt_medium(m=13, n=28, k=26, tile_m=4, tile_n=2, threads=64, grouping=4, minblocks=2) , # 1109.32 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=28, k=28, tile_m=2, tile_n=4, w=14, v=26, threads=64, grouping=16, minblocks=2) , # 1123.07 GFlop/s
-  Kernel_dnt_medium(m=13, n=28, k=32, tile_m=4, tile_n=2, threads=64, grouping=30, minblocks=1) , # 1134.83 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=28, k=45, tile_m=4, tile_n=2, w=14, v=20, threads=64, grouping=16, minblocks=1) , # 1175.77 GFlop/s
-  Kernel_dnt_medium(m=13, n=32, k=4, tile_m=2, tile_n=4, threads=64, grouping=26, minblocks=6) , # 873.764 GFlop/s
-  Kernel_dnt_medium(m=13, n=32, k=5, tile_m=2, tile_n=4, threads=64, grouping=32, minblocks=6) , # 870.626 GFlop/s
-  Kernel_dnt_medium(m=13, n=32, k=7, tile_m=1, tile_n=5, threads=96, grouping=32, minblocks=9) , # 981.108 GFlop/s
-  Kernel_dnt_medium(m=13, n=32, k=9, tile_m=1, tile_n=5, threads=96, grouping=32, minblocks=9) , # 1008.75 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=32, k=12, tile_m=4, tile_n=2, w=6, v=20, threads=64, grouping=16, minblocks=1) , # 1074.65 GFlop/s
-  Kernel_dnt_medium(m=13, n=32, k=13, tile_m=4, tile_n=1, threads=128, grouping=5, minblocks=9) , # 1073.99 GFlop/s
-  Kernel_dnt_medium(m=13, n=32, k=14, tile_m=4, tile_n=1, threads=128, grouping=5, minblocks=9) , # 1087.04 GFlop/s
-  Kernel_dnt_medium(m=13, n=32, k=16, tile_m=4, tile_n=1, threads=128, grouping=4, minblocks=8) , # 1122.91 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=32, k=24, tile_m=4, tile_n=2, w=12, v=28, threads=64, grouping=16, minblocks=1) , # 1168.27 GFlop/s
-  Kernel_dnt_medium(m=13, n=32, k=25, tile_m=4, tile_n=2, threads=64, grouping=4, minblocks=2) , # 1155.19 GFlop/s
-  Kernel_dnt_medium(m=13, n=32, k=26, tile_m=4, tile_n=2, threads=64, grouping=4, minblocks=4) , # 1166.22 GFlop/s
-  Kernel_dnt_medium(m=13, n=32, k=28, tile_m=4, tile_n=2, threads=64, grouping=3, minblocks=1) , # 1176.77 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=32, k=32, tile_m=2, tile_n=2, w=12, v=14, threads=128, grouping=16, minblocks=1) , # 1205.05 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=32, k=45, tile_m=2, tile_n=2, w=12, v=32, threads=128, grouping=16, minblocks=1) , # 1231.88 GFlop/s
-  Kernel_dnt_medium(m=13, n=45, k=4, tile_m=2, tile_n=5, threads=64, grouping=32, minblocks=5) , # 879.247 GFlop/s
-  Kernel_dnt_medium(m=13, n=45, k=5, tile_m=1, tile_n=5, threads=128, grouping=32, minblocks=9) , # 909.587 GFlop/s
-  Kernel_dnt_medium(m=13, n=45, k=7, tile_m=1, tile_n=5, threads=128, grouping=32, minblocks=9) , # 1015.1 GFlop/s
-  Kernel_dnt_medium(m=13, n=45, k=9, tile_m=1, tile_n=5, threads=128, grouping=32, minblocks=9) , # 1091.53 GFlop/s
-  Kernel_dnt_medium(m=13, n=45, k=13, tile_m=1, tile_n=5, threads=192, grouping=29, minblocks=5) , # 1152.46 GFlop/s
-  Kernel_dnt_medium(m=13, n=45, k=25, tile_m=4, tile_n=3, threads=64, grouping=29, minblocks=4) , # 1240.6 GFlop/s
-  Kernel_dnt_medium(m=13, n=45, k=26, tile_m=4, tile_n=3, threads=64, grouping=4, minblocks=4) , # 1247.15 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=45, k=28, tile_m=2, tile_n=4, w=14, v=20, threads=96, grouping=16, minblocks=4) , # 1271.38 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=45, k=32, tile_m=4, tile_n=3, w=8, v=12, threads=64, grouping=16, minblocks=4) , # 1291.85 GFlop/s
-  Kernel_dnt_largeDB2(m=13, n=45, k=45, tile_m=2, tile_n=5, w=12, v=26, threads=64, grouping=16, minblocks=4) , # 1331.96 GFlop/s
-  Kernel_dnt_medium(m=14, n=13, k=13, tile_m=2, tile_n=2, threads=64, grouping=26, minblocks=4) , # 819.111 GFlop/s
-  Kernel_dnt_medium(m=14, n=13, k=14, tile_m=1, tile_n=4, threads=64, grouping=32, minblocks=3) , # 829.012 GFlop/s
-  Kernel_dnt_medium(m=14, n=13, k=25, tile_m=2, tile_n=1, threads=128, grouping=5, minblocks=7) , # 861.359 GFlop/s
-  Kernel_dnt_medium(m=14, n=13, k=26, tile_m=1, tile_n=2, threads=128, grouping=5, minblocks=7) , # 876.462 GFlop/s
-  Kernel_dnt_medium(m=14, n=13, k=32, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=6) , # 900.065 GFlop/s
-  Kernel_dnt_medium(m=14, n=14, k=13, tile_m=1, tile_n=4, threads=96, grouping=32, minblocks=9) , # 876.026 GFlop/s
-  Kernel_dnt_medium(m=14, n=14, k=14, tile_m=2, tile_n=2, threads=64, grouping=26, minblocks=7) , # 878.284 GFlop/s
-  Kernel_dnt_medium(m=14, n=14, k=16, tile_m=1, tile_n=2, threads=128, grouping=32, minblocks=4) , # 902.555 GFlop/s
-  Kernel_dnt_medium(m=14, n=14, k=25, tile_m=1, tile_n=2, threads=128, grouping=6, minblocks=3) , # 915.718 GFlop/s
-  Kernel_dnt_medium(m=14, n=14, k=26, tile_m=1, tile_n=2, threads=128, grouping=5, minblocks=5) , # 924.538 GFlop/s
-  Kernel_dnt_medium(m=14, n=14, k=29, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=3) , # 924.968 GFlop/s
-  Kernel_dnt_medium(m=14, n=14, k=32, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=5) , # 948.827 GFlop/s
-  Kernel_dnt_medium(m=14, n=16, k=14, tile_m=1, tile_n=4, threads=64, grouping=29, minblocks=1) , # 920.926 GFlop/s
-  Kernel_dnt_medium(m=14, n=16, k=16, tile_m=1, tile_n=4, threads=64, grouping=24, minblocks=11) , # 934.112 GFlop/s
-  Kernel_dnt_medium(m=14, n=16, k=29, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=5) , # 985.695 GFlop/s
-  Kernel_dnt_medium(m=14, n=25, k=13, tile_m=1, tile_n=3, threads=128, grouping=32, minblocks=9) , # 1036.53 GFlop/s
-  Kernel_dnt_medium(m=14, n=25, k=14, tile_m=1, tile_n=3, threads=128, grouping=6, minblocks=10) , # 1064.78 GFlop/s
-  Kernel_dnt_medium(m=14, n=25, k=25, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=5) , # 1135.93 GFlop/s
-  Kernel_dnt_medium(m=14, n=25, k=26, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=1) , # 1146.21 GFlop/s
-  Kernel_dnt_medium(m=14, n=25, k=32, tile_m=1, tile_n=2, threads=224, grouping=3, minblocks=2) , # 1180.89 GFlop/s
-  Kernel_dnt_medium(m=14, n=26, k=13, tile_m=1, tile_n=3, threads=128, grouping=6, minblocks=10) , # 1059.97 GFlop/s
-  Kernel_dnt_medium(m=14, n=26, k=14, tile_m=1, tile_n=3, threads=128, grouping=4, minblocks=10) , # 1080.3 GFlop/s
-  Kernel_dnt_medium(m=14, n=26, k=25, tile_m=1, tile_n=3, threads=128, grouping=3, minblocks=2) , # 1164.2 GFlop/s
-  Kernel_dnt_medium(m=14, n=26, k=26, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=5) , # 1170.35 GFlop/s
-  Kernel_dnt_medium(m=14, n=26, k=32, tile_m=1, tile_n=2, threads=224, grouping=4, minblocks=4) , # 1204.18 GFlop/s
-  Kernel_dnt_medium(m=14, n=29, k=14, tile_m=1, tile_n=5, threads=128, grouping=5, minblocks=8) , # 1099.41 GFlop/s
-  Kernel_dnt_medium(m=14, n=29, k=16, tile_m=1, tile_n=5, threads=128, grouping=4, minblocks=7) , # 1136.55 GFlop/s
-  Kernel_dnt_medium(m=14, n=29, k=29, tile_m=1, tile_n=3, threads=160, grouping=4, minblocks=2) , # 1205.08 GFlop/s
-  Kernel_dnt_medium(m=14, n=29, k=32, tile_m=1, tile_n=3, threads=160, grouping=4, minblocks=3) , # 1227.39 GFlop/s
-  Kernel_dnt_medium(m=14, n=32, k=13, tile_m=1, tile_n=4, threads=128, grouping=4, minblocks=9) , # 1144.56 GFlop/s
-  Kernel_dnt_medium(m=14, n=32, k=14, tile_m=1, tile_n=4, threads=128, grouping=5, minblocks=8) , # 1157.34 GFlop/s
-  Kernel_dnt_medium(m=14, n=32, k=25, tile_m=1, tile_n=3, threads=224, grouping=4, minblocks=5) , # 1247.65 GFlop/s
-  Kernel_dnt_medium(m=14, n=32, k=26, tile_m=1, tile_n=2, threads=224, grouping=4, minblocks=4) , # 1256.51 GFlop/s
-  Kernel_dnt_medium(m=14, n=32, k=29, tile_m=1, tile_n=3, threads=160, grouping=3, minblocks=4) , # 1258.33 GFlop/s
-  Kernel_dnt_medium(m=14, n=32, k=32, tile_m=1, tile_n=3, threads=224, grouping=3, minblocks=4) , # 1281.96 GFlop/s
-  Kernel_dnt_medium(m=15, n=4, k=4, tile_m=2, tile_n=1, threads=32, grouping=16, minblocks=21) , # 349.797 GFlop/s
-  Kernel_dnt_medium(m=15, n=4, k=10, tile_m=2, tile_n=1, threads=32, grouping=13, minblocks=5) , # 430.134 GFlop/s
-  Kernel_dnt_medium(m=15, n=4, k=15, tile_m=2, tile_n=1, threads=64, grouping=6, minblocks=11) , # 443.27 GFlop/s
-  Kernel_dnt_medium(m=15, n=10, k=4, tile_m=5, tile_n=1, threads=32, grouping=12, minblocks=22) , # 594.569 GFlop/s
-  Kernel_dnt_medium(m=15, n=10, k=10, tile_m=2, tile_n=2, threads=64, grouping=22, minblocks=6) , # 728.427 GFlop/s
-  Kernel_dnt_medium(m=15, n=10, k=15, tile_m=2, tile_n=2, threads=64, grouping=29, minblocks=9) , # 747.245 GFlop/s
-  Kernel_dnt_medium(m=15, n=15, k=4, tile_m=2, tile_n=2, threads=64, grouping=19, minblocks=6) , # 738.168 GFlop/s
-  Kernel_dnt_medium(m=15, n=15, k=10, tile_m=2, tile_n=2, threads=64, grouping=29, minblocks=10) , # 904.696 GFlop/s
-  Kernel_dnt_medium(m=15, n=15, k=15, tile_m=2, tile_n=2, threads=64, grouping=32, minblocks=2) , # 928.082 GFlop/s
-  Kernel_dnt_medium(m=16, n=5, k=5, tile_m=1, tile_n=3, threads=32, grouping=12, minblocks=23) , # 501.288 GFlop/s
-  Kernel_dnt_medium(m=16, n=5, k=13, tile_m=1, tile_n=3, threads=64, grouping=4, minblocks=19) , # 503.261 GFlop/s
-  Kernel_dnt_medium(m=16, n=5, k=16, tile_m=1, tile_n=3, threads=96, grouping=29, minblocks=11) , # 524.682 GFlop/s
-  Kernel_dnt_medium(m=16, n=5, k=32, tile_m=1, tile_n=1, threads=128, grouping=32, minblocks=3) , # 534.391 GFlop/s
-  Kernel_dnt_medium(m=16, n=13, k=5, tile_m=2, tile_n=4, threads=32, grouping=16, minblocks=4) , # 723.746 GFlop/s
-  Kernel_dnt_medium(m=16, n=13, k=13, tile_m=2, tile_n=2, threads=64, grouping=26, minblocks=9) , # 871.757 GFlop/s
-  Kernel_dnt_medium(m=16, n=13, k=16, tile_m=2, tile_n=2, threads=64, grouping=32, minblocks=1) , # 897.477 GFlop/s
-  Kernel_dnt_medium(m=16, n=13, k=32, tile_m=1, tile_n=2, threads=160, grouping=4, minblocks=1) , # 953.971 GFlop/s
-  Kernel_dnt_medium(m=16, n=14, k=14, tile_m=2, tile_n=2, threads=64, grouping=32, minblocks=12) , # 927.004 GFlop/s
-  Kernel_dnt_medium(m=16, n=14, k=16, tile_m=1, tile_n=4, threads=96, grouping=5, minblocks=11) , # 936.063 GFlop/s
-  Kernel_dnt_medium(m=16, n=14, k=29, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=3) , # 985.795 GFlop/s
-  Kernel_dnt_medium(m=16, n=16, k=5, tile_m=2, tile_n=5, threads=32, grouping=19, minblocks=14) , # 857.219 GFlop/s
-  Kernel_dnt_medium(m=16, n=16, k=13, tile_m=2, tile_n=2, threads=64, grouping=26, minblocks=9) , # 1001.92 GFlop/s
-  Kernel_dnt_medium(m=16, n=16, k=14, tile_m=2, tile_n=2, threads=64, grouping=32, minblocks=12) , # 1018.98 GFlop/s
-  Kernel_dnt_small(m=16, n=16, k=16, tile_m=2, tile_n=2, threads=64, grouping=29, minblocks=8) , # 1035.54 GFlop/s
-  Kernel_dnt_medium(m=16, n=16, k=29, tile_m=1, tile_n=2, threads=160, grouping=4, minblocks=2) , # 1062.17 GFlop/s
-  Kernel_dnt_medium(m=16, n=16, k=32, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=3) , # 1086.81 GFlop/s
-  Kernel_dnt_medium(m=16, n=16, k=55, tile_m=1, tile_n=2, threads=128, grouping=3, minblocks=1) , # 1104.86 GFlop/s
-  Kernel_dnt_medium(m=16, n=29, k=14, tile_m=1, tile_n=5, threads=128, grouping=4, minblocks=9) , # 1221.28 GFlop/s
-  Kernel_dnt_medium(m=16, n=29, k=16, tile_m=1, tile_n=4, threads=128, grouping=4, minblocks=7) , # 1236.07 GFlop/s
-  Kernel_dnt_medium(m=16, n=29, k=29, tile_m=1, tile_n=3, threads=160, grouping=4, minblocks=4) , # 1318.25 GFlop/s
-  Kernel_dnt_largeDB2(m=16, n=29, k=55, tile_m=1, tile_n=3, w=16, v=16, threads=160, grouping=16, minblocks=1) , # 1388.25 GFlop/s
-  Kernel_dnt_medium(m=16, n=32, k=5, tile_m=1, tile_n=6, threads=96, grouping=32, minblocks=9) , # 1015.49 GFlop/s
-  Kernel_dnt_medium(m=16, n=32, k=13, tile_m=1, tile_n=4, threads=128, grouping=5, minblocks=8) , # 1239.79 GFlop/s
-  Kernel_dnt_medium(m=16, n=32, k=16, tile_m=1, tile_n=4, threads=160, grouping=4, minblocks=7) , # 1304.45 GFlop/s
-  Kernel_dnt_medium(m=16, n=32, k=32, tile_m=1, tile_n=3, threads=192, grouping=3, minblocks=3) , # 1401.94 GFlop/s
-  Kernel_dnt_medium(m=16, n=55, k=16, tile_m=1, tile_n=5, threads=192, grouping=4, minblocks=5) , # 1477.07 GFlop/s
-  Kernel_dnt_medium(m=16, n=55, k=29, tile_m=1, tile_n=5, threads=192, grouping=32, minblocks=2) , # 1548.78 GFlop/s
-  Kernel_dnt_largeDB2(m=16, n=55, k=55, tile_m=2, tile_n=2, w=14, v=40, threads=224, grouping=16, minblocks=1) , # 1648.17 GFlop/s
-  Kernel_dnt_medium(m=17, n=17, k=17, tile_m=1, tile_n=6, threads=128, grouping=6, minblocks=9) , # 1025.78 GFlop/s
-  Kernel_dnt_medium(m=18, n=18, k=18, tile_m=1, tile_n=4, threads=128, grouping=4, minblocks=8) , # 1117.66 GFlop/s
-  Kernel_dnt_medium(m=19, n=19, k=19, tile_m=1, tile_n=4, threads=160, grouping=4, minblocks=7) , # 1155.59 GFlop/s
-  Kernel_dnt_medium(m=20, n=20, k=20, tile_m=1, tile_n=4, threads=160, grouping=4, minblocks=7) , # 1246.17 GFlop/s
-  Kernel_dnt_medium(m=21, n=21, k=21, tile_m=3, tile_n=3, threads=64, grouping=5, minblocks=4) , # 1259.48 GFlop/s
-  Kernel_dnt_medium(m=22, n=9, k=9, tile_m=1, tile_n=5, threads=64, grouping=22, minblocks=14) , # 745.394 GFlop/s
-  Kernel_dnt_medium(m=22, n=9, k=22, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=4) , # 816.342 GFlop/s
-  Kernel_dnt_medium(m=22, n=9, k=32, tile_m=1, tile_n=2, threads=160, grouping=4, minblocks=3) , # 851.574 GFlop/s
-  Kernel_dnt_medium(m=22, n=22, k=9, tile_m=1, tile_n=6, threads=96, grouping=32, minblocks=9) , # 1180.32 GFlop/s
-  Kernel_dnt_medium(m=22, n=22, k=22, tile_m=3, tile_n=3, threads=64, grouping=4, minblocks=5) , # 1354.56 GFlop/s
-  Kernel_dnt_medium(m=22, n=22, k=32, tile_m=3, tile_n=3, threads=64, grouping=3, minblocks=2) , # 1423.15 GFlop/s
-  Kernel_dnt_medium(m=22, n=32, k=9, tile_m=3, tile_n=4, threads=64, grouping=30, minblocks=4) , # 1281.35 GFlop/s
-  Kernel_dnt_medium(m=22, n=32, k=22, tile_m=1, tile_n=4, threads=192, grouping=4, minblocks=5) , # 1571.65 GFlop/s
-  Kernel_dnt_largeDB2(m=22, n=32, k=32, tile_m=3, tile_n=4, w=16, v=20, threads=64, grouping=16, minblocks=1) , # 1641.78 GFlop/s
-  Kernel_dnt_medium(m=23, n=23, k=23, tile_m=3, tile_n=2, threads=96, grouping=4, minblocks=4) , # 1399.21 GFlop/s
-  Kernel_dnt_medium(m=24, n=5, k=5, tile_m=1, tile_n=5, threads=32, grouping=13, minblocks=16) , # 537.802 GFlop/s
-  Kernel_dnt_medium(m=24, n=5, k=13, tile_m=1, tile_n=3, threads=96, grouping=32, minblocks=3) , # 547.371 GFlop/s
-  Kernel_dnt_medium(m=24, n=5, k=24, tile_m=1, tile_n=1, threads=128, grouping=32, minblocks=7) , # 570.165 GFlop/s
-  Kernel_dnt_medium(m=24, n=5, k=26, tile_m=1, tile_n=1, threads=192, grouping=4, minblocks=8) , # 574.898 GFlop/s
-  Kernel_dnt_medium(m=24, n=5, k=32, tile_m=1, tile_n=1, threads=192, grouping=3, minblocks=1) , # 586.204 GFlop/s
-  Kernel_dnt_medium(m=24, n=13, k=5, tile_m=3, tile_n=2, threads=64, grouping=26, minblocks=9) , # 828.944 GFlop/s
-  Kernel_dnt_medium(m=24, n=13, k=13, tile_m=1, tile_n=5, threads=96, grouping=6, minblocks=11) , # 980.411 GFlop/s
-  Kernel_dnt_largeDB2(m=24, n=13, k=24, tile_m=3, tile_n=2, w=12, v=12, threads=64, grouping=16, minblocks=4) , # 1080.39 GFlop/s
-  Kernel_dnt_medium(m=24, n=13, k=26, tile_m=1, tile_n=3, threads=128, grouping=3, minblocks=2) , # 1074.3 GFlop/s
-  Kernel_dnt_medium(m=24, n=13, k=32, tile_m=1, tile_n=3, threads=128, grouping=3, minblocks=2) , # 1107.01 GFlop/s
-  Kernel_dnt_medium(m=24, n=24, k=5, tile_m=3, tile_n=3, threads=64, grouping=32, minblocks=8) , # 1126.34 GFlop/s
-  Kernel_dnt_medium(m=24, n=24, k=13, tile_m=1, tile_n=6, threads=160, grouping=4, minblocks=8) , # 1384.19 GFlop/s
-  Kernel_dnt_medium(m=24, n=24, k=24, tile_m=1, tile_n=3, threads=192, grouping=3, minblocks=5) , # 1523.95 GFlop/s
-  Kernel_dnt_medium(m=24, n=24, k=26, tile_m=1, tile_n=3, threads=224, grouping=4, minblocks=1) , # 1513.76 GFlop/s
-  Kernel_dnt_medium(m=24, n=24, k=32, tile_m=1, tile_n=3, threads=192, grouping=3, minblocks=1) , # 1578.31 GFlop/s
-  Kernel_dnt_medium(m=24, n=26, k=5, tile_m=1, tile_n=6, threads=160, grouping=12, minblocks=8) , # 1069.19 GFlop/s
-  Kernel_dnt_medium(m=24, n=26, k=13, tile_m=1, tile_n=6, threads=128, grouping=5, minblocks=8) , # 1390.67 GFlop/s
-  Kernel_dnt_medium(m=24, n=26, k=24, tile_m=3, tile_n=4, threads=64, grouping=3, minblocks=4) , # 1507.26 GFlop/s
-  Kernel_dnt_medium(m=24, n=26, k=26, tile_m=1, tile_n=3, threads=256, grouping=32, minblocks=3) , # 1507.58 GFlop/s
-  Kernel_dnt_largeDB2(m=24, n=26, k=32, tile_m=3, tile_n=4, w=16, v=18, threads=64, grouping=16, minblocks=1) , # 1559.19 GFlop/s
-  Kernel_dnt_medium(m=24, n=32, k=5, tile_m=1, tile_n=4, threads=192, grouping=10, minblocks=7) , # 1142.19 GFlop/s
-  Kernel_dnt_medium(m=24, n=32, k=13, tile_m=3, tile_n=4, threads=64, grouping=24, minblocks=5) , # 1488.17 GFlop/s
-  Kernel_dnt_medium(m=24, n=32, k=24, tile_m=3, tile_n=2, threads=128, grouping=32, minblocks=2) , # 1672.01 GFlop/s
-  Kernel_dnt_medium(m=24, n=32, k=26, tile_m=1, tile_n=4, threads=224, grouping=3, minblocks=4) , # 1681.57 GFlop/s
-  Kernel_dnt_largeDB2(m=24, n=32, k=32, tile_m=3, tile_n=5, w=8, v=32, threads=64, grouping=16, minblocks=2) , # 1724.89 GFlop/s
-  Kernel_dnt_medium(m=25, n=4, k=4, tile_m=1, tile_n=4, threads=32, grouping=13, minblocks=20) , # 445.461 GFlop/s
-  Kernel_dnt_medium(m=25, n=4, k=5, tile_m=1, tile_n=5, threads=32, grouping=12, minblocks=11) , # 455.068 GFlop/s
-  Kernel_dnt_medium(m=25, n=4, k=7, tile_m=1, tile_n=4, threads=32, grouping=16, minblocks=15) , # 457.448 GFlop/s
-  Kernel_dnt_medium(m=25, n=4, k=9, tile_m=1, tile_n=5, threads=64, grouping=26, minblocks=10) , # 453.929 GFlop/s
-  Kernel_dnt_medium(m=25, n=4, k=13, tile_m=1, tile_n=2, threads=64, grouping=4, minblocks=12) , # 469.649 GFlop/s
-  Kernel_dnt_medium(m=25, n=4, k=25, tile_m=1, tile_n=2, threads=128, grouping=3, minblocks=1) , # 480.107 GFlop/s
-  Kernel_dnt_medium(m=25, n=4, k=26, tile_m=1, tile_n=2, threads=128, grouping=3, minblocks=8) , # 482.817 GFlop/s
-  Kernel_dnt_medium(m=25, n=4, k=28, tile_m=1, tile_n=2, threads=128, grouping=3, minblocks=1) , # 487.851 GFlop/s
-  Kernel_dnt_medium(m=25, n=4, k=32, tile_m=1, tile_n=2, threads=160, grouping=3, minblocks=2) , # 489.45 GFlop/s
-  Kernel_dnt_medium(m=25, n=4, k=45, tile_m=1, tile_n=1, threads=192, grouping=2, minblocks=2) , # 489.336 GFlop/s
-  Kernel_dnt_medium(m=25, n=5, k=4, tile_m=1, tile_n=6, threads=32, grouping=13, minblocks=24) , # 501.601 GFlop/s
-  Kernel_dnt_medium(m=25, n=5, k=5, tile_m=1, tile_n=5, threads=32, grouping=16, minblocks=16) , # 516.776 GFlop/s
-  Kernel_dnt_medium(m=25, n=5, k=7, tile_m=1, tile_n=5, threads=64, grouping=22, minblocks=13) , # 515.647 GFlop/s
-  Kernel_dnt_medium(m=25, n=5, k=9, tile_m=1, tile_n=6, threads=64, grouping=26, minblocks=15) , # 540.279 GFlop/s
-  Kernel_dnt_medium(m=25, n=5, k=13, tile_m=3, tile_n=1, threads=96, grouping=32, minblocks=10) , # 542.948 GFlop/s
-  Kernel_dnt_medium(m=25, n=5, k=25, tile_m=1, tile_n=1, threads=128, grouping=3, minblocks=8) , # 570.33 GFlop/s
-  Kernel_dnt_medium(m=25, n=5, k=26, tile_m=1, tile_n=1, threads=192, grouping=4, minblocks=4) , # 569.355 GFlop/s
-  Kernel_dnt_medium(m=25, n=5, k=28, tile_m=1, tile_n=1, threads=192, grouping=4, minblocks=2) , # 571.981 GFlop/s
-  Kernel_dnt_medium(m=25, n=5, k=32, tile_m=1, tile_n=1, threads=192, grouping=3, minblocks=2) , # 588.39 GFlop/s
-  Kernel_dnt_medium(m=25, n=5, k=45, tile_m=1, tile_n=1, threads=256, grouping=3, minblocks=1) , # 585.125 GFlop/s
-  Kernel_dnt_medium(m=25, n=7, k=4, tile_m=3, tile_n=3, threads=32, grouping=15, minblocks=2) , # 580.754 GFlop/s
-  Kernel_dnt_medium(m=25, n=7, k=5, tile_m=3, tile_n=1, threads=64, grouping=21, minblocks=19) , # 598.77 GFlop/s
-  Kernel_dnt_medium(m=25, n=7, k=7, tile_m=3, tile_n=1, threads=64, grouping=22, minblocks=3) , # 660.441 GFlop/s
-  Kernel_dnt_medium(m=25, n=7, k=9, tile_m=3, tile_n=1, threads=64, grouping=26, minblocks=10) , # 684.274 GFlop/s
-  Kernel_dnt_medium(m=25, n=7, k=13, tile_m=3, tile_n=1, threads=96, grouping=29, minblocks=1) , # 698.671 GFlop/s
-  Kernel_dnt_medium(m=25, n=7, k=25, tile_m=1, tile_n=3, threads=192, grouping=4, minblocks=7) , # 718.262 GFlop/s
-  Kernel_dnt_medium(m=25, n=7, k=26, tile_m=3, tile_n=1, threads=192, grouping=29, minblocks=3) , # 721.455 GFlop/s
-  Kernel_dnt_medium(m=25, n=7, k=28, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=2) , # 724.329 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=7, k=32, tile_m=3, tile_n=1, w=16, v=6, threads=64, grouping=16, minblocks=4) , # 735.427 GFlop/s
-  Kernel_dnt_medium(m=25, n=7, k=45, tile_m=3, tile_n=1, threads=128, grouping=30, minblocks=4) , # 735.753 GFlop/s
-  Kernel_dnt_medium(m=25, n=9, k=4, tile_m=1, tile_n=5, threads=64, grouping=24, minblocks=3) , # 615.95 GFlop/s
-  Kernel_dnt_medium(m=25, n=9, k=5, tile_m=1, tile_n=5, threads=64, grouping=24, minblocks=2) , # 696.734 GFlop/s
-  Kernel_dnt_medium(m=25, n=9, k=7, tile_m=1, tile_n=5, threads=64, grouping=26, minblocks=13) , # 767.41 GFlop/s
-  Kernel_dnt_medium(m=25, n=9, k=9, tile_m=1, tile_n=5, threads=96, grouping=32, minblocks=10) , # 772.896 GFlop/s
-  Kernel_dnt_medium(m=25, n=9, k=13, tile_m=1, tile_n=3, threads=128, grouping=32, minblocks=9) , # 812.472 GFlop/s
-  Kernel_dnt_medium(m=25, n=9, k=25, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=1) , # 854.308 GFlop/s
-  Kernel_dnt_medium(m=25, n=9, k=26, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=5) , # 860.057 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=9, k=28, tile_m=1, tile_n=2, w=10, v=8, threads=128, grouping=16, minblocks=4) , # 875.354 GFlop/s
-  Kernel_dnt_medium(m=25, n=9, k=32, tile_m=1, tile_n=2, threads=160, grouping=3, minblocks=4) , # 882.376 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=9, k=45, tile_m=1, tile_n=2, w=14, v=8, threads=128, grouping=16, minblocks=1) , # 892.009 GFlop/s
-  Kernel_dnt_medium(m=25, n=12, k=12, tile_m=1, tile_n=4, threads=96, grouping=32, minblocks=9) , # 945.839 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=12, k=25, tile_m=3, tile_n=2, w=10, v=12, threads=64, grouping=16, minblocks=1) , # 1042.28 GFlop/s
-  Kernel_dnt_medium(m=25, n=13, k=4, tile_m=3, tile_n=2, threads=64, grouping=26, minblocks=7) , # 772.213 GFlop/s
-  Kernel_dnt_medium(m=25, n=13, k=5, tile_m=3, tile_n=2, threads=64, grouping=26, minblocks=9) , # 811.652 GFlop/s
-  Kernel_dnt_medium(m=25, n=13, k=7, tile_m=3, tile_n=2, threads=64, grouping=29, minblocks=1) , # 894.47 GFlop/s
-  Kernel_dnt_medium(m=25, n=13, k=9, tile_m=3, tile_n=2, threads=64, grouping=32, minblocks=7) , # 937.943 GFlop/s
-  Kernel_dnt_medium(m=25, n=13, k=13, tile_m=1, tile_n=3, threads=128, grouping=7, minblocks=10) , # 975.605 GFlop/s
-  Kernel_dnt_medium(m=25, n=13, k=14, tile_m=1, tile_n=3, threads=128, grouping=7, minblocks=10) , # 992.46 GFlop/s
-  Kernel_dnt_medium(m=25, n=13, k=25, tile_m=1, tile_n=3, threads=128, grouping=4, minblocks=5) , # 1066.09 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=13, k=26, tile_m=3, tile_n=2, w=12, v=4, threads=64, grouping=16, minblocks=2) , # 1073.76 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=13, k=28, tile_m=3, tile_n=2, w=12, v=12, threads=64, grouping=16, minblocks=1) , # 1099.51 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=13, k=32, tile_m=3, tile_n=2, w=14, v=12, threads=64, grouping=16, minblocks=2) , # 1111.26 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=13, k=45, tile_m=3, tile_n=2, w=12, v=10, threads=64, grouping=16, minblocks=1) , # 1133.67 GFlop/s
-  Kernel_dnt_medium(m=25, n=14, k=13, tile_m=1, tile_n=3, threads=128, grouping=6, minblocks=9) , # 1028.26 GFlop/s
-  Kernel_dnt_medium(m=25, n=14, k=14, tile_m=1, tile_n=3, threads=128, grouping=6, minblocks=9) , # 1048.08 GFlop/s
-  Kernel_dnt_medium(m=25, n=14, k=25, tile_m=1, tile_n=3, threads=128, grouping=3, minblocks=1) , # 1119.23 GFlop/s
-  Kernel_dnt_medium(m=25, n=14, k=26, tile_m=1, tile_n=3, threads=128, grouping=3, minblocks=3) , # 1118.61 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=14, k=32, tile_m=3, tile_n=2, w=16, v=14, threads=64, grouping=16, minblocks=2) , # 1161.79 GFlop/s
-  Kernel_dnt_medium(m=25, n=25, k=4, tile_m=3, tile_n=4, threads=64, grouping=32, minblocks=4) , # 976.486 GFlop/s
-  Kernel_dnt_medium(m=25, n=25, k=5, tile_m=1, tile_n=5, threads=128, grouping=32, minblocks=9) , # 1070.36 GFlop/s
-  Kernel_dnt_medium(m=25, n=25, k=7, tile_m=1, tile_n=5, threads=128, grouping=32, minblocks=9) , # 1194.1 GFlop/s
-  Kernel_dnt_medium(m=25, n=25, k=9, tile_m=1, tile_n=5, threads=128, grouping=32, minblocks=9) , # 1269.67 GFlop/s
-  Kernel_dnt_medium(m=25, n=25, k=12, tile_m=1, tile_n=5, threads=128, grouping=32, minblocks=9) , # 1365.39 GFlop/s
-  Kernel_dnt_medium(m=25, n=25, k=13, tile_m=1, tile_n=5, threads=128, grouping=29, minblocks=5) , # 1367.05 GFlop/s
-  Kernel_dnt_medium(m=25, n=25, k=14, tile_m=1, tile_n=5, threads=192, grouping=29, minblocks=5) , # 1390.72 GFlop/s
-  Kernel_dnt_medium(m=25, n=25, k=25, tile_m=3, tile_n=4, threads=64, grouping=3, minblocks=4) , # 1504.46 GFlop/s
-  Kernel_dnt_medium(m=25, n=25, k=26, tile_m=3, tile_n=4, threads=64, grouping=30, minblocks=1) , # 1498.12 GFlop/s
-  Kernel_dnt_medium(m=25, n=25, k=28, tile_m=3, tile_n=4, threads=64, grouping=4, minblocks=2) , # 1526.33 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=25, k=32, tile_m=3, tile_n=4, w=8, v=24, threads=64, grouping=16, minblocks=2) , # 1548.35 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=25, k=45, tile_m=3, tile_n=4, w=20, v=8, threads=64, grouping=16, minblocks=2) , # 1587.51 GFlop/s
-  Kernel_dnt_medium(m=25, n=26, k=4, tile_m=3, tile_n=4, threads=64, grouping=32, minblocks=5) , # 974.726 GFlop/s
-  Kernel_dnt_medium(m=25, n=26, k=5, tile_m=1, tile_n=6, threads=160, grouping=14, minblocks=8) , # 1032.18 GFlop/s
-  Kernel_dnt_medium(m=25, n=26, k=7, tile_m=1, tile_n=6, threads=192, grouping=10, minblocks=8) , # 1153.33 GFlop/s
-  Kernel_dnt_medium(m=25, n=26, k=9, tile_m=3, tile_n=4, threads=64, grouping=27, minblocks=3) , # 1238.92 GFlop/s
-  Kernel_dnt_medium(m=25, n=26, k=13, tile_m=1, tile_n=6, threads=128, grouping=24, minblocks=6) , # 1358.07 GFlop/s
-  Kernel_dnt_medium(m=25, n=26, k=14, tile_m=1, tile_n=6, threads=128, grouping=24, minblocks=6) , # 1398.79 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=26, k=25, tile_m=3, tile_n=4, w=8, v=26, threads=64, grouping=16, minblocks=2) , # 1510.79 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=26, k=26, tile_m=3, tile_n=4, w=8, v=26, threads=64, grouping=16, minblocks=8) , # 1521.72 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=26, k=28, tile_m=3, tile_n=4, w=8, v=26, threads=64, grouping=16, minblocks=2) , # 1547.14 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=26, k=32, tile_m=3, tile_n=4, w=8, v=26, threads=64, grouping=16, minblocks=4) , # 1582.6 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=26, k=45, tile_m=3, tile_n=4, w=18, v=26, threads=64, grouping=16, minblocks=2) , # 1621.87 GFlop/s
-  Kernel_dnt_medium(m=25, n=28, k=4, tile_m=3, tile_n=4, threads=64, grouping=32, minblocks=3) , # 1038.23 GFlop/s
-  Kernel_dnt_medium(m=25, n=28, k=5, tile_m=1, tile_n=6, threads=160, grouping=9, minblocks=8) , # 1102.36 GFlop/s
-  Kernel_dnt_medium(m=25, n=28, k=7, tile_m=1, tile_n=6, threads=128, grouping=7, minblocks=8) , # 1200.18 GFlop/s
-  Kernel_dnt_medium(m=25, n=28, k=9, tile_m=1, tile_n=6, threads=128, grouping=6, minblocks=8) , # 1319.69 GFlop/s
-  Kernel_dnt_medium(m=25, n=28, k=13, tile_m=1, tile_n=6, threads=128, grouping=4, minblocks=8) , # 1432.84 GFlop/s
-  Kernel_dnt_medium(m=25, n=28, k=25, tile_m=3, tile_n=4, threads=64, grouping=3, minblocks=2) , # 1590.64 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=28, k=26, tile_m=3, tile_n=4, w=8, v=28, threads=64, grouping=16, minblocks=2) , # 1589.92 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=28, k=28, tile_m=3, tile_n=4, w=8, v=28, threads=64, grouping=16, minblocks=1) , # 1612.35 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=28, k=32, tile_m=3, tile_n=4, w=8, v=28, threads=64, grouping=16, minblocks=4) , # 1653.53 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=28, k=45, tile_m=3, tile_n=4, w=18, v=28, threads=64, grouping=16, minblocks=4) , # 1684.81 GFlop/s
-  Kernel_dnt_medium(m=25, n=32, k=4, tile_m=5, tile_n=1, threads=160, grouping=12, minblocks=7) , # 1025.19 GFlop/s
-  Kernel_dnt_medium(m=25, n=32, k=5, tile_m=5, tile_n=1, threads=192, grouping=16, minblocks=7) , # 1111.36 GFlop/s
-  Kernel_dnt_medium(m=25, n=32, k=7, tile_m=3, tile_n=5, threads=64, grouping=24, minblocks=3) , # 1256.28 GFlop/s
-  Kernel_dnt_medium(m=25, n=32, k=9, tile_m=5, tile_n=3, threads=64, grouping=29, minblocks=2) , # 1364.67 GFlop/s
-  Kernel_dnt_medium(m=25, n=32, k=13, tile_m=3, tile_n=5, threads=64, grouping=29, minblocks=1) , # 1484.69 GFlop/s
-  Kernel_dnt_medium(m=25, n=32, k=14, tile_m=3, tile_n=5, threads=64, grouping=29, minblocks=4) , # 1517.54 GFlop/s
-  Kernel_dnt_medium(m=25, n=32, k=25, tile_m=5, tile_n=3, threads=64, grouping=29, minblocks=1) , # 1655.28 GFlop/s
-  Kernel_dnt_medium(m=25, n=32, k=26, tile_m=3, tile_n=5, threads=64, grouping=3, minblocks=3) , # 1680.88 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=32, k=28, tile_m=5, tile_n=3, w=14, v=32, threads=64, grouping=16, minblocks=1) , # 1689.82 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=32, k=32, tile_m=5, tile_n=3, w=8, v=32, threads=64, grouping=16, minblocks=1) , # 1750.62 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=32, k=45, tile_m=5, tile_n=3, w=8, v=32, threads=64, grouping=16, minblocks=4) , # 1784.12 GFlop/s
-  Kernel_dnt_medium(m=25, n=45, k=4, tile_m=3, tile_n=5, threads=96, grouping=30, minblocks=4) , # 1026.08 GFlop/s
-  Kernel_dnt_medium(m=25, n=45, k=5, tile_m=5, tile_n=2, threads=128, grouping=24, minblocks=2) , # 1149.65 GFlop/s
-  Kernel_dnt_medium(m=25, n=45, k=7, tile_m=3, tile_n=5, threads=96, grouping=24, minblocks=2) , # 1315.18 GFlop/s
-  Kernel_dnt_medium(m=25, n=45, k=9, tile_m=5, tile_n=2, threads=128, grouping=32, minblocks=3) , # 1432.35 GFlop/s
-  Kernel_dnt_medium(m=25, n=45, k=13, tile_m=3, tile_n=5, threads=96, grouping=24, minblocks=1) , # 1592.59 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=45, k=25, tile_m=5, tile_n=4, w=10, v=22, threads=64, grouping=16, minblocks=1) , # 1834.49 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=45, k=26, tile_m=5, tile_n=4, w=10, v=44, threads=64, grouping=16, minblocks=4) , # 1856.86 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=45, k=28, tile_m=5, tile_n=4, w=10, v=44, threads=64, grouping=16, minblocks=1) , # 1880.32 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=45, k=32, tile_m=5, tile_n=4, w=8, v=22, threads=64, grouping=16, minblocks=1) , # 1931.76 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=45, k=45, tile_m=5, tile_n=4, w=10, v=14, threads=64, grouping=16, minblocks=4) , # 2021.91 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=4, tile_m=1, tile_n=4, threads=32, grouping=13, minblocks=8) , # 455.983 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=5, tile_m=1, tile_n=4, threads=32, grouping=13, minblocks=13) , # 453.07 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=7, tile_m=1, tile_n=4, threads=32, grouping=16, minblocks=8) , # 462.367 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=9, tile_m=1, tile_n=2, threads=64, grouping=26, minblocks=7) , # 461.91 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=13, tile_m=1, tile_n=2, threads=64, grouping=32, minblocks=1) , # 478.188 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=25, tile_m=1, tile_n=2, threads=128, grouping=3, minblocks=2) , # 483.153 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=26, tile_m=1, tile_n=2, threads=128, grouping=3, minblocks=4) , # 487.755 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=28, tile_m=1, tile_n=2, threads=128, grouping=3, minblocks=3) , # 489.503 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=32, tile_m=1, tile_n=1, threads=192, grouping=3, minblocks=4) , # 493.24 GFlop/s
-  Kernel_dnt_medium(m=26, n=4, k=45, tile_m=1, tile_n=1, threads=256, grouping=2, minblocks=2) , # 495.988 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=4, tile_m=1, tile_n=5, threads=32, grouping=13, minblocks=27) , # 513.002 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=5, tile_m=5, tile_n=1, threads=32, grouping=18, minblocks=10) , # 517.591 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=7, tile_m=1, tile_n=3, threads=64, grouping=22, minblocks=1) , # 525.335 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=9, tile_m=1, tile_n=3, threads=64, grouping=26, minblocks=12) , # 550.268 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=12, tile_m=1, tile_n=3, threads=64, grouping=32, minblocks=11) , # 560.898 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=13, tile_m=1, tile_n=3, threads=96, grouping=29, minblocks=9) , # 549.663 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=24, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=4) , # 573.419 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=25, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=7) , # 570.821 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=26, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=7) , # 573.903 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=28, tile_m=1, tile_n=3, threads=160, grouping=24, minblocks=3) , # 573.438 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=32, tile_m=1, tile_n=1, threads=224, grouping=3, minblocks=6) , # 587.174 GFlop/s
-  Kernel_dnt_medium(m=26, n=5, k=45, tile_m=1, tile_n=1, threads=256, grouping=3, minblocks=1) , # 590.001 GFlop/s
-  Kernel_dnt_medium(m=26, n=7, k=4, tile_m=2, tile_n=4, threads=32, grouping=16, minblocks=1) , # 594.471 GFlop/s
-  Kernel_dnt_medium(m=26, n=7, k=5, tile_m=3, tile_n=1, threads=64, grouping=22, minblocks=17) , # 613.113 GFlop/s
-  Kernel_dnt_medium(m=26, n=7, k=7, tile_m=1, tile_n=4, threads=64, grouping=22, minblocks=6) , # 672.9 GFlop/s
-  Kernel_dnt_medium(m=26, n=7, k=9, tile_m=3, tile_n=1, threads=64, grouping=26, minblocks=1) , # 697.663 GFlop/s
-  Kernel_dnt_medium(m=26, n=7, k=13, tile_m=3, tile_n=1, threads=96, grouping=32, minblocks=7) , # 710.135 GFlop/s
-  Kernel_dnt_medium(m=26, n=7, k=25, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=7) , # 730.136 GFlop/s
-  Kernel_dnt_medium(m=26, n=7, k=26, tile_m=1, tile_n=2, threads=192, grouping=5, minblocks=3) , # 735.317 GFlop/s
-  Kernel_dnt_medium(m=26, n=7, k=28, tile_m=1, tile_n=2, threads=224, grouping=4, minblocks=6) , # 737.392 GFlop/s
-  Kernel_dnt_medium(m=26, n=7, k=32, tile_m=1, tile_n=2, threads=256, grouping=4, minblocks=5) , # 751.816 GFlop/s
-  Kernel_dnt_medium(m=26, n=7, k=45, tile_m=1, tile_n=1, threads=192, grouping=3, minblocks=4) , # 754.379 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=4, tile_m=1, tile_n=5, threads=64, grouping=24, minblocks=4) , # 645.89 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=5, tile_m=1, tile_n=5, threads=64, grouping=26, minblocks=16) , # 708.797 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=7, tile_m=1, tile_n=5, threads=64, grouping=25, minblocks=15) , # 783.549 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=9, tile_m=1, tile_n=5, threads=96, grouping=32, minblocks=11) , # 797.252 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=13, tile_m=1, tile_n=3, threads=128, grouping=18, minblocks=4) , # 821.531 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=25, tile_m=1, tile_n=3, threads=128, grouping=4, minblocks=6) , # 862.508 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=26, tile_m=1, tile_n=3, threads=256, grouping=5, minblocks=5) , # 871.198 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=28, tile_m=1, tile_n=3, threads=128, grouping=4, minblocks=3) , # 877.813 GFlop/s
-  Kernel_dnt_medium(m=26, n=9, k=32, tile_m=1, tile_n=3, threads=128, grouping=3, minblocks=5) , # 895.509 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=9, k=45, tile_m=3, tile_n=1, w=10, v=6, threads=96, grouping=16, minblocks=8) , # 902.055 GFlop/s
-  Kernel_dnt_medium(m=26, n=12, k=5, tile_m=1, tile_n=6, threads=64, grouping=24, minblocks=11) , # 853.834 GFlop/s
-  Kernel_dnt_medium(m=26, n=12, k=12, tile_m=1, tile_n=2, threads=160, grouping=6, minblocks=11) , # 965.748 GFlop/s
-  Kernel_dnt_medium(m=26, n=12, k=13, tile_m=1, tile_n=2, threads=160, grouping=6, minblocks=1) , # 969.942 GFlop/s
-  Kernel_dnt_medium(m=26, n=12, k=26, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=6) , # 1059.98 GFlop/s
-  Kernel_dnt_medium(m=26, n=12, k=32, tile_m=1, tile_n=2, threads=192, grouping=3, minblocks=3) , # 1091.93 GFlop/s
-  Kernel_dnt_medium(m=26, n=13, k=4, tile_m=3, tile_n=2, threads=64, grouping=26, minblocks=8) , # 799.987 GFlop/s
-  Kernel_dnt_medium(m=26, n=13, k=5, tile_m=3, tile_n=2, threads=64, grouping=26, minblocks=2) , # 797.258 GFlop/s
-  Kernel_dnt_medium(m=26, n=13, k=7, tile_m=1, tile_n=5, threads=96, grouping=26, minblocks=13) , # 922.13 GFlop/s
-  Kernel_dnt_medium(m=26, n=13, k=9, tile_m=1, tile_n=5, threads=128, grouping=32, minblocks=10) , # 949.735 GFlop/s
-  Kernel_dnt_medium(m=26, n=13, k=12, tile_m=1, tile_n=5, threads=96, grouping=32, minblocks=10) , # 997.362 GFlop/s
-  Kernel_dnt_medium(m=26, n=13, k=13, tile_m=1, tile_n=5, threads=96, grouping=6, minblocks=11) , # 991.96 GFlop/s
-  Kernel_dnt_medium(m=26, n=13, k=14, tile_m=1, tile_n=4, threads=128, grouping=24, minblocks=6) , # 1008.41 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=13, k=24, tile_m=3, tile_n=2, w=12, v=12, threads=64, grouping=16, minblocks=1) , # 1092.08 GFlop/s
-  Kernel_dnt_medium(m=26, n=13, k=25, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=5) , # 1088.18 GFlop/s
-  Kernel_dnt_medium(m=26, n=13, k=26, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=3) , # 1101.37 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=13, k=28, tile_m=3, tile_n=2, w=14, v=8, threads=64, grouping=16, minblocks=2) , # 1105.61 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=13, k=32, tile_m=3, tile_n=2, w=14, v=12, threads=64, grouping=16, minblocks=8) , # 1128.15 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=13, k=45, tile_m=3, tile_n=2, w=12, v=8, threads=64, grouping=16, minblocks=1) , # 1156.84 GFlop/s
-  Kernel_dnt_medium(m=26, n=14, k=13, tile_m=1, tile_n=5, threads=96, grouping=4, minblocks=11) , # 1046.07 GFlop/s
-  Kernel_dnt_medium(m=26, n=14, k=14, tile_m=1, tile_n=5, threads=128, grouping=5, minblocks=9) , # 1076.05 GFlop/s
-  Kernel_dnt_medium(m=26, n=14, k=25, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=2) , # 1153.33 GFlop/s
-  Kernel_dnt_medium(m=26, n=14, k=26, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=2) , # 1159.6 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=14, k=32, tile_m=3, tile_n=2, w=16, v=14, threads=64, grouping=16, minblocks=4) , # 1196.64 GFlop/s
-  Kernel_dnt_medium(m=26, n=24, k=5, tile_m=1, tile_n=4, threads=160, grouping=32, minblocks=9) , # 1078.8 GFlop/s
-  Kernel_dnt_medium(m=26, n=24, k=13, tile_m=1, tile_n=6, threads=128, grouping=4, minblocks=7) , # 1387.5 GFlop/s
-  Kernel_dnt_medium(m=26, n=24, k=24, tile_m=1, tile_n=4, threads=160, grouping=3, minblocks=5) , # 1530.31 GFlop/s
-  Kernel_dnt_medium(m=26, n=24, k=26, tile_m=1, tile_n=4, threads=192, grouping=24, minblocks=4) , # 1507.25 GFlop/s
-  Kernel_dnt_medium(m=26, n=24, k=32, tile_m=1, tile_n=4, threads=256, grouping=32, minblocks=3) , # 1570.75 GFlop/s
-  Kernel_dnt_medium(m=26, n=25, k=4, tile_m=3, tile_n=4, threads=64, grouping=32, minblocks=8) , # 973.176 GFlop/s
-  Kernel_dnt_medium(m=26, n=25, k=5, tile_m=1, tile_n=5, threads=160, grouping=13, minblocks=8) , # 1040.55 GFlop/s
-  Kernel_dnt_medium(m=26, n=25, k=7, tile_m=1, tile_n=4, threads=192, grouping=18, minblocks=8) , # 1170.93 GFlop/s
-  Kernel_dnt_medium(m=26, n=25, k=9, tile_m=3, tile_n=4, threads=64, grouping=26, minblocks=3) , # 1241.28 GFlop/s
-  Kernel_dnt_medium(m=26, n=25, k=13, tile_m=1, tile_n=5, threads=160, grouping=6, minblocks=6) , # 1351.85 GFlop/s
-  Kernel_dnt_medium(m=26, n=25, k=14, tile_m=1, tile_n=5, threads=192, grouping=29, minblocks=6) , # 1386.15 GFlop/s
-  Kernel_dnt_medium(m=26, n=25, k=25, tile_m=3, tile_n=4, threads=64, grouping=30, minblocks=4) , # 1508.73 GFlop/s
-  Kernel_dnt_medium(m=26, n=25, k=26, tile_m=3, tile_n=5, threads=64, grouping=29, minblocks=2) , # 1524.65 GFlop/s
-  Kernel_dnt_medium(m=26, n=25, k=28, tile_m=1, tile_n=5, threads=192, grouping=24, minblocks=4) , # 1536.17 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=25, k=32, tile_m=3, tile_n=4, w=8, v=22, threads=64, grouping=16, minblocks=8) , # 1588.12 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=25, k=45, tile_m=3, tile_n=4, w=18, v=20, threads=64, grouping=16, minblocks=4) , # 1619.09 GFlop/s
-  Kernel_dnt_medium(m=26, n=26, k=4, tile_m=3, tile_n=4, threads=64, grouping=32, minblocks=5) , # 1064.38 GFlop/s
-  Kernel_dnt_medium(m=26, n=26, k=5, tile_m=3, tile_n=2, threads=160, grouping=9, minblocks=8) , # 1092.54 GFlop/s
-  Kernel_dnt_medium(m=26, n=26, k=7, tile_m=1, tile_n=4, threads=192, grouping=9, minblocks=8) , # 1229.79 GFlop/s
-  Kernel_dnt_medium(m=26, n=26, k=9, tile_m=1, tile_n=5, threads=160, grouping=9, minblocks=7) , # 1308.23 GFlop/s
-  Kernel_dnt_medium(m=26, n=26, k=12, tile_m=1, tile_n=5, threads=160, grouping=5, minblocks=7) , # 1442.33 GFlop/s
-  Kernel_dnt_medium(m=26, n=26, k=13, tile_m=1, tile_n=5, threads=160, grouping=5, minblocks=6) , # 1449.82 GFlop/s
-  Kernel_dnt_medium(m=26, n=26, k=14, tile_m=1, tile_n=5, threads=160, grouping=5, minblocks=6) , # 1481.84 GFlop/s
-  Kernel_dnt_medium(m=26, n=26, k=24, tile_m=3, tile_n=4, threads=64, grouping=3, minblocks=4) , # 1576.45 GFlop/s
-  Kernel_dnt_medium(m=26, n=26, k=25, tile_m=1, tile_n=4, threads=192, grouping=32, minblocks=1) , # 1587.9 GFlop/s
-  Kernel_dnt_medium(m=26, n=26, k=26, tile_m=1, tile_n=4, threads=192, grouping=4, minblocks=4) , # 1597.11 GFlop/s
-  Kernel_dnt_medium(m=26, n=26, k=28, tile_m=3, tile_n=4, threads=64, grouping=3, minblocks=2) , # 1611.35 GFlop/s
-  Kernel_dnt_medium(m=26, n=26, k=32, tile_m=3, tile_n=4, threads=64, grouping=3, minblocks=2) , # 1634.06 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=26, k=45, tile_m=3, tile_n=4, w=18, v=14, threads=64, grouping=16, minblocks=4) , # 1658.01 GFlop/s
-  Kernel_dnt_medium(m=26, n=28, k=4, tile_m=3, tile_n=4, threads=64, grouping=32, minblocks=2) , # 1060.2 GFlop/s
-  Kernel_dnt_medium(m=26, n=28, k=5, tile_m=1, tile_n=5, threads=160, grouping=9, minblocks=8) , # 1126.12 GFlop/s
-  Kernel_dnt_medium(m=26, n=28, k=7, tile_m=1, tile_n=4, threads=224, grouping=27, minblocks=6) , # 1233.99 GFlop/s
-  Kernel_dnt_medium(m=26, n=28, k=9, tile_m=3, tile_n=4, threads=64, grouping=25, minblocks=3) , # 1333.66 GFlop/s
-  Kernel_dnt_medium(m=26, n=28, k=13, tile_m=1, tile_n=5, threads=160, grouping=5, minblocks=6) , # 1462.23 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=28, k=25, tile_m=3, tile_n=4, w=8, v=28, threads=64, grouping=16, minblocks=1) , # 1614.7 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=28, k=26, tile_m=3, tile_n=4, w=8, v=28, threads=64, grouping=16, minblocks=1) , # 1634.02 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=28, k=28, tile_m=3, tile_n=4, w=8, v=28, threads=64, grouping=16, minblocks=2) , # 1644.78 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=28, k=32, tile_m=3, tile_n=4, w=8, v=28, threads=64, grouping=16, minblocks=1) , # 1687.3 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=28, k=45, tile_m=3, tile_n=3, w=16, v=28, threads=96, grouping=16, minblocks=1) , # 1724.14 GFlop/s
-  Kernel_dnt_medium(m=26, n=32, k=4, tile_m=1, tile_n=6, threads=160, grouping=12, minblocks=7) , # 1067.11 GFlop/s
-  Kernel_dnt_medium(m=26, n=32, k=5, tile_m=1, tile_n=6, threads=192, grouping=12, minblocks=6) , # 1162.16 GFlop/s
-  Kernel_dnt_medium(m=26, n=32, k=7, tile_m=3, tile_n=5, threads=64, grouping=26, minblocks=6) , # 1279.84 GFlop/s
-  Kernel_dnt_medium(m=26, n=32, k=9, tile_m=1, tile_n=6, threads=160, grouping=10, minblocks=7) , # 1389.5 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=32, k=12, tile_m=7, tile_n=2, w=6, v=32, threads=64, grouping=16, minblocks=1) , # 1501.3 GFlop/s
-  Kernel_dnt_medium(m=26, n=32, k=13, tile_m=1, tile_n=6, threads=160, grouping=5, minblocks=6) , # 1539.69 GFlop/s
-  Kernel_dnt_medium(m=26, n=32, k=14, tile_m=1, tile_n=6, threads=160, grouping=5, minblocks=6) , # 1590.16 GFlop/s
-  Kernel_dnt_medium(m=26, n=32, k=24, tile_m=3, tile_n=5, threads=64, grouping=3, minblocks=3) , # 1705.11 GFlop/s
-  Kernel_dnt_medium(m=26, n=32, k=25, tile_m=3, tile_n=5, threads=64, grouping=3, minblocks=2) , # 1687.93 GFlop/s
-  Kernel_dnt_medium(m=26, n=32, k=26, tile_m=3, tile_n=5, threads=64, grouping=3, minblocks=2) , # 1732.07 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=32, k=28, tile_m=3, tile_n=5, w=14, v=26, threads=64, grouping=16, minblocks=1) , # 1728.22 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=32, k=32, tile_m=3, tile_n=5, w=8, v=32, threads=64, grouping=16, minblocks=4) , # 1778.97 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=32, k=45, tile_m=3, tile_n=5, w=16, v=30, threads=64, grouping=16, minblocks=1) , # 1831.59 GFlop/s
-  Kernel_dnt_medium(m=26, n=45, k=4, tile_m=1, tile_n=6, threads=224, grouping=29, minblocks=5) , # 1073.89 GFlop/s
-  Kernel_dnt_medium(m=26, n=45, k=5, tile_m=1, tile_n=5, threads=256, grouping=29, minblocks=5) , # 1204.58 GFlop/s
-  Kernel_dnt_medium(m=26, n=45, k=7, tile_m=3, tile_n=5, threads=96, grouping=25, minblocks=3) , # 1351.98 GFlop/s
-  Kernel_dnt_medium(m=26, n=45, k=9, tile_m=1, tile_n=5, threads=256, grouping=29, minblocks=5) , # 1490.07 GFlop/s
-  Kernel_dnt_medium(m=26, n=45, k=13, tile_m=3, tile_n=5, threads=96, grouping=24, minblocks=2) , # 1646.86 GFlop/s
-  Kernel_dnt_medium(m=26, n=45, k=25, tile_m=1, tile_n=5, threads=256, grouping=32, minblocks=3) , # 1858.51 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=45, k=26, tile_m=7, tile_n=3, w=8, v=42, threads=64, grouping=16, minblocks=2) , # 1878.25 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=45, k=28, tile_m=7, tile_n=3, w=8, v=38, threads=64, grouping=16, minblocks=2) , # 1924.64 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=45, k=32, tile_m=7, tile_n=3, w=8, v=22, threads=64, grouping=16, minblocks=1) , # 1985.28 GFlop/s
-  Kernel_dnt_largeDB2(m=26, n=45, k=45, tile_m=7, tile_n=3, w=14, v=36, threads=64, grouping=16, minblocks=4) , # 2060.31 GFlop/s
-  Kernel_dnt_medium(m=27, n=27, k=27, tile_m=3, tile_n=4, threads=64, grouping=3, minblocks=3) , # 1627.88 GFlop/s
-  Kernel_dnt_medium(m=28, n=4, k=4, tile_m=1, tile_n=5, threads=32, grouping=13, minblocks=23) , # 461.401 GFlop/s
-  Kernel_dnt_medium(m=28, n=4, k=5, tile_m=1, tile_n=5, threads=32, grouping=13, minblocks=21) , # 448.695 GFlop/s
-  Kernel_dnt_medium(m=28, n=4, k=7, tile_m=1, tile_n=2, threads=64, grouping=24, minblocks=7) , # 463.739 GFlop/s
-  Kernel_dnt_medium(m=28, n=4, k=9, tile_m=1, tile_n=2, threads=64, grouping=5, minblocks=2) , # 475.527 GFlop/s
-  Kernel_dnt_medium(m=28, n=4, k=13, tile_m=1, tile_n=2, threads=64, grouping=29, minblocks=6) , # 481.891 GFlop/s
-  Kernel_dnt_medium(m=28, n=4, k=25, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=4) , # 486.812 GFlop/s
-  Kernel_dnt_medium(m=28, n=4, k=26, tile_m=1, tile_n=2, threads=128, grouping=32, minblocks=1) , # 486.174 GFlop/s
-  Kernel_dnt_medium(m=28, n=4, k=28, tile_m=1, tile_n=2, threads=128, grouping=6, minblocks=3) , # 487.386 GFlop/s
-  Kernel_dnt_medium(m=28, n=4, k=32, tile_m=1, tile_n=1, threads=192, grouping=4, minblocks=1) , # 493.569 GFlop/s
-  Kernel_dnt_medium(m=28, n=4, k=45, tile_m=1, tile_n=1, threads=256, grouping=2, minblocks=3) , # 499.71 GFlop/s
-  Kernel_dnt_medium(m=28, n=5, k=4, tile_m=1, tile_n=5, threads=32, grouping=15, minblocks=13) , # 512.554 GFlop/s
-  Kernel_dnt_medium(m=28, n=5, k=5, tile_m=1, tile_n=5, threads=32, grouping=16, minblocks=24) , # 527.04 GFlop/s
-  Kernel_dnt_medium(m=28, n=5, k=7, tile_m=1, tile_n=5, threads=64, grouping=22, minblocks=17) , # 539.965 GFlop/s
-  Kernel_dnt_medium(m=28, n=5, k=9, tile_m=3, tile_n=1, threads=64, grouping=26, minblocks=12) , # 563.57 GFlop/s
-  Kernel_dnt_medium(m=28, n=5, k=13, tile_m=1, tile_n=3, threads=96, grouping=29, minblocks=3) , # 557.175 GFlop/s
-  Kernel_dnt_medium(m=28, n=5, k=25, tile_m=1, tile_n=3, threads=192, grouping=4, minblocks=7) , # 578.247 GFlop/s
-  Kernel_dnt_medium(m=28, n=5, k=26, tile_m=1, tile_n=2, threads=160, grouping=5, minblocks=3) , # 579.676 GFlop/s
-  Kernel_dnt_medium(m=28, n=5, k=28, tile_m=1, tile_n=1, threads=160, grouping=4, minblocks=1) , # 584.008 GFlop/s
-  Kernel_dnt_medium(m=28, n=5, k=32, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=3) , # 594.508 GFlop/s
-  Kernel_dnt_medium(m=28, n=5, k=45, tile_m=1, tile_n=1, threads=256, grouping=3, minblocks=3) , # 598.534 GFlop/s
-  Kernel_dnt_medium(m=28, n=7, k=4, tile_m=2, tile_n=4, threads=32, grouping=17, minblocks=10) , # 622.45 GFlop/s
-  Kernel_dnt_medium(m=28, n=7, k=5, tile_m=1, tile_n=4, threads=64, grouping=22, minblocks=7) , # 627.062 GFlop/s
-  Kernel_dnt_medium(m=28, n=7, k=7, tile_m=1, tile_n=5, threads=64, grouping=26, minblocks=9) , # 683.291 GFlop/s
-  Kernel_dnt_medium(m=28, n=7, k=9, tile_m=1, tile_n=4, threads=64, grouping=24, minblocks=1) , # 714.393 GFlop/s
-  Kernel_dnt_medium(m=28, n=7, k=13, tile_m=1, tile_n=3, threads=96, grouping=29, minblocks=9) , # 722.039 GFlop/s
-  Kernel_dnt_medium(m=28, n=7, k=25, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=6) , # 745.291 GFlop/s
-  Kernel_dnt_medium(m=28, n=7, k=26, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=4) , # 747.448 GFlop/s
-  Kernel_dnt_medium(m=28, n=7, k=28, tile_m=1, tile_n=2, threads=224, grouping=3, minblocks=6) , # 754.047 GFlop/s
-  Kernel_dnt_medium(m=28, n=7, k=32, tile_m=1, tile_n=2, threads=256, grouping=4, minblocks=5) , # 768.773 GFlop/s
-  Kernel_dnt_medium(m=28, n=7, k=45, tile_m=1, tile_n=2, threads=192, grouping=3, minblocks=2) , # 768.667 GFlop/s
-  Kernel_dnt_medium(m=28, n=9, k=4, tile_m=1, tile_n=5, threads=64, grouping=24, minblocks=11) , # 686.434 GFlop/s
-  Kernel_dnt_medium(m=28, n=9, k=5, tile_m=1, tile_n=5, threads=64, grouping=22, minblocks=19) , # 738.32 GFlop/s
-  Kernel_dnt_medium(m=28, n=9, k=7, tile_m=1, tile_n=5, threads=64, grouping=26, minblocks=16) , # 808.579 GFlop/s
-  Kernel_dnt_medium(m=28, n=9, k=9, tile_m=1, tile_n=3, threads=96, grouping=32, minblocks=3) , # 825.886 GFlop/s
-  Kernel_dnt_medium(m=28, n=9, k=13, tile_m=1, tile_n=3, threads=128, grouping=32, minblocks=9) , # 844.884 GFlop/s
-  Kernel_dnt_medium(m=28, n=9, k=25, tile_m=1, tile_n=3, threads=256, grouping=4, minblocks=6) , # 895.124 GFlop/s
-  Kernel_dnt_medium(m=28, n=9, k=26, tile_m=1, tile_n=3, threads=256, grouping=4, minblocks=6) , # 891.424 GFlop/s
-  Kernel_dnt_medium(m=28, n=9, k=28, tile_m=1, tile_n=2, threads=256, grouping=5, minblocks=5) , # 897.496 GFlop/s
-  Kernel_dnt_medium(m=28, n=9, k=32, tile_m=1, tile_n=3, threads=128, grouping=3, minblocks=3) , # 918.668 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=9, k=45, tile_m=1, tile_n=3, w=10, v=4, threads=96, grouping=16, minblocks=4) , # 930.129 GFlop/s
-  Kernel_dnt_medium(m=28, n=13, k=4, tile_m=2, tile_n=4, threads=64, grouping=26, minblocks=7) , # 836.442 GFlop/s
-  Kernel_dnt_medium(m=28, n=13, k=5, tile_m=1, tile_n=5, threads=96, grouping=12, minblocks=12) , # 827.406 GFlop/s
-  Kernel_dnt_medium(m=28, n=13, k=7, tile_m=1, tile_n=5, threads=96, grouping=26, minblocks=11) , # 960.632 GFlop/s
-  Kernel_dnt_medium(m=28, n=13, k=9, tile_m=1, tile_n=5, threads=128, grouping=32, minblocks=9) , # 996.46 GFlop/s
-  Kernel_dnt_medium(m=28, n=13, k=13, tile_m=1, tile_n=5, threads=96, grouping=4, minblocks=10) , # 1030.59 GFlop/s
-  Kernel_dnt_medium(m=28, n=13, k=25, tile_m=1, tile_n=3, threads=192, grouping=5, minblocks=5) , # 1115.36 GFlop/s
-  Kernel_dnt_medium(m=28, n=13, k=26, tile_m=1, tile_n=3, threads=160, grouping=4, minblocks=4) , # 1114.24 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=13, k=28, tile_m=1, tile_n=4, w=10, v=12, threads=128, grouping=16, minblocks=2) , # 1122.82 GFlop/s
-  Kernel_dnt_medium(m=28, n=13, k=32, tile_m=1, tile_n=5, threads=128, grouping=24, minblocks=4) , # 1145.54 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=13, k=45, tile_m=1, tile_n=7, w=12, v=8, threads=64, grouping=16, minblocks=8) , # 1176.78 GFlop/s
-  Kernel_dnt_medium(m=28, n=25, k=4, tile_m=4, tile_n=3, threads=64, grouping=32, minblocks=3) , # 1029.26 GFlop/s
-  Kernel_dnt_medium(m=28, n=25, k=5, tile_m=1, tile_n=5, threads=160, grouping=9, minblocks=8) , # 1103.4 GFlop/s
-  Kernel_dnt_medium(m=28, n=25, k=7, tile_m=5, tile_n=3, threads=64, grouping=24, minblocks=2) , # 1185.57 GFlop/s
-  Kernel_dnt_medium(m=28, n=25, k=9, tile_m=1, tile_n=5, threads=160, grouping=10, minblocks=7) , # 1283.85 GFlop/s
-  Kernel_dnt_medium(m=28, n=25, k=13, tile_m=1, tile_n=5, threads=160, grouping=29, minblocks=5) , # 1423.58 GFlop/s
-  Kernel_dnt_medium(m=28, n=25, k=25, tile_m=3, tile_n=5, threads=64, grouping=3, minblocks=3) , # 1582.11 GFlop/s
-  Kernel_dnt_medium(m=28, n=25, k=26, tile_m=3, tile_n=5, threads=64, grouping=3, minblocks=4) , # 1581.68 GFlop/s
-  Kernel_dnt_medium(m=28, n=25, k=28, tile_m=1, tile_n=5, threads=160, grouping=24, minblocks=4) , # 1601.02 GFlop/s
-  Kernel_dnt_medium(m=28, n=25, k=32, tile_m=3, tile_n=3, threads=128, grouping=32, minblocks=1) , # 1631.38 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=25, k=45, tile_m=3, tile_n=5, w=12, v=14, threads=64, grouping=16, minblocks=4) , # 1683.73 GFlop/s
-  Kernel_dnt_medium(m=28, n=26, k=4, tile_m=4, tile_n=3, threads=64, grouping=32, minblocks=2) , # 1046.4 GFlop/s
-  Kernel_dnt_medium(m=28, n=26, k=5, tile_m=1, tile_n=6, threads=160, grouping=9, minblocks=8) , # 1116.46 GFlop/s
-  Kernel_dnt_medium(m=28, n=26, k=7, tile_m=5, tile_n=3, threads=64, grouping=25, minblocks=4) , # 1206.91 GFlop/s
-  Kernel_dnt_medium(m=28, n=26, k=9, tile_m=5, tile_n=3, threads=64, grouping=21, minblocks=2) , # 1308.19 GFlop/s
-  Kernel_dnt_medium(m=28, n=26, k=13, tile_m=3, tile_n=5, threads=64, grouping=5, minblocks=5) , # 1440.64 GFlop/s
-  Kernel_dnt_medium(m=28, n=26, k=25, tile_m=3, tile_n=5, threads=64, grouping=3, minblocks=2) , # 1615.94 GFlop/s
-  Kernel_dnt_medium(m=28, n=26, k=26, tile_m=3, tile_n=5, threads=64, grouping=3, minblocks=3) , # 1620.78 GFlop/s
-  Kernel_dnt_medium(m=28, n=26, k=28, tile_m=3, tile_n=3, threads=96, grouping=3, minblocks=1) , # 1637.82 GFlop/s
-  Kernel_dnt_medium(m=28, n=26, k=32, tile_m=3, tile_n=3, threads=128, grouping=32, minblocks=2) , # 1665.27 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=26, k=45, tile_m=3, tile_n=3, w=16, v=26, threads=96, grouping=16, minblocks=2) , # 1738.17 GFlop/s
-  Kernel_dnt_medium(m=28, n=28, k=4, tile_m=2, tile_n=4, threads=128, grouping=24, minblocks=3) , # 1053.5 GFlop/s
-  Kernel_dnt_medium(m=28, n=28, k=5, tile_m=1, tile_n=6, threads=160, grouping=9, minblocks=7) , # 1153.08 GFlop/s
-  Kernel_dnt_medium(m=28, n=28, k=7, tile_m=5, tile_n=3, threads=64, grouping=25, minblocks=3) , # 1291.9 GFlop/s
-  Kernel_dnt_medium(m=28, n=28, k=9, tile_m=5, tile_n=3, threads=64, grouping=29, minblocks=3) , # 1407.79 GFlop/s
-  Kernel_dnt_medium(m=28, n=28, k=13, tile_m=1, tile_n=6, threads=160, grouping=5, minblocks=6) , # 1560.57 GFlop/s
-  Kernel_dnt_medium(m=28, n=28, k=25, tile_m=3, tile_n=5, threads=64, grouping=3, minblocks=3) , # 1712.97 GFlop/s
-  Kernel_dnt_medium(m=28, n=28, k=26, tile_m=3, tile_n=5, threads=64, grouping=3, minblocks=2) , # 1708.21 GFlop/s
-  Kernel_dnt_medium(m=28, n=28, k=28, tile_m=3, tile_n=5, threads=64, grouping=3, minblocks=3) , # 1700.13 GFlop/s
-  Kernel_dnt_medium(m=28, n=28, k=32, tile_m=3, tile_n=5, threads=96, grouping=3, minblocks=2) , # 1753.32 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=28, k=45, tile_m=5, tile_n=3, w=8, v=14, threads=64, grouping=16, minblocks=4) , # 1784.75 GFlop/s
-  Kernel_dnt_medium(m=28, n=32, k=4, tile_m=3, tile_n=2, threads=160, grouping=29, minblocks=5) , # 1074.89 GFlop/s
-  Kernel_dnt_medium(m=28, n=32, k=5, tile_m=1, tile_n=4, threads=224, grouping=9, minblocks=6) , # 1179.11 GFlop/s
-  Kernel_dnt_medium(m=28, n=32, k=7, tile_m=1, tile_n=4, threads=256, grouping=29, minblocks=5) , # 1331.58 GFlop/s
-  Kernel_dnt_medium(m=28, n=32, k=9, tile_m=4, tile_n=4, threads=64, grouping=29, minblocks=2) , # 1423.42 GFlop/s
-  Kernel_dnt_medium(m=28, n=32, k=13, tile_m=3, tile_n=2, threads=160, grouping=29, minblocks=5) , # 1552.86 GFlop/s
-  Kernel_dnt_medium(m=28, n=32, k=25, tile_m=1, tile_n=4, threads=224, grouping=4, minblocks=4) , # 1787.13 GFlop/s
-  Kernel_dnt_medium(m=28, n=32, k=26, tile_m=1, tile_n=4, threads=256, grouping=32, minblocks=3) , # 1777.2 GFlop/s
-  Kernel_dnt_medium(m=28, n=32, k=28, tile_m=5, tile_n=2, threads=96, grouping=3, minblocks=2) , # 1795.81 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=32, k=32, tile_m=5, tile_n=2, w=16, v=18, threads=96, grouping=16, minblocks=4) , # 1849.83 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=32, k=45, tile_m=3, tile_n=6, w=10, v=16, threads=64, grouping=16, minblocks=1) , # 1909.3 GFlop/s
-  Kernel_dnt_medium(m=28, n=45, k=4, tile_m=3, tile_n=5, threads=96, grouping=29, minblocks=1) , # 1163.62 GFlop/s
-  Kernel_dnt_medium(m=28, n=45, k=5, tile_m=1, tile_n=5, threads=256, grouping=16, minblocks=4) , # 1262.25 GFlop/s
-  Kernel_dnt_medium(m=28, n=45, k=7, tile_m=3, tile_n=5, threads=96, grouping=25, minblocks=4) , # 1441 GFlop/s
-  Kernel_dnt_medium(m=28, n=45, k=9, tile_m=3, tile_n=4, threads=128, grouping=32, minblocks=1) , # 1569.32 GFlop/s
-  Kernel_dnt_medium(m=28, n=45, k=13, tile_m=3, tile_n=5, threads=96, grouping=24, minblocks=4) , # 1754.86 GFlop/s
-  Kernel_dnt_medium(m=28, n=45, k=25, tile_m=3, tile_n=4, threads=128, grouping=32, minblocks=2) , # 1976.24 GFlop/s
-  Kernel_dnt_medium(m=28, n=45, k=26, tile_m=3, tile_n=4, threads=128, grouping=32, minblocks=3) , # 1998.55 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=45, k=28, tile_m=7, tile_n=3, w=8, v=20, threads=64, grouping=16, minblocks=4) , # 2023.14 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=45, k=32, tile_m=7, tile_n=3, w=8, v=20, threads=64, grouping=16, minblocks=1) , # 2082.87 GFlop/s
-  Kernel_dnt_largeDB2(m=28, n=45, k=45, tile_m=7, tile_n=3, w=8, v=40, threads=64, grouping=16, minblocks=2) , # 2164.99 GFlop/s
-  Kernel_dnt_medium(m=29, n=14, k=14, tile_m=1, tile_n=5, threads=128, grouping=6, minblocks=9) , # 1094.19 GFlop/s
-  Kernel_dnt_medium(m=29, n=14, k=16, tile_m=1, tile_n=5, threads=128, grouping=5, minblocks=8) , # 1132.98 GFlop/s
-  Kernel_dnt_largeDB2(m=29, n=14, k=29, tile_m=3, tile_n=3, w=12, v=14, threads=64, grouping=16, minblocks=8) , # 1191.43 GFlop/s
-  Kernel_dnt_medium(m=29, n=14, k=32, tile_m=3, tile_n=3, threads=64, grouping=29, minblocks=1) , # 1211.15 GFlop/s
-  Kernel_dnt_medium(m=29, n=16, k=14, tile_m=1, tile_n=4, threads=128, grouping=4, minblocks=9) , # 1200.6 GFlop/s
-  Kernel_dnt_medium(m=29, n=16, k=16, tile_m=1, tile_n=4, threads=128, grouping=4, minblocks=8) , # 1237.1 GFlop/s
-  Kernel_dnt_largeDB2(m=29, n=16, k=29, tile_m=3, tile_n=1, w=10, v=14, threads=160, grouping=16, minblocks=1) , # 1302.52 GFlop/s
-  Kernel_dnt_largeDB2(m=29, n=16, k=55, tile_m=3, tile_n=3, w=14, v=16, threads=64, grouping=16, minblocks=1) , # 1381.48 GFlop/s
-  Kernel_dnt_medium(m=29, n=29, k=14, tile_m=3, tile_n=2, threads=160, grouping=32, minblocks=1) , # 1562.65 GFlop/s
-  Kernel_dnt_medium(m=29, n=29, k=16, tile_m=3, tile_n=2, threads=160, grouping=32, minblocks=1) , # 1616.32 GFlop/s
-  Kernel_dnt_medium(m=29, n=29, k=29, tile_m=3, tile_n=5, threads=96, grouping=24, minblocks=3) , # 1736.13 GFlop/s
-  Kernel_dnt_medium(m=29, n=29, k=32, tile_m=3, tile_n=5, threads=96, grouping=3, minblocks=2) , # 1807.51 GFlop/s
-  Kernel_dnt_largeDB2(m=29, n=29, k=55, tile_m=3, tile_n=5, w=12, v=26, threads=64, grouping=16, minblocks=1) , # 1881.61 GFlop/s
-  Kernel_dnt_medium(m=29, n=32, k=14, tile_m=3, tile_n=2, threads=192, grouping=29, minblocks=5) , # 1630.9 GFlop/s
-  Kernel_dnt_largeDB2(m=29, n=32, k=29, tile_m=5, tile_n=2, w=12, v=28, threads=96, grouping=16, minblocks=1) , # 1818.21 GFlop/s
-  Kernel_dnt_medium(m=29, n=32, k=32, tile_m=3, tile_n=3, threads=128, grouping=32, minblocks=2) , # 1865.52 GFlop/s
-  Kernel_dnt_largeDB2(m=29, n=32, k=55, tile_m=3, tile_n=6, w=10, v=32, threads=64, grouping=16, minblocks=4) , # 1977.23 GFlop/s
-  Kernel_dnt_medium(m=29, n=55, k=16, tile_m=3, tile_n=5, threads=128, grouping=32, minblocks=1) , # 1958.07 GFlop/s
-  Kernel_dnt_medium(m=29, n=55, k=29, tile_m=3, tile_n=5, threads=128, grouping=32, minblocks=1) , # 2173.7 GFlop/s
-  Kernel_dnt_largeDB2(m=29, n=55, k=32, tile_m=4, tile_n=7, w=8, v=36, threads=64, grouping=16, minblocks=4) , # 2227.18 GFlop/s
-  Kernel_dnt_largeDB2(m=29, n=55, k=55, tile_m=5, tile_n=6, w=6, v=36, threads=64, grouping=16, minblocks=4) , # 2364.15 GFlop/s
-  Kernel_dnt_medium(m=30, n=30, k=30, tile_m=5, tile_n=3, threads=64, grouping=3, minblocks=1) , # 1838.1 GFlop/s
-  Kernel_dnt_medium(m=31, n=31, k=31, tile_m=4, tile_n=4, threads=64, grouping=24, minblocks=1) , # 1830.67 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=4, tile_m=1, tile_n=6, threads=32, grouping=13, minblocks=2) , # 463.773 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=5, tile_m=1, tile_n=4, threads=32, grouping=16, minblocks=13) , # 469.138 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=7, tile_m=1, tile_n=2, threads=64, grouping=24, minblocks=7) , # 479.728 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=9, tile_m=1, tile_n=2, threads=64, grouping=6, minblocks=15) , # 482.038 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=13, tile_m=1, tile_n=2, threads=64, grouping=26, minblocks=11) , # 493.254 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=25, tile_m=1, tile_n=1, threads=160, grouping=4, minblocks=5) , # 498.236 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=26, tile_m=1, tile_n=1, threads=192, grouping=3, minblocks=5) , # 498.907 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=28, tile_m=1, tile_n=2, threads=256, grouping=4, minblocks=6) , # 503.858 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=32, tile_m=1, tile_n=1, threads=256, grouping=3, minblocks=1) , # 510.352 GFlop/s
-  Kernel_dnt_medium(m=32, n=4, k=45, tile_m=1, tile_n=1, threads=256, grouping=3, minblocks=3) , # 514.431 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=4, tile_m=1, tile_n=5, threads=32, grouping=17, minblocks=26) , # 521.537 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=5, tile_m=1, tile_n=5, threads=32, grouping=16, minblocks=14) , # 535.38 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=7, tile_m=1, tile_n=5, threads=64, grouping=26, minblocks=13) , # 556.583 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=9, tile_m=1, tile_n=3, threads=64, grouping=29, minblocks=9) , # 568.533 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=12, tile_m=1, tile_n=3, threads=96, grouping=32, minblocks=5) , # 578.088 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=13, tile_m=1, tile_n=2, threads=96, grouping=32, minblocks=10) , # 571.398 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=16, tile_m=1, tile_n=2, threads=128, grouping=32, minblocks=7) , # 590.624 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=24, tile_m=1, tile_n=1, threads=192, grouping=5, minblocks=5) , # 595.227 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=25, tile_m=1, tile_n=1, threads=192, grouping=3, minblocks=1) , # 593.569 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=26, tile_m=1, tile_n=2, threads=160, grouping=4, minblocks=4) , # 597.402 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=28, tile_m=1, tile_n=1, threads=192, grouping=3, minblocks=1) , # 604.614 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=32, tile_m=1, tile_n=1, threads=256, grouping=3, minblocks=2) , # 611.583 GFlop/s
-  Kernel_dnt_medium(m=32, n=5, k=45, tile_m=1, tile_n=1, threads=256, grouping=3, minblocks=3) , # 618.945 GFlop/s
-  Kernel_dnt_medium(m=32, n=7, k=4, tile_m=2, tile_n=4, threads=32, grouping=19, minblocks=13) , # 635.452 GFlop/s
-  Kernel_dnt_medium(m=32, n=7, k=5, tile_m=1, tile_n=4, threads=64, grouping=22, minblocks=4) , # 657.342 GFlop/s
-  Kernel_dnt_medium(m=32, n=7, k=7, tile_m=1, tile_n=4, threads=64, grouping=26, minblocks=7) , # 710.551 GFlop/s
-  Kernel_dnt_medium(m=32, n=7, k=9, tile_m=1, tile_n=4, threads=64, grouping=26, minblocks=12) , # 727.544 GFlop/s
-  Kernel_dnt_medium(m=32, n=7, k=13, tile_m=1, tile_n=2, threads=128, grouping=32, minblocks=6) , # 739.552 GFlop/s
-  Kernel_dnt_medium(m=32, n=7, k=25, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=4) , # 775.794 GFlop/s
-  Kernel_dnt_medium(m=32, n=7, k=26, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=3) , # 776.845 GFlop/s
-  Kernel_dnt_medium(m=32, n=7, k=28, tile_m=1, tile_n=2, threads=224, grouping=4, minblocks=3) , # 780.958 GFlop/s
-  Kernel_dnt_medium(m=32, n=7, k=32, tile_m=1, tile_n=2, threads=256, grouping=4, minblocks=4) , # 799.863 GFlop/s
-  Kernel_dnt_medium(m=32, n=7, k=45, tile_m=1, tile_n=1, threads=256, grouping=3, minblocks=3) , # 803.204 GFlop/s
-  Kernel_dnt_medium(m=32, n=9, k=4, tile_m=1, tile_n=5, threads=64, grouping=24, minblocks=11) , # 719.416 GFlop/s
-  Kernel_dnt_medium(m=32, n=9, k=5, tile_m=1, tile_n=6, threads=64, grouping=23, minblocks=13) , # 768.086 GFlop/s
-  Kernel_dnt_medium(m=32, n=9, k=7, tile_m=1, tile_n=6, threads=64, grouping=25, minblocks=14) , # 830.63 GFlop/s
-  Kernel_dnt_medium(m=32, n=9, k=9, tile_m=1, tile_n=5, threads=96, grouping=32, minblocks=10) , # 853.67 GFlop/s
-  Kernel_dnt_medium(m=32, n=9, k=13, tile_m=1, tile_n=3, threads=128, grouping=4, minblocks=5) , # 873.679 GFlop/s
-  Kernel_dnt_medium(m=32, n=9, k=22, tile_m=1, tile_n=3, threads=224, grouping=4, minblocks=5) , # 922.783 GFlop/s
-  Kernel_dnt_medium(m=32, n=9, k=25, tile_m=1, tile_n=3, threads=256, grouping=4, minblocks=5) , # 926.612 GFlop/s
-  Kernel_dnt_medium(m=32, n=9, k=26, tile_m=1, tile_n=3, threads=256, grouping=4, minblocks=5) , # 937.269 GFlop/s
-  Kernel_dnt_medium(m=32, n=9, k=28, tile_m=1, tile_n=2, threads=160, grouping=3, minblocks=1) , # 943.269 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=9, k=32, tile_m=1, tile_n=3, w=8, v=8, threads=96, grouping=16, minblocks=2) , # 954.006 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=9, k=45, tile_m=1, tile_n=3, w=10, v=4, threads=96, grouping=16, minblocks=1) , # 967.274 GFlop/s
-  Kernel_dnt_medium(m=32, n=12, k=5, tile_m=1, tile_n=6, threads=64, grouping=26, minblocks=12) , # 908.801 GFlop/s
-  Kernel_dnt_medium(m=32, n=12, k=12, tile_m=1, tile_n=3, threads=160, grouping=5, minblocks=9) , # 1047.84 GFlop/s
-  Kernel_dnt_medium(m=32, n=12, k=13, tile_m=1, tile_n=4, threads=160, grouping=4, minblocks=9) , # 1058.78 GFlop/s
-  Kernel_dnt_medium(m=32, n=12, k=26, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=5) , # 1144.79 GFlop/s
-  Kernel_dnt_medium(m=32, n=12, k=32, tile_m=1, tile_n=2, threads=192, grouping=3, minblocks=4) , # 1176.59 GFlop/s
-  Kernel_dnt_medium(m=32, n=13, k=4, tile_m=2, tile_n=4, threads=64, grouping=26, minblocks=1) , # 880.033 GFlop/s
-  Kernel_dnt_medium(m=32, n=13, k=5, tile_m=1, tile_n=5, threads=96, grouping=24, minblocks=11) , # 897.283 GFlop/s
-  Kernel_dnt_medium(m=32, n=13, k=7, tile_m=1, tile_n=5, threads=96, grouping=29, minblocks=11) , # 1013.1 GFlop/s
-  Kernel_dnt_medium(m=32, n=13, k=9, tile_m=1, tile_n=5, threads=128, grouping=32, minblocks=9) , # 1040.81 GFlop/s
-  Kernel_dnt_medium(m=32, n=13, k=12, tile_m=1, tile_n=3, threads=160, grouping=5, minblocks=9) , # 1085.48 GFlop/s
-  Kernel_dnt_medium(m=32, n=13, k=13, tile_m=1, tile_n=5, threads=128, grouping=4, minblocks=8) , # 1085.19 GFlop/s
-  Kernel_dnt_medium(m=32, n=13, k=14, tile_m=1, tile_n=5, threads=128, grouping=4, minblocks=7) , # 1105.19 GFlop/s
-  Kernel_dnt_medium(m=32, n=13, k=16, tile_m=1, tile_n=4, threads=128, grouping=4, minblocks=7) , # 1140.15 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=13, k=24, tile_m=1, tile_n=4, w=12, v=10, threads=128, grouping=16, minblocks=1) , # 1184.2 GFlop/s
-  Kernel_dnt_medium(m=32, n=13, k=25, tile_m=1, tile_n=3, threads=224, grouping=4, minblocks=5) , # 1177.19 GFlop/s
-  Kernel_dnt_medium(m=32, n=13, k=26, tile_m=1, tile_n=2, threads=224, grouping=4, minblocks=3) , # 1192.35 GFlop/s
-  Kernel_dnt_medium(m=32, n=13, k=28, tile_m=1, tile_n=2, threads=224, grouping=4, minblocks=2) , # 1204.64 GFlop/s
-  Kernel_dnt_medium(m=32, n=13, k=32, tile_m=1, tile_n=3, threads=192, grouping=3, minblocks=4) , # 1221.29 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=13, k=45, tile_m=1, tile_n=3, w=12, v=8, threads=160, grouping=16, minblocks=2) , # 1240.12 GFlop/s
-  Kernel_dnt_medium(m=32, n=14, k=13, tile_m=1, tile_n=5, threads=128, grouping=4, minblocks=9) , # 1143.59 GFlop/s
-  Kernel_dnt_medium(m=32, n=14, k=14, tile_m=1, tile_n=4, threads=128, grouping=5, minblocks=8) , # 1160.77 GFlop/s
-  Kernel_dnt_medium(m=32, n=14, k=25, tile_m=1, tile_n=3, threads=224, grouping=3, minblocks=5) , # 1240.88 GFlop/s
-  Kernel_dnt_medium(m=32, n=14, k=26, tile_m=1, tile_n=2, threads=224, grouping=4, minblocks=5) , # 1258.77 GFlop/s
-  Kernel_dnt_medium(m=32, n=14, k=29, tile_m=1, tile_n=3, threads=160, grouping=3, minblocks=4) , # 1262.69 GFlop/s
-  Kernel_dnt_medium(m=32, n=14, k=32, tile_m=1, tile_n=2, threads=224, grouping=3, minblocks=1) , # 1286.87 GFlop/s
-  Kernel_dnt_medium(m=32, n=16, k=5, tile_m=1, tile_n=6, threads=96, grouping=32, minblocks=10) , # 1010.78 GFlop/s
-  Kernel_dnt_medium(m=32, n=16, k=13, tile_m=1, tile_n=5, threads=128, grouping=4, minblocks=9) , # 1239.79 GFlop/s
-  Kernel_dnt_medium(m=32, n=16, k=16, tile_m=1, tile_n=4, threads=160, grouping=5, minblocks=7) , # 1289.33 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=16, k=32, tile_m=1, tile_n=4, w=12, v=16, threads=128, grouping=16, minblocks=2) , # 1400.34 GFlop/s
-  Kernel_dnt_medium(m=32, n=22, k=9, tile_m=1, tile_n=6, threads=128, grouping=6, minblocks=8) , # 1313.03 GFlop/s
-  Kernel_dnt_medium(m=32, n=22, k=22, tile_m=1, tile_n=4, threads=192, grouping=5, minblocks=4) , # 1573.89 GFlop/s
-  Kernel_dnt_medium(m=32, n=22, k=32, tile_m=1, tile_n=3, threads=256, grouping=32, minblocks=2) , # 1639.19 GFlop/s
-  Kernel_dnt_medium(m=32, n=24, k=5, tile_m=1, tile_n=4, threads=192, grouping=9, minblocks=7) , # 1147.88 GFlop/s
-  Kernel_dnt_medium(m=32, n=24, k=13, tile_m=1, tile_n=6, threads=160, grouping=29, minblocks=5) , # 1516.34 GFlop/s
-  Kernel_dnt_medium(m=32, n=24, k=24, tile_m=1, tile_n=6, threads=128, grouping=3, minblocks=4) , # 1673.42 GFlop/s
-  Kernel_dnt_medium(m=32, n=24, k=26, tile_m=1, tile_n=4, threads=224, grouping=3, minblocks=4) , # 1689.58 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=24, k=32, tile_m=1, tile_n=4, w=16, v=24, threads=192, grouping=16, minblocks=1) , # 1736.99 GFlop/s
-  Kernel_dnt_medium(m=32, n=25, k=4, tile_m=1, tile_n=5, threads=192, grouping=12, minblocks=7) , # 1051.58 GFlop/s
-  Kernel_dnt_medium(m=32, n=25, k=5, tile_m=1, tile_n=5, threads=192, grouping=9, minblocks=7) , # 1163.15 GFlop/s
-  Kernel_dnt_medium(m=32, n=25, k=7, tile_m=1, tile_n=5, threads=256, grouping=16, minblocks=5) , # 1273.22 GFlop/s
-  Kernel_dnt_medium(m=32, n=25, k=9, tile_m=1, tile_n=5, threads=160, grouping=6, minblocks=7) , # 1389.05 GFlop/s
-  Kernel_dnt_medium(m=32, n=25, k=13, tile_m=1, tile_n=5, threads=160, grouping=4, minblocks=7) , # 1543.97 GFlop/s
-  Kernel_dnt_medium(m=32, n=25, k=14, tile_m=1, tile_n=5, threads=160, grouping=29, minblocks=5) , # 1565.97 GFlop/s
-  Kernel_dnt_medium(m=32, n=25, k=25, tile_m=1, tile_n=5, threads=160, grouping=3, minblocks=4) , # 1683.41 GFlop/s
-  Kernel_dnt_medium(m=32, n=25, k=26, tile_m=1, tile_n=5, threads=192, grouping=4, minblocks=4) , # 1695.86 GFlop/s
-  Kernel_dnt_medium(m=32, n=25, k=28, tile_m=1, tile_n=5, threads=224, grouping=32, minblocks=3) , # 1709.63 GFlop/s
-  Kernel_dnt_medium(m=32, n=25, k=32, tile_m=1, tile_n=5, threads=256, grouping=32, minblocks=3) , # 1751.37 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=25, k=45, tile_m=3, tile_n=5, w=16, v=20, threads=64, grouping=16, minblocks=1) , # 1795.15 GFlop/s
-  Kernel_dnt_medium(m=32, n=26, k=4, tile_m=1, tile_n=6, threads=160, grouping=10, minblocks=7) , # 1059.64 GFlop/s
-  Kernel_dnt_medium(m=32, n=26, k=5, tile_m=1, tile_n=6, threads=192, grouping=24, minblocks=6) , # 1158.06 GFlop/s
-  Kernel_dnt_medium(m=32, n=26, k=7, tile_m=5, tile_n=3, threads=64, grouping=24, minblocks=3) , # 1280.12 GFlop/s
-  Kernel_dnt_medium(m=32, n=26, k=9, tile_m=1, tile_n=6, threads=160, grouping=6, minblocks=7) , # 1392.26 GFlop/s
-  Kernel_dnt_medium(m=32, n=26, k=12, tile_m=5, tile_n=3, threads=64, grouping=24, minblocks=1) , # 1502.2 GFlop/s
-  Kernel_dnt_medium(m=32, n=26, k=13, tile_m=1, tile_n=6, threads=160, grouping=5, minblocks=6) , # 1540.86 GFlop/s
-  Kernel_dnt_medium(m=32, n=26, k=14, tile_m=1, tile_n=6, threads=160, grouping=4, minblocks=6) , # 1592.55 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=26, k=24, tile_m=5, tile_n=3, w=12, v=26, threads=64, grouping=16, minblocks=1) , # 1704.87 GFlop/s
-  Kernel_dnt_medium(m=32, n=26, k=25, tile_m=5, tile_n=3, threads=64, grouping=3, minblocks=3) , # 1702.43 GFlop/s
-  Kernel_dnt_medium(m=32, n=26, k=26, tile_m=1, tile_n=4, threads=224, grouping=32, minblocks=3) , # 1710.53 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=26, k=28, tile_m=2, tile_n=5, w=14, v=24, threads=96, grouping=16, minblocks=4) , # 1736.93 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=26, k=32, tile_m=1, tile_n=5, w=16, v=26, threads=192, grouping=16, minblocks=2) , # 1778.77 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=26, k=45, tile_m=2, tile_n=7, w=12, v=26, threads=64, grouping=16, minblocks=1) , # 1845.15 GFlop/s
-  Kernel_dnt_medium(m=32, n=28, k=4, tile_m=1, tile_n=6, threads=160, grouping=29, minblocks=5) , # 1093.69 GFlop/s
-  Kernel_dnt_medium(m=32, n=28, k=5, tile_m=1, tile_n=5, threads=192, grouping=10, minblocks=6) , # 1203.06 GFlop/s
-  Kernel_dnt_medium(m=32, n=28, k=7, tile_m=1, tile_n=4, threads=256, grouping=24, minblocks=6) , # 1352.54 GFlop/s
-  Kernel_dnt_medium(m=32, n=28, k=9, tile_m=1, tile_n=6, threads=160, grouping=6, minblocks=6) , # 1453.34 GFlop/s
-  Kernel_dnt_medium(m=32, n=28, k=13, tile_m=1, tile_n=6, threads=160, grouping=29, minblocks=5) , # 1612.39 GFlop/s
-  Kernel_dnt_medium(m=32, n=28, k=25, tile_m=1, tile_n=4, threads=224, grouping=4, minblocks=4) , # 1803.09 GFlop/s
-  Kernel_dnt_medium(m=32, n=28, k=26, tile_m=1, tile_n=4, threads=224, grouping=32, minblocks=3) , # 1791.09 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=28, k=28, tile_m=2, tile_n=7, w=10, v=26, threads=64, grouping=16, minblocks=1) , # 1810.27 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=28, k=32, tile_m=1, tile_n=5, w=16, v=28, threads=192, grouping=16, minblocks=1) , # 1860.59 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=28, k=45, tile_m=2, tile_n=7, w=12, v=8, threads=64, grouping=16, minblocks=1) , # 1916.4 GFlop/s
-  Kernel_dnt_medium(m=32, n=29, k=14, tile_m=1, tile_n=6, threads=160, grouping=4, minblocks=6) , # 1690.58 GFlop/s
-  Kernel_dnt_medium(m=32, n=29, k=29, tile_m=1, tile_n=5, threads=192, grouping=32, minblocks=3) , # 1821.2 GFlop/s
-  Kernel_dnt_medium(m=32, n=29, k=32, tile_m=1, tile_n=5, threads=192, grouping=32, minblocks=2) , # 1879.76 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=29, k=55, tile_m=6, tile_n=3, w=14, v=18, threads=64, grouping=16, minblocks=2) , # 1972.82 GFlop/s
-  Kernel_dnt_medium(m=32, n=32, k=4, tile_m=2, tile_n=4, threads=128, grouping=29, minblocks=1) , # 1153.41 GFlop/s
-  Kernel_dnt_medium(m=32, n=32, k=5, tile_m=1, tile_n=6, threads=192, grouping=29, minblocks=5) , # 1275.62 GFlop/s
-  Kernel_dnt_medium(m=32, n=32, k=7, tile_m=4, tile_n=4, threads=64, grouping=29, minblocks=1) , # 1445.13 GFlop/s
-  Kernel_dnt_medium(m=32, n=32, k=9, tile_m=4, tile_n=4, threads=64, grouping=30, minblocks=2) , # 1569.35 GFlop/s
-  Kernel_dnt_medium(m=32, n=32, k=12, tile_m=1, tile_n=6, threads=192, grouping=29, minblocks=5) , # 1716.9 GFlop/s
-  Kernel_dnt_medium(m=32, n=32, k=13, tile_m=1, tile_n=6, threads=192, grouping=5, minblocks=5) , # 1747.15 GFlop/s
-  Kernel_dnt_medium(m=32, n=32, k=14, tile_m=1, tile_n=6, threads=192, grouping=5, minblocks=5) , # 1782.16 GFlop/s
-  Kernel_dnt_medium(m=32, n=32, k=16, tile_m=1, tile_n=6, threads=192, grouping=4, minblocks=5) , # 1837.55 GFlop/s
-  Kernel_dnt_medium(m=32, n=32, k=22, tile_m=1, tile_n=4, threads=256, grouping=4, minblocks=4) , # 1920.38 GFlop/s
-  Kernel_dnt_medium(m=32, n=32, k=24, tile_m=4, tile_n=4, threads=64, grouping=3, minblocks=3) , # 1928.13 GFlop/s
-  Kernel_dnt_medium(m=32, n=32, k=25, tile_m=1, tile_n=4, threads=256, grouping=32, minblocks=3) , # 1922.43 GFlop/s
-  Kernel_dnt_medium(m=32, n=32, k=26, tile_m=1, tile_n=4, threads=256, grouping=32, minblocks=3) , # 1932.91 GFlop/s
-  Kernel_dnt_medium(m=32, n=32, k=28, tile_m=4, tile_n=4, threads=64, grouping=3, minblocks=1) , # 1945.61 GFlop/s
-  Kernel_dnt_medium(m=32, n=32, k=29, tile_m=1, tile_n=4, threads=256, grouping=3, minblocks=3) , # 1953.05 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=32, k=32, tile_m=4, tile_n=4, w=8, v=32, threads=64, grouping=16, minblocks=2) , # 1988.65 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=32, k=45, tile_m=2, tile_n=8, w=10, v=16, threads=64, grouping=16, minblocks=1) , # 2049.85 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=32, k=55, tile_m=2, tile_n=8, w=10, v=32, threads=64, grouping=16, minblocks=2) , # 2095.89 GFlop/s
-  Kernel_dnt_medium(m=32, n=45, k=4, tile_m=2, tile_n=6, threads=192, grouping=32, minblocks=1) , # 1189.96 GFlop/s
-  Kernel_dnt_medium(m=32, n=45, k=5, tile_m=1, tile_n=6, threads=256, grouping=24, minblocks=4) , # 1353.3 GFlop/s
-  Kernel_dnt_medium(m=32, n=45, k=7, tile_m=1, tile_n=6, threads=256, grouping=26, minblocks=4) , # 1511.94 GFlop/s
-  Kernel_dnt_medium(m=32, n=45, k=9, tile_m=4, tile_n=4, threads=96, grouping=32, minblocks=2) , # 1646.51 GFlop/s
-  Kernel_dnt_medium(m=32, n=45, k=13, tile_m=2, tile_n=6, threads=128, grouping=32, minblocks=1) , # 1808.85 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=45, k=25, tile_m=5, tile_n=5, w=8, v=40, threads=64, grouping=16, minblocks=4) , # 2094.65 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=45, k=26, tile_m=5, tile_n=5, w=6, v=24, threads=64, grouping=16, minblocks=4) , # 2121.03 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=45, k=28, tile_m=5, tile_n=5, w=8, v=34, threads=64, grouping=16, minblocks=1) , # 2167.72 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=45, k=32, tile_m=5, tile_n=5, w=8, v=30, threads=64, grouping=16, minblocks=4) , # 2242.67 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=45, k=45, tile_m=5, tile_n=5, w=8, v=16, threads=64, grouping=16, minblocks=4) , # 2335 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=55, k=29, tile_m=4, tile_n=7, w=14, v=36, threads=64, grouping=16, minblocks=2) , # 2308.45 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=55, k=32, tile_m=4, tile_n=7, w=8, v=38, threads=64, grouping=16, minblocks=1) , # 2402.8 GFlop/s
-  Kernel_dnt_largeDB2(m=32, n=55, k=55, tile_m=6, tile_n=6, w=12, v=20, threads=64, grouping=16, minblocks=4) , # 2483.08 GFlop/s
-  Kernel_dnt_medium(m=45, n=4, k=4, tile_m=6, tile_n=1, threads=64, grouping=19, minblocks=16) , # 447.443 GFlop/s
-  Kernel_dnt_medium(m=45, n=4, k=5, tile_m=6, tile_n=1, threads=64, grouping=25, minblocks=16) , # 452.508 GFlop/s
-  Kernel_dnt_medium(m=45, n=4, k=7, tile_m=3, tile_n=1, threads=64, grouping=24, minblocks=2) , # 473.476 GFlop/s
-  Kernel_dnt_medium(m=45, n=4, k=9, tile_m=1, tile_n=4, threads=64, grouping=29, minblocks=6) , # 479.338 GFlop/s
-  Kernel_dnt_medium(m=45, n=4, k=13, tile_m=1, tile_n=2, threads=128, grouping=6, minblocks=4) , # 488.528 GFlop/s
-  Kernel_dnt_medium(m=45, n=4, k=25, tile_m=1, tile_n=2, threads=128, grouping=3, minblocks=2) , # 509.978 GFlop/s
-  Kernel_dnt_medium(m=45, n=4, k=26, tile_m=1, tile_n=2, threads=192, grouping=3, minblocks=1) , # 511.579 GFlop/s
-  Kernel_dnt_medium(m=45, n=4, k=28, tile_m=1, tile_n=2, threads=128, grouping=3, minblocks=2) , # 517.616 GFlop/s
-  Kernel_dnt_medium(m=45, n=4, k=32, tile_m=1, tile_n=2, threads=256, grouping=3, minblocks=3) , # 524.404 GFlop/s
-  Kernel_dnt_medium(m=45, n=4, k=45, tile_m=1, tile_n=2, threads=256, grouping=3, minblocks=1) , # 530.028 GFlop/s
-  Kernel_dnt_medium(m=45, n=5, k=4, tile_m=1, tile_n=6, threads=64, grouping=26, minblocks=10) , # 511.613 GFlop/s
-  Kernel_dnt_medium(m=45, n=5, k=5, tile_m=1, tile_n=5, threads=64, grouping=26, minblocks=10) , # 529.849 GFlop/s
-  Kernel_dnt_medium(m=45, n=5, k=7, tile_m=1, tile_n=5, threads=64, grouping=32, minblocks=7) , # 554.528 GFlop/s
-  Kernel_dnt_medium(m=45, n=5, k=9, tile_m=1, tile_n=5, threads=64, grouping=26, minblocks=11) , # 565.503 GFlop/s
-  Kernel_dnt_medium(m=45, n=5, k=13, tile_m=1, tile_n=3, threads=128, grouping=4, minblocks=9) , # 581.404 GFlop/s
-  Kernel_dnt_medium(m=45, n=5, k=25, tile_m=1, tile_n=3, threads=192, grouping=3, minblocks=2) , # 614.32 GFlop/s
-  Kernel_dnt_medium(m=45, n=5, k=26, tile_m=1, tile_n=2, threads=192, grouping=3, minblocks=4) , # 613.164 GFlop/s
-  Kernel_dnt_medium(m=45, n=5, k=28, tile_m=1, tile_n=2, threads=256, grouping=3, minblocks=3) , # 622.314 GFlop/s
-  Kernel_dnt_medium(m=45, n=5, k=32, tile_m=1, tile_n=2, threads=256, grouping=3, minblocks=1) , # 630.744 GFlop/s
-  Kernel_dnt_medium(m=45, n=5, k=45, tile_m=1, tile_n=1, threads=256, grouping=3, minblocks=1) , # 638.115 GFlop/s
-  Kernel_dnt_medium(m=45, n=7, k=4, tile_m=5, tile_n=1, threads=64, grouping=25, minblocks=14) , # 640.697 GFlop/s
-  Kernel_dnt_medium(m=45, n=7, k=5, tile_m=5, tile_n=1, threads=64, grouping=26, minblocks=17) , # 669.324 GFlop/s
-  Kernel_dnt_medium(m=45, n=7, k=7, tile_m=6, tile_n=1, threads=64, grouping=32, minblocks=11) , # 712.064 GFlop/s
-  Kernel_dnt_medium(m=45, n=7, k=9, tile_m=1, tile_n=4, threads=96, grouping=32, minblocks=2) , # 727.757 GFlop/s
-  Kernel_dnt_medium(m=45, n=7, k=13, tile_m=1, tile_n=4, threads=128, grouping=24, minblocks=4) , # 753.039 GFlop/s
-  Kernel_dnt_medium(m=45, n=7, k=25, tile_m=1, tile_n=2, threads=192, grouping=3, minblocks=4) , # 807.2 GFlop/s
-  Kernel_dnt_medium(m=45, n=7, k=26, tile_m=1, tile_n=2, threads=192, grouping=3, minblocks=3) , # 815.315 GFlop/s
-  Kernel_dnt_medium(m=45, n=7, k=28, tile_m=1, tile_n=2, threads=256, grouping=3, minblocks=3) , # 821.715 GFlop/s
-  Kernel_dnt_medium(m=45, n=7, k=32, tile_m=1, tile_n=2, threads=256, grouping=3, minblocks=3) , # 837.239 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=7, k=45, tile_m=1, tile_n=2, w=12, v=4, threads=192, grouping=16, minblocks=4) , # 833.545 GFlop/s
-  Kernel_dnt_medium(m=45, n=9, k=4, tile_m=3, tile_n=3, threads=64, grouping=32, minblocks=9) , # 735.448 GFlop/s
-  Kernel_dnt_medium(m=45, n=9, k=5, tile_m=3, tile_n=3, threads=64, grouping=32, minblocks=3) , # 771.229 GFlop/s
-  Kernel_dnt_medium(m=45, n=9, k=7, tile_m=1, tile_n=5, threads=96, grouping=32, minblocks=12) , # 843.763 GFlop/s
-  Kernel_dnt_medium(m=45, n=9, k=9, tile_m=1, tile_n=5, threads=96, grouping=32, minblocks=11) , # 864.971 GFlop/s
-  Kernel_dnt_medium(m=45, n=9, k=13, tile_m=1, tile_n=3, threads=160, grouping=5, minblocks=3) , # 908.669 GFlop/s
-  Kernel_dnt_medium(m=45, n=9, k=25, tile_m=1, tile_n=3, threads=256, grouping=4, minblocks=1) , # 980.24 GFlop/s
-  Kernel_dnt_medium(m=45, n=9, k=26, tile_m=1, tile_n=3, threads=256, grouping=3, minblocks=4) , # 988.361 GFlop/s
-  Kernel_dnt_medium(m=45, n=9, k=28, tile_m=1, tile_n=2, threads=256, grouping=3, minblocks=3) , # 997.761 GFlop/s
-  Kernel_dnt_medium(m=45, n=9, k=32, tile_m=1, tile_n=3, threads=160, grouping=3, minblocks=2) , # 1009.32 GFlop/s
-  Kernel_dnt_medium(m=45, n=9, k=45, tile_m=1, tile_n=3, threads=256, grouping=3, minblocks=1) , # 1014.45 GFlop/s
-  Kernel_dnt_medium(m=45, n=13, k=4, tile_m=5, tile_n=2, threads=64, grouping=32, minblocks=1) , # 885.5 GFlop/s
-  Kernel_dnt_medium(m=45, n=13, k=5, tile_m=5, tile_n=1, threads=128, grouping=32, minblocks=9) , # 912.85 GFlop/s
-  Kernel_dnt_medium(m=45, n=13, k=7, tile_m=5, tile_n=1, threads=128, grouping=32, minblocks=9) , # 1016.11 GFlop/s
-  Kernel_dnt_medium(m=45, n=13, k=9, tile_m=5, tile_n=1, threads=128, grouping=32, minblocks=9) , # 1076.14 GFlop/s
-  Kernel_dnt_medium(m=45, n=13, k=13, tile_m=1, tile_n=5, threads=192, grouping=5, minblocks=6) , # 1153.04 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=13, k=25, tile_m=3, tile_n=4, w=8, v=10, threads=64, grouping=16, minblocks=8) , # 1237.7 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=13, k=26, tile_m=3, tile_n=4, w=8, v=12, threads=64, grouping=16, minblocks=4) , # 1247.69 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=13, k=28, tile_m=5, tile_n=2, w=14, v=12, threads=64, grouping=16, minblocks=2) , # 1268.39 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=13, k=32, tile_m=5, tile_n=2, w=12, v=10, threads=64, grouping=16, minblocks=2) , # 1290.64 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=13, k=45, tile_m=5, tile_n=2, w=12, v=12, threads=64, grouping=16, minblocks=1) , # 1334.66 GFlop/s
-  Kernel_dnt_medium(m=45, n=25, k=4, tile_m=3, tile_n=5, threads=96, grouping=29, minblocks=4) , # 1027.95 GFlop/s
-  Kernel_dnt_medium(m=45, n=25, k=5, tile_m=5, tile_n=2, threads=128, grouping=24, minblocks=4) , # 1152.55 GFlop/s
-  Kernel_dnt_medium(m=45, n=25, k=7, tile_m=5, tile_n=3, threads=96, grouping=24, minblocks=1) , # 1310.14 GFlop/s
-  Kernel_dnt_medium(m=45, n=25, k=9, tile_m=5, tile_n=2, threads=128, grouping=32, minblocks=3) , # 1429.19 GFlop/s
-  Kernel_dnt_medium(m=45, n=25, k=13, tile_m=3, tile_n=5, threads=96, grouping=24, minblocks=4) , # 1595.31 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=25, k=25, tile_m=3, tile_n=7, w=10, v=14, threads=64, grouping=16, minblocks=2) , # 1830.75 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=25, k=26, tile_m=5, tile_n=4, w=10, v=12, threads=64, grouping=16, minblocks=2) , # 1854.31 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=25, k=28, tile_m=5, tile_n=4, w=12, v=22, threads=64, grouping=16, minblocks=4) , # 1879.95 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=25, k=32, tile_m=5, tile_n=4, w=8, v=12, threads=64, grouping=16, minblocks=4) , # 1929.59 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=25, k=45, tile_m=5, tile_n=4, w=12, v=16, threads=64, grouping=16, minblocks=2) , # 2025.82 GFlop/s
-  Kernel_dnt_medium(m=45, n=26, k=4, tile_m=3, tile_n=5, threads=96, grouping=29, minblocks=4) , # 1069.89 GFlop/s
-  Kernel_dnt_medium(m=45, n=26, k=5, tile_m=3, tile_n=3, threads=160, grouping=24, minblocks=4) , # 1144.5 GFlop/s
-  Kernel_dnt_medium(m=45, n=26, k=7, tile_m=3, tile_n=5, threads=96, grouping=24, minblocks=4) , # 1348.87 GFlop/s
-  Kernel_dnt_medium(m=45, n=26, k=9, tile_m=5, tile_n=2, threads=128, grouping=32, minblocks=2) , # 1480.85 GFlop/s
-  Kernel_dnt_medium(m=45, n=26, k=13, tile_m=3, tile_n=5, threads=96, grouping=24, minblocks=3) , # 1643.06 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=26, k=25, tile_m=5, tile_n=4, w=12, v=26, threads=64, grouping=16, minblocks=1) , # 1877.75 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=26, k=26, tile_m=5, tile_n=4, w=12, v=26, threads=64, grouping=16, minblocks=4) , # 1901.17 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=26, k=28, tile_m=3, tile_n=7, w=8, v=16, threads=64, grouping=16, minblocks=1) , # 1935.75 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=26, k=32, tile_m=5, tile_n=4, w=8, v=26, threads=64, grouping=16, minblocks=2) , # 1991.83 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=26, k=45, tile_m=5, tile_n=4, w=12, v=26, threads=64, grouping=16, minblocks=1) , # 2075.74 GFlop/s
-  Kernel_dnt_medium(m=45, n=28, k=4, tile_m=3, tile_n=5, threads=96, grouping=29, minblocks=3) , # 1161.39 GFlop/s
-  Kernel_dnt_medium(m=45, n=28, k=5, tile_m=5, tile_n=2, threads=128, grouping=24, minblocks=4) , # 1229.89 GFlop/s
-  Kernel_dnt_medium(m=45, n=28, k=7, tile_m=3, tile_n=5, threads=96, grouping=24, minblocks=4) , # 1432.27 GFlop/s
-  Kernel_dnt_medium(m=45, n=28, k=9, tile_m=5, tile_n=2, threads=128, grouping=32, minblocks=2) , # 1563.84 GFlop/s
-  Kernel_dnt_medium(m=45, n=28, k=13, tile_m=3, tile_n=5, threads=96, grouping=24, minblocks=4) , # 1719.62 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=28, k=25, tile_m=5, tile_n=4, w=12, v=20, threads=64, grouping=16, minblocks=4) , # 1977.98 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=28, k=26, tile_m=5, tile_n=4, w=12, v=28, threads=64, grouping=16, minblocks=1) , # 1994.7 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=28, k=28, tile_m=3, tile_n=7, w=14, v=28, threads=64, grouping=16, minblocks=2) , # 2029.85 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=28, k=32, tile_m=5, tile_n=4, w=8, v=28, threads=64, grouping=16, minblocks=2) , # 2089.27 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=28, k=45, tile_m=3, tile_n=7, w=8, v=16, threads=64, grouping=16, minblocks=2) , # 2179.89 GFlop/s
-  Kernel_dnt_medium(m=45, n=32, k=4, tile_m=6, tile_n=2, threads=192, grouping=32, minblocks=2) , # 1191.44 GFlop/s
-  Kernel_dnt_medium(m=45, n=32, k=5, tile_m=3, tile_n=4, threads=128, grouping=25, minblocks=2) , # 1315.4 GFlop/s
-  Kernel_dnt_medium(m=45, n=32, k=7, tile_m=3, tile_n=4, threads=128, grouping=32, minblocks=1) , # 1521.68 GFlop/s
-  Kernel_dnt_medium(m=45, n=32, k=9, tile_m=3, tile_n=4, threads=128, grouping=32, minblocks=1) , # 1691.63 GFlop/s
-  Kernel_dnt_medium(m=45, n=32, k=13, tile_m=3, tile_n=4, threads=128, grouping=32, minblocks=1) , # 1848.13 GFlop/s
-  Kernel_dnt_medium(m=45, n=32, k=25, tile_m=3, tile_n=4, threads=128, grouping=32, minblocks=1) , # 2107.65 GFlop/s
-  Kernel_dnt_medium(m=45, n=32, k=26, tile_m=3, tile_n=4, threads=128, grouping=32, minblocks=1) , # 2137 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=32, k=28, tile_m=6, tile_n=4, w=8, v=8, threads=64, grouping=16, minblocks=1) , # 2172 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=32, k=32, tile_m=6, tile_n=4, w=8, v=16, threads=64, grouping=16, minblocks=2) , # 2249.68 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=32, k=45, tile_m=6, tile_n=4, w=8, v=16, threads=64, grouping=16, minblocks=2) , # 2341.8 GFlop/s
-  Kernel_dnt_medium(m=45, n=45, k=4, tile_m=6, tile_n=2, threads=192, grouping=32, minblocks=2) , # 1271.92 GFlop/s
-  Kernel_dnt_medium(m=45, n=45, k=5, tile_m=6, tile_n=2, threads=256, grouping=29, minblocks=1) , # 1313.41 GFlop/s
-  Kernel_dnt_medium(m=45, n=45, k=7, tile_m=3, tile_n=4, threads=192, grouping=29, minblocks=1) , # 1559.15 GFlop/s
-  Kernel_dnt_medium(m=45, n=45, k=9, tile_m=3, tile_n=4, threads=192, grouping=29, minblocks=2) , # 1743.9 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=45, k=13, tile_m=6, tile_n=6, w=6, v=28, threads=64, grouping=16, minblocks=2) , # 1951.48 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=45, k=25, tile_m=6, tile_n=6, w=12, v=26, threads=64, grouping=16, minblocks=2) , # 2366.95 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=45, k=26, tile_m=6, tile_n=6, w=10, v=26, threads=64, grouping=16, minblocks=1) , # 2409.7 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=45, k=28, tile_m=7, tile_n=5, w=14, v=18, threads=64, grouping=16, minblocks=1) , # 2479.64 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=45, k=32, tile_m=7, tile_n=5, w=12, v=22, threads=64, grouping=16, minblocks=4) , # 2550.51 GFlop/s
-  Kernel_dnt_largeDB2(m=45, n=45, k=45, tile_m=6, tile_n=6, w=12, v=18, threads=64, grouping=16, minblocks=2) , # 2690.9 GFlop/s
-  Kernel_dnt_medium(m=55, n=16, k=16, tile_m=1, tile_n=4, threads=256, grouping=4, minblocks=5) , # 1448.91 GFlop/s
-  Kernel_dnt_largeDB2(m=55, n=16, k=29, tile_m=2, tile_n=8, w=8, v=8, threads=64, grouping=16, minblocks=8) , # 1544.22 GFlop/s
-  Kernel_dnt_largeDB2(m=55, n=16, k=55, tile_m=2, tile_n=8, w=8, v=12, threads=64, grouping=16, minblocks=4) , # 1652.51 GFlop/s
-  Kernel_dnt_largeDB2(m=55, n=29, k=16, tile_m=7, tile_n=4, w=8, v=22, threads=64, grouping=16, minblocks=2) , # 1916.32 GFlop/s
-  Kernel_dnt_largeDB2(m=55, n=29, k=29, tile_m=3, tile_n=6, w=10, v=18, threads=96, grouping=16, minblocks=4) , # 2161.11 GFlop/s
-  Kernel_dnt_largeDB2(m=55, n=29, k=32, tile_m=7, tile_n=4, w=8, v=22, threads=64, grouping=16, minblocks=2) , # 2241.72 GFlop/s
-  Kernel_dnt_largeDB2(m=55, n=29, k=55, tile_m=3, tile_n=6, w=14, v=16, threads=96, grouping=16, minblocks=2) , # 2370.43 GFlop/s
-  Kernel_dnt_largeDB2(m=55, n=32, k=29, tile_m=7, tile_n=4, w=14, v=20, threads=64, grouping=16, minblocks=1) , # 2315.88 GFlop/s
-  Kernel_dnt_largeDB2(m=55, n=32, k=32, tile_m=7, tile_n=4, w=8, v=24, threads=64, grouping=16, minblocks=1) , # 2400.75 GFlop/s
-  Kernel_dnt_largeDB2(m=55, n=32, k=55, tile_m=7, tile_n=4, w=6, v=12, threads=64, grouping=16, minblocks=4) , # 2531.29 GFlop/s
-  Kernel_dnt_largeDB2(m=55, n=55, k=16, tile_m=7, tile_n=4, w=8, v=32, threads=128, grouping=16, minblocks=1) , # 2371.04 GFlop/s
-  Kernel_dnt_largeDB2(m=55, n=55, k=29, tile_m=7, tile_n=7, w=10, v=28, threads=64, grouping=16, minblocks=1) , # 2634.65 GFlop/s
-  Kernel_dnt_largeDB2(m=55, n=55, k=32, tile_m=7, tile_n=7, w=10, v=28, threads=64, grouping=16, minblocks=2) , # 2696.5 GFlop/s
-  Kernel_dnt_largeDB2(m=55, n=55, k=55, tile_m=7, tile_n=7, w=10, v=24, threads=64, grouping=16, minblocks=1) , # 2934.2 GFlop/s
-  Kernel_dnt_largeDB2(m=64, n=64, k=64, tile_m=9, tile_n=4, w=22, v=32, threads=128, grouping=16, minblocks=2) , # 3072.53 GFlop/s
-  Kernel_dnt_largeDB1(m=78, n=78, k=78, tile_m=10, tile_n=5, w=8, v=30, threads=128, grouping=16, minblocks=1) , # 3319.77 GFlop/s
-  Kernel_dnt_largeDB2(m=10, n=12, k=12, tile_m=1, tile_n=2, w=6, v=12, threads=64, grouping=16, minblocks=8) , # 710.062 GFlop/s
-  Kernel_dnt_largeDB2(m=11, n=20, k=20, tile_m=4, tile_n=1, w=10, v=8, threads=64, grouping=16, minblocks=2) , # 900.568 GFlop/s
-  Kernel_dnt_largeDB2(m=11, n=25, k=20, tile_m=2, tile_n=3, w=10, v=24, threads=64, grouping=16, minblocks=1) , # 968.954 GFlop/s
-  Kernel_dnt_largeDB2(m=11, n=25, k=25, tile_m=2, tile_n=3, w=10, v=22, threads=64, grouping=16, minblocks=4) , # 972.814 GFlop/s
-  Kernel_dnt_largeDB2(m=11, n=32, k=12, tile_m=6, tile_n=1, w=6, v=28, threads=64, grouping=16, minblocks=8) , # 971.263 GFlop/s
-  Kernel_dnt_largeDB2(m=11, n=32, k=20, tile_m=3, tile_n=2, w=10, v=32, threads=64, grouping=16, minblocks=2) , # 1040.31 GFlop/s
-  Kernel_dnt_largeDB2(m=11, n=32, k=32, tile_m=2, tile_n=2, w=8, v=8, threads=96, grouping=16, minblocks=4) , # 1093.93 GFlop/s
-  Kernel_dnt_largeDB2(m=12, n=10, k=12, tile_m=1, tile_n=2, w=6, v=10, threads=64, grouping=16, minblocks=2) , # 707.143 GFlop/s
-  Kernel_dnt_largeDB2(m=12, n=10, k=32, tile_m=1, tile_n=2, w=8, v=10, threads=64, grouping=16, minblocks=12) , # 743.602 GFlop/s
-  Kernel_dnt_largeDB2(m=12, n=20, k=20, tile_m=1, tile_n=3, w=10, v=12, threads=96, grouping=16, minblocks=4) , # 960.877 GFlop/s
-  Kernel_dnt_largeDB2(m=12, n=20, k=32, tile_m=2, tile_n=2, w=16, v=20, threads=64, grouping=16, minblocks=4) , # 1003.8 GFlop/s
-  Kernel_dnt_largeDB2(m=12, n=25, k=20, tile_m=2, tile_n=3, w=10, v=24, threads=64, grouping=16, minblocks=1) , # 1028.48 GFlop/s
-  Kernel_dnt_largeDB2(m=12, n=9, k=32, tile_m=1, tile_n=2, w=16, v=6, threads=64, grouping=16, minblocks=2) , # 698.588 GFlop/s
-  Kernel_dnt_largeDB2(m=20, n=11, k=20, tile_m=1, tile_n=2, w=10, v=8, threads=128, grouping=16, minblocks=1) , # 904.021 GFlop/s
-  Kernel_dnt_largeDB2(m=20, n=11, k=32, tile_m=1, tile_n=2, w=16, v=8, threads=128, grouping=16, minblocks=1) , # 944.417 GFlop/s
-  Kernel_dnt_largeDB2(m=20, n=12, k=20, tile_m=1, tile_n=2, w=10, v=4, threads=128, grouping=16, minblocks=4) , # 960.236 GFlop/s
-  Kernel_dnt_largeDB2(m=20, n=12, k=32, tile_m=1, tile_n=2, w=16, v=12, threads=128, grouping=16, minblocks=4) , # 1001.05 GFlop/s
-  Kernel_dnt_largeDB2(m=20, n=25, k=12, tile_m=3, tile_n=3, w=6, v=18, threads=64, grouping=16, minblocks=4) , # 1244.17 GFlop/s
-  Kernel_dnt_largeDB2(m=20, n=25, k=20, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=4) , # 1334.34 GFlop/s
-  Kernel_dnt_largeDB2(m=20, n=25, k=25, tile_m=3, tile_n=3, w=10, v=22, threads=64, grouping=16, minblocks=8) , # 1361.83 GFlop/s
-  Kernel_dnt_largeDB2(m=20, n=25, k=32, tile_m=3, tile_n=2, w=16, v=18, threads=96, grouping=16, minblocks=4) , # 1400.96 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=11, k=20, tile_m=2, tile_n=3, w=10, v=8, threads=64, grouping=16, minblocks=4) , # 956.932 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=11, k=25, tile_m=2, tile_n=3, w=10, v=6, threads=64, grouping=16, minblocks=8) , # 962.602 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=11, k=32, tile_m=3, tile_n=2, w=16, v=6, threads=64, grouping=16, minblocks=1) , # 996.876 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=12, k=20, tile_m=3, tile_n=2, w=10, v=12, threads=64, grouping=16, minblocks=4) , # 1028.89 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=12, k=32, tile_m=3, tile_n=2, w=16, v=12, threads=64, grouping=16, minblocks=1) , # 1070.25 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=20, k=12, tile_m=3, tile_n=3, w=6, v=20, threads=64, grouping=16, minblocks=4) , # 1253.35 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=20, k=20, tile_m=3, tile_n=2, w=10, v=16, threads=96, grouping=16, minblocks=4) , # 1333.39 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=20, k=25, tile_m=3, tile_n=3, w=10, v=16, threads=64, grouping=16, minblocks=4) , # 1355.68 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=20, k=32, tile_m=3, tile_n=2, w=16, v=18, threads=96, grouping=16, minblocks=4) , # 1408.81 GFlop/s
-  Kernel_dnt_largeDB2(m=25, n=32, k=12, tile_m=7, tile_n=2, w=6, v=32, threads=64, grouping=16, minblocks=4) , # 1481.41 GFlop/s
-  Kernel_dnt_largeDB2(m=9, n=12, k=32, tile_m=1, tile_n=2, w=8, v=12, threads=64, grouping=16, minblocks=1) , # 699.295 GFlop/s
-  Kernel_dnt_medium(m=10, n=10, k=11, tile_m=1, tile_n=2, threads=64, grouping=6, minblocks=19) , # 649.449 GFlop/s
-  Kernel_dnt_medium(m=10, n=10, k=12, tile_m=1, tile_n=2, threads=64, grouping=22, minblocks=3) , # 678.945 GFlop/s
-  Kernel_dnt_medium(m=10, n=10, k=32, tile_m=1, tile_n=2, threads=128, grouping=3, minblocks=8) , # 692.008 GFlop/s
-  Kernel_dnt_medium(m=10, n=10, k=9, tile_m=1, tile_n=4, threads=32, grouping=19, minblocks=23) , # 645.292 GFlop/s
-  Kernel_dnt_medium(m=10, n=12, k=10, tile_m=1, tile_n=2, threads=64, grouping=22, minblocks=6) , # 690.625 GFlop/s
-  Kernel_dnt_medium(m=10, n=12, k=32, tile_m=1, tile_n=2, threads=128, grouping=3, minblocks=4) , # 749.015 GFlop/s
-  Kernel_dnt_medium(m=10, n=12, k=9, tile_m=1, tile_n=4, threads=32, grouping=13, minblocks=15) , # 669.43 GFlop/s
-  Kernel_dnt_medium(m=10, n=32, k=10, tile_m=1, tile_n=6, threads=128, grouping=32, minblocks=9) , # 906.799 GFlop/s
-  Kernel_dnt_medium(m=10, n=32, k=12, tile_m=1, tile_n=3, threads=128, grouping=32, minblocks=10) , # 938.098 GFlop/s
-  Kernel_dnt_medium(m=10, n=32, k=32, tile_m=1, tile_n=2, threads=192, grouping=3, minblocks=2) , # 1031.68 GFlop/s
-  Kernel_dnt_medium(m=10, n=32, k=9, tile_m=2, tile_n=2, threads=96, grouping=32, minblocks=9) , # 905.73 GFlop/s
-  Kernel_dnt_medium(m=10, n=9, k=10, tile_m=1, tile_n=3, threads=32, grouping=11, minblocks=6) , # 598.408 GFlop/s
-  Kernel_dnt_medium(m=10, n=9, k=12, tile_m=1, tile_n=3, threads=32, grouping=12, minblocks=10) , # 630.235 GFlop/s
-  Kernel_dnt_medium(m=10, n=9, k=32, tile_m=1, tile_n=1, threads=96, grouping=4, minblocks=7) , # 654.862 GFlop/s
-  Kernel_dnt_medium(m=10, n=9, k=9, tile_m=1, tile_n=3, threads=32, grouping=16, minblocks=22) , # 617.477 GFlop/s
-  Kernel_dnt_medium(m=11, n=11, k=12, tile_m=1, tile_n=3, threads=64, grouping=26, minblocks=7) , # 710.594 GFlop/s
-  Kernel_dnt_medium(m=11, n=11, k=20, tile_m=2, tile_n=2, threads=96, grouping=32, minblocks=10) , # 718.795 GFlop/s
-  Kernel_dnt_medium(m=11, n=11, k=25, tile_m=2, tile_n=1, threads=96, grouping=32, minblocks=8) , # 723.132 GFlop/s
-  Kernel_dnt_medium(m=11, n=11, k=32, tile_m=2, tile_n=1, threads=128, grouping=4, minblocks=2) , # 748.109 GFlop/s
-  Kernel_dnt_medium(m=11, n=12, k=11, tile_m=2, tile_n=2, threads=64, grouping=26, minblocks=6) , # 693.544 GFlop/s
-  Kernel_dnt_medium(m=11, n=12, k=12, tile_m=1, tile_n=3, threads=64, grouping=26, minblocks=17) , # 710.581 GFlop/s
-  Kernel_dnt_medium(m=11, n=12, k=20, tile_m=2, tile_n=2, threads=64, grouping=7, minblocks=13) , # 732.24 GFlop/s
-  Kernel_dnt_medium(m=11, n=12, k=25, tile_m=2, tile_n=1, threads=96, grouping=5, minblocks=8) , # 740.308 GFlop/s
-  Kernel_dnt_medium(m=11, n=12, k=32, tile_m=2, tile_n=1, threads=128, grouping=4, minblocks=6) , # 766.012 GFlop/s
-  Kernel_dnt_medium(m=11, n=20, k=11, tile_m=2, tile_n=2, threads=64, grouping=26, minblocks=11) , # 859.155 GFlop/s
-  Kernel_dnt_medium(m=11, n=20, k=12, tile_m=2, tile_n=2, threads=64, grouping=26, minblocks=9) , # 859.574 GFlop/s
-  Kernel_dnt_medium(m=11, n=20, k=25, tile_m=2, tile_n=1, threads=128, grouping=4, minblocks=7) , # 918.74 GFlop/s
-  Kernel_dnt_medium(m=11, n=20, k=32, tile_m=2, tile_n=1, threads=128, grouping=4, minblocks=5) , # 948.189 GFlop/s
-  Kernel_dnt_medium(m=11, n=25, k=11, tile_m=1, tile_n=5, threads=128, grouping=32, minblocks=9) , # 895.515 GFlop/s
-  Kernel_dnt_medium(m=11, n=25, k=12, tile_m=1, tile_n=5, threads=64, grouping=32, minblocks=1) , # 894.023 GFlop/s
-  Kernel_dnt_medium(m=11, n=25, k=32, tile_m=2, tile_n=1, threads=192, grouping=4, minblocks=5) , # 1003.35 GFlop/s
-  Kernel_dnt_medium(m=11, n=32, k=11, tile_m=6, tile_n=1, threads=128, grouping=32, minblocks=9) , # 967.416 GFlop/s
-  Kernel_dnt_medium(m=11, n=32, k=25, tile_m=2, tile_n=1, threads=192, grouping=4, minblocks=4) , # 1053.09 GFlop/s
-  Kernel_dnt_medium(m=12, n=10, k=10, tile_m=1, tile_n=2, threads=64, grouping=22, minblocks=12) , # 695.265 GFlop/s
-  Kernel_dnt_medium(m=12, n=10, k=9, tile_m=4, tile_n=1, threads=32, grouping=12, minblocks=10) , # 663.302 GFlop/s
-  Kernel_dnt_medium(m=12, n=11, k=11, tile_m=1, tile_n=3, threads=64, grouping=26, minblocks=10) , # 707.91 GFlop/s
-  Kernel_dnt_medium(m=12, n=11, k=12, tile_m=1, tile_n=3, threads=64, grouping=26, minblocks=18) , # 722.854 GFlop/s
-  Kernel_dnt_medium(m=12, n=11, k=20, tile_m=1, tile_n=3, threads=64, grouping=6, minblocks=5) , # 748.533 GFlop/s
-  Kernel_dnt_medium(m=12, n=11, k=25, tile_m=1, tile_n=2, threads=96, grouping=5, minblocks=6) , # 746.389 GFlop/s
-  Kernel_dnt_medium(m=12, n=11, k=32, tile_m=2, tile_n=1, threads=128, grouping=4, minblocks=5) , # 772.265 GFlop/s
-  Kernel_dnt_medium(m=12, n=12, k=10, tile_m=1, tile_n=3, threads=64, grouping=22, minblocks=5) , # 782.428 GFlop/s
-  Kernel_dnt_medium(m=12, n=12, k=11, tile_m=1, tile_n=3, threads=64, grouping=26, minblocks=1) , # 773.895 GFlop/s
-  Kernel_dnt_medium(m=12, n=12, k=16, tile_m=1, tile_n=3, threads=64, grouping=32, minblocks=14) , # 797.978 GFlop/s
-  Kernel_dnt_medium(m=12, n=12, k=20, tile_m=1, tile_n=3, threads=64, grouping=32, minblocks=3) , # 789.883 GFlop/s
-  Kernel_dnt_medium(m=12, n=16, k=12, tile_m=3, tile_n=1, threads=64, grouping=26, minblocks=12) , # 850.387 GFlop/s
-  Kernel_dnt_medium(m=12, n=16, k=16, tile_m=1, tile_n=2, threads=96, grouping=32, minblocks=7) , # 884.496 GFlop/s
-  Kernel_dnt_medium(m=12, n=16, k=32, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=3) , # 928.761 GFlop/s
-  Kernel_dnt_medium(m=12, n=20, k=11, tile_m=1, tile_n=4, threads=64, grouping=26, minblocks=11) , # 895.574 GFlop/s
-  Kernel_dnt_medium(m=12, n=20, k=12, tile_m=2, tile_n=2, threads=64, grouping=26, minblocks=8) , # 908.586 GFlop/s
-  Kernel_dnt_medium(m=12, n=20, k=25, tile_m=1, tile_n=2, threads=128, grouping=5, minblocks=4) , # 972.699 GFlop/s
-  Kernel_dnt_medium(m=12, n=25, k=11, tile_m=1, tile_n=5, threads=64, grouping=32, minblocks=7) , # 936.728 GFlop/s
-  Kernel_dnt_medium(m=12, n=25, k=32, tile_m=1, tile_n=2, threads=192, grouping=3, minblocks=3) , # 1082.11 GFlop/s
-  Kernel_dnt_medium(m=12, n=32, k=10, tile_m=1, tile_n=4, threads=128, grouping=32, minblocks=10) , # 1022.68 GFlop/s
-  Kernel_dnt_medium(m=12, n=32, k=11, tile_m=1, tile_n=4, threads=96, grouping=32, minblocks=10) , # 1031.57 GFlop/s
-  Kernel_dnt_medium(m=12, n=32, k=16, tile_m=1, tile_n=4, threads=128, grouping=4, minblocks=8) , # 1084.77 GFlop/s
-  Kernel_dnt_medium(m=12, n=32, k=20, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=1) , # 1106.6 GFlop/s
-  Kernel_dnt_medium(m=12, n=32, k=25, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=3) , # 1128.97 GFlop/s
-  Kernel_dnt_medium(m=12, n=32, k=9, tile_m=1, tile_n=4, threads=128, grouping=32, minblocks=9) , # 1009.07 GFlop/s
-  Kernel_dnt_medium(m=12, n=9, k=10, tile_m=2, tile_n=2, threads=64, grouping=18, minblocks=16) , # 645.924 GFlop/s
-  Kernel_dnt_medium(m=16, n=12, k=12, tile_m=1, tile_n=3, threads=64, grouping=26, minblocks=15) , # 854.169 GFlop/s
-  Kernel_dnt_medium(m=16, n=12, k=16, tile_m=1, tile_n=2, threads=96, grouping=32, minblocks=11) , # 887.754 GFlop/s
-  Kernel_dnt_medium(m=16, n=12, k=32, tile_m=2, tile_n=1, threads=160, grouping=5, minblocks=3) , # 925.265 GFlop/s
-  Kernel_dnt_medium(m=16, n=16, k=12, tile_m=2, tile_n=2, threads=64, grouping=32, minblocks=3) , # 1009.93 GFlop/s
-  Kernel_dnt_medium(m=16, n=32, k=12, tile_m=1, tile_n=4, threads=128, grouping=4, minblocks=8) , # 1231.07 GFlop/s
-  Kernel_dnt_medium(m=20, n=11, k=11, tile_m=1, tile_n=4, threads=64, grouping=24, minblocks=1) , # 849.388 GFlop/s
-  Kernel_dnt_medium(m=20, n=11, k=12, tile_m=1, tile_n=4, threads=64, grouping=24, minblocks=11) , # 853.531 GFlop/s
-  Kernel_dnt_medium(m=20, n=11, k=25, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=4) , # 922.024 GFlop/s
-  Kernel_dnt_medium(m=20, n=12, k=11, tile_m=1, tile_n=4, threads=64, grouping=26, minblocks=12) , # 897.705 GFlop/s
-  Kernel_dnt_medium(m=20, n=12, k=12, tile_m=1, tile_n=4, threads=64, grouping=29, minblocks=4) , # 906.799 GFlop/s
-  Kernel_dnt_medium(m=20, n=12, k=25, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=2) , # 970.235 GFlop/s
-  Kernel_dnt_medium(m=20, n=20, k=11, tile_m=1, tile_n=5, threads=96, grouping=32, minblocks=12) , # 1153.6 GFlop/s
-  Kernel_dnt_medium(m=20, n=20, k=12, tile_m=1, tile_n=5, threads=96, grouping=4, minblocks=12) , # 1160.25 GFlop/s
-  Kernel_dnt_medium(m=20, n=20, k=25, tile_m=1, tile_n=4, threads=160, grouping=4, minblocks=6) , # 1275.85 GFlop/s
-  Kernel_dnt_medium(m=20, n=20, k=32, tile_m=1, tile_n=3, threads=160, grouping=3, minblocks=2) , # 1309.2 GFlop/s
-  Kernel_dnt_medium(m=20, n=25, k=11, tile_m=3, tile_n=2, threads=96, grouping=29, minblocks=10) , # 1187.93 GFlop/s
-  Kernel_dnt_medium(m=20, n=32, k=11, tile_m=1, tile_n=6, threads=128, grouping=5, minblocks=8) , # 1336.45 GFlop/s
-  Kernel_dnt_medium(m=20, n=32, k=12, tile_m=1, tile_n=6, threads=128, grouping=4, minblocks=7) , # 1364.22 GFlop/s
-  Kernel_dnt_medium(m=20, n=32, k=20, tile_m=1, tile_n=4, threads=160, grouping=4, minblocks=5) , # 1493.29 GFlop/s
-  Kernel_dnt_medium(m=20, n=32, k=25, tile_m=1, tile_n=4, threads=160, grouping=4, minblocks=4) , # 1517.83 GFlop/s
-  Kernel_dnt_medium(m=20, n=32, k=32, tile_m=1, tile_n=4, threads=256, grouping=32, minblocks=3) , # 1557.15 GFlop/s
-  Kernel_dnt_medium(m=25, n=11, k=11, tile_m=1, tile_n=6, threads=128, grouping=32, minblocks=9) , # 883.488 GFlop/s
-  Kernel_dnt_medium(m=25, n=11, k=12, tile_m=1, tile_n=4, threads=96, grouping=32, minblocks=10) , # 895.478 GFlop/s
-  Kernel_dnt_medium(m=25, n=12, k=11, tile_m=1, tile_n=4, threads=96, grouping=6, minblocks=13) , # 921.389 GFlop/s
-  Kernel_dnt_medium(m=25, n=20, k=11, tile_m=1, tile_n=4, threads=128, grouping=6, minblocks=10) , # 1206.16 GFlop/s
-  Kernel_dnt_medium(m=25, n=25, k=11, tile_m=1, tile_n=5, threads=128, grouping=32, minblocks=9) , # 1340.23 GFlop/s
-  Kernel_dnt_medium(m=25, n=25, k=20, tile_m=1, tile_n=5, threads=192, grouping=5, minblocks=6) , # 1480.51 GFlop/s
-  Kernel_dnt_medium(m=25, n=32, k=11, tile_m=3, tile_n=5, threads=64, grouping=24, minblocks=6) , # 1423.93 GFlop/s
-  Kernel_dnt_medium(m=25, n=32, k=20, tile_m=3, tile_n=5, threads=64, grouping=3, minblocks=3) , # 1636.95 GFlop/s
-  Kernel_dnt_medium(m=32, n=10, k=10, tile_m=1, tile_n=5, threads=128, grouping=32, minblocks=9) , # 915.443 GFlop/s
-  Kernel_dnt_medium(m=32, n=10, k=12, tile_m=1, tile_n=3, threads=128, grouping=32, minblocks=9) , # 944.867 GFlop/s
-  Kernel_dnt_medium(m=32, n=10, k=32, tile_m=1, tile_n=2, threads=192, grouping=3, minblocks=1) , # 1031.19 GFlop/s
-  Kernel_dnt_medium(m=32, n=10, k=9, tile_m=1, tile_n=5, threads=96, grouping=32, minblocks=10) , # 918.728 GFlop/s
-  Kernel_dnt_medium(m=32, n=11, k=11, tile_m=1, tile_n=4, threads=128, grouping=4, minblocks=11) , # 978.001 GFlop/s
-  Kernel_dnt_medium(m=32, n=11, k=12, tile_m=1, tile_n=3, threads=160, grouping=5, minblocks=9) , # 984.847 GFlop/s
-  Kernel_dnt_medium(m=32, n=11, k=20, tile_m=1, tile_n=3, threads=224, grouping=4, minblocks=6) , # 1051.13 GFlop/s
-  Kernel_dnt_medium(m=32, n=11, k=25, tile_m=1, tile_n=3, threads=160, grouping=3, minblocks=2) , # 1058.32 GFlop/s
-  Kernel_dnt_medium(m=32, n=11, k=32, tile_m=1, tile_n=2, threads=192, grouping=3, minblocks=4) , # 1102.32 GFlop/s
-  Kernel_dnt_medium(m=32, n=12, k=10, tile_m=1, tile_n=3, threads=128, grouping=32, minblocks=11) , # 1036.39 GFlop/s
-  Kernel_dnt_medium(m=32, n=12, k=11, tile_m=1, tile_n=4, threads=96, grouping=32, minblocks=11) , # 1023.16 GFlop/s
-  Kernel_dnt_medium(m=32, n=12, k=16, tile_m=1, tile_n=3, threads=128, grouping=4, minblocks=2) , # 1090.93 GFlop/s
-  Kernel_dnt_medium(m=32, n=12, k=20, tile_m=1, tile_n=3, threads=128, grouping=3, minblocks=6) , # 1116.25 GFlop/s
-  Kernel_dnt_medium(m=32, n=12, k=25, tile_m=1, tile_n=2, threads=192, grouping=4, minblocks=5) , # 1131.14 GFlop/s
-  Kernel_dnt_medium(m=32, n=12, k=9, tile_m=1, tile_n=3, threads=128, grouping=32, minblocks=10) , # 1015.3 GFlop/s
-  Kernel_dnt_medium(m=32, n=16, k=12, tile_m=1, tile_n=4, threads=128, grouping=4, minblocks=10) , # 1235.03 GFlop/s
-  Kernel_dnt_medium(m=32, n=20, k=12, tile_m=1, tile_n=5, threads=128, grouping=4, minblocks=8) , # 1367.22 GFlop/s
-  Kernel_dnt_medium(m=32, n=20, k=20, tile_m=1, tile_n=4, threads=192, grouping=4, minblocks=5) , # 1490.8 GFlop/s
-  Kernel_dnt_medium(m=32, n=20, k=25, tile_m=1, tile_n=4, threads=160, grouping=4, minblocks=4) , # 1527.53 GFlop/s
-  Kernel_dnt_medium(m=32, n=20, k=32, tile_m=1, tile_n=3, threads=224, grouping=3, minblocks=1) , # 1575.35 GFlop/s
-  Kernel_dnt_medium(m=32, n=25, k=11, tile_m=1, tile_n=5, threads=160, grouping=29, minblocks=5) , # 1465.98 GFlop/s
-  Kernel_dnt_medium(m=32, n=25, k=12, tile_m=1, tile_n=5, threads=160, grouping=5, minblocks=7) , # 1501.64 GFlop/s
-  Kernel_dnt_medium(m=32, n=25, k=20, tile_m=1, tile_n=5, threads=224, grouping=4, minblocks=5) , # 1673.05 GFlop/s
-  Kernel_dnt_medium(m=32, n=32, k=10, tile_m=1, tile_n=6, threads=192, grouping=29, minblocks=5) , # 1639.09 GFlop/s
-  Kernel_dnt_medium(m=32, n=32, k=11, tile_m=1, tile_n=6, threads=192, grouping=29, minblocks=5) , # 1658.37 GFlop/s
-  Kernel_dnt_medium(m=32, n=32, k=20, tile_m=1, tile_n=4, threads=256, grouping=5, minblocks=4) , # 1879.26 GFlop/s
-  Kernel_dnt_medium(m=32, n=9, k=10, tile_m=1, tile_n=3, threads=96, grouping=29, minblocks=10) , # 863.579 GFlop/s
-  Kernel_dnt_medium(m=32, n=9, k=12, tile_m=1, tile_n=3, threads=128, grouping=6, minblocks=11) , # 873.588 GFlop/s
-  Kernel_dnt_medium(m=9, n=10, k=10, tile_m=3, tile_n=1, threads=32, grouping=11, minblocks=2) , # 590.348 GFlop/s
-  Kernel_dnt_medium(m=9, n=10, k=12, tile_m=3, tile_n=1, threads=64, grouping=22, minblocks=18) , # 616.887 GFlop/s
-  Kernel_dnt_medium(m=9, n=10, k=32, tile_m=1, tile_n=2, threads=128, grouping=4, minblocks=10) , # 649.51 GFlop/s
-  Kernel_dnt_medium(m=9, n=10, k=9, tile_m=3, tile_n=1, threads=32, grouping=13, minblocks=16) , # 603.196 GFlop/s
-  Kernel_dnt_medium(m=9, n=12, k=10, tile_m=2, tile_n=2, threads=32, grouping=12, minblocks=17) , # 641.738 GFlop/s
-  Kernel_dnt_medium(m=9, n=32, k=10, tile_m=3, tile_n=1, threads=96, grouping=32, minblocks=3) , # 854.866 GFlop/s
-  Kernel_dnt_medium(m=9, n=32, k=12, tile_m=5, tile_n=1, threads=128, grouping=5, minblocks=10) , # 866.147 GFlop/s
-  Kernel_dnt_medium(m=9, n=9, k=10, tile_m=3, tile_n=1, threads=32, grouping=18, minblocks=5) , # 598.238 GFlop/s
-  Kernel_dnt_medium(m=32, n=20, k=11, tile_m=1, tile_n=5, threads=128, grouping=4, minblocks=9) , # 1342.48 GFlop/s
+{"m": 4, "n": 4, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 9, "algorithm": "medium", "perf": 146.542},
+{"m": 4, "n": 4, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 18, "minblocks": 10, "algorithm": "medium", "perf": 177.041},
+{"m": 4, "n": 4, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 16, "algorithm": "medium", "perf": 206.475},
+{"m": 4, "n": 4, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 9, "algorithm": "medium", "perf": 219.254},
+{"m": 4, "n": 4, "k": 8, "threads": 32, "grouping": 12, "minblocks": 28, "algorithm": "tiny", "perf": 224.843},
+{"m": 4, "n": 4, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 2, "algorithm": "medium", "perf": 212.125},
+{"m": 4, "n": 4, "k": 10, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 23, "algorithm": "medium", "perf": 230.568},
+{"m": 4, "n": 4, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 12, "minblocks": 26, "algorithm": "medium", "perf": 277.241},
+{"m": 4, "n": 4, "k": 15, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 12, "minblocks": 18, "algorithm": "medium", "perf": 306.278},
+{"m": 4, "n": 4, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 18, "minblocks": 17, "algorithm": "medium", "perf": 296.162},
+{"m": 4, "n": 4, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 18, "algorithm": "medium", "perf": 298.901},
+{"m": 4, "n": 4, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 11, "algorithm": "medium", "perf": 299.878},
+{"m": 4, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 3, "minblocks": 14, "algorithm": "small", "perf": 303.953},
+{"m": 4, "n": 4, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 294.358},
+{"m": 4, "n": 5, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 18, "minblocks": 11, "algorithm": "medium", "perf": 177.692},
+{"m": 4, "n": 5, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 11, "algorithm": "medium", "perf": 217.191},
+{"m": 4, "n": 5, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 22, "algorithm": "medium", "perf": 236.563},
+{"m": 4, "n": 5, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 21, "algorithm": "medium", "perf": 211.342},
+{"m": 4, "n": 5, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 221.036},
+{"m": 4, "n": 5, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 229.753},
+{"m": 4, "n": 5, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 9, "algorithm": "medium", "perf": 289.348},
+{"m": 4, "n": 5, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 3, "minblocks": 13, "algorithm": "medium", "perf": 321.429},
+{"m": 4, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 3, "minblocks": 10, "algorithm": "medium", "perf": 314.511},
+{"m": 4, "n": 5, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 320.416},
+{"m": 4, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 3, "minblocks": 21, "algorithm": "medium", "perf": 329.232},
+{"m": 4, "n": 5, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 9, "algorithm": "medium", "perf": 321.273},
+{"m": 4, "n": 6, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 18, "minblocks": 15, "algorithm": "medium", "perf": 212.803},
+{"m": 4, "n": 6, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 5, "algorithm": "medium", "perf": 249.115},
+{"m": 4, "n": 6, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 7, "algorithm": "medium", "perf": 220.182},
+{"m": 4, "n": 6, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 25, "algorithm": "medium", "perf": 249.712},
+{"m": 4, "n": 6, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 11, "algorithm": "medium", "perf": 261.366},
+{"m": 4, "n": 6, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 7, "algorithm": "medium", "perf": 270.512},
+{"m": 4, "n": 7, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 18, "minblocks": 3, "algorithm": "medium", "perf": 247.865},
+{"m": 4, "n": 7, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 10, "algorithm": "medium", "perf": 221.348},
+{"m": 4, "n": 7, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 15, "minblocks": 21, "algorithm": "medium", "perf": 253.675},
+{"m": 4, "n": 7, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 26, "algorithm": "medium", "perf": 283.879},
+{"m": 4, "n": 7, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 27, "algorithm": "medium", "perf": 296.012},
+{"m": 4, "n": 7, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 1, "algorithm": "medium", "perf": 308.449},
+{"m": 4, "n": 7, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 11, "minblocks": 20, "algorithm": "medium", "perf": 367.159},
+{"m": 4, "n": 7, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 359.977},
+{"m": 4, "n": 7, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 18, "algorithm": "medium", "perf": 366.138},
+{"m": 4, "n": 7, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 9, "algorithm": "medium", "perf": 366.881},
+{"m": 4, "n": 7, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 17, "algorithm": "medium", "perf": 372.257},
+{"m": 4, "n": 7, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 364.346},
+{"m": 4, "n": 8, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 27, "algorithm": "medium", "perf": 238.702},
+{"m": 4, "n": 8, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 2, "algorithm": "medium", "perf": 250.59},
+{"m": 4, "n": 8, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 15, "minblocks": 19, "algorithm": "medium", "perf": 289.589},
+{"m": 4, "n": 8, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 13, "algorithm": "medium", "perf": 321.553},
+{"m": 4, "n": 8, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 11, "minblocks": 25, "algorithm": "medium", "perf": 316.767},
+{"m": 4, "n": 8, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 27, "algorithm": "medium", "perf": 338.79},
+{"m": 4, "n": 9, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 2, "algorithm": "medium", "perf": 227.781},
+{"m": 4, "n": 9, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 7, "algorithm": "medium", "perf": 266.956},
+{"m": 4, "n": 9, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 7, "algorithm": "medium", "perf": 312.537},
+{"m": 4, "n": 9, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 12, "minblocks": 8, "algorithm": "medium", "perf": 337.427},
+{"m": 4, "n": 9, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 19, "algorithm": "medium", "perf": 339.161},
+{"m": 4, "n": 9, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 21, "algorithm": "medium", "perf": 345.165},
+{"m": 4, "n": 9, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 5, "algorithm": "medium", "perf": 387.107},
+{"m": 4, "n": 9, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 386.259},
+{"m": 4, "n": 9, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 17, "algorithm": "medium", "perf": 388.032},
+{"m": 4, "n": 9, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 16, "algorithm": "medium", "perf": 393.694},
+{"m": 4, "n": 9, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 8, "algorithm": "medium", "perf": 394.752},
+{"m": 4, "n": 9, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 391.427},
+{"m": 4, "n": 10, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 2, "algorithm": "medium", "perf": 250.088},
+{"m": 4, "n": 10, "k": 10, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 11, "algorithm": "medium", "perf": 391.438},
+{"m": 4, "n": 10, "k": 15, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 12, "algorithm": "medium", "perf": 397.304},
+{"m": 4, "n": 13, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 6, "algorithm": "medium", "perf": 311.366},
+{"m": 4, "n": 13, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 10, "algorithm": "medium", "perf": 351.076},
+{"m": 4, "n": 13, "k": 7, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 12, "minblocks": 17, "algorithm": "medium", "perf": 428.77},
+{"m": 4, "n": 13, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 19, "algorithm": "medium", "perf": 418.275},
+{"m": 4, "n": 13, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 6, "minblocks": 5, "algorithm": "medium", "perf": 420.747},
+{"m": 4, "n": 13, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 13, "algorithm": "medium", "perf": 427.859},
+{"m": 4, "n": 13, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 9, "algorithm": "medium", "perf": 434.909},
+{"m": 4, "n": 13, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 436.522},
+{"m": 4, "n": 13, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 8, "algorithm": "medium", "perf": 438.394},
+{"m": 4, "n": 13, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 436.72},
+{"m": 4, "n": 15, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 5, "algorithm": "medium", "perf": 354.445},
+{"m": 4, "n": 15, "k": 10, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 14, "algorithm": "medium", "perf": 431.464},
+{"m": 4, "n": 15, "k": 15, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 12, "algorithm": "medium", "perf": 442.867},
+{"m": 4, "n": 25, "k": 4, "tile_m": 5, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 7, "algorithm": "medium", "perf": 445.525},
+{"m": 4, "n": 25, "k": 5, "tile_m": 6, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 2, "algorithm": "medium", "perf": 455.615},
+{"m": 4, "n": 25, "k": 7, "tile_m": 4, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 454.983},
+{"m": 4, "n": 25, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 64, "grouping": 24, "minblocks": 7, "algorithm": "medium", "perf": 458.769},
+{"m": 4, "n": 25, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 13, "algorithm": "medium", "perf": 471.674},
+{"m": 4, "n": 25, "k": 25, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 3, "minblocks": 5, "algorithm": "medium", "perf": 481.216},
+{"m": 4, "n": 25, "k": 26, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 484.075},
+{"m": 4, "n": 25, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 486.834},
+{"m": 4, "n": 25, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 492.058},
+{"m": 4, "n": 25, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 490.296},
+{"m": 4, "n": 26, "k": 4, "tile_m": 4, "tile_n": 1, "threads": 32, "grouping": 12, "minblocks": 2, "algorithm": "medium", "perf": 450.52},
+{"m": 4, "n": 26, "k": 5, "tile_m": 4, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 3, "algorithm": "medium", "perf": 452.479},
+{"m": 4, "n": 26, "k": 7, "tile_m": 2, "tile_n": 2, "threads": 32, "grouping": 18, "minblocks": 4, "algorithm": "medium", "perf": 462.349},
+{"m": 4, "n": 26, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 1, "algorithm": "medium", "perf": 458.638},
+{"m": 4, "n": 26, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 7, "algorithm": "medium", "perf": 475.833},
+{"m": 4, "n": 26, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 3, "minblocks": 5, "algorithm": "medium", "perf": 485.815},
+{"m": 4, "n": 26, "k": 26, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 3, "minblocks": 6, "algorithm": "medium", "perf": 486.965},
+{"m": 4, "n": 26, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 3, "minblocks": 5, "algorithm": "medium", "perf": 488.784},
+{"m": 4, "n": 26, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 2, "minblocks": 3, "algorithm": "medium", "perf": 494.485},
+{"m": 4, "n": 26, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 494.086},
+{"m": 4, "n": 28, "k": 4, "tile_m": 1, "tile_n": 5, "threads": 32, "grouping": 13, "minblocks": 6, "algorithm": "medium", "perf": 442.777},
+{"m": 4, "n": 28, "k": 5, "tile_m": 6, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 23, "algorithm": "medium", "perf": 450.581},
+{"m": 4, "n": 28, "k": 7, "tile_m": 4, "tile_n": 1, "threads": 64, "grouping": 22, "minblocks": 8, "algorithm": "medium", "perf": 462.427},
+{"m": 4, "n": 28, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 17, "algorithm": "medium", "perf": 474.408},
+{"m": 4, "n": 28, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 64, "grouping": 32, "minblocks": 7, "algorithm": "medium", "perf": 484.113},
+{"m": 4, "n": 28, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 5, "minblocks": 7, "algorithm": "medium", "perf": 487.596},
+{"m": 4, "n": 28, "k": 26, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 487.843},
+{"m": 4, "n": 28, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 489.847},
+{"m": 4, "n": 28, "k": 32, "tile_m": 2, "tile_n": 1, "threads": 192, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 497.128},
+{"m": 4, "n": 28, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 502.934},
+{"m": 4, "n": 32, "k": 4, "tile_m": 4, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 2, "algorithm": "medium", "perf": 460.973},
+{"m": 4, "n": 32, "k": 5, "tile_m": 5, "tile_n": 1, "threads": 32, "grouping": 17, "minblocks": 5, "algorithm": "medium", "perf": 463.913},
+{"m": 4, "n": 32, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 21, "algorithm": "medium", "perf": 475.538},
+{"m": 4, "n": 32, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 4, "minblocks": 8, "algorithm": "medium", "perf": 481.514},
+{"m": 4, "n": 32, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 32, "minblocks": 5, "algorithm": "medium", "perf": 491.05},
+{"m": 4, "n": 32, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 5, "minblocks": 6, "algorithm": "medium", "perf": 495.767},
+{"m": 4, "n": 32, "k": 26, "tile_m": 1, "tile_n": 2, "w": 8, "v": 16, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 500.984},
+{"m": 4, "n": 32, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 5, "minblocks": 6, "algorithm": "medium", "perf": 501.158},
+{"m": 4, "n": 32, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 508.453},
+{"m": 4, "n": 32, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 513.575},
+{"m": 4, "n": 45, "k": 4, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 19, "minblocks": 2, "algorithm": "medium", "perf": 451.602},
+{"m": 4, "n": 45, "k": 5, "tile_m": 1, "tile_n": 6, "threads": 64, "grouping": 26, "minblocks": 12, "algorithm": "medium", "perf": 455.413},
+{"m": 4, "n": 45, "k": 7, "tile_m": 4, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 4, "algorithm": "medium", "perf": 473.951},
+{"m": 4, "n": 45, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 29, "minblocks": 12, "algorithm": "medium", "perf": 476.94},
+{"m": 4, "n": 45, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 5, "algorithm": "medium", "perf": 489.857},
+{"m": 4, "n": 45, "k": 25, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 508.404},
+{"m": 4, "n": 45, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 512.756},
+{"m": 4, "n": 45, "k": 28, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 516.097},
+{"m": 4, "n": 45, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 523.467},
+{"m": 4, "n": 45, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 529.993},
+{"m": 5, "n": 4, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 18, "minblocks": 15, "algorithm": "medium", "perf": 177.029},
+{"m": 5, "n": 4, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 18, "minblocks": 3, "algorithm": "medium", "perf": 214.145},
+{"m": 5, "n": 4, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 233.353},
+{"m": 5, "n": 4, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 24, "algorithm": "medium", "perf": 211.838},
+{"m": 5, "n": 4, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 220.845},
+{"m": 5, "n": 4, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 14, "algorithm": "medium", "perf": 228.292},
+{"m": 5, "n": 4, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 20, "algorithm": "medium", "perf": 276.437},
+{"m": 5, "n": 4, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 312.504},
+{"m": 5, "n": 4, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 9, "minblocks": 17, "algorithm": "medium", "perf": 310.699},
+{"m": 5, "n": 4, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 23, "algorithm": "medium", "perf": 314.448},
+{"m": 5, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 3, "minblocks": 21, "algorithm": "medium", "perf": 327.177},
+{"m": 5, "n": 4, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 3, "minblocks": 5, "algorithm": "medium", "perf": 314.251},
+{"m": 5, "n": 5, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 225.089},
+{"m": 5, "n": 5, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 15, "algorithm": "medium", "perf": 260.59},
+{"m": 5, "n": 5, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 10, "algorithm": "medium", "perf": 285.889},
+{"m": 5, "n": 5, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 17, "algorithm": "medium", "perf": 262.967},
+{"m": 5, "n": 5, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 14, "algorithm": "medium", "perf": 288.785},
+{"m": 5, "n": 5, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 17, "algorithm": "medium", "perf": 311.74},
+{"m": 5, "n": 5, "k": 12, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 12, "minblocks": 3, "algorithm": "medium", "perf": 375.736},
+{"m": 5, "n": 5, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 17, "algorithm": "medium", "perf": 363.798},
+{"m": 5, "n": 5, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 13, "algorithm": "medium", "perf": 384.724},
+{"m": 5, "n": 5, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 22, "algorithm": "medium", "perf": 372.44},
+{"m": 5, "n": 5, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 3, "minblocks": 23, "algorithm": "medium", "perf": 364.992},
+{"m": 5, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 358.249},
+{"m": 5, "n": 5, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 12, "algorithm": "medium", "perf": 359.923},
+{"m": 5, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 2, "minblocks": 17, "algorithm": "medium", "perf": 370.681},
+{"m": 5, "n": 5, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 3, "minblocks": 12, "algorithm": "medium", "perf": 356.319},
+{"m": 5, "n": 6, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 18, "minblocks": 23, "algorithm": "medium", "perf": 264.288},
+{"m": 5, "n": 6, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 6, "algorithm": "medium", "perf": 293.115},
+{"m": 5, "n": 6, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 15, "minblocks": 7, "algorithm": "medium", "perf": 274.264},
+{"m": 5, "n": 6, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 20, "algorithm": "medium", "perf": 273.457},
+{"m": 5, "n": 6, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 7, "algorithm": "medium", "perf": 305.918},
+{"m": 5, "n": 6, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 16, "algorithm": "medium", "perf": 328.197},
+{"m": 5, "n": 7, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 20, "algorithm": "medium", "perf": 262.885},
+{"m": 5, "n": 7, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 2, "algorithm": "medium", "perf": 256.737},
+{"m": 5, "n": 7, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 20, "algorithm": "medium", "perf": 291.538},
+{"m": 5, "n": 7, "k": 7, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 16, "minblocks": 10, "algorithm": "medium", "perf": 295.189},
+{"m": 5, "n": 7, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 25, "algorithm": "medium", "perf": 327.718},
+{"m": 5, "n": 7, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 16, "algorithm": "medium", "perf": 349.89},
+{"m": 5, "n": 7, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 18, "algorithm": "medium", "perf": 396.99},
+{"m": 5, "n": 7, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 10, "algorithm": "medium", "perf": 395.03},
+{"m": 5, "n": 7, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 400.328},
+{"m": 5, "n": 7, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 400.111},
+{"m": 5, "n": 7, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 408.48},
+{"m": 5, "n": 7, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 3, "minblocks": 7, "algorithm": "medium", "perf": 402.851},
+{"m": 5, "n": 8, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 9, "algorithm": "medium", "perf": 260.853},
+{"m": 5, "n": 8, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 20, "algorithm": "medium", "perf": 290.836},
+{"m": 5, "n": 8, "k": 6, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 16, "minblocks": 3, "algorithm": "medium", "perf": 332.611},
+{"m": 5, "n": 8, "k": 7, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 16, "minblocks": 14, "algorithm": "medium", "perf": 332.852},
+{"m": 5, "n": 8, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 14, "algorithm": "medium", "perf": 364.813},
+{"m": 5, "n": 8, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 14, "algorithm": "medium", "perf": 383.158},
+{"m": 5, "n": 9, "k": 4, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 16, "minblocks": 16, "algorithm": "medium", "perf": 273.232},
+{"m": 5, "n": 9, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 7, "algorithm": "medium", "perf": 321.78},
+{"m": 5, "n": 9, "k": 6, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 5, "algorithm": "medium", "perf": 370.575},
+{"m": 5, "n": 9, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 21, "algorithm": "medium", "perf": 372.988},
+{"m": 5, "n": 9, "k": 8, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 2, "algorithm": "medium", "perf": 397.604},
+{"m": 5, "n": 9, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 24, "algorithm": "medium", "perf": 420.547},
+{"m": 5, "n": 9, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 26, "algorithm": "medium", "perf": 428.436},
+{"m": 5, "n": 9, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 7, "algorithm": "medium", "perf": 437.524},
+{"m": 5, "n": 9, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 12, "algorithm": "medium", "perf": 442.884},
+{"m": 5, "n": 9, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 11, "algorithm": "medium", "perf": 446.122},
+{"m": 5, "n": 9, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 451.393},
+{"m": 5, "n": 9, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 448.595},
+{"m": 5, "n": 12, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 12, "minblocks": 12, "algorithm": "medium", "perf": 403.762},
+{"m": 5, "n": 12, "k": 12, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 2, "algorithm": "medium", "perf": 482.763},
+{"m": 5, "n": 12, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 4, "minblocks": 9, "algorithm": "medium", "perf": 472.41},
+{"m": 5, "n": 12, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 493.318},
+{"m": 5, "n": 12, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 499.203},
+{"m": 5, "n": 13, "k": 4, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 14, "algorithm": "medium", "perf": 371.523},
+{"m": 5, "n": 13, "k": 5, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 12, "minblocks": 3, "algorithm": "medium", "perf": 420.528},
+{"m": 5, "n": 13, "k": 7, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 15, "algorithm": "medium", "perf": 463.048},
+{"m": 5, "n": 13, "k": 9, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 15, "algorithm": "medium", "perf": 476.293},
+{"m": 5, "n": 13, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 22, "minblocks": 17, "algorithm": "medium", "perf": 487.729},
+{"m": 5, "n": 13, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 5, "minblocks": 1, "algorithm": "medium", "perf": 469.163},
+{"m": 5, "n": 13, "k": 16, "tile_m": 1, "tile_n": 3, "threads": 96, "grouping": 29, "minblocks": 8, "algorithm": "medium", "perf": 486.36},
+{"m": 5, "n": 13, "k": 24, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 491.279},
+{"m": 5, "n": 13, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 5, "minblocks": 12, "algorithm": "medium", "perf": 485.413},
+{"m": 5, "n": 13, "k": 26, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 487.003},
+{"m": 5, "n": 13, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 4, "minblocks": 8, "algorithm": "medium", "perf": 491.337},
+{"m": 5, "n": 13, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 5, "minblocks": 2, "algorithm": "medium", "perf": 504.563},
+{"m": 5, "n": 13, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 499.154},
+{"m": 5, "n": 16, "k": 5, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 11, "minblocks": 16, "algorithm": "medium", "perf": 500.621},
+{"m": 5, "n": 16, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 4, "minblocks": 20, "algorithm": "medium", "perf": 504.808},
+{"m": 5, "n": 16, "k": 16, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 6, "minblocks": 14, "algorithm": "medium", "perf": 518.964},
+{"m": 5, "n": 16, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 532.529},
+{"m": 5, "n": 24, "k": 5, "tile_m": 1, "tile_n": 4, "threads": 32, "grouping": 13, "minblocks": 19, "algorithm": "medium", "perf": 529.873},
+{"m": 5, "n": 24, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 32, "minblocks": 12, "algorithm": "medium", "perf": 547.828},
+{"m": 5, "n": 24, "k": 24, "tile_m": 1, "tile_n": 2, "w": 8, "v": 24, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 573.313},
+{"m": 5, "n": 24, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 3, "minblocks": 8, "algorithm": "medium", "perf": 570.406},
+{"m": 5, "n": 24, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 2, "minblocks": 5, "algorithm": "medium", "perf": 579.512},
+{"m": 5, "n": 25, "k": 4, "tile_m": 5, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 1, "algorithm": "medium", "perf": 498.541},
+{"m": 5, "n": 25, "k": 5, "tile_m": 6, "tile_n": 1, "threads": 32, "grouping": 15, "minblocks": 8, "algorithm": "medium", "perf": 512.665},
+{"m": 5, "n": 25, "k": 7, "tile_m": 4, "tile_n": 1, "threads": 64, "grouping": 22, "minblocks": 3, "algorithm": "medium", "perf": 511.578},
+{"m": 5, "n": 25, "k": 9, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 10, "algorithm": "medium", "perf": 542.861},
+{"m": 5, "n": 25, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 6, "minblocks": 12, "algorithm": "medium", "perf": 540.652},
+{"m": 5, "n": 25, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 3, "minblocks": 5, "algorithm": "medium", "perf": 567.148},
+{"m": 5, "n": 25, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 5, "minblocks": 1, "algorithm": "medium", "perf": 571.256},
+{"m": 5, "n": 25, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 571.421},
+{"m": 5, "n": 25, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 224, "grouping": 3, "minblocks": 6, "algorithm": "medium", "perf": 584.779},
+{"m": 5, "n": 25, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 583.507},
+{"m": 5, "n": 26, "k": 4, "tile_m": 5, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 11, "algorithm": "medium", "perf": 507.889},
+{"m": 5, "n": 26, "k": 5, "tile_m": 5, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 520.031},
+{"m": 5, "n": 26, "k": 7, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 22, "minblocks": 15, "algorithm": "medium", "perf": 521.285},
+{"m": 5, "n": 26, "k": 9, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 9, "algorithm": "medium", "perf": 549.571},
+{"m": 5, "n": 26, "k": 12, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 554.52},
+{"m": 5, "n": 26, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 96, "grouping": 32, "minblocks": 12, "algorithm": "medium", "perf": 549.535},
+{"m": 5, "n": 26, "k": 24, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 571.163},
+{"m": 5, "n": 26, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 568.459},
+{"m": 5, "n": 26, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 572.317},
+{"m": 5, "n": 26, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 5, "minblocks": 7, "algorithm": "medium", "perf": 573.92},
+{"m": 5, "n": 26, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 224, "grouping": 3, "minblocks": 6, "algorithm": "medium", "perf": 584.452},
+{"m": 5, "n": 26, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 587.258},
+{"m": 5, "n": 28, "k": 4, "tile_m": 1, "tile_n": 5, "threads": 32, "grouping": 16, "minblocks": 21, "algorithm": "medium", "perf": 507.593},
+{"m": 5, "n": 28, "k": 5, "tile_m": 5, "tile_n": 1, "threads": 32, "grouping": 19, "minblocks": 10, "algorithm": "medium", "perf": 526.317},
+{"m": 5, "n": 28, "k": 7, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 13, "algorithm": "medium", "perf": 538.63},
+{"m": 5, "n": 28, "k": 9, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 2, "algorithm": "medium", "perf": 561.006},
+{"m": 5, "n": 28, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 96, "grouping": 32, "minblocks": 11, "algorithm": "medium", "perf": 561.153},
+{"m": 5, "n": 28, "k": 25, "tile_m": 3, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 577.262},
+{"m": 5, "n": 28, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 578.939},
+{"m": 5, "n": 28, "k": 28, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 581.324},
+{"m": 5, "n": 28, "k": 32, "tile_m": 3, "tile_n": 1, "threads": 128, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 589.399},
+{"m": 5, "n": 28, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 595.274},
+{"m": 5, "n": 32, "k": 4, "tile_m": 6, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 20, "algorithm": "medium", "perf": 523.602},
+{"m": 5, "n": 32, "k": 5, "tile_m": 6, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 15, "algorithm": "medium", "perf": 535.714},
+{"m": 5, "n": 32, "k": 7, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 4, "algorithm": "medium", "perf": 554.629},
+{"m": 5, "n": 32, "k": 9, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 30, "minblocks": 1, "algorithm": "medium", "perf": 565.992},
+{"m": 5, "n": 32, "k": 12, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 574.485},
+{"m": 5, "n": 32, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 96, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 572.183},
+{"m": 5, "n": 32, "k": 16, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 5, "minblocks": 4, "algorithm": "medium", "perf": 583.958},
+{"m": 5, "n": 32, "k": 24, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 593.51},
+{"m": 5, "n": 32, "k": 25, "tile_m": 3, "tile_n": 1, "threads": 128, "grouping": 5, "minblocks": 1, "algorithm": "medium", "perf": 593.335},
+{"m": 5, "n": 32, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 593.116},
+{"m": 5, "n": 32, "k": 28, "tile_m": 3, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 596.857},
+{"m": 5, "n": 32, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 610.053},
+{"m": 5, "n": 32, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 612.697},
+{"m": 5, "n": 45, "k": 4, "tile_m": 5, "tile_n": 1, "threads": 64, "grouping": 22, "minblocks": 15, "algorithm": "medium", "perf": 510.03},
+{"m": 5, "n": 45, "k": 5, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 26, "minblocks": 15, "algorithm": "medium", "perf": 528.041},
+{"m": 5, "n": 45, "k": 7, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 26, "minblocks": 4, "algorithm": "medium", "perf": 553.915},
+{"m": 5, "n": 45, "k": 9, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 29, "minblocks": 3, "algorithm": "medium", "perf": 564.82},
+{"m": 5, "n": 45, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 5, "minblocks": 8, "algorithm": "medium", "perf": 579.618},
+{"m": 5, "n": 45, "k": 25, "tile_m": 3, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 612.003},
+{"m": 5, "n": 45, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 612.137},
+{"m": 5, "n": 45, "k": 28, "tile_m": 3, "tile_n": 1, "threads": 160, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 623.505},
+{"m": 5, "n": 45, "k": 32, "tile_m": 3, "tile_n": 1, "threads": 192, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 630.854},
+{"m": 5, "n": 45, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 635.739},
+{"m": 6, "n": 4, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 18, "minblocks": 3, "algorithm": "medium", "perf": 212.84},
+{"m": 6, "n": 4, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 25, "algorithm": "medium", "perf": 250.003},
+{"m": 6, "n": 4, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 24, "algorithm": "medium", "perf": 227.238},
+{"m": 6, "n": 4, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 5, "algorithm": "medium", "perf": 253.726},
+{"m": 6, "n": 4, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 13, "algorithm": "medium", "perf": 260.467},
+{"m": 6, "n": 4, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 12, "algorithm": "medium", "perf": 268.788},
+{"m": 6, "n": 5, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 18, "minblocks": 25, "algorithm": "medium", "perf": 265.113},
+{"m": 6, "n": 5, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 292.379},
+{"m": 6, "n": 5, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 20, "algorithm": "medium", "perf": 278.719},
+{"m": 6, "n": 5, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 13, "algorithm": "medium", "perf": 273.867},
+{"m": 6, "n": 5, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 13, "algorithm": "medium", "perf": 306.256},
+{"m": 6, "n": 5, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 12, "minblocks": 2, "algorithm": "medium", "perf": 330.458},
+{"m": 6, "n": 6, "k": 4, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 16, "minblocks": 20, "algorithm": "medium", "perf": 279.038},
+{"m": 6, "n": 6, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 13, "algorithm": "medium", "perf": 324.604},
+{"m": 6, "n": 6, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 26, "algorithm": "medium", "perf": 309.661},
+{"m": 6, "n": 6, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 11, "algorithm": "medium", "perf": 347.979},
+{"m": 6, "n": 6, "k": 8, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 4, "algorithm": "medium", "perf": 388.615},
+{"m": 6, "n": 6, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 11, "minblocks": 15, "algorithm": "medium", "perf": 414.229},
+{"m": 6, "n": 7, "k": 4, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 16, "minblocks": 22, "algorithm": "medium", "perf": 310.207},
+{"m": 6, "n": 7, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 16, "minblocks": 2, "algorithm": "medium", "perf": 307.915},
+{"m": 6, "n": 7, "k": 6, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 27, "algorithm": "medium", "perf": 311.923},
+{"m": 6, "n": 7, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 18, "algorithm": "medium", "perf": 348.666},
+{"m": 6, "n": 7, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 3, "algorithm": "medium", "perf": 391.768},
+{"m": 6, "n": 7, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 16, "algorithm": "medium", "perf": 421.422},
+{"m": 6, "n": 8, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 13, "algorithm": "medium", "perf": 306.933},
+{"m": 6, "n": 8, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 16, "minblocks": 27, "algorithm": "medium", "perf": 346.794},
+{"m": 6, "n": 8, "k": 6, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 2, "algorithm": "medium", "perf": 356.722},
+{"m": 6, "n": 8, "k": 7, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 1, "algorithm": "medium", "perf": 397.923},
+{"m": 6, "n": 8, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 2, "algorithm": "medium", "perf": 434.94},
+{"m": 6, "n": 8, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 19, "algorithm": "medium", "perf": 449.288},
+{"m": 6, "n": 9, "k": 4, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 16, "minblocks": 26, "algorithm": "medium", "perf": 326.343},
+{"m": 6, "n": 9, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 17, "algorithm": "medium", "perf": 387.121},
+{"m": 6, "n": 9, "k": 6, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 12, "minblocks": 13, "algorithm": "medium", "perf": 390.83},
+{"m": 6, "n": 9, "k": 7, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 4, "algorithm": "medium", "perf": 440.029},
+{"m": 6, "n": 9, "k": 8, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 27, "algorithm": "medium", "perf": 468.53},
+{"m": 6, "n": 9, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 13, "algorithm": "medium", "perf": 476.022},
+{"m": 7, "n": 4, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 18, "minblocks": 9, "algorithm": "medium", "perf": 247.91},
+{"m": 7, "n": 4, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 11, "algorithm": "medium", "perf": 222.094},
+{"m": 7, "n": 4, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 3, "algorithm": "medium", "perf": 256.908},
+{"m": 7, "n": 4, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 20, "algorithm": "medium", "perf": 286.148},
+{"m": 7, "n": 4, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 15, "algorithm": "medium", "perf": 296.218},
+{"m": 7, "n": 4, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 8, "algorithm": "medium", "perf": 306.346},
+{"m": 7, "n": 4, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 12, "minblocks": 25, "algorithm": "medium", "perf": 361.319},
+{"m": 7, "n": 4, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 21, "algorithm": "medium", "perf": 356.58},
+{"m": 7, "n": 4, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 21, "algorithm": "medium", "perf": 362.674},
+{"m": 7, "n": 4, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 6, "minblocks": 5, "algorithm": "medium", "perf": 363.829},
+{"m": 7, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 3, "minblocks": 8, "algorithm": "medium", "perf": 371.107},
+{"m": 7, "n": 4, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 9, "algorithm": "medium", "perf": 363.482},
+{"m": 7, "n": 5, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 19, "algorithm": "medium", "perf": 270.919},
+{"m": 7, "n": 5, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 27, "algorithm": "medium", "perf": 263.9},
+{"m": 7, "n": 5, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 23, "algorithm": "medium", "perf": 304.548},
+{"m": 7, "n": 5, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 20, "algorithm": "medium", "perf": 302.41},
+{"m": 7, "n": 5, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 14, "algorithm": "medium", "perf": 332.161},
+{"m": 7, "n": 5, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 25, "algorithm": "medium", "perf": 349.89},
+{"m": 7, "n": 5, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 21, "algorithm": "medium", "perf": 397.427},
+{"m": 7, "n": 5, "k": 25, "tile_m": 2, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 20, "algorithm": "medium", "perf": 400.125},
+{"m": 7, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 12, "algorithm": "medium", "perf": 397.999},
+{"m": 7, "n": 5, "k": 28, "tile_m": 2, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 402.797},
+{"m": 7, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 3, "minblocks": 11, "algorithm": "medium", "perf": 409.525},
+{"m": 7, "n": 5, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 3, "minblocks": 5, "algorithm": "medium", "perf": 401.97},
+{"m": 7, "n": 6, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 24, "algorithm": "medium", "perf": 313.286},
+{"m": 7, "n": 6, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 19, "algorithm": "medium", "perf": 312.621},
+{"m": 7, "n": 6, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 3, "algorithm": "medium", "perf": 321.111},
+{"m": 7, "n": 6, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 350.795},
+{"m": 7, "n": 6, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 13, "algorithm": "medium", "perf": 385.441},
+{"m": 7, "n": 6, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 15, "algorithm": "medium", "perf": 418.272},
+{"m": 7, "n": 7, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 1, "algorithm": "medium", "perf": 364.566},
+{"m": 7, "n": 7, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 11, "algorithm": "medium", "perf": 358.669},
+{"m": 7, "n": 7, "k": 6, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 3, "algorithm": "medium", "perf": 406.525},
+{"m": 7, "n": 7, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 11, "minblocks": 27, "algorithm": "medium", "perf": 449.927},
+{"m": 7, "n": 7, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 11, "minblocks": 12, "algorithm": "medium", "perf": 495.144},
+{"m": 7, "n": 7, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 5, "algorithm": "medium", "perf": 495.72},
+{"m": 7, "n": 7, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 18, "minblocks": 27, "algorithm": "medium", "perf": 488.334},
+{"m": 7, "n": 7, "k": 25, "tile_m": 2, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 10, "algorithm": "medium", "perf": 489.312},
+{"m": 7, "n": 7, "k": 26, "tile_m": 2, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 490.132},
+{"m": 7, "n": 7, "k": 28, "tile_m": 2, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 9, "algorithm": "medium", "perf": 490.192},
+{"m": 7, "n": 7, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 11, "algorithm": "medium", "perf": 499.565},
+{"m": 7, "n": 7, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 3, "minblocks": 7, "algorithm": "medium", "perf": 491.99},
+{"m": 7, "n": 8, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 354.633},
+{"m": 7, "n": 8, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 9, "algorithm": "medium", "perf": 359.16},
+{"m": 7, "n": 8, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 19, "algorithm": "medium", "perf": 411.24},
+{"m": 7, "n": 8, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 18, "algorithm": "medium", "perf": 455.7},
+{"m": 7, "n": 8, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 23, "algorithm": "medium", "perf": 500.053},
+{"m": 7, "n": 8, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 11, "minblocks": 3, "algorithm": "medium", "perf": 501.545},
+{"m": 7, "n": 9, "k": 4, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 25, "algorithm": "medium", "perf": 357.248},
+{"m": 7, "n": 9, "k": 5, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 5, "algorithm": "medium", "perf": 380.106},
+{"m": 7, "n": 9, "k": 6, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 13, "minblocks": 1, "algorithm": "medium", "perf": 421.294},
+{"m": 7, "n": 9, "k": 7, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 26, "algorithm": "medium", "perf": 474.232},
+{"m": 7, "n": 9, "k": 8, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 25, "algorithm": "medium", "perf": 498.036},
+{"m": 7, "n": 9, "k": 9, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 13, "minblocks": 19, "algorithm": "medium", "perf": 512.04},
+{"m": 7, "n": 9, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 5, "minblocks": 22, "algorithm": "medium", "perf": 509.15},
+{"m": 7, "n": 9, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 9, "algorithm": "medium", "perf": 538.393},
+{"m": 7, "n": 9, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 539.44},
+{"m": 7, "n": 9, "k": 28, "tile_m": 1, "tile_n": 1, "w": 14, "v": 8, "threads": 64, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 544.807},
+{"m": 7, "n": 9, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 3, "minblocks": 10, "algorithm": "medium", "perf": 550.841},
+{"m": 7, "n": 9, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 3, "minblocks": 8, "algorithm": "medium", "perf": 548.66},
+{"m": 7, "n": 13, "k": 4, "tile_m": 4, "tile_n": 1, "threads": 32, "grouping": 15, "minblocks": 24, "algorithm": "medium", "perf": 473.871},
+{"m": 7, "n": 13, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 20, "algorithm": "medium", "perf": 484.652},
+{"m": 7, "n": 13, "k": 7, "tile_m": 4, "tile_n": 1, "threads": 32, "grouping": 14, "minblocks": 22, "algorithm": "medium", "perf": 568.233},
+{"m": 7, "n": 13, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 32, "grouping": 12, "minblocks": 25, "algorithm": "medium", "perf": 575.698},
+{"m": 7, "n": 13, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 17, "algorithm": "medium", "perf": 576.55},
+{"m": 7, "n": 13, "k": 25, "tile_m": 2, "tile_n": 1, "threads": 64, "grouping": 6, "minblocks": 2, "algorithm": "medium", "perf": 602.965},
+{"m": 7, "n": 13, "k": 26, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 5, "minblocks": 1, "algorithm": "medium", "perf": 607.199},
+{"m": 7, "n": 13, "k": 28, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 4, "minblocks": 8, "algorithm": "medium", "perf": 615.391},
+{"m": 7, "n": 13, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 622.982},
+{"m": 7, "n": 13, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 626.534},
+{"m": 7, "n": 25, "k": 4, "tile_m": 4, "tile_n": 2, "threads": 32, "grouping": 16, "minblocks": 10, "algorithm": "medium", "perf": 580.16},
+{"m": 7, "n": 25, "k": 5, "tile_m": 4, "tile_n": 1, "threads": 64, "grouping": 22, "minblocks": 18, "algorithm": "medium", "perf": 597.952},
+{"m": 7, "n": 25, "k": 7, "tile_m": 4, "tile_n": 1, "threads": 64, "grouping": 22, "minblocks": 12, "algorithm": "medium", "perf": 658.065},
+{"m": 7, "n": 25, "k": 9, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 22, "minblocks": 2, "algorithm": "medium", "perf": 683.511},
+{"m": 7, "n": 25, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 96, "grouping": 29, "minblocks": 11, "algorithm": "medium", "perf": 697.002},
+{"m": 7, "n": 25, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 721.815},
+{"m": 7, "n": 25, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 5, "minblocks": 3, "algorithm": "medium", "perf": 726.291},
+{"m": 7, "n": 25, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 224, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 733.469},
+{"m": 7, "n": 25, "k": 32, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 738.173},
+{"m": 7, "n": 25, "k": 45, "tile_m": 1, "tile_n": 2, "w": 22, "v": 24, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 744.304},
+{"m": 7, "n": 26, "k": 4, "tile_m": 4, "tile_n": 2, "threads": 32, "grouping": 16, "minblocks": 7, "algorithm": "medium", "perf": 597.715},
+{"m": 7, "n": 26, "k": 5, "tile_m": 4, "tile_n": 2, "threads": 64, "grouping": 22, "minblocks": 14, "algorithm": "medium", "perf": 612.13},
+{"m": 7, "n": 26, "k": 7, "tile_m": 4, "tile_n": 1, "threads": 64, "grouping": 22, "minblocks": 9, "algorithm": "medium", "perf": 669.6},
+{"m": 7, "n": 26, "k": 9, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 26, "minblocks": 14, "algorithm": "medium", "perf": 695},
+{"m": 7, "n": 26, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 96, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 708.859},
+{"m": 7, "n": 26, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 732.407},
+{"m": 7, "n": 26, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 5, "minblocks": 2, "algorithm": "medium", "perf": 739.029},
+{"m": 7, "n": 26, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 224, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 743.234},
+{"m": 7, "n": 26, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 256, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 753.794},
+{"m": 7, "n": 26, "k": 45, "tile_m": 2, "tile_n": 2, "w": 16, "v": 26, "threads": 64, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 753.616},
+{"m": 7, "n": 28, "k": 4, "tile_m": 4, "tile_n": 2, "threads": 32, "grouping": 16, "minblocks": 16, "algorithm": "medium", "perf": 621.956},
+{"m": 7, "n": 28, "k": 5, "tile_m": 4, "tile_n": 1, "threads": 64, "grouping": 22, "minblocks": 12, "algorithm": "medium", "perf": 630.557},
+{"m": 7, "n": 28, "k": 7, "tile_m": 4, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 8, "algorithm": "medium", "perf": 687.436},
+{"m": 7, "n": 28, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 11, "algorithm": "medium", "perf": 709.918},
+{"m": 7, "n": 28, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 12, "minblocks": 7, "algorithm": "medium", "perf": 710.614},
+{"m": 7, "n": 28, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 5, "minblocks": 3, "algorithm": "medium", "perf": 746.919},
+{"m": 7, "n": 28, "k": 26, "tile_m": 2, "tile_n": 1, "threads": 192, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 752.82},
+{"m": 7, "n": 28, "k": 28, "tile_m": 2, "tile_n": 1, "threads": 224, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 754.704},
+{"m": 7, "n": 28, "k": 32, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 766.488},
+{"m": 7, "n": 28, "k": 45, "tile_m": 2, "tile_n": 1, "w": 12, "v": 24, "threads": 128, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 770.322},
+{"m": 7, "n": 32, "k": 4, "tile_m": 4, "tile_n": 2, "threads": 32, "grouping": 19, "minblocks": 15, "algorithm": "medium", "perf": 627.174},
+{"m": 7, "n": 32, "k": 5, "tile_m": 4, "tile_n": 1, "threads": 64, "grouping": 21, "minblocks": 3, "algorithm": "medium", "perf": 656.782},
+{"m": 7, "n": 32, "k": 7, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 22, "minblocks": 11, "algorithm": "medium", "perf": 701.471},
+{"m": 7, "n": 32, "k": 9, "tile_m": 4, "tile_n": 1, "threads": 64, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 721.47},
+{"m": 7, "n": 32, "k": 13, "tile_m": 4, "tile_n": 1, "threads": 96, "grouping": 6, "minblocks": 10, "algorithm": "medium", "perf": 736.094},
+{"m": 7, "n": 32, "k": 25, "tile_m": 2, "tile_n": 1, "threads": 192, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 769.295},
+{"m": 7, "n": 32, "k": 26, "tile_m": 2, "tile_n": 1, "threads": 192, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 776.776},
+{"m": 7, "n": 32, "k": 28, "tile_m": 2, "tile_n": 1, "threads": 256, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 778.504},
+{"m": 7, "n": 32, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 32, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 790.893},
+{"m": 7, "n": 32, "k": 45, "tile_m": 2, "tile_n": 1, "w": 12, "v": 32, "threads": 128, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 802.202},
+{"m": 7, "n": 45, "k": 4, "tile_m": 2, "tile_n": 3, "threads": 64, "grouping": 28, "minblocks": 2, "algorithm": "medium", "perf": 631.988},
+{"m": 7, "n": 45, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 27, "minblocks": 5, "algorithm": "medium", "perf": 663.525},
+{"m": 7, "n": 45, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 32, "minblocks": 7, "algorithm": "medium", "perf": 709.225},
+{"m": 7, "n": 45, "k": 9, "tile_m": 4, "tile_n": 1, "threads": 128, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 727.897},
+{"m": 7, "n": 45, "k": 13, "tile_m": 4, "tile_n": 1, "threads": 128, "grouping": 29, "minblocks": 3, "algorithm": "medium", "perf": 755.771},
+{"m": 7, "n": 45, "k": 25, "tile_m": 2, "tile_n": 1, "threads": 192, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 801.315},
+{"m": 7, "n": 45, "k": 26, "tile_m": 2, "tile_n": 1, "threads": 224, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 810.209},
+{"m": 7, "n": 45, "k": 28, "tile_m": 2, "tile_n": 1, "threads": 256, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 818.919},
+{"m": 7, "n": 45, "k": 32, "tile_m": 2, "tile_n": 1, "threads": 256, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 832.676},
+{"m": 7, "n": 45, "k": 45, "tile_m": 4, "tile_n": 1, "w": 12, "v": 32, "threads": 96, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 841.043},
+{"m": 8, "n": 4, "k": 4, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 18, "minblocks": 27, "algorithm": "medium", "perf": 241.107},
+{"m": 8, "n": 4, "k": 5, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 253.28},
+{"m": 8, "n": 4, "k": 6, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 292.754},
+{"m": 8, "n": 4, "k": 7, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 5, "algorithm": "medium", "perf": 322.969},
+{"m": 8, "n": 4, "k": 8, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 9, "minblocks": 7, "algorithm": "small", "perf": 312.182},
+{"m": 8, "n": 4, "k": 9, "tile_m": 1, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 25, "algorithm": "medium", "perf": 336.929},
+{"m": 8, "n": 5, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 27, "algorithm": "medium", "perf": 261.066},
+{"m": 8, "n": 5, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 25, "algorithm": "medium", "perf": 297.369},
+{"m": 8, "n": 5, "k": 6, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 25, "algorithm": "medium", "perf": 344.888},
+{"m": 8, "n": 5, "k": 7, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 21, "algorithm": "medium", "perf": 335.855},
+{"m": 8, "n": 5, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 4, "algorithm": "medium", "perf": 362.704},
+{"m": 8, "n": 5, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 27, "algorithm": "medium", "perf": 388.028},
+{"m": 8, "n": 6, "k": 4, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 15, "minblocks": 24, "algorithm": "medium", "perf": 306.873},
+{"m": 8, "n": 6, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 19, "algorithm": "medium", "perf": 351.046},
+{"m": 8, "n": 6, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 20, "algorithm": "medium", "perf": 357.061},
+{"m": 8, "n": 6, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 25, "algorithm": "medium", "perf": 398.063},
+{"m": 8, "n": 6, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 27, "algorithm": "medium", "perf": 432.142},
+{"m": 8, "n": 6, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 2, "algorithm": "medium", "perf": 451.4},
+{"m": 8, "n": 7, "k": 4, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 15, "minblocks": 11, "algorithm": "medium", "perf": 354.317},
+{"m": 8, "n": 7, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 6, "algorithm": "medium", "perf": 358.106},
+{"m": 8, "n": 7, "k": 6, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 17, "algorithm": "medium", "perf": 412.399},
+{"m": 8, "n": 7, "k": 7, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 11, "algorithm": "medium", "perf": 463.962},
+{"m": 8, "n": 7, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 25, "algorithm": "medium", "perf": 495.994},
+{"m": 8, "n": 7, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 26, "algorithm": "medium", "perf": 501.068},
+{"m": 8, "n": 8, "k": 4, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 16, "minblocks": 11, "algorithm": "medium", "perf": 423.915},
+{"m": 8, "n": 8, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 12, "algorithm": "medium", "perf": 468.053},
+{"m": 8, "n": 8, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 11, "minblocks": 17, "algorithm": "medium", "perf": 531.999},
+{"m": 8, "n": 8, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 11, "minblocks": 1, "algorithm": "medium", "perf": 571.337},
+{"m": 8, "n": 8, "k": 8, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 25, "algorithm": "medium", "perf": 605.152},
+{"m": 8, "n": 8, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 5, "algorithm": "medium", "perf": 571.958},
+{"m": 8, "n": 9, "k": 4, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 15, "minblocks": 25, "algorithm": "medium", "perf": 378.51},
+{"m": 8, "n": 9, "k": 5, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 433.932},
+{"m": 8, "n": 9, "k": 6, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 13, "minblocks": 12, "algorithm": "medium", "perf": 500.839},
+{"m": 8, "n": 9, "k": 7, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 11, "minblocks": 25, "algorithm": "medium", "perf": 544.839},
+{"m": 8, "n": 9, "k": 8, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 13, "minblocks": 9, "algorithm": "medium", "perf": 572.229},
+{"m": 8, "n": 9, "k": 9, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 16, "minblocks": 20, "algorithm": "medium", "perf": 567.681},
+{"m": 9, "n": 4, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 27, "algorithm": "medium", "perf": 223.697},
+{"m": 9, "n": 4, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 264.552},
+{"m": 9, "n": 4, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 12, "algorithm": "medium", "perf": 305.331},
+{"m": 9, "n": 4, "k": 7, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 25, "algorithm": "medium", "perf": 335.175},
+{"m": 9, "n": 4, "k": 8, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 16, "minblocks": 26, "algorithm": "medium", "perf": 321.571},
+{"m": 9, "n": 4, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 6, "algorithm": "medium", "perf": 341.86},
+{"m": 9, "n": 4, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 5, "algorithm": "medium", "perf": 381.012},
+{"m": 9, "n": 4, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 5, "minblocks": 4, "algorithm": "medium", "perf": 380.088},
+{"m": 9, "n": 4, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 29, "minblocks": 1, "algorithm": "medium", "perf": 384.187},
+{"m": 9, "n": 4, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 7, "minblocks": 5, "algorithm": "medium", "perf": 389.01},
+{"m": 9, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 11, "algorithm": "medium", "perf": 391.946},
+{"m": 9, "n": 4, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 3, "minblocks": 9, "algorithm": "medium", "perf": 387.535},
+{"m": 9, "n": 5, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 2, "algorithm": "medium", "perf": 274.355},
+{"m": 9, "n": 5, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 7, "algorithm": "medium", "perf": 325.528},
+{"m": 9, "n": 5, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 3, "algorithm": "medium", "perf": 371.15},
+{"m": 9, "n": 5, "k": 7, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 1, "algorithm": "medium", "perf": 371.567},
+{"m": 9, "n": 5, "k": 8, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 19, "algorithm": "medium", "perf": 394.72},
+{"m": 9, "n": 5, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 2, "algorithm": "medium", "perf": 417.155},
+{"m": 9, "n": 5, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 16, "minblocks": 13, "algorithm": "medium", "perf": 424.207},
+{"m": 9, "n": 5, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 15, "algorithm": "medium", "perf": 441.803},
+{"m": 9, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 441.181},
+{"m": 9, "n": 5, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 13, "algorithm": "medium", "perf": 447.972},
+{"m": 9, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 455.083},
+{"m": 9, "n": 5, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 5, "minblocks": 2, "algorithm": "medium", "perf": 447.72},
+{"m": 9, "n": 6, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 16, "algorithm": "medium", "perf": 324.725},
+{"m": 9, "n": 6, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 2, "algorithm": "medium", "perf": 383.299},
+{"m": 9, "n": 6, "k": 6, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 9, "algorithm": "medium", "perf": 384.354},
+{"m": 9, "n": 6, "k": 7, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 15, "algorithm": "medium", "perf": 435.21},
+{"m": 9, "n": 6, "k": 8, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 14, "algorithm": "medium", "perf": 469.311},
+{"m": 9, "n": 6, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 9, "algorithm": "medium", "perf": 476.433},
+{"m": 9, "n": 7, "k": 4, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 3, "algorithm": "medium", "perf": 360.754},
+{"m": 9, "n": 7, "k": 5, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 5, "algorithm": "medium", "perf": 379.473},
+{"m": 9, "n": 7, "k": 6, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 13, "minblocks": 20, "algorithm": "medium", "perf": 420.882},
+{"m": 9, "n": 7, "k": 7, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 27, "algorithm": "medium", "perf": 478.365},
+{"m": 9, "n": 7, "k": 8, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 1, "algorithm": "medium", "perf": 493.848},
+{"m": 9, "n": 7, "k": 9, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 2, "algorithm": "medium", "perf": 516.64},
+{"m": 9, "n": 7, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 13, "minblocks": 1, "algorithm": "medium", "perf": 510.27},
+{"m": 9, "n": 7, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 12, "algorithm": "medium", "perf": 537.082},
+{"m": 9, "n": 7, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 540.279},
+{"m": 9, "n": 7, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 4, "minblocks": 11, "algorithm": "medium", "perf": 545.866},
+{"m": 9, "n": 7, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 11, "algorithm": "medium", "perf": 551.821},
+{"m": 9, "n": 7, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 550.203},
+{"m": 9, "n": 8, "k": 4, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 15, "minblocks": 3, "algorithm": "medium", "perf": 375.31},
+{"m": 9, "n": 8, "k": 5, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 26, "algorithm": "medium", "perf": 428.946},
+{"m": 9, "n": 8, "k": 6, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 13, "minblocks": 22, "algorithm": "medium", "perf": 484.981},
+{"m": 9, "n": 8, "k": 7, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 9, "algorithm": "medium", "perf": 540.555},
+{"m": 9, "n": 8, "k": 8, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 2, "algorithm": "medium", "perf": 563.409},
+{"m": 9, "n": 8, "k": 9, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 16, "minblocks": 20, "algorithm": "medium", "perf": 561.368},
+{"m": 9, "n": 9, "k": 4, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 16, "algorithm": "medium", "perf": 449.812},
+{"m": 9, "n": 9, "k": 5, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 12, "minblocks": 25, "algorithm": "medium", "perf": 520.817},
+{"m": 9, "n": 9, "k": 6, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 12, "minblocks": 11, "algorithm": "medium", "perf": 584.233},
+{"m": 9, "n": 9, "k": 7, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 25, "algorithm": "medium", "perf": 593.141},
+{"m": 9, "n": 9, "k": 8, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 2, "algorithm": "medium", "perf": 609.153},
+{"m": 9, "n": 9, "k": 9, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 13, "minblocks": 20, "algorithm": "medium", "perf": 596.262},
+{"m": 9, "n": 9, "k": 12, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 18, "minblocks": 16, "algorithm": "medium", "perf": 608.863},
+{"m": 9, "n": 9, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 21, "minblocks": 3, "algorithm": "medium", "perf": 598.854},
+{"m": 9, "n": 9, "k": 22, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 2, "algorithm": "medium", "perf": 602.914},
+{"m": 9, "n": 9, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 5, "minblocks": 11, "algorithm": "medium", "perf": 604.486},
+{"m": 9, "n": 9, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 5, "minblocks": 9, "algorithm": "medium", "perf": 606.896},
+{"m": 9, "n": 9, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 12, "algorithm": "medium", "perf": 623.854},
+{"m": 9, "n": 9, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 619.696},
+{"m": 9, "n": 9, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 224, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 621.925},
+{"m": 9, "n": 12, "k": 9, "tile_m": 1, "tile_n": 4, "threads": 32, "grouping": 13, "minblocks": 25, "algorithm": "medium", "perf": 636.186},
+{"m": 9, "n": 12, "k": 12, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 22, "minblocks": 15, "algorithm": "medium", "perf": 653.32},
+{"m": 9, "n": 13, "k": 4, "tile_m": 5, "tile_n": 1, "threads": 32, "grouping": 12, "minblocks": 8, "algorithm": "medium", "perf": 520.652},
+{"m": 9, "n": 13, "k": 5, "tile_m": 5, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 13, "algorithm": "medium", "perf": 570.99},
+{"m": 9, "n": 13, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 32, "grouping": 16, "minblocks": 2, "algorithm": "medium", "perf": 619.584},
+{"m": 9, "n": 13, "k": 9, "tile_m": 5, "tile_n": 1, "threads": 32, "grouping": 12, "minblocks": 21, "algorithm": "medium", "perf": 635.789},
+{"m": 9, "n": 13, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 18, "algorithm": "medium", "perf": 675.011},
+{"m": 9, "n": 13, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 6, "algorithm": "medium", "perf": 695.157},
+{"m": 9, "n": 13, "k": 26, "tile_m": 1, "tile_n": 2, "w": 12, "v": 12, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 706.349},
+{"m": 9, "n": 13, "k": 28, "tile_m": 1, "tile_n": 2, "w": 12, "v": 8, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 709.773},
+{"m": 9, "n": 13, "k": 32, "tile_m": 1, "tile_n": 2, "w": 14, "v": 8, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 720.317},
+{"m": 9, "n": 13, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 3, "minblocks": 6, "algorithm": "medium", "perf": 722.283},
+{"m": 9, "n": 22, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 32, "minblocks": 5, "algorithm": "medium", "perf": 751.681},
+{"m": 9, "n": 22, "k": 22, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 5, "minblocks": 7, "algorithm": "medium", "perf": 814.968},
+{"m": 9, "n": 22, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 22, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 851.65},
+{"m": 9, "n": 25, "k": 4, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 22, "minblocks": 19, "algorithm": "medium", "perf": 627.071},
+{"m": 9, "n": 25, "k": 5, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 22, "minblocks": 11, "algorithm": "medium", "perf": 697.048},
+{"m": 9, "n": 25, "k": 7, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 27, "minblocks": 11, "algorithm": "medium", "perf": 759.221},
+{"m": 9, "n": 25, "k": 9, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 29, "minblocks": 10, "algorithm": "medium", "perf": 780.691},
+{"m": 9, "n": 25, "k": 13, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 9, "minblocks": 9, "algorithm": "medium", "perf": 806.204},
+{"m": 9, "n": 25, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 850.306},
+{"m": 9, "n": 25, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 860.479},
+{"m": 9, "n": 25, "k": 28, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 868.917},
+{"m": 9, "n": 25, "k": 32, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 876.897},
+{"m": 9, "n": 25, "k": 45, "tile_m": 1, "tile_n": 2, "w": 14, "v": 14, "threads": 128, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 889.424},
+{"m": 9, "n": 26, "k": 4, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 22, "minblocks": 20, "algorithm": "medium", "perf": 651.805},
+{"m": 9, "n": 26, "k": 5, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 26, "minblocks": 19, "algorithm": "medium", "perf": 709.356},
+{"m": 9, "n": 26, "k": 7, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 26, "minblocks": 11, "algorithm": "medium", "perf": 779.501},
+{"m": 9, "n": 26, "k": 9, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 26, "minblocks": 11, "algorithm": "medium", "perf": 790.313},
+{"m": 9, "n": 26, "k": 13, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 820.423},
+{"m": 9, "n": 26, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 859.973},
+{"m": 9, "n": 26, "k": 26, "tile_m": 1, "tile_n": 5, "w": 10, "v": 26, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 873.449},
+{"m": 9, "n": 26, "k": 28, "tile_m": 1, "tile_n": 3, "w": 10, "v": 14, "threads": 96, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 879.817},
+{"m": 9, "n": 26, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 884.616},
+{"m": 9, "n": 26, "k": 45, "tile_m": 1, "tile_n": 2, "w": 12, "v": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 907.729},
+{"m": 9, "n": 28, "k": 4, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 22, "minblocks": 14, "algorithm": "medium", "perf": 687.488},
+{"m": 9, "n": 28, "k": 5, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 21, "minblocks": 10, "algorithm": "medium", "perf": 735.829},
+{"m": 9, "n": 28, "k": 7, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 26, "minblocks": 14, "algorithm": "medium", "perf": 806.204},
+{"m": 9, "n": 28, "k": 9, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 26, "minblocks": 11, "algorithm": "medium", "perf": 821.996},
+{"m": 9, "n": 28, "k": 13, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 21, "minblocks": 7, "algorithm": "medium", "perf": 840.047},
+{"m": 9, "n": 28, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 5, "minblocks": 1, "algorithm": "medium", "perf": 890.192},
+{"m": 9, "n": 28, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 256, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 897.077},
+{"m": 9, "n": 28, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 256, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 904.627},
+{"m": 9, "n": 28, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 915.991},
+{"m": 9, "n": 28, "k": 45, "tile_m": 1, "tile_n": 2, "w": 10, "v": 28, "threads": 128, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 927.821},
+{"m": 9, "n": 32, "k": 4, "tile_m": 5, "tile_n": 1, "threads": 64, "grouping": 22, "minblocks": 14, "algorithm": "medium", "perf": 721.352},
+{"m": 9, "n": 32, "k": 5, "tile_m": 3, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 3, "algorithm": "medium", "perf": 765.332},
+{"m": 9, "n": 32, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 26, "minblocks": 6, "algorithm": "medium", "perf": 832},
+{"m": 9, "n": 32, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 851.008},
+{"m": 9, "n": 32, "k": 13, "tile_m": 5, "tile_n": 1, "threads": 128, "grouping": 5, "minblocks": 10, "algorithm": "medium", "perf": 869.42},
+{"m": 9, "n": 32, "k": 22, "tile_m": 3, "tile_n": 2, "w": 8, "v": 32, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 910.237},
+{"m": 9, "n": 32, "k": 25, "tile_m": 3, "tile_n": 1, "w": 10, "v": 26, "threads": 96, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 918.498},
+{"m": 9, "n": 32, "k": 26, "tile_m": 3, "tile_n": 1, "w": 10, "v": 18, "threads": 96, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 925},
+{"m": 9, "n": 32, "k": 28, "tile_m": 3, "tile_n": 1, "w": 10, "v": 26, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 928.218},
+{"m": 9, "n": 32, "k": 32, "tile_m": 1, "tile_n": 5, "w": 12, "v": 32, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 944.428},
+{"m": 9, "n": 32, "k": 45, "tile_m": 3, "tile_n": 1, "w": 10, "v": 28, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 965.569},
+{"m": 9, "n": 45, "k": 4, "tile_m": 6, "tile_n": 2, "threads": 64, "grouping": 30, "minblocks": 10, "algorithm": "medium", "perf": 732.692},
+{"m": 9, "n": 45, "k": 5, "tile_m": 5, "tile_n": 2, "threads": 64, "grouping": 30, "minblocks": 11, "algorithm": "medium", "perf": 771.67},
+{"m": 9, "n": 45, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 29, "minblocks": 10, "algorithm": "medium", "perf": 833.778},
+{"m": 9, "n": 45, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 859.465},
+{"m": 9, "n": 45, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 160, "grouping": 5, "minblocks": 7, "algorithm": "medium", "perf": 903.628},
+{"m": 9, "n": 45, "k": 25, "tile_m": 5, "tile_n": 1, "threads": 256, "grouping": 24, "minblocks": 4, "algorithm": "medium", "perf": 967.166},
+{"m": 9, "n": 45, "k": 26, "tile_m": 5, "tile_n": 1, "w": 10, "v": 18, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 977.295},
+{"m": 9, "n": 45, "k": 28, "tile_m": 5, "tile_n": 1, "threads": 256, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 990.414},
+{"m": 9, "n": 45, "k": 32, "tile_m": 5, "tile_n": 1, "threads": 128, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 1004.63},
+{"m": 9, "n": 45, "k": 45, "tile_m": 2, "tile_n": 2, "w": 12, "v": 16, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1022.05},
+{"m": 10, "n": 4, "k": 4, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 247.284},
+{"m": 10, "n": 4, "k": 10, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 22, "algorithm": "medium", "perf": 389.557},
+{"m": 10, "n": 4, "k": 15, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 6, "minblocks": 27, "algorithm": "medium", "perf": 396.818},
+{"m": 10, "n": 10, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 22, "algorithm": "medium", "perf": 526.19},
+{"m": 10, "n": 10, "k": 10, "tile_m": 1, "tile_n": 4, "threads": 32, "grouping": 18, "minblocks": 22, "algorithm": "medium", "perf": 663.631},
+{"m": 10, "n": 10, "k": 15, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 24, "minblocks": 4, "algorithm": "medium", "perf": 666.283},
+{"m": 10, "n": 15, "k": 4, "tile_m": 5, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 7, "algorithm": "medium", "perf": 610.102},
+{"m": 10, "n": 15, "k": 10, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 24, "minblocks": 17, "algorithm": "medium", "perf": 729.268},
+{"m": 10, "n": 15, "k": 15, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 22, "minblocks": 6, "algorithm": "medium", "perf": 749.635},
+{"m": 11, "n": 11, "k": 11, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 5, "algorithm": "medium", "perf": 702.059},
+{"m": 12, "n": 5, "k": 5, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 11, "minblocks": 6, "algorithm": "medium", "perf": 414.313},
+{"m": 12, "n": 5, "k": 12, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 1, "algorithm": "medium", "perf": 489.381},
+{"m": 12, "n": 5, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 4, "minblocks": 8, "algorithm": "medium", "perf": 472.929},
+{"m": 12, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 5, "minblocks": 6, "algorithm": "medium", "perf": 492.364},
+{"m": 12, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 501.048},
+{"m": 12, "n": 9, "k": 9, "tile_m": 4, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 25, "algorithm": "medium", "perf": 630.854},
+{"m": 12, "n": 9, "k": 12, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 22, "minblocks": 5, "algorithm": "medium", "perf": 663.387},
+{"m": 12, "n": 12, "k": 5, "tile_m": 6, "tile_n": 1, "threads": 32, "grouping": 15, "minblocks": 3, "algorithm": "medium", "perf": 704.113},
+{"m": 12, "n": 12, "k": 9, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 22, "minblocks": 10, "algorithm": "medium", "perf": 766.851},
+{"m": 12, "n": 12, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 26, "minblocks": 1, "algorithm": "medium", "perf": 787.849},
+{"m": 12, "n": 12, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 783.946},
+{"m": 12, "n": 12, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 6, "minblocks": 5, "algorithm": "medium", "perf": 798.948},
+{"m": 12, "n": 12, "k": 26, "tile_m": 1, "tile_n": 3, "threads": 160, "grouping": 5, "minblocks": 8, "algorithm": "medium", "perf": 794.647},
+{"m": 12, "n": 12, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 821.891},
+{"m": 12, "n": 13, "k": 5, "tile_m": 3, "tile_n": 2, "threads": 32, "grouping": 14, "minblocks": 12, "algorithm": "medium", "perf": 671.755},
+{"m": 12, "n": 13, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 24, "minblocks": 17, "algorithm": "medium", "perf": 785.316},
+{"m": 12, "n": 13, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 12, "algorithm": "medium", "perf": 777.453},
+{"m": 12, "n": 13, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 5, "minblocks": 3, "algorithm": "medium", "perf": 821.309},
+{"m": 12, "n": 13, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 841.375},
+{"m": 12, "n": 25, "k": 12, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 953.604},
+{"m": 12, "n": 25, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 1042.81},
+{"m": 12, "n": 26, "k": 5, "tile_m": 1, "tile_n": 6, "threads": 64, "grouping": 26, "minblocks": 12, "algorithm": "medium", "perf": 857.411},
+{"m": 12, "n": 26, "k": 12, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 9, "minblocks": 3, "algorithm": "medium", "perf": 961.121},
+{"m": 12, "n": 26, "k": 13, "tile_m": 1, "tile_n": 6, "threads": 96, "grouping": 5, "minblocks": 11, "algorithm": "medium", "perf": 975.617},
+{"m": 12, "n": 26, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 1066.53},
+{"m": 12, "n": 26, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 1099.3},
+{"m": 12, "n": 32, "k": 5, "tile_m": 6, "tile_n": 1, "threads": 64, "grouping": 29, "minblocks": 12, "algorithm": "medium", "perf": 905.659},
+{"m": 12, "n": 32, "k": 12, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 4, "minblocks": 11, "algorithm": "medium", "perf": 1037.69},
+{"m": 12, "n": 32, "k": 13, "tile_m": 1, "tile_n": 4, "threads": 160, "grouping": 5, "minblocks": 8, "algorithm": "medium", "perf": 1052.61},
+{"m": 12, "n": 32, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 1139.65},
+{"m": 12, "n": 32, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 1180.17},
+{"m": 13, "n": 4, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 6, "algorithm": "medium", "perf": 309.329},
+{"m": 13, "n": 4, "k": 5, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 16, "minblocks": 19, "algorithm": "medium", "perf": 351.076},
+{"m": 13, "n": 4, "k": 7, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 11, "minblocks": 12, "algorithm": "medium", "perf": 430.38},
+{"m": 13, "n": 4, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 7, "algorithm": "medium", "perf": 412.394},
+{"m": 13, "n": 4, "k": 13, "tile_m": 1, "tile_n": 1, "threads": 64, "grouping": 4, "minblocks": 27, "algorithm": "medium", "perf": 421.461},
+{"m": 13, "n": 4, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 422.942},
+{"m": 13, "n": 4, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 10, "algorithm": "medium", "perf": 428.057},
+{"m": 13, "n": 4, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 436.195},
+{"m": 13, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 440.449},
+{"m": 13, "n": 4, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 3, "minblocks": 5, "algorithm": "medium", "perf": 436.899},
+{"m": 13, "n": 5, "k": 4, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 16, "minblocks": 13, "algorithm": "medium", "perf": 362.493},
+{"m": 13, "n": 5, "k": 5, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 13, "minblocks": 1, "algorithm": "medium", "perf": 414.824},
+{"m": 13, "n": 5, "k": 7, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 13, "minblocks": 16, "algorithm": "medium", "perf": 451.746},
+{"m": 13, "n": 5, "k": 9, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 18, "algorithm": "medium", "perf": 474.015},
+{"m": 13, "n": 5, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 18, "minblocks": 16, "algorithm": "medium", "perf": 489.219},
+{"m": 13, "n": 5, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 6, "minblocks": 12, "algorithm": "medium", "perf": 460.079},
+{"m": 13, "n": 5, "k": 16, "tile_m": 1, "tile_n": 3, "threads": 96, "grouping": 30, "minblocks": 3, "algorithm": "medium", "perf": 482.507},
+{"m": 13, "n": 5, "k": 24, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 5, "minblocks": 1, "algorithm": "medium", "perf": 491.453},
+{"m": 13, "n": 5, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 5, "minblocks": 11, "algorithm": "medium", "perf": 487.722},
+{"m": 13, "n": 5, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 485.067},
+{"m": 13, "n": 5, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 3, "minblocks": 7, "algorithm": "medium", "perf": 493.982},
+{"m": 13, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 501.16},
+{"m": 13, "n": 5, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 501.227},
+{"m": 13, "n": 7, "k": 4, "tile_m": 1, "tile_n": 4, "threads": 32, "grouping": 13, "minblocks": 12, "algorithm": "medium", "perf": 476.167},
+{"m": 13, "n": 7, "k": 5, "tile_m": 2, "tile_n": 2, "threads": 32, "grouping": 13, "minblocks": 13, "algorithm": "medium", "perf": 472.557},
+{"m": 13, "n": 7, "k": 7, "tile_m": 4, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 22, "algorithm": "medium", "perf": 566.505},
+{"m": 13, "n": 7, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 32, "grouping": 16, "minblocks": 23, "algorithm": "medium", "perf": 562.908},
+{"m": 13, "n": 7, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 6, "minblocks": 9, "algorithm": "medium", "perf": 575.653},
+{"m": 13, "n": 7, "k": 25, "tile_m": 1, "tile_n": 2, "w": 12, "v": 6, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 598.682},
+{"m": 13, "n": 7, "k": 26, "tile_m": 1, "tile_n": 2, "w": 12, "v": 4, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 609.262},
+{"m": 13, "n": 7, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 5, "minblocks": 4, "algorithm": "medium", "perf": 611.772},
+{"m": 13, "n": 7, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 6, "minblocks": 5, "algorithm": "medium", "perf": 622.583},
+{"m": 13, "n": 7, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 3, "minblocks": 6, "algorithm": "medium", "perf": 627.27},
+{"m": 13, "n": 9, "k": 4, "tile_m": 5, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 27, "algorithm": "medium", "perf": 500.98},
+{"m": 13, "n": 9, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 32, "grouping": 13, "minblocks": 12, "algorithm": "medium", "perf": 558.304},
+{"m": 13, "n": 9, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 32, "grouping": 14, "minblocks": 25, "algorithm": "medium", "perf": 614.166},
+{"m": 13, "n": 9, "k": 9, "tile_m": 2, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 19, "algorithm": "medium", "perf": 633.01},
+{"m": 13, "n": 9, "k": 13, "tile_m": 2, "tile_n": 1, "threads": 64, "grouping": 22, "minblocks": 3, "algorithm": "medium", "perf": 674.039},
+{"m": 13, "n": 9, "k": 25, "tile_m": 2, "tile_n": 1, "w": 12, "v": 8, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 696.232},
+{"m": 13, "n": 9, "k": 26, "tile_m": 2, "tile_n": 1, "w": 10, "v": 8, "threads": 64, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 700.495},
+{"m": 13, "n": 9, "k": 28, "tile_m": 2, "tile_n": 1, "w": 14, "v": 6, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 716.029},
+{"m": 13, "n": 9, "k": 32, "tile_m": 2, "tile_n": 1, "w": 14, "v": 8, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 717.374},
+{"m": 13, "n": 9, "k": 45, "tile_m": 2, "tile_n": 1, "w": 14, "v": 6, "threads": 64, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 720.997},
+{"m": 13, "n": 12, "k": 5, "tile_m": 1, "tile_n": 6, "threads": 32, "grouping": 13, "minblocks": 23, "algorithm": "medium", "perf": 669.522},
+{"m": 13, "n": 12, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 26, "minblocks": 17, "algorithm": "medium", "perf": 782.744},
+{"m": 13, "n": 12, "k": 13, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 22, "minblocks": 6, "algorithm": "medium", "perf": 773.206},
+{"m": 13, "n": 12, "k": 26, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 5, "minblocks": 9, "algorithm": "medium", "perf": 802.307},
+{"m": 13, "n": 12, "k": 32, "tile_m": 4, "tile_n": 1, "w": 16, "v": 12, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 828.44},
+{"m": 13, "n": 13, "k": 4, "tile_m": 4, "tile_n": 2, "threads": 32, "grouping": 15, "minblocks": 15, "algorithm": "medium", "perf": 645.445},
+{"m": 13, "n": 13, "k": 5, "tile_m": 3, "tile_n": 3, "threads": 32, "grouping": 17, "minblocks": 13, "algorithm": "medium", "perf": 687.167},
+{"m": 13, "n": 13, "k": 7, "tile_m": 4, "tile_n": 2, "threads": 32, "grouping": 20, "minblocks": 14, "algorithm": "medium", "perf": 753.739},
+{"m": 13, "n": 13, "k": 9, "tile_m": 4, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 5, "algorithm": "medium", "perf": 798.832},
+{"m": 13, "n": 13, "k": 12, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 4, "algorithm": "medium", "perf": 819.816},
+{"m": 13, "n": 13, "k": 13, "tile_m": 4, "tile_n": 1, "threads": 64, "grouping": 32, "minblocks": 6, "algorithm": "medium", "perf": 808.211},
+{"m": 13, "n": 13, "k": 14, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 828.516},
+{"m": 13, "n": 13, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 32, "minblocks": 7, "algorithm": "medium", "perf": 829.325},
+{"m": 13, "n": 13, "k": 24, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 5, "minblocks": 4, "algorithm": "medium", "perf": 846.028},
+{"m": 13, "n": 13, "k": 25, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 5, "minblocks": 5, "algorithm": "medium", "perf": 843.072},
+{"m": 13, "n": 13, "k": 26, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 847.219},
+{"m": 13, "n": 13, "k": 28, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 855.86},
+{"m": 13, "n": 13, "k": 32, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 5, "minblocks": 2, "algorithm": "medium", "perf": 869.632},
+{"m": 13, "n": 13, "k": 45, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 862.482},
+{"m": 13, "n": 14, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 3, "algorithm": "medium", "perf": 818.092},
+{"m": 13, "n": 14, "k": 14, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 32, "minblocks": 6, "algorithm": "medium", "perf": 824.853},
+{"m": 13, "n": 14, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 6, "minblocks": 1, "algorithm": "medium", "perf": 867.323},
+{"m": 13, "n": 14, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 5, "minblocks": 7, "algorithm": "medium", "perf": 875.867},
+{"m": 13, "n": 14, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 14, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 894.079},
+{"m": 13, "n": 16, "k": 5, "tile_m": 4, "tile_n": 2, "threads": 32, "grouping": 17, "minblocks": 14, "algorithm": "medium", "perf": 721.863},
+{"m": 13, "n": 16, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 1, "algorithm": "medium", "perf": 866.035},
+{"m": 13, "n": 16, "k": 16, "tile_m": 4, "tile_n": 1, "threads": 96, "grouping": 4, "minblocks": 13, "algorithm": "medium", "perf": 894.502},
+{"m": 13, "n": 16, "k": 32, "tile_m": 4, "tile_n": 1, "w": 16, "v": 16, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 942.893},
+{"m": 13, "n": 24, "k": 5, "tile_m": 2, "tile_n": 3, "threads": 64, "grouping": 26, "minblocks": 10, "algorithm": "medium", "perf": 834.262},
+{"m": 13, "n": 24, "k": 13, "tile_m": 4, "tile_n": 1, "threads": 96, "grouping": 5, "minblocks": 12, "algorithm": "medium", "perf": 976.165},
+{"m": 13, "n": 24, "k": 24, "tile_m": 3, "tile_n": 2, "w": 12, "v": 20, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1079.09},
+{"m": 13, "n": 24, "k": 26, "tile_m": 2, "tile_n": 3, "w": 10, "v": 22, "threads": 64, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 1075.11},
+{"m": 13, "n": 24, "k": 32, "tile_m": 2, "tile_n": 3, "w": 16, "v": 22, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1104.28},
+{"m": 13, "n": 25, "k": 4, "tile_m": 2, "tile_n": 3, "threads": 64, "grouping": 25, "minblocks": 9, "algorithm": "medium", "perf": 775.128},
+{"m": 13, "n": 25, "k": 5, "tile_m": 2, "tile_n": 3, "threads": 64, "grouping": 27, "minblocks": 5, "algorithm": "medium", "perf": 818.248},
+{"m": 13, "n": 25, "k": 7, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 895.315},
+{"m": 13, "n": 25, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 937.417},
+{"m": 13, "n": 25, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 7, "minblocks": 9, "algorithm": "medium", "perf": 972.388},
+{"m": 13, "n": 25, "k": 14, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 993.182},
+{"m": 13, "n": 25, "k": 25, "tile_m": 2, "tile_n": 3, "w": 10, "v": 14, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1071.67},
+{"m": 13, "n": 25, "k": 26, "tile_m": 2, "tile_n": 3, "w": 10, "v": 22, "threads": 64, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 1087.2},
+{"m": 13, "n": 25, "k": 28, "tile_m": 2, "tile_n": 3, "w": 14, "v": 14, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1098.76},
+{"m": 13, "n": 25, "k": 32, "tile_m": 2, "tile_n": 3, "w": 16, "v": 20, "threads": 64, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 1113.24},
+{"m": 13, "n": 25, "k": 45, "tile_m": 2, "tile_n": 3, "w": 10, "v": 14, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1134.6},
+{"m": 13, "n": 26, "k": 4, "tile_m": 2, "tile_n": 3, "threads": 64, "grouping": 24, "minblocks": 3, "algorithm": "medium", "perf": 796.636},
+{"m": 13, "n": 26, "k": 5, "tile_m": 2, "tile_n": 3, "threads": 64, "grouping": 26, "minblocks": 10, "algorithm": "medium", "perf": 799.952},
+{"m": 13, "n": 26, "k": 7, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 916.63},
+{"m": 13, "n": 26, "k": 9, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 32, "minblocks": 12, "algorithm": "medium", "perf": 954.576},
+{"m": 13, "n": 26, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 160, "grouping": 6, "minblocks": 9, "algorithm": "medium", "perf": 999.327},
+{"m": 13, "n": 26, "k": 13, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 1007.42},
+{"m": 13, "n": 26, "k": 14, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 5, "minblocks": 10, "algorithm": "medium", "perf": 1015.55},
+{"m": 13, "n": 26, "k": 24, "tile_m": 2, "tile_n": 2, "w": 8, "v": 26, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1094.14},
+{"m": 13, "n": 26, "k": 25, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 1087.67},
+{"m": 13, "n": 26, "k": 26, "tile_m": 2, "tile_n": 2, "w": 10, "v": 10, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1091.97},
+{"m": 13, "n": 26, "k": 28, "tile_m": 2, "tile_n": 2, "w": 14, "v": 26, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1110.06},
+{"m": 13, "n": 26, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 26, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1133.28},
+{"m": 13, "n": 26, "k": 45, "tile_m": 2, "tile_n": 3, "w": 12, "v": 26, "threads": 64, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 1150.11},
+{"m": 13, "n": 28, "k": 4, "tile_m": 4, "tile_n": 4, "threads": 64, "grouping": 24, "minblocks": 12, "algorithm": "medium", "perf": 824.545},
+{"m": 13, "n": 28, "k": 5, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 9, "minblocks": 14, "algorithm": "medium", "perf": 835.315},
+{"m": 13, "n": 28, "k": 7, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 942.428},
+{"m": 13, "n": 28, "k": 9, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 29, "minblocks": 10, "algorithm": "medium", "perf": 986.164},
+{"m": 13, "n": 28, "k": 13, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 1028.12},
+{"m": 13, "n": 28, "k": 25, "tile_m": 4, "tile_n": 2, "threads": 64, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 1096.2},
+{"m": 13, "n": 28, "k": 26, "tile_m": 4, "tile_n": 2, "threads": 64, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 1109.32},
+{"m": 13, "n": 28, "k": 28, "tile_m": 2, "tile_n": 4, "w": 14, "v": 26, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1123.07},
+{"m": 13, "n": 28, "k": 32, "tile_m": 4, "tile_n": 2, "threads": 64, "grouping": 30, "minblocks": 1, "algorithm": "medium", "perf": 1134.83},
+{"m": 13, "n": 28, "k": 45, "tile_m": 4, "tile_n": 2, "w": 14, "v": 20, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1175.77},
+{"m": 13, "n": 32, "k": 4, "tile_m": 2, "tile_n": 4, "threads": 64, "grouping": 26, "minblocks": 6, "algorithm": "medium", "perf": 873.764},
+{"m": 13, "n": 32, "k": 5, "tile_m": 2, "tile_n": 4, "threads": 64, "grouping": 32, "minblocks": 6, "algorithm": "medium", "perf": 870.626},
+{"m": 13, "n": 32, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 981.108},
+{"m": 13, "n": 32, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 1008.75},
+{"m": 13, "n": 32, "k": 12, "tile_m": 4, "tile_n": 2, "w": 6, "v": 20, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1074.65},
+{"m": 13, "n": 32, "k": 13, "tile_m": 4, "tile_n": 1, "threads": 128, "grouping": 5, "minblocks": 9, "algorithm": "medium", "perf": 1073.99},
+{"m": 13, "n": 32, "k": 14, "tile_m": 4, "tile_n": 1, "threads": 128, "grouping": 5, "minblocks": 9, "algorithm": "medium", "perf": 1087.04},
+{"m": 13, "n": 32, "k": 16, "tile_m": 4, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 8, "algorithm": "medium", "perf": 1122.91},
+{"m": 13, "n": 32, "k": 24, "tile_m": 4, "tile_n": 2, "w": 12, "v": 28, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1168.27},
+{"m": 13, "n": 32, "k": 25, "tile_m": 4, "tile_n": 2, "threads": 64, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 1155.19},
+{"m": 13, "n": 32, "k": 26, "tile_m": 4, "tile_n": 2, "threads": 64, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 1166.22},
+{"m": 13, "n": 32, "k": 28, "tile_m": 4, "tile_n": 2, "threads": 64, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 1176.77},
+{"m": 13, "n": 32, "k": 32, "tile_m": 2, "tile_n": 2, "w": 12, "v": 14, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1205.05},
+{"m": 13, "n": 32, "k": 45, "tile_m": 2, "tile_n": 2, "w": 12, "v": 32, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1231.88},
+{"m": 13, "n": 45, "k": 4, "tile_m": 2, "tile_n": 5, "threads": 64, "grouping": 32, "minblocks": 5, "algorithm": "medium", "perf": 879.247},
+{"m": 13, "n": 45, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 909.587},
+{"m": 13, "n": 45, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 1015.1},
+{"m": 13, "n": 45, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 1091.53},
+{"m": 13, "n": 45, "k": 13, "tile_m": 1, "tile_n": 5, "threads": 192, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1152.46},
+{"m": 13, "n": 45, "k": 25, "tile_m": 4, "tile_n": 3, "threads": 64, "grouping": 29, "minblocks": 4, "algorithm": "medium", "perf": 1240.6},
+{"m": 13, "n": 45, "k": 26, "tile_m": 4, "tile_n": 3, "threads": 64, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 1247.15},
+{"m": 13, "n": 45, "k": 28, "tile_m": 2, "tile_n": 4, "w": 14, "v": 20, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1271.38},
+{"m": 13, "n": 45, "k": 32, "tile_m": 4, "tile_n": 3, "w": 8, "v": 12, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1291.85},
+{"m": 13, "n": 45, "k": 45, "tile_m": 2, "tile_n": 5, "w": 12, "v": 26, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1331.96},
+{"m": 14, "n": 13, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 4, "algorithm": "medium", "perf": 819.111},
+{"m": 14, "n": 13, "k": 14, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 829.012},
+{"m": 14, "n": 13, "k": 25, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 5, "minblocks": 7, "algorithm": "medium", "perf": 861.359},
+{"m": 14, "n": 13, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 5, "minblocks": 7, "algorithm": "medium", "perf": 876.462},
+{"m": 14, "n": 13, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 900.065},
+{"m": 14, "n": 14, "k": 13, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 876.026},
+{"m": 14, "n": 14, "k": 14, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 7, "algorithm": "medium", "perf": 878.284},
+{"m": 14, "n": 14, "k": 16, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 32, "minblocks": 4, "algorithm": "medium", "perf": 902.555},
+{"m": 14, "n": 14, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 6, "minblocks": 3, "algorithm": "medium", "perf": 915.718},
+{"m": 14, "n": 14, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 5, "minblocks": 5, "algorithm": "medium", "perf": 924.538},
+{"m": 14, "n": 14, "k": 29, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 924.968},
+{"m": 14, "n": 14, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 948.827},
+{"m": 14, "n": 16, "k": 14, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 29, "minblocks": 1, "algorithm": "medium", "perf": 920.926},
+{"m": 14, "n": 16, "k": 16, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 24, "minblocks": 11, "algorithm": "medium", "perf": 934.112},
+{"m": 14, "n": 16, "k": 29, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 985.695},
+{"m": 14, "n": 25, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 1036.53},
+{"m": 14, "n": 25, "k": 14, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 6, "minblocks": 10, "algorithm": "medium", "perf": 1064.78},
+{"m": 14, "n": 25, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 1135.93},
+{"m": 14, "n": 25, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 1146.21},
+{"m": 14, "n": 25, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 224, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1180.89},
+{"m": 14, "n": 26, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 6, "minblocks": 10, "algorithm": "medium", "perf": 1059.97},
+{"m": 14, "n": 26, "k": 14, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 4, "minblocks": 10, "algorithm": "medium", "perf": 1080.3},
+{"m": 14, "n": 26, "k": 25, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1164.2},
+{"m": 14, "n": 26, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 1170.35},
+{"m": 14, "n": 26, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 224, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 1204.18},
+{"m": 14, "n": 29, "k": 14, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 5, "minblocks": 8, "algorithm": "medium", "perf": 1099.41},
+{"m": 14, "n": 29, "k": 16, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 1136.55},
+{"m": 14, "n": 29, "k": 29, "tile_m": 1, "tile_n": 3, "threads": 160, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 1205.08},
+{"m": 14, "n": 29, "k": 32, "tile_m": 1, "tile_n": 3, "threads": 160, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 1227.39},
+{"m": 14, "n": 32, "k": 13, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 4, "minblocks": 9, "algorithm": "medium", "perf": 1144.56},
+{"m": 14, "n": 32, "k": 14, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 5, "minblocks": 8, "algorithm": "medium", "perf": 1157.34},
+{"m": 14, "n": 32, "k": 25, "tile_m": 1, "tile_n": 3, "threads": 224, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 1247.65},
+{"m": 14, "n": 32, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 224, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 1256.51},
+{"m": 14, "n": 32, "k": 29, "tile_m": 1, "tile_n": 3, "threads": 160, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 1258.33},
+{"m": 14, "n": 32, "k": 32, "tile_m": 1, "tile_n": 3, "threads": 224, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 1281.96},
+{"m": 15, "n": 4, "k": 4, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 16, "minblocks": 21, "algorithm": "medium", "perf": 349.797},
+{"m": 15, "n": 4, "k": 10, "tile_m": 2, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 5, "algorithm": "medium", "perf": 430.134},
+{"m": 15, "n": 4, "k": 15, "tile_m": 2, "tile_n": 1, "threads": 64, "grouping": 6, "minblocks": 11, "algorithm": "medium", "perf": 443.27},
+{"m": 15, "n": 10, "k": 4, "tile_m": 5, "tile_n": 1, "threads": 32, "grouping": 12, "minblocks": 22, "algorithm": "medium", "perf": 594.569},
+{"m": 15, "n": 10, "k": 10, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 22, "minblocks": 6, "algorithm": "medium", "perf": 728.427},
+{"m": 15, "n": 10, "k": 15, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 29, "minblocks": 9, "algorithm": "medium", "perf": 747.245},
+{"m": 15, "n": 15, "k": 4, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 19, "minblocks": 6, "algorithm": "medium", "perf": 738.168},
+{"m": 15, "n": 15, "k": 10, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 29, "minblocks": 10, "algorithm": "medium", "perf": 904.696},
+{"m": 15, "n": 15, "k": 15, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 928.082},
+{"m": 16, "n": 5, "k": 5, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 12, "minblocks": 23, "algorithm": "medium", "perf": 501.288},
+{"m": 16, "n": 5, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 4, "minblocks": 19, "algorithm": "medium", "perf": 503.261},
+{"m": 16, "n": 5, "k": 16, "tile_m": 1, "tile_n": 3, "threads": 96, "grouping": 29, "minblocks": 11, "algorithm": "medium", "perf": 524.682},
+{"m": 16, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 534.391},
+{"m": 16, "n": 13, "k": 5, "tile_m": 2, "tile_n": 4, "threads": 32, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 723.746},
+{"m": 16, "n": 13, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 9, "algorithm": "medium", "perf": 871.757},
+{"m": 16, "n": 13, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 897.477},
+{"m": 16, "n": 13, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 953.971},
+{"m": 16, "n": 14, "k": 14, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 32, "minblocks": 12, "algorithm": "medium", "perf": 927.004},
+{"m": 16, "n": 14, "k": 16, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 5, "minblocks": 11, "algorithm": "medium", "perf": 936.063},
+{"m": 16, "n": 14, "k": 29, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 985.795},
+{"m": 16, "n": 16, "k": 5, "tile_m": 2, "tile_n": 5, "threads": 32, "grouping": 19, "minblocks": 14, "algorithm": "medium", "perf": 857.219},
+{"m": 16, "n": 16, "k": 13, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 9, "algorithm": "medium", "perf": 1001.92},
+{"m": 16, "n": 16, "k": 14, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 32, "minblocks": 12, "algorithm": "medium", "perf": 1018.98},
+{"m": 16, "n": 16, "k": 16, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 29, "minblocks": 8, "algorithm": "small", "perf": 1035.54},
+{"m": 16, "n": 16, "k": 29, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 1062.17},
+{"m": 16, "n": 16, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 1086.81},
+{"m": 16, "n": 16, "k": 55, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 1104.86},
+{"m": 16, "n": 29, "k": 14, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 4, "minblocks": 9, "algorithm": "medium", "perf": 1221.28},
+{"m": 16, "n": 29, "k": 16, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 1236.07},
+{"m": 16, "n": 29, "k": 29, "tile_m": 1, "tile_n": 3, "threads": 160, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 1318.25},
+{"m": 16, "n": 29, "k": 55, "tile_m": 1, "tile_n": 3, "w": 16, "v": 16, "threads": 160, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1388.25},
+{"m": 16, "n": 32, "k": 5, "tile_m": 1, "tile_n": 6, "threads": 96, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 1015.49},
+{"m": 16, "n": 32, "k": 13, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 5, "minblocks": 8, "algorithm": "medium", "perf": 1239.79},
+{"m": 16, "n": 32, "k": 16, "tile_m": 1, "tile_n": 4, "threads": 160, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 1304.45},
+{"m": 16, "n": 32, "k": 32, "tile_m": 1, "tile_n": 3, "threads": 192, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 1401.94},
+{"m": 16, "n": 55, "k": 16, "tile_m": 1, "tile_n": 5, "threads": 192, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 1477.07},
+{"m": 16, "n": 55, "k": 29, "tile_m": 1, "tile_n": 5, "threads": 192, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 1548.78},
+{"m": 16, "n": 55, "k": 55, "tile_m": 2, "tile_n": 2, "w": 14, "v": 40, "threads": 224, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1648.17},
+{"m": 17, "n": 17, "k": 17, "tile_m": 1, "tile_n": 6, "threads": 128, "grouping": 6, "minblocks": 9, "algorithm": "medium", "perf": 1025.78},
+{"m": 18, "n": 18, "k": 18, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 4, "minblocks": 8, "algorithm": "medium", "perf": 1117.66},
+{"m": 19, "n": 19, "k": 19, "tile_m": 1, "tile_n": 4, "threads": 160, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 1155.59},
+{"m": 20, "n": 20, "k": 20, "tile_m": 1, "tile_n": 4, "threads": 160, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 1246.17},
+{"m": 21, "n": 21, "k": 21, "tile_m": 3, "tile_n": 3, "threads": 64, "grouping": 5, "minblocks": 4, "algorithm": "medium", "perf": 1259.48},
+{"m": 22, "n": 9, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 22, "minblocks": 14, "algorithm": "medium", "perf": 745.394},
+{"m": 22, "n": 9, "k": 22, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 816.342},
+{"m": 22, "n": 9, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 851.574},
+{"m": 22, "n": 22, "k": 9, "tile_m": 1, "tile_n": 6, "threads": 96, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 1180.32},
+{"m": 22, "n": 22, "k": 22, "tile_m": 3, "tile_n": 3, "threads": 64, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 1354.56},
+{"m": 22, "n": 22, "k": 32, "tile_m": 3, "tile_n": 3, "threads": 64, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1423.15},
+{"m": 22, "n": 32, "k": 9, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 30, "minblocks": 4, "algorithm": "medium", "perf": 1281.35},
+{"m": 22, "n": 32, "k": 22, "tile_m": 1, "tile_n": 4, "threads": 192, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 1571.65},
+{"m": 22, "n": 32, "k": 32, "tile_m": 3, "tile_n": 4, "w": 16, "v": 20, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1641.78},
+{"m": 23, "n": 23, "k": 23, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 1399.21},
+{"m": 24, "n": 5, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 32, "grouping": 13, "minblocks": 16, "algorithm": "medium", "perf": 537.802},
+{"m": 24, "n": 5, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 96, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 547.371},
+{"m": 24, "n": 5, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 32, "minblocks": 7, "algorithm": "medium", "perf": 570.165},
+{"m": 24, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 4, "minblocks": 8, "algorithm": "medium", "perf": 574.898},
+{"m": 24, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 586.204},
+{"m": 24, "n": 13, "k": 5, "tile_m": 3, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 9, "algorithm": "medium", "perf": 828.944},
+{"m": 24, "n": 13, "k": 13, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 6, "minblocks": 11, "algorithm": "medium", "perf": 980.411},
+{"m": 24, "n": 13, "k": 24, "tile_m": 3, "tile_n": 2, "w": 12, "v": 12, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1080.39},
+{"m": 24, "n": 13, "k": 26, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1074.3},
+{"m": 24, "n": 13, "k": 32, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1107.01},
+{"m": 24, "n": 24, "k": 5, "tile_m": 3, "tile_n": 3, "threads": 64, "grouping": 32, "minblocks": 8, "algorithm": "medium", "perf": 1126.34},
+{"m": 24, "n": 24, "k": 13, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 4, "minblocks": 8, "algorithm": "medium", "perf": 1384.19},
+{"m": 24, "n": 24, "k": 24, "tile_m": 1, "tile_n": 3, "threads": 192, "grouping": 3, "minblocks": 5, "algorithm": "medium", "perf": 1523.95},
+{"m": 24, "n": 24, "k": 26, "tile_m": 1, "tile_n": 3, "threads": 224, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 1513.76},
+{"m": 24, "n": 24, "k": 32, "tile_m": 1, "tile_n": 3, "threads": 192, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 1578.31},
+{"m": 24, "n": 26, "k": 5, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 12, "minblocks": 8, "algorithm": "medium", "perf": 1069.19},
+{"m": 24, "n": 26, "k": 13, "tile_m": 1, "tile_n": 6, "threads": 128, "grouping": 5, "minblocks": 8, "algorithm": "medium", "perf": 1390.67},
+{"m": 24, "n": 26, "k": 24, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 1507.26},
+{"m": 24, "n": 26, "k": 26, "tile_m": 1, "tile_n": 3, "threads": 256, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 1507.58},
+{"m": 24, "n": 26, "k": 32, "tile_m": 3, "tile_n": 4, "w": 16, "v": 18, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1559.19},
+{"m": 24, "n": 32, "k": 5, "tile_m": 1, "tile_n": 4, "threads": 192, "grouping": 10, "minblocks": 7, "algorithm": "medium", "perf": 1142.19},
+{"m": 24, "n": 32, "k": 13, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 24, "minblocks": 5, "algorithm": "medium", "perf": 1488.17},
+{"m": 24, "n": 32, "k": 24, "tile_m": 3, "tile_n": 2, "threads": 128, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 1672.01},
+{"m": 24, "n": 32, "k": 26, "tile_m": 1, "tile_n": 4, "threads": 224, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 1681.57},
+{"m": 24, "n": 32, "k": 32, "tile_m": 3, "tile_n": 5, "w": 8, "v": 32, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1724.89},
+{"m": 25, "n": 4, "k": 4, "tile_m": 1, "tile_n": 4, "threads": 32, "grouping": 13, "minblocks": 20, "algorithm": "medium", "perf": 445.461},
+{"m": 25, "n": 4, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 32, "grouping": 12, "minblocks": 11, "algorithm": "medium", "perf": 455.068},
+{"m": 25, "n": 4, "k": 7, "tile_m": 1, "tile_n": 4, "threads": 32, "grouping": 16, "minblocks": 15, "algorithm": "medium", "perf": 457.448},
+{"m": 25, "n": 4, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 26, "minblocks": 10, "algorithm": "medium", "perf": 453.929},
+{"m": 25, "n": 4, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 4, "minblocks": 12, "algorithm": "medium", "perf": 469.649},
+{"m": 25, "n": 4, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 480.107},
+{"m": 25, "n": 4, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 3, "minblocks": 8, "algorithm": "medium", "perf": 482.817},
+{"m": 25, "n": 4, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 487.851},
+{"m": 25, "n": 4, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 489.45},
+{"m": 25, "n": 4, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 2, "minblocks": 2, "algorithm": "medium", "perf": 489.336},
+{"m": 25, "n": 5, "k": 4, "tile_m": 1, "tile_n": 6, "threads": 32, "grouping": 13, "minblocks": 24, "algorithm": "medium", "perf": 501.601},
+{"m": 25, "n": 5, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 32, "grouping": 16, "minblocks": 16, "algorithm": "medium", "perf": 516.776},
+{"m": 25, "n": 5, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 22, "minblocks": 13, "algorithm": "medium", "perf": 515.647},
+{"m": 25, "n": 5, "k": 9, "tile_m": 1, "tile_n": 6, "threads": 64, "grouping": 26, "minblocks": 15, "algorithm": "medium", "perf": 540.279},
+{"m": 25, "n": 5, "k": 13, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 542.948},
+{"m": 25, "n": 5, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 128, "grouping": 3, "minblocks": 8, "algorithm": "medium", "perf": 570.33},
+{"m": 25, "n": 5, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 569.355},
+{"m": 25, "n": 5, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 571.981},
+{"m": 25, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 588.39},
+{"m": 25, "n": 5, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 585.125},
+{"m": 25, "n": 7, "k": 4, "tile_m": 3, "tile_n": 3, "threads": 32, "grouping": 15, "minblocks": 2, "algorithm": "medium", "perf": 580.754},
+{"m": 25, "n": 7, "k": 5, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 21, "minblocks": 19, "algorithm": "medium", "perf": 598.77},
+{"m": 25, "n": 7, "k": 7, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 22, "minblocks": 3, "algorithm": "medium", "perf": 660.441},
+{"m": 25, "n": 7, "k": 9, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 10, "algorithm": "medium", "perf": 684.274},
+{"m": 25, "n": 7, "k": 13, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 29, "minblocks": 1, "algorithm": "medium", "perf": 698.671},
+{"m": 25, "n": 7, "k": 25, "tile_m": 1, "tile_n": 3, "threads": 192, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 718.262},
+{"m": 25, "n": 7, "k": 26, "tile_m": 3, "tile_n": 1, "threads": 192, "grouping": 29, "minblocks": 3, "algorithm": "medium", "perf": 721.455},
+{"m": 25, "n": 7, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 724.329},
+{"m": 25, "n": 7, "k": 32, "tile_m": 3, "tile_n": 1, "w": 16, "v": 6, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 735.427},
+{"m": 25, "n": 7, "k": 45, "tile_m": 3, "tile_n": 1, "threads": 128, "grouping": 30, "minblocks": 4, "algorithm": "medium", "perf": 735.753},
+{"m": 25, "n": 9, "k": 4, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 24, "minblocks": 3, "algorithm": "medium", "perf": 615.95},
+{"m": 25, "n": 9, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 24, "minblocks": 2, "algorithm": "medium", "perf": 696.734},
+{"m": 25, "n": 9, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 26, "minblocks": 13, "algorithm": "medium", "perf": 767.41},
+{"m": 25, "n": 9, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 772.896},
+{"m": 25, "n": 9, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 812.472},
+{"m": 25, "n": 9, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 854.308},
+{"m": 25, "n": 9, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 860.057},
+{"m": 25, "n": 9, "k": 28, "tile_m": 1, "tile_n": 2, "w": 10, "v": 8, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 875.354},
+{"m": 25, "n": 9, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 882.376},
+{"m": 25, "n": 9, "k": 45, "tile_m": 1, "tile_n": 2, "w": 14, "v": 8, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 892.009},
+{"m": 25, "n": 12, "k": 12, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 945.839},
+{"m": 25, "n": 12, "k": 25, "tile_m": 3, "tile_n": 2, "w": 10, "v": 12, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1042.28},
+{"m": 25, "n": 13, "k": 4, "tile_m": 3, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 7, "algorithm": "medium", "perf": 772.213},
+{"m": 25, "n": 13, "k": 5, "tile_m": 3, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 9, "algorithm": "medium", "perf": 811.652},
+{"m": 25, "n": 13, "k": 7, "tile_m": 3, "tile_n": 2, "threads": 64, "grouping": 29, "minblocks": 1, "algorithm": "medium", "perf": 894.47},
+{"m": 25, "n": 13, "k": 9, "tile_m": 3, "tile_n": 2, "threads": 64, "grouping": 32, "minblocks": 7, "algorithm": "medium", "perf": 937.943},
+{"m": 25, "n": 13, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 7, "minblocks": 10, "algorithm": "medium", "perf": 975.605},
+{"m": 25, "n": 13, "k": 14, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 7, "minblocks": 10, "algorithm": "medium", "perf": 992.46},
+{"m": 25, "n": 13, "k": 25, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 1066.09},
+{"m": 25, "n": 13, "k": 26, "tile_m": 3, "tile_n": 2, "w": 12, "v": 4, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1073.76},
+{"m": 25, "n": 13, "k": 28, "tile_m": 3, "tile_n": 2, "w": 12, "v": 12, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1099.51},
+{"m": 25, "n": 13, "k": 32, "tile_m": 3, "tile_n": 2, "w": 14, "v": 12, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1111.26},
+{"m": 25, "n": 13, "k": 45, "tile_m": 3, "tile_n": 2, "w": 12, "v": 10, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1133.67},
+{"m": 25, "n": 14, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 6, "minblocks": 9, "algorithm": "medium", "perf": 1028.26},
+{"m": 25, "n": 14, "k": 14, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 6, "minblocks": 9, "algorithm": "medium", "perf": 1048.08},
+{"m": 25, "n": 14, "k": 25, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 1119.23},
+{"m": 25, "n": 14, "k": 26, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 1118.61},
+{"m": 25, "n": 14, "k": 32, "tile_m": 3, "tile_n": 2, "w": 16, "v": 14, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1161.79},
+{"m": 25, "n": 25, "k": 4, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 32, "minblocks": 4, "algorithm": "medium", "perf": 976.486},
+{"m": 25, "n": 25, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 1070.36},
+{"m": 25, "n": 25, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 1194.1},
+{"m": 25, "n": 25, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 1269.67},
+{"m": 25, "n": 25, "k": 12, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 1365.39},
+{"m": 25, "n": 25, "k": 13, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1367.05},
+{"m": 25, "n": 25, "k": 14, "tile_m": 1, "tile_n": 5, "threads": 192, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1390.72},
+{"m": 25, "n": 25, "k": 25, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 1504.46},
+{"m": 25, "n": 25, "k": 26, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 30, "minblocks": 1, "algorithm": "medium", "perf": 1498.12},
+{"m": 25, "n": 25, "k": 28, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 1526.33},
+{"m": 25, "n": 25, "k": 32, "tile_m": 3, "tile_n": 4, "w": 8, "v": 24, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1548.35},
+{"m": 25, "n": 25, "k": 45, "tile_m": 3, "tile_n": 4, "w": 20, "v": 8, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1587.51},
+{"m": 25, "n": 26, "k": 4, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 32, "minblocks": 5, "algorithm": "medium", "perf": 974.726},
+{"m": 25, "n": 26, "k": 5, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 14, "minblocks": 8, "algorithm": "medium", "perf": 1032.18},
+{"m": 25, "n": 26, "k": 7, "tile_m": 1, "tile_n": 6, "threads": 192, "grouping": 10, "minblocks": 8, "algorithm": "medium", "perf": 1153.33},
+{"m": 25, "n": 26, "k": 9, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 27, "minblocks": 3, "algorithm": "medium", "perf": 1238.92},
+{"m": 25, "n": 26, "k": 13, "tile_m": 1, "tile_n": 6, "threads": 128, "grouping": 24, "minblocks": 6, "algorithm": "medium", "perf": 1358.07},
+{"m": 25, "n": 26, "k": 14, "tile_m": 1, "tile_n": 6, "threads": 128, "grouping": 24, "minblocks": 6, "algorithm": "medium", "perf": 1398.79},
+{"m": 25, "n": 26, "k": 25, "tile_m": 3, "tile_n": 4, "w": 8, "v": 26, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1510.79},
+{"m": 25, "n": 26, "k": 26, "tile_m": 3, "tile_n": 4, "w": 8, "v": 26, "threads": 64, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 1521.72},
+{"m": 25, "n": 26, "k": 28, "tile_m": 3, "tile_n": 4, "w": 8, "v": 26, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1547.14},
+{"m": 25, "n": 26, "k": 32, "tile_m": 3, "tile_n": 4, "w": 8, "v": 26, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1582.6},
+{"m": 25, "n": 26, "k": 45, "tile_m": 3, "tile_n": 4, "w": 18, "v": 26, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1621.87},
+{"m": 25, "n": 28, "k": 4, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 1038.23},
+{"m": 25, "n": 28, "k": 5, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 9, "minblocks": 8, "algorithm": "medium", "perf": 1102.36},
+{"m": 25, "n": 28, "k": 7, "tile_m": 1, "tile_n": 6, "threads": 128, "grouping": 7, "minblocks": 8, "algorithm": "medium", "perf": 1200.18},
+{"m": 25, "n": 28, "k": 9, "tile_m": 1, "tile_n": 6, "threads": 128, "grouping": 6, "minblocks": 8, "algorithm": "medium", "perf": 1319.69},
+{"m": 25, "n": 28, "k": 13, "tile_m": 1, "tile_n": 6, "threads": 128, "grouping": 4, "minblocks": 8, "algorithm": "medium", "perf": 1432.84},
+{"m": 25, "n": 28, "k": 25, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1590.64},
+{"m": 25, "n": 28, "k": 26, "tile_m": 3, "tile_n": 4, "w": 8, "v": 28, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1589.92},
+{"m": 25, "n": 28, "k": 28, "tile_m": 3, "tile_n": 4, "w": 8, "v": 28, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1612.35},
+{"m": 25, "n": 28, "k": 32, "tile_m": 3, "tile_n": 4, "w": 8, "v": 28, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1653.53},
+{"m": 25, "n": 28, "k": 45, "tile_m": 3, "tile_n": 4, "w": 18, "v": 28, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1684.81},
+{"m": 25, "n": 32, "k": 4, "tile_m": 5, "tile_n": 1, "threads": 160, "grouping": 12, "minblocks": 7, "algorithm": "medium", "perf": 1025.19},
+{"m": 25, "n": 32, "k": 5, "tile_m": 5, "tile_n": 1, "threads": 192, "grouping": 16, "minblocks": 7, "algorithm": "medium", "perf": 1111.36},
+{"m": 25, "n": 32, "k": 7, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 24, "minblocks": 3, "algorithm": "medium", "perf": 1256.28},
+{"m": 25, "n": 32, "k": 9, "tile_m": 5, "tile_n": 3, "threads": 64, "grouping": 29, "minblocks": 2, "algorithm": "medium", "perf": 1364.67},
+{"m": 25, "n": 32, "k": 13, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 29, "minblocks": 1, "algorithm": "medium", "perf": 1484.69},
+{"m": 25, "n": 32, "k": 14, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 29, "minblocks": 4, "algorithm": "medium", "perf": 1517.54},
+{"m": 25, "n": 32, "k": 25, "tile_m": 5, "tile_n": 3, "threads": 64, "grouping": 29, "minblocks": 1, "algorithm": "medium", "perf": 1655.28},
+{"m": 25, "n": 32, "k": 26, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 1680.88},
+{"m": 25, "n": 32, "k": 28, "tile_m": 5, "tile_n": 3, "w": 14, "v": 32, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1689.82},
+{"m": 25, "n": 32, "k": 32, "tile_m": 5, "tile_n": 3, "w": 8, "v": 32, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1750.62},
+{"m": 25, "n": 32, "k": 45, "tile_m": 5, "tile_n": 3, "w": 8, "v": 32, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1784.12},
+{"m": 25, "n": 45, "k": 4, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 30, "minblocks": 4, "algorithm": "medium", "perf": 1026.08},
+{"m": 25, "n": 45, "k": 5, "tile_m": 5, "tile_n": 2, "threads": 128, "grouping": 24, "minblocks": 2, "algorithm": "medium", "perf": 1149.65},
+{"m": 25, "n": 45, "k": 7, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 24, "minblocks": 2, "algorithm": "medium", "perf": 1315.18},
+{"m": 25, "n": 45, "k": 9, "tile_m": 5, "tile_n": 2, "threads": 128, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 1432.35},
+{"m": 25, "n": 45, "k": 13, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 24, "minblocks": 1, "algorithm": "medium", "perf": 1592.59},
+{"m": 25, "n": 45, "k": 25, "tile_m": 5, "tile_n": 4, "w": 10, "v": 22, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1834.49},
+{"m": 25, "n": 45, "k": 26, "tile_m": 5, "tile_n": 4, "w": 10, "v": 44, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1856.86},
+{"m": 25, "n": 45, "k": 28, "tile_m": 5, "tile_n": 4, "w": 10, "v": 44, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1880.32},
+{"m": 25, "n": 45, "k": 32, "tile_m": 5, "tile_n": 4, "w": 8, "v": 22, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1931.76},
+{"m": 25, "n": 45, "k": 45, "tile_m": 5, "tile_n": 4, "w": 10, "v": 14, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 2021.91},
+{"m": 26, "n": 4, "k": 4, "tile_m": 1, "tile_n": 4, "threads": 32, "grouping": 13, "minblocks": 8, "algorithm": "medium", "perf": 455.983},
+{"m": 26, "n": 4, "k": 5, "tile_m": 1, "tile_n": 4, "threads": 32, "grouping": 13, "minblocks": 13, "algorithm": "medium", "perf": 453.07},
+{"m": 26, "n": 4, "k": 7, "tile_m": 1, "tile_n": 4, "threads": 32, "grouping": 16, "minblocks": 8, "algorithm": "medium", "perf": 462.367},
+{"m": 26, "n": 4, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 7, "algorithm": "medium", "perf": 461.91},
+{"m": 26, "n": 4, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 478.188},
+{"m": 26, "n": 4, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 483.153},
+{"m": 26, "n": 4, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 487.755},
+{"m": 26, "n": 4, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 489.503},
+{"m": 26, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 493.24},
+{"m": 26, "n": 4, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 2, "minblocks": 2, "algorithm": "medium", "perf": 495.988},
+{"m": 26, "n": 5, "k": 4, "tile_m": 1, "tile_n": 5, "threads": 32, "grouping": 13, "minblocks": 27, "algorithm": "medium", "perf": 513.002},
+{"m": 26, "n": 5, "k": 5, "tile_m": 5, "tile_n": 1, "threads": 32, "grouping": 18, "minblocks": 10, "algorithm": "medium", "perf": 517.591},
+{"m": 26, "n": 5, "k": 7, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 22, "minblocks": 1, "algorithm": "medium", "perf": 525.335},
+{"m": 26, "n": 5, "k": 9, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 26, "minblocks": 12, "algorithm": "medium", "perf": 550.268},
+{"m": 26, "n": 5, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 32, "minblocks": 11, "algorithm": "medium", "perf": 560.898},
+{"m": 26, "n": 5, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 96, "grouping": 29, "minblocks": 9, "algorithm": "medium", "perf": 549.663},
+{"m": 26, "n": 5, "k": 24, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 573.419},
+{"m": 26, "n": 5, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 570.821},
+{"m": 26, "n": 5, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 573.903},
+{"m": 26, "n": 5, "k": 28, "tile_m": 1, "tile_n": 3, "threads": 160, "grouping": 24, "minblocks": 3, "algorithm": "medium", "perf": 573.438},
+{"m": 26, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 224, "grouping": 3, "minblocks": 6, "algorithm": "medium", "perf": 587.174},
+{"m": 26, "n": 5, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 590.001},
+{"m": 26, "n": 7, "k": 4, "tile_m": 2, "tile_n": 4, "threads": 32, "grouping": 16, "minblocks": 1, "algorithm": "medium", "perf": 594.471},
+{"m": 26, "n": 7, "k": 5, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 22, "minblocks": 17, "algorithm": "medium", "perf": 613.113},
+{"m": 26, "n": 7, "k": 7, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 22, "minblocks": 6, "algorithm": "medium", "perf": 672.9},
+{"m": 26, "n": 7, "k": 9, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 1, "algorithm": "medium", "perf": 697.663},
+{"m": 26, "n": 7, "k": 13, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 32, "minblocks": 7, "algorithm": "medium", "perf": 710.135},
+{"m": 26, "n": 7, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 730.136},
+{"m": 26, "n": 7, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 5, "minblocks": 3, "algorithm": "medium", "perf": 735.317},
+{"m": 26, "n": 7, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 224, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 737.392},
+{"m": 26, "n": 7, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 256, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 751.816},
+{"m": 26, "n": 7, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 754.379},
+{"m": 26, "n": 9, "k": 4, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 24, "minblocks": 4, "algorithm": "medium", "perf": 645.89},
+{"m": 26, "n": 9, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 26, "minblocks": 16, "algorithm": "medium", "perf": 708.797},
+{"m": 26, "n": 9, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 25, "minblocks": 15, "algorithm": "medium", "perf": 783.549},
+{"m": 26, "n": 9, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 32, "minblocks": 11, "algorithm": "medium", "perf": 797.252},
+{"m": 26, "n": 9, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 18, "minblocks": 4, "algorithm": "medium", "perf": 821.531},
+{"m": 26, "n": 9, "k": 25, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 862.508},
+{"m": 26, "n": 9, "k": 26, "tile_m": 1, "tile_n": 3, "threads": 256, "grouping": 5, "minblocks": 5, "algorithm": "medium", "perf": 871.198},
+{"m": 26, "n": 9, "k": 28, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 877.813},
+{"m": 26, "n": 9, "k": 32, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 3, "minblocks": 5, "algorithm": "medium", "perf": 895.509},
+{"m": 26, "n": 9, "k": 45, "tile_m": 3, "tile_n": 1, "w": 10, "v": 6, "threads": 96, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 902.055},
+{"m": 26, "n": 12, "k": 5, "tile_m": 1, "tile_n": 6, "threads": 64, "grouping": 24, "minblocks": 11, "algorithm": "medium", "perf": 853.834},
+{"m": 26, "n": 12, "k": 12, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 6, "minblocks": 11, "algorithm": "medium", "perf": 965.748},
+{"m": 26, "n": 12, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 6, "minblocks": 1, "algorithm": "medium", "perf": 969.942},
+{"m": 26, "n": 12, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 1059.98},
+{"m": 26, "n": 12, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 1091.93},
+{"m": 26, "n": 13, "k": 4, "tile_m": 3, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 8, "algorithm": "medium", "perf": 799.987},
+{"m": 26, "n": 13, "k": 5, "tile_m": 3, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 2, "algorithm": "medium", "perf": 797.258},
+{"m": 26, "n": 13, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 26, "minblocks": 13, "algorithm": "medium", "perf": 922.13},
+{"m": 26, "n": 13, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 949.735},
+{"m": 26, "n": 13, "k": 12, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 997.362},
+{"m": 26, "n": 13, "k": 13, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 6, "minblocks": 11, "algorithm": "medium", "perf": 991.96},
+{"m": 26, "n": 13, "k": 14, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 24, "minblocks": 6, "algorithm": "medium", "perf": 1008.41},
+{"m": 26, "n": 13, "k": 24, "tile_m": 3, "tile_n": 2, "w": 12, "v": 12, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1092.08},
+{"m": 26, "n": 13, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 1088.18},
+{"m": 26, "n": 13, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 1101.37},
+{"m": 26, "n": 13, "k": 28, "tile_m": 3, "tile_n": 2, "w": 14, "v": 8, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1105.61},
+{"m": 26, "n": 13, "k": 32, "tile_m": 3, "tile_n": 2, "w": 14, "v": 12, "threads": 64, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 1128.15},
+{"m": 26, "n": 13, "k": 45, "tile_m": 3, "tile_n": 2, "w": 12, "v": 8, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1156.84},
+{"m": 26, "n": 14, "k": 13, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 4, "minblocks": 11, "algorithm": "medium", "perf": 1046.07},
+{"m": 26, "n": 14, "k": 14, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 5, "minblocks": 9, "algorithm": "medium", "perf": 1076.05},
+{"m": 26, "n": 14, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 1153.33},
+{"m": 26, "n": 14, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 1159.6},
+{"m": 26, "n": 14, "k": 32, "tile_m": 3, "tile_n": 2, "w": 16, "v": 14, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1196.64},
+{"m": 26, "n": 24, "k": 5, "tile_m": 1, "tile_n": 4, "threads": 160, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 1078.8},
+{"m": 26, "n": 24, "k": 13, "tile_m": 1, "tile_n": 6, "threads": 128, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 1387.5},
+{"m": 26, "n": 24, "k": 24, "tile_m": 1, "tile_n": 4, "threads": 160, "grouping": 3, "minblocks": 5, "algorithm": "medium", "perf": 1530.31},
+{"m": 26, "n": 24, "k": 26, "tile_m": 1, "tile_n": 4, "threads": 192, "grouping": 24, "minblocks": 4, "algorithm": "medium", "perf": 1507.25},
+{"m": 26, "n": 24, "k": 32, "tile_m": 1, "tile_n": 4, "threads": 256, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 1570.75},
+{"m": 26, "n": 25, "k": 4, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 32, "minblocks": 8, "algorithm": "medium", "perf": 973.176},
+{"m": 26, "n": 25, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 160, "grouping": 13, "minblocks": 8, "algorithm": "medium", "perf": 1040.55},
+{"m": 26, "n": 25, "k": 7, "tile_m": 1, "tile_n": 4, "threads": 192, "grouping": 18, "minblocks": 8, "algorithm": "medium", "perf": 1170.93},
+{"m": 26, "n": 25, "k": 9, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 26, "minblocks": 3, "algorithm": "medium", "perf": 1241.28},
+{"m": 26, "n": 25, "k": 13, "tile_m": 1, "tile_n": 5, "threads": 160, "grouping": 6, "minblocks": 6, "algorithm": "medium", "perf": 1351.85},
+{"m": 26, "n": 25, "k": 14, "tile_m": 1, "tile_n": 5, "threads": 192, "grouping": 29, "minblocks": 6, "algorithm": "medium", "perf": 1386.15},
+{"m": 26, "n": 25, "k": 25, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 30, "minblocks": 4, "algorithm": "medium", "perf": 1508.73},
+{"m": 26, "n": 25, "k": 26, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 29, "minblocks": 2, "algorithm": "medium", "perf": 1524.65},
+{"m": 26, "n": 25, "k": 28, "tile_m": 1, "tile_n": 5, "threads": 192, "grouping": 24, "minblocks": 4, "algorithm": "medium", "perf": 1536.17},
+{"m": 26, "n": 25, "k": 32, "tile_m": 3, "tile_n": 4, "w": 8, "v": 22, "threads": 64, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 1588.12},
+{"m": 26, "n": 25, "k": 45, "tile_m": 3, "tile_n": 4, "w": 18, "v": 20, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1619.09},
+{"m": 26, "n": 26, "k": 4, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 32, "minblocks": 5, "algorithm": "medium", "perf": 1064.38},
+{"m": 26, "n": 26, "k": 5, "tile_m": 3, "tile_n": 2, "threads": 160, "grouping": 9, "minblocks": 8, "algorithm": "medium", "perf": 1092.54},
+{"m": 26, "n": 26, "k": 7, "tile_m": 1, "tile_n": 4, "threads": 192, "grouping": 9, "minblocks": 8, "algorithm": "medium", "perf": 1229.79},
+{"m": 26, "n": 26, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 160, "grouping": 9, "minblocks": 7, "algorithm": "medium", "perf": 1308.23},
+{"m": 26, "n": 26, "k": 12, "tile_m": 1, "tile_n": 5, "threads": 160, "grouping": 5, "minblocks": 7, "algorithm": "medium", "perf": 1442.33},
+{"m": 26, "n": 26, "k": 13, "tile_m": 1, "tile_n": 5, "threads": 160, "grouping": 5, "minblocks": 6, "algorithm": "medium", "perf": 1449.82},
+{"m": 26, "n": 26, "k": 14, "tile_m": 1, "tile_n": 5, "threads": 160, "grouping": 5, "minblocks": 6, "algorithm": "medium", "perf": 1481.84},
+{"m": 26, "n": 26, "k": 24, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 1576.45},
+{"m": 26, "n": 26, "k": 25, "tile_m": 1, "tile_n": 4, "threads": 192, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 1587.9},
+{"m": 26, "n": 26, "k": 26, "tile_m": 1, "tile_n": 4, "threads": 192, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 1597.11},
+{"m": 26, "n": 26, "k": 28, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1611.35},
+{"m": 26, "n": 26, "k": 32, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1634.06},
+{"m": 26, "n": 26, "k": 45, "tile_m": 3, "tile_n": 4, "w": 18, "v": 14, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1658.01},
+{"m": 26, "n": 28, "k": 4, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 1060.2},
+{"m": 26, "n": 28, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 160, "grouping": 9, "minblocks": 8, "algorithm": "medium", "perf": 1126.12},
+{"m": 26, "n": 28, "k": 7, "tile_m": 1, "tile_n": 4, "threads": 224, "grouping": 27, "minblocks": 6, "algorithm": "medium", "perf": 1233.99},
+{"m": 26, "n": 28, "k": 9, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 25, "minblocks": 3, "algorithm": "medium", "perf": 1333.66},
+{"m": 26, "n": 28, "k": 13, "tile_m": 1, "tile_n": 5, "threads": 160, "grouping": 5, "minblocks": 6, "algorithm": "medium", "perf": 1462.23},
+{"m": 26, "n": 28, "k": 25, "tile_m": 3, "tile_n": 4, "w": 8, "v": 28, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1614.7},
+{"m": 26, "n": 28, "k": 26, "tile_m": 3, "tile_n": 4, "w": 8, "v": 28, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1634.02},
+{"m": 26, "n": 28, "k": 28, "tile_m": 3, "tile_n": 4, "w": 8, "v": 28, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1644.78},
+{"m": 26, "n": 28, "k": 32, "tile_m": 3, "tile_n": 4, "w": 8, "v": 28, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1687.3},
+{"m": 26, "n": 28, "k": 45, "tile_m": 3, "tile_n": 3, "w": 16, "v": 28, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1724.14},
+{"m": 26, "n": 32, "k": 4, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 12, "minblocks": 7, "algorithm": "medium", "perf": 1067.11},
+{"m": 26, "n": 32, "k": 5, "tile_m": 1, "tile_n": 6, "threads": 192, "grouping": 12, "minblocks": 6, "algorithm": "medium", "perf": 1162.16},
+{"m": 26, "n": 32, "k": 7, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 26, "minblocks": 6, "algorithm": "medium", "perf": 1279.84},
+{"m": 26, "n": 32, "k": 9, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 10, "minblocks": 7, "algorithm": "medium", "perf": 1389.5},
+{"m": 26, "n": 32, "k": 12, "tile_m": 7, "tile_n": 2, "w": 6, "v": 32, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1501.3},
+{"m": 26, "n": 32, "k": 13, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 5, "minblocks": 6, "algorithm": "medium", "perf": 1539.69},
+{"m": 26, "n": 32, "k": 14, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 5, "minblocks": 6, "algorithm": "medium", "perf": 1590.16},
+{"m": 26, "n": 32, "k": 24, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 1705.11},
+{"m": 26, "n": 32, "k": 25, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1687.93},
+{"m": 26, "n": 32, "k": 26, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1732.07},
+{"m": 26, "n": 32, "k": 28, "tile_m": 3, "tile_n": 5, "w": 14, "v": 26, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1728.22},
+{"m": 26, "n": 32, "k": 32, "tile_m": 3, "tile_n": 5, "w": 8, "v": 32, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1778.97},
+{"m": 26, "n": 32, "k": 45, "tile_m": 3, "tile_n": 5, "w": 16, "v": 30, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1831.59},
+{"m": 26, "n": 45, "k": 4, "tile_m": 1, "tile_n": 6, "threads": 224, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1073.89},
+{"m": 26, "n": 45, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 256, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1204.58},
+{"m": 26, "n": 45, "k": 7, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 25, "minblocks": 3, "algorithm": "medium", "perf": 1351.98},
+{"m": 26, "n": 45, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 256, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1490.07},
+{"m": 26, "n": 45, "k": 13, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 24, "minblocks": 2, "algorithm": "medium", "perf": 1646.86},
+{"m": 26, "n": 45, "k": 25, "tile_m": 1, "tile_n": 5, "threads": 256, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 1858.51},
+{"m": 26, "n": 45, "k": 26, "tile_m": 7, "tile_n": 3, "w": 8, "v": 42, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1878.25},
+{"m": 26, "n": 45, "k": 28, "tile_m": 7, "tile_n": 3, "w": 8, "v": 38, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1924.64},
+{"m": 26, "n": 45, "k": 32, "tile_m": 7, "tile_n": 3, "w": 8, "v": 22, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1985.28},
+{"m": 26, "n": 45, "k": 45, "tile_m": 7, "tile_n": 3, "w": 14, "v": 36, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 2060.31},
+{"m": 27, "n": 27, "k": 27, "tile_m": 3, "tile_n": 4, "threads": 64, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 1627.88},
+{"m": 28, "n": 4, "k": 4, "tile_m": 1, "tile_n": 5, "threads": 32, "grouping": 13, "minblocks": 23, "algorithm": "medium", "perf": 461.401},
+{"m": 28, "n": 4, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 32, "grouping": 13, "minblocks": 21, "algorithm": "medium", "perf": 448.695},
+{"m": 28, "n": 4, "k": 7, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 24, "minblocks": 7, "algorithm": "medium", "perf": 463.739},
+{"m": 28, "n": 4, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 5, "minblocks": 2, "algorithm": "medium", "perf": 475.527},
+{"m": 28, "n": 4, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 29, "minblocks": 6, "algorithm": "medium", "perf": 481.891},
+{"m": 28, "n": 4, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 486.812},
+{"m": 28, "n": 4, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 486.174},
+{"m": 28, "n": 4, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 6, "minblocks": 3, "algorithm": "medium", "perf": 487.386},
+{"m": 28, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 493.569},
+{"m": 28, "n": 4, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 2, "minblocks": 3, "algorithm": "medium", "perf": 499.71},
+{"m": 28, "n": 5, "k": 4, "tile_m": 1, "tile_n": 5, "threads": 32, "grouping": 15, "minblocks": 13, "algorithm": "medium", "perf": 512.554},
+{"m": 28, "n": 5, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 32, "grouping": 16, "minblocks": 24, "algorithm": "medium", "perf": 527.04},
+{"m": 28, "n": 5, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 22, "minblocks": 17, "algorithm": "medium", "perf": 539.965},
+{"m": 28, "n": 5, "k": 9, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 12, "algorithm": "medium", "perf": 563.57},
+{"m": 28, "n": 5, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 96, "grouping": 29, "minblocks": 3, "algorithm": "medium", "perf": 557.175},
+{"m": 28, "n": 5, "k": 25, "tile_m": 1, "tile_n": 3, "threads": 192, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 578.247},
+{"m": 28, "n": 5, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 5, "minblocks": 3, "algorithm": "medium", "perf": 579.676},
+{"m": 28, "n": 5, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 584.008},
+{"m": 28, "n": 5, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 594.508},
+{"m": 28, "n": 5, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 598.534},
+{"m": 28, "n": 7, "k": 4, "tile_m": 2, "tile_n": 4, "threads": 32, "grouping": 17, "minblocks": 10, "algorithm": "medium", "perf": 622.45},
+{"m": 28, "n": 7, "k": 5, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 22, "minblocks": 7, "algorithm": "medium", "perf": 627.062},
+{"m": 28, "n": 7, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 26, "minblocks": 9, "algorithm": "medium", "perf": 683.291},
+{"m": 28, "n": 7, "k": 9, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 24, "minblocks": 1, "algorithm": "medium", "perf": 714.393},
+{"m": 28, "n": 7, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 96, "grouping": 29, "minblocks": 9, "algorithm": "medium", "perf": 722.039},
+{"m": 28, "n": 7, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 745.291},
+{"m": 28, "n": 7, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 747.448},
+{"m": 28, "n": 7, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 224, "grouping": 3, "minblocks": 6, "algorithm": "medium", "perf": 754.047},
+{"m": 28, "n": 7, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 256, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 768.773},
+{"m": 28, "n": 7, "k": 45, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 768.667},
+{"m": 28, "n": 9, "k": 4, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 24, "minblocks": 11, "algorithm": "medium", "perf": 686.434},
+{"m": 28, "n": 9, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 22, "minblocks": 19, "algorithm": "medium", "perf": 738.32},
+{"m": 28, "n": 9, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 26, "minblocks": 16, "algorithm": "medium", "perf": 808.579},
+{"m": 28, "n": 9, "k": 9, "tile_m": 1, "tile_n": 3, "threads": 96, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 825.886},
+{"m": 28, "n": 9, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 844.884},
+{"m": 28, "n": 9, "k": 25, "tile_m": 1, "tile_n": 3, "threads": 256, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 895.124},
+{"m": 28, "n": 9, "k": 26, "tile_m": 1, "tile_n": 3, "threads": 256, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 891.424},
+{"m": 28, "n": 9, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 256, "grouping": 5, "minblocks": 5, "algorithm": "medium", "perf": 897.496},
+{"m": 28, "n": 9, "k": 32, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 918.668},
+{"m": 28, "n": 9, "k": 45, "tile_m": 1, "tile_n": 3, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 930.129},
+{"m": 28, "n": 13, "k": 4, "tile_m": 2, "tile_n": 4, "threads": 64, "grouping": 26, "minblocks": 7, "algorithm": "medium", "perf": 836.442},
+{"m": 28, "n": 13, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 12, "minblocks": 12, "algorithm": "medium", "perf": 827.406},
+{"m": 28, "n": 13, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 26, "minblocks": 11, "algorithm": "medium", "perf": 960.632},
+{"m": 28, "n": 13, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 996.46},
+{"m": 28, "n": 13, "k": 13, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 4, "minblocks": 10, "algorithm": "medium", "perf": 1030.59},
+{"m": 28, "n": 13, "k": 25, "tile_m": 1, "tile_n": 3, "threads": 192, "grouping": 5, "minblocks": 5, "algorithm": "medium", "perf": 1115.36},
+{"m": 28, "n": 13, "k": 26, "tile_m": 1, "tile_n": 3, "threads": 160, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 1114.24},
+{"m": 28, "n": 13, "k": 28, "tile_m": 1, "tile_n": 4, "w": 10, "v": 12, "threads": 128, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1122.82},
+{"m": 28, "n": 13, "k": 32, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 24, "minblocks": 4, "algorithm": "medium", "perf": 1145.54},
+{"m": 28, "n": 13, "k": 45, "tile_m": 1, "tile_n": 7, "w": 12, "v": 8, "threads": 64, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 1176.78},
+{"m": 28, "n": 25, "k": 4, "tile_m": 4, "tile_n": 3, "threads": 64, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 1029.26},
+{"m": 28, "n": 25, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 160, "grouping": 9, "minblocks": 8, "algorithm": "medium", "perf": 1103.4},
+{"m": 28, "n": 25, "k": 7, "tile_m": 5, "tile_n": 3, "threads": 64, "grouping": 24, "minblocks": 2, "algorithm": "medium", "perf": 1185.57},
+{"m": 28, "n": 25, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 160, "grouping": 10, "minblocks": 7, "algorithm": "medium", "perf": 1283.85},
+{"m": 28, "n": 25, "k": 13, "tile_m": 1, "tile_n": 5, "threads": 160, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1423.58},
+{"m": 28, "n": 25, "k": 25, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 1582.11},
+{"m": 28, "n": 25, "k": 26, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 1581.68},
+{"m": 28, "n": 25, "k": 28, "tile_m": 1, "tile_n": 5, "threads": 160, "grouping": 24, "minblocks": 4, "algorithm": "medium", "perf": 1601.02},
+{"m": 28, "n": 25, "k": 32, "tile_m": 3, "tile_n": 3, "threads": 128, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 1631.38},
+{"m": 28, "n": 25, "k": 45, "tile_m": 3, "tile_n": 5, "w": 12, "v": 14, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1683.73},
+{"m": 28, "n": 26, "k": 4, "tile_m": 4, "tile_n": 3, "threads": 64, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 1046.4},
+{"m": 28, "n": 26, "k": 5, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 9, "minblocks": 8, "algorithm": "medium", "perf": 1116.46},
+{"m": 28, "n": 26, "k": 7, "tile_m": 5, "tile_n": 3, "threads": 64, "grouping": 25, "minblocks": 4, "algorithm": "medium", "perf": 1206.91},
+{"m": 28, "n": 26, "k": 9, "tile_m": 5, "tile_n": 3, "threads": 64, "grouping": 21, "minblocks": 2, "algorithm": "medium", "perf": 1308.19},
+{"m": 28, "n": 26, "k": 13, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 5, "minblocks": 5, "algorithm": "medium", "perf": 1440.64},
+{"m": 28, "n": 26, "k": 25, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1615.94},
+{"m": 28, "n": 26, "k": 26, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 1620.78},
+{"m": 28, "n": 26, "k": 28, "tile_m": 3, "tile_n": 3, "threads": 96, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 1637.82},
+{"m": 28, "n": 26, "k": 32, "tile_m": 3, "tile_n": 3, "threads": 128, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 1665.27},
+{"m": 28, "n": 26, "k": 45, "tile_m": 3, "tile_n": 3, "w": 16, "v": 26, "threads": 96, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1738.17},
+{"m": 28, "n": 28, "k": 4, "tile_m": 2, "tile_n": 4, "threads": 128, "grouping": 24, "minblocks": 3, "algorithm": "medium", "perf": 1053.5},
+{"m": 28, "n": 28, "k": 5, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 9, "minblocks": 7, "algorithm": "medium", "perf": 1153.08},
+{"m": 28, "n": 28, "k": 7, "tile_m": 5, "tile_n": 3, "threads": 64, "grouping": 25, "minblocks": 3, "algorithm": "medium", "perf": 1291.9},
+{"m": 28, "n": 28, "k": 9, "tile_m": 5, "tile_n": 3, "threads": 64, "grouping": 29, "minblocks": 3, "algorithm": "medium", "perf": 1407.79},
+{"m": 28, "n": 28, "k": 13, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 5, "minblocks": 6, "algorithm": "medium", "perf": 1560.57},
+{"m": 28, "n": 28, "k": 25, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 1712.97},
+{"m": 28, "n": 28, "k": 26, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1708.21},
+{"m": 28, "n": 28, "k": 28, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 1700.13},
+{"m": 28, "n": 28, "k": 32, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1753.32},
+{"m": 28, "n": 28, "k": 45, "tile_m": 5, "tile_n": 3, "w": 8, "v": 14, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1784.75},
+{"m": 28, "n": 32, "k": 4, "tile_m": 3, "tile_n": 2, "threads": 160, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1074.89},
+{"m": 28, "n": 32, "k": 5, "tile_m": 1, "tile_n": 4, "threads": 224, "grouping": 9, "minblocks": 6, "algorithm": "medium", "perf": 1179.11},
+{"m": 28, "n": 32, "k": 7, "tile_m": 1, "tile_n": 4, "threads": 256, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1331.58},
+{"m": 28, "n": 32, "k": 9, "tile_m": 4, "tile_n": 4, "threads": 64, "grouping": 29, "minblocks": 2, "algorithm": "medium", "perf": 1423.42},
+{"m": 28, "n": 32, "k": 13, "tile_m": 3, "tile_n": 2, "threads": 160, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1552.86},
+{"m": 28, "n": 32, "k": 25, "tile_m": 1, "tile_n": 4, "threads": 224, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 1787.13},
+{"m": 28, "n": 32, "k": 26, "tile_m": 1, "tile_n": 4, "threads": 256, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 1777.2},
+{"m": 28, "n": 32, "k": 28, "tile_m": 5, "tile_n": 2, "threads": 96, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1795.81},
+{"m": 28, "n": 32, "k": 32, "tile_m": 5, "tile_n": 2, "w": 16, "v": 18, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1849.83},
+{"m": 28, "n": 32, "k": 45, "tile_m": 3, "tile_n": 6, "w": 10, "v": 16, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1909.3},
+{"m": 28, "n": 45, "k": 4, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 29, "minblocks": 1, "algorithm": "medium", "perf": 1163.62},
+{"m": 28, "n": 45, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 256, "grouping": 16, "minblocks": 4, "algorithm": "medium", "perf": 1262.25},
+{"m": 28, "n": 45, "k": 7, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 25, "minblocks": 4, "algorithm": "medium", "perf": 1441},
+{"m": 28, "n": 45, "k": 9, "tile_m": 3, "tile_n": 4, "threads": 128, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 1569.32},
+{"m": 28, "n": 45, "k": 13, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 24, "minblocks": 4, "algorithm": "medium", "perf": 1754.86},
+{"m": 28, "n": 45, "k": 25, "tile_m": 3, "tile_n": 4, "threads": 128, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 1976.24},
+{"m": 28, "n": 45, "k": 26, "tile_m": 3, "tile_n": 4, "threads": 128, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 1998.55},
+{"m": 28, "n": 45, "k": 28, "tile_m": 7, "tile_n": 3, "w": 8, "v": 20, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 2023.14},
+{"m": 28, "n": 45, "k": 32, "tile_m": 7, "tile_n": 3, "w": 8, "v": 20, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 2082.87},
+{"m": 28, "n": 45, "k": 45, "tile_m": 7, "tile_n": 3, "w": 8, "v": 40, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 2164.99},
+{"m": 29, "n": 14, "k": 14, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 6, "minblocks": 9, "algorithm": "medium", "perf": 1094.19},
+{"m": 29, "n": 14, "k": 16, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 5, "minblocks": 8, "algorithm": "medium", "perf": 1132.98},
+{"m": 29, "n": 14, "k": 29, "tile_m": 3, "tile_n": 3, "w": 12, "v": 14, "threads": 64, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 1191.43},
+{"m": 29, "n": 14, "k": 32, "tile_m": 3, "tile_n": 3, "threads": 64, "grouping": 29, "minblocks": 1, "algorithm": "medium", "perf": 1211.15},
+{"m": 29, "n": 16, "k": 14, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 4, "minblocks": 9, "algorithm": "medium", "perf": 1200.6},
+{"m": 29, "n": 16, "k": 16, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 4, "minblocks": 8, "algorithm": "medium", "perf": 1237.1},
+{"m": 29, "n": 16, "k": 29, "tile_m": 3, "tile_n": 1, "w": 10, "v": 14, "threads": 160, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1302.52},
+{"m": 29, "n": 16, "k": 55, "tile_m": 3, "tile_n": 3, "w": 14, "v": 16, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1381.48},
+{"m": 29, "n": 29, "k": 14, "tile_m": 3, "tile_n": 2, "threads": 160, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 1562.65},
+{"m": 29, "n": 29, "k": 16, "tile_m": 3, "tile_n": 2, "threads": 160, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 1616.32},
+{"m": 29, "n": 29, "k": 29, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 24, "minblocks": 3, "algorithm": "medium", "perf": 1736.13},
+{"m": 29, "n": 29, "k": 32, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1807.51},
+{"m": 29, "n": 29, "k": 55, "tile_m": 3, "tile_n": 5, "w": 12, "v": 26, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1881.61},
+{"m": 29, "n": 32, "k": 14, "tile_m": 3, "tile_n": 2, "threads": 192, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1630.9},
+{"m": 29, "n": 32, "k": 29, "tile_m": 5, "tile_n": 2, "w": 12, "v": 28, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1818.21},
+{"m": 29, "n": 32, "k": 32, "tile_m": 3, "tile_n": 3, "threads": 128, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 1865.52},
+{"m": 29, "n": 32, "k": 55, "tile_m": 3, "tile_n": 6, "w": 10, "v": 32, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1977.23},
+{"m": 29, "n": 55, "k": 16, "tile_m": 3, "tile_n": 5, "threads": 128, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 1958.07},
+{"m": 29, "n": 55, "k": 29, "tile_m": 3, "tile_n": 5, "threads": 128, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 2173.7},
+{"m": 29, "n": 55, "k": 32, "tile_m": 4, "tile_n": 7, "w": 8, "v": 36, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 2227.18},
+{"m": 29, "n": 55, "k": 55, "tile_m": 5, "tile_n": 6, "w": 6, "v": 36, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 2364.15},
+{"m": 30, "n": 30, "k": 30, "tile_m": 5, "tile_n": 3, "threads": 64, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 1838.1},
+{"m": 31, "n": 31, "k": 31, "tile_m": 4, "tile_n": 4, "threads": 64, "grouping": 24, "minblocks": 1, "algorithm": "medium", "perf": 1830.67},
+{"m": 32, "n": 4, "k": 4, "tile_m": 1, "tile_n": 6, "threads": 32, "grouping": 13, "minblocks": 2, "algorithm": "medium", "perf": 463.773},
+{"m": 32, "n": 4, "k": 5, "tile_m": 1, "tile_n": 4, "threads": 32, "grouping": 16, "minblocks": 13, "algorithm": "medium", "perf": 469.138},
+{"m": 32, "n": 4, "k": 7, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 24, "minblocks": 7, "algorithm": "medium", "perf": 479.728},
+{"m": 32, "n": 4, "k": 9, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 6, "minblocks": 15, "algorithm": "medium", "perf": 482.038},
+{"m": 32, "n": 4, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 11, "algorithm": "medium", "perf": 493.254},
+{"m": 32, "n": 4, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 160, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 498.236},
+{"m": 32, "n": 4, "k": 26, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 3, "minblocks": 5, "algorithm": "medium", "perf": 498.907},
+{"m": 32, "n": 4, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 256, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 503.858},
+{"m": 32, "n": 4, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 510.352},
+{"m": 32, "n": 4, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 514.431},
+{"m": 32, "n": 5, "k": 4, "tile_m": 1, "tile_n": 5, "threads": 32, "grouping": 17, "minblocks": 26, "algorithm": "medium", "perf": 521.537},
+{"m": 32, "n": 5, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 32, "grouping": 16, "minblocks": 14, "algorithm": "medium", "perf": 535.38},
+{"m": 32, "n": 5, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 26, "minblocks": 13, "algorithm": "medium", "perf": 556.583},
+{"m": 32, "n": 5, "k": 9, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 29, "minblocks": 9, "algorithm": "medium", "perf": 568.533},
+{"m": 32, "n": 5, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 96, "grouping": 32, "minblocks": 5, "algorithm": "medium", "perf": 578.088},
+{"m": 32, "n": 5, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 571.398},
+{"m": 32, "n": 5, "k": 16, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 32, "minblocks": 7, "algorithm": "medium", "perf": 590.624},
+{"m": 32, "n": 5, "k": 24, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 5, "minblocks": 5, "algorithm": "medium", "perf": 595.227},
+{"m": 32, "n": 5, "k": 25, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 593.569},
+{"m": 32, "n": 5, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 597.402},
+{"m": 32, "n": 5, "k": 28, "tile_m": 1, "tile_n": 1, "threads": 192, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 604.614},
+{"m": 32, "n": 5, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 611.583},
+{"m": 32, "n": 5, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 618.945},
+{"m": 32, "n": 7, "k": 4, "tile_m": 2, "tile_n": 4, "threads": 32, "grouping": 19, "minblocks": 13, "algorithm": "medium", "perf": 635.452},
+{"m": 32, "n": 7, "k": 5, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 22, "minblocks": 4, "algorithm": "medium", "perf": 657.342},
+{"m": 32, "n": 7, "k": 7, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 26, "minblocks": 7, "algorithm": "medium", "perf": 710.551},
+{"m": 32, "n": 7, "k": 9, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 26, "minblocks": 12, "algorithm": "medium", "perf": 727.544},
+{"m": 32, "n": 7, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 32, "minblocks": 6, "algorithm": "medium", "perf": 739.552},
+{"m": 32, "n": 7, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 775.794},
+{"m": 32, "n": 7, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 776.845},
+{"m": 32, "n": 7, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 224, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 780.958},
+{"m": 32, "n": 7, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 256, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 799.863},
+{"m": 32, "n": 7, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 803.204},
+{"m": 32, "n": 9, "k": 4, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 24, "minblocks": 11, "algorithm": "medium", "perf": 719.416},
+{"m": 32, "n": 9, "k": 5, "tile_m": 1, "tile_n": 6, "threads": 64, "grouping": 23, "minblocks": 13, "algorithm": "medium", "perf": 768.086},
+{"m": 32, "n": 9, "k": 7, "tile_m": 1, "tile_n": 6, "threads": 64, "grouping": 25, "minblocks": 14, "algorithm": "medium", "perf": 830.63},
+{"m": 32, "n": 9, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 853.67},
+{"m": 32, "n": 9, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 873.679},
+{"m": 32, "n": 9, "k": 22, "tile_m": 1, "tile_n": 3, "threads": 224, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 922.783},
+{"m": 32, "n": 9, "k": 25, "tile_m": 1, "tile_n": 3, "threads": 256, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 926.612},
+{"m": 32, "n": 9, "k": 26, "tile_m": 1, "tile_n": 3, "threads": 256, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 937.269},
+{"m": 32, "n": 9, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 160, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 943.269},
+{"m": 32, "n": 9, "k": 32, "tile_m": 1, "tile_n": 3, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 954.006},
+{"m": 32, "n": 9, "k": 45, "tile_m": 1, "tile_n": 3, "w": 10, "v": 4, "threads": 96, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 967.274},
+{"m": 32, "n": 12, "k": 5, "tile_m": 1, "tile_n": 6, "threads": 64, "grouping": 26, "minblocks": 12, "algorithm": "medium", "perf": 908.801},
+{"m": 32, "n": 12, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 160, "grouping": 5, "minblocks": 9, "algorithm": "medium", "perf": 1047.84},
+{"m": 32, "n": 12, "k": 13, "tile_m": 1, "tile_n": 4, "threads": 160, "grouping": 4, "minblocks": 9, "algorithm": "medium", "perf": 1058.78},
+{"m": 32, "n": 12, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 1144.79},
+{"m": 32, "n": 12, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 1176.59},
+{"m": 32, "n": 13, "k": 4, "tile_m": 2, "tile_n": 4, "threads": 64, "grouping": 26, "minblocks": 1, "algorithm": "medium", "perf": 880.033},
+{"m": 32, "n": 13, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 24, "minblocks": 11, "algorithm": "medium", "perf": 897.283},
+{"m": 32, "n": 13, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 29, "minblocks": 11, "algorithm": "medium", "perf": 1013.1},
+{"m": 32, "n": 13, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 1040.81},
+{"m": 32, "n": 13, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 160, "grouping": 5, "minblocks": 9, "algorithm": "medium", "perf": 1085.48},
+{"m": 32, "n": 13, "k": 13, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 4, "minblocks": 8, "algorithm": "medium", "perf": 1085.19},
+{"m": 32, "n": 13, "k": 14, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 1105.19},
+{"m": 32, "n": 13, "k": 16, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 1140.15},
+{"m": 32, "n": 13, "k": 24, "tile_m": 1, "tile_n": 4, "w": 12, "v": 10, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1184.2},
+{"m": 32, "n": 13, "k": 25, "tile_m": 1, "tile_n": 3, "threads": 224, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 1177.19},
+{"m": 32, "n": 13, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 224, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 1192.35},
+{"m": 32, "n": 13, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 224, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 1204.64},
+{"m": 32, "n": 13, "k": 32, "tile_m": 1, "tile_n": 3, "threads": 192, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 1221.29},
+{"m": 32, "n": 13, "k": 45, "tile_m": 1, "tile_n": 3, "w": 12, "v": 8, "threads": 160, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1240.12},
+{"m": 32, "n": 14, "k": 13, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 4, "minblocks": 9, "algorithm": "medium", "perf": 1143.59},
+{"m": 32, "n": 14, "k": 14, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 5, "minblocks": 8, "algorithm": "medium", "perf": 1160.77},
+{"m": 32, "n": 14, "k": 25, "tile_m": 1, "tile_n": 3, "threads": 224, "grouping": 3, "minblocks": 5, "algorithm": "medium", "perf": 1240.88},
+{"m": 32, "n": 14, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 224, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 1258.77},
+{"m": 32, "n": 14, "k": 29, "tile_m": 1, "tile_n": 3, "threads": 160, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 1262.69},
+{"m": 32, "n": 14, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 224, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 1286.87},
+{"m": 32, "n": 16, "k": 5, "tile_m": 1, "tile_n": 6, "threads": 96, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 1010.78},
+{"m": 32, "n": 16, "k": 13, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 4, "minblocks": 9, "algorithm": "medium", "perf": 1239.79},
+{"m": 32, "n": 16, "k": 16, "tile_m": 1, "tile_n": 4, "threads": 160, "grouping": 5, "minblocks": 7, "algorithm": "medium", "perf": 1289.33},
+{"m": 32, "n": 16, "k": 32, "tile_m": 1, "tile_n": 4, "w": 12, "v": 16, "threads": 128, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1400.34},
+{"m": 32, "n": 22, "k": 9, "tile_m": 1, "tile_n": 6, "threads": 128, "grouping": 6, "minblocks": 8, "algorithm": "medium", "perf": 1313.03},
+{"m": 32, "n": 22, "k": 22, "tile_m": 1, "tile_n": 4, "threads": 192, "grouping": 5, "minblocks": 4, "algorithm": "medium", "perf": 1573.89},
+{"m": 32, "n": 22, "k": 32, "tile_m": 1, "tile_n": 3, "threads": 256, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 1639.19},
+{"m": 32, "n": 24, "k": 5, "tile_m": 1, "tile_n": 4, "threads": 192, "grouping": 9, "minblocks": 7, "algorithm": "medium", "perf": 1147.88},
+{"m": 32, "n": 24, "k": 13, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1516.34},
+{"m": 32, "n": 24, "k": 24, "tile_m": 1, "tile_n": 6, "threads": 128, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 1673.42},
+{"m": 32, "n": 24, "k": 26, "tile_m": 1, "tile_n": 4, "threads": 224, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 1689.58},
+{"m": 32, "n": 24, "k": 32, "tile_m": 1, "tile_n": 4, "w": 16, "v": 24, "threads": 192, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1736.99},
+{"m": 32, "n": 25, "k": 4, "tile_m": 1, "tile_n": 5, "threads": 192, "grouping": 12, "minblocks": 7, "algorithm": "medium", "perf": 1051.58},
+{"m": 32, "n": 25, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 192, "grouping": 9, "minblocks": 7, "algorithm": "medium", "perf": 1163.15},
+{"m": 32, "n": 25, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 256, "grouping": 16, "minblocks": 5, "algorithm": "medium", "perf": 1273.22},
+{"m": 32, "n": 25, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 160, "grouping": 6, "minblocks": 7, "algorithm": "medium", "perf": 1389.05},
+{"m": 32, "n": 25, "k": 13, "tile_m": 1, "tile_n": 5, "threads": 160, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 1543.97},
+{"m": 32, "n": 25, "k": 14, "tile_m": 1, "tile_n": 5, "threads": 160, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1565.97},
+{"m": 32, "n": 25, "k": 25, "tile_m": 1, "tile_n": 5, "threads": 160, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 1683.41},
+{"m": 32, "n": 25, "k": 26, "tile_m": 1, "tile_n": 5, "threads": 192, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 1695.86},
+{"m": 32, "n": 25, "k": 28, "tile_m": 1, "tile_n": 5, "threads": 224, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 1709.63},
+{"m": 32, "n": 25, "k": 32, "tile_m": 1, "tile_n": 5, "threads": 256, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 1751.37},
+{"m": 32, "n": 25, "k": 45, "tile_m": 3, "tile_n": 5, "w": 16, "v": 20, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1795.15},
+{"m": 32, "n": 26, "k": 4, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 10, "minblocks": 7, "algorithm": "medium", "perf": 1059.64},
+{"m": 32, "n": 26, "k": 5, "tile_m": 1, "tile_n": 6, "threads": 192, "grouping": 24, "minblocks": 6, "algorithm": "medium", "perf": 1158.06},
+{"m": 32, "n": 26, "k": 7, "tile_m": 5, "tile_n": 3, "threads": 64, "grouping": 24, "minblocks": 3, "algorithm": "medium", "perf": 1280.12},
+{"m": 32, "n": 26, "k": 9, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 6, "minblocks": 7, "algorithm": "medium", "perf": 1392.26},
+{"m": 32, "n": 26, "k": 12, "tile_m": 5, "tile_n": 3, "threads": 64, "grouping": 24, "minblocks": 1, "algorithm": "medium", "perf": 1502.2},
+{"m": 32, "n": 26, "k": 13, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 5, "minblocks": 6, "algorithm": "medium", "perf": 1540.86},
+{"m": 32, "n": 26, "k": 14, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 1592.55},
+{"m": 32, "n": 26, "k": 24, "tile_m": 5, "tile_n": 3, "w": 12, "v": 26, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1704.87},
+{"m": 32, "n": 26, "k": 25, "tile_m": 5, "tile_n": 3, "threads": 64, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 1702.43},
+{"m": 32, "n": 26, "k": 26, "tile_m": 1, "tile_n": 4, "threads": 224, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 1710.53},
+{"m": 32, "n": 26, "k": 28, "tile_m": 2, "tile_n": 5, "w": 14, "v": 24, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1736.93},
+{"m": 32, "n": 26, "k": 32, "tile_m": 1, "tile_n": 5, "w": 16, "v": 26, "threads": 192, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1778.77},
+{"m": 32, "n": 26, "k": 45, "tile_m": 2, "tile_n": 7, "w": 12, "v": 26, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1845.15},
+{"m": 32, "n": 28, "k": 4, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1093.69},
+{"m": 32, "n": 28, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 192, "grouping": 10, "minblocks": 6, "algorithm": "medium", "perf": 1203.06},
+{"m": 32, "n": 28, "k": 7, "tile_m": 1, "tile_n": 4, "threads": 256, "grouping": 24, "minblocks": 6, "algorithm": "medium", "perf": 1352.54},
+{"m": 32, "n": 28, "k": 9, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 6, "minblocks": 6, "algorithm": "medium", "perf": 1453.34},
+{"m": 32, "n": 28, "k": 13, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1612.39},
+{"m": 32, "n": 28, "k": 25, "tile_m": 1, "tile_n": 4, "threads": 224, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 1803.09},
+{"m": 32, "n": 28, "k": 26, "tile_m": 1, "tile_n": 4, "threads": 224, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 1791.09},
+{"m": 32, "n": 28, "k": 28, "tile_m": 2, "tile_n": 7, "w": 10, "v": 26, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1810.27},
+{"m": 32, "n": 28, "k": 32, "tile_m": 1, "tile_n": 5, "w": 16, "v": 28, "threads": 192, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1860.59},
+{"m": 32, "n": 28, "k": 45, "tile_m": 2, "tile_n": 7, "w": 12, "v": 8, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1916.4},
+{"m": 32, "n": 29, "k": 14, "tile_m": 1, "tile_n": 6, "threads": 160, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 1690.58},
+{"m": 32, "n": 29, "k": 29, "tile_m": 1, "tile_n": 5, "threads": 192, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 1821.2},
+{"m": 32, "n": 29, "k": 32, "tile_m": 1, "tile_n": 5, "threads": 192, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 1879.76},
+{"m": 32, "n": 29, "k": 55, "tile_m": 6, "tile_n": 3, "w": 14, "v": 18, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1972.82},
+{"m": 32, "n": 32, "k": 4, "tile_m": 2, "tile_n": 4, "threads": 128, "grouping": 29, "minblocks": 1, "algorithm": "medium", "perf": 1153.41},
+{"m": 32, "n": 32, "k": 5, "tile_m": 1, "tile_n": 6, "threads": 192, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1275.62},
+{"m": 32, "n": 32, "k": 7, "tile_m": 4, "tile_n": 4, "threads": 64, "grouping": 29, "minblocks": 1, "algorithm": "medium", "perf": 1445.13},
+{"m": 32, "n": 32, "k": 9, "tile_m": 4, "tile_n": 4, "threads": 64, "grouping": 30, "minblocks": 2, "algorithm": "medium", "perf": 1569.35},
+{"m": 32, "n": 32, "k": 12, "tile_m": 1, "tile_n": 6, "threads": 192, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1716.9},
+{"m": 32, "n": 32, "k": 13, "tile_m": 1, "tile_n": 6, "threads": 192, "grouping": 5, "minblocks": 5, "algorithm": "medium", "perf": 1747.15},
+{"m": 32, "n": 32, "k": 14, "tile_m": 1, "tile_n": 6, "threads": 192, "grouping": 5, "minblocks": 5, "algorithm": "medium", "perf": 1782.16},
+{"m": 32, "n": 32, "k": 16, "tile_m": 1, "tile_n": 6, "threads": 192, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 1837.55},
+{"m": 32, "n": 32, "k": 22, "tile_m": 1, "tile_n": 4, "threads": 256, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 1920.38},
+{"m": 32, "n": 32, "k": 24, "tile_m": 4, "tile_n": 4, "threads": 64, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 1928.13},
+{"m": 32, "n": 32, "k": 25, "tile_m": 1, "tile_n": 4, "threads": 256, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 1922.43},
+{"m": 32, "n": 32, "k": 26, "tile_m": 1, "tile_n": 4, "threads": 256, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 1932.91},
+{"m": 32, "n": 32, "k": 28, "tile_m": 4, "tile_n": 4, "threads": 64, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 1945.61},
+{"m": 32, "n": 32, "k": 29, "tile_m": 1, "tile_n": 4, "threads": 256, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 1953.05},
+{"m": 32, "n": 32, "k": 32, "tile_m": 4, "tile_n": 4, "w": 8, "v": 32, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1988.65},
+{"m": 32, "n": 32, "k": 45, "tile_m": 2, "tile_n": 8, "w": 10, "v": 16, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 2049.85},
+{"m": 32, "n": 32, "k": 55, "tile_m": 2, "tile_n": 8, "w": 10, "v": 32, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 2095.89},
+{"m": 32, "n": 45, "k": 4, "tile_m": 2, "tile_n": 6, "threads": 192, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 1189.96},
+{"m": 32, "n": 45, "k": 5, "tile_m": 1, "tile_n": 6, "threads": 256, "grouping": 24, "minblocks": 4, "algorithm": "medium", "perf": 1353.3},
+{"m": 32, "n": 45, "k": 7, "tile_m": 1, "tile_n": 6, "threads": 256, "grouping": 26, "minblocks": 4, "algorithm": "medium", "perf": 1511.94},
+{"m": 32, "n": 45, "k": 9, "tile_m": 4, "tile_n": 4, "threads": 96, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 1646.51},
+{"m": 32, "n": 45, "k": 13, "tile_m": 2, "tile_n": 6, "threads": 128, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 1808.85},
+{"m": 32, "n": 45, "k": 25, "tile_m": 5, "tile_n": 5, "w": 8, "v": 40, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 2094.65},
+{"m": 32, "n": 45, "k": 26, "tile_m": 5, "tile_n": 5, "w": 6, "v": 24, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 2121.03},
+{"m": 32, "n": 45, "k": 28, "tile_m": 5, "tile_n": 5, "w": 8, "v": 34, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 2167.72},
+{"m": 32, "n": 45, "k": 32, "tile_m": 5, "tile_n": 5, "w": 8, "v": 30, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 2242.67},
+{"m": 32, "n": 45, "k": 45, "tile_m": 5, "tile_n": 5, "w": 8, "v": 16, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 2335},
+{"m": 32, "n": 55, "k": 29, "tile_m": 4, "tile_n": 7, "w": 14, "v": 36, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 2308.45},
+{"m": 32, "n": 55, "k": 32, "tile_m": 4, "tile_n": 7, "w": 8, "v": 38, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 2402.8},
+{"m": 32, "n": 55, "k": 55, "tile_m": 6, "tile_n": 6, "w": 12, "v": 20, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 2483.08},
+{"m": 45, "n": 4, "k": 4, "tile_m": 6, "tile_n": 1, "threads": 64, "grouping": 19, "minblocks": 16, "algorithm": "medium", "perf": 447.443},
+{"m": 45, "n": 4, "k": 5, "tile_m": 6, "tile_n": 1, "threads": 64, "grouping": 25, "minblocks": 16, "algorithm": "medium", "perf": 452.508},
+{"m": 45, "n": 4, "k": 7, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 24, "minblocks": 2, "algorithm": "medium", "perf": 473.476},
+{"m": 45, "n": 4, "k": 9, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 29, "minblocks": 6, "algorithm": "medium", "perf": 479.338},
+{"m": 45, "n": 4, "k": 13, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 6, "minblocks": 4, "algorithm": "medium", "perf": 488.528},
+{"m": 45, "n": 4, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 509.978},
+{"m": 45, "n": 4, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 511.579},
+{"m": 45, "n": 4, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 517.616},
+{"m": 45, "n": 4, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 256, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 524.404},
+{"m": 45, "n": 4, "k": 45, "tile_m": 1, "tile_n": 2, "threads": 256, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 530.028},
+{"m": 45, "n": 5, "k": 4, "tile_m": 1, "tile_n": 6, "threads": 64, "grouping": 26, "minblocks": 10, "algorithm": "medium", "perf": 511.613},
+{"m": 45, "n": 5, "k": 5, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 26, "minblocks": 10, "algorithm": "medium", "perf": 529.849},
+{"m": 45, "n": 5, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 32, "minblocks": 7, "algorithm": "medium", "perf": 554.528},
+{"m": 45, "n": 5, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 26, "minblocks": 11, "algorithm": "medium", "perf": 565.503},
+{"m": 45, "n": 5, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 4, "minblocks": 9, "algorithm": "medium", "perf": 581.404},
+{"m": 45, "n": 5, "k": 25, "tile_m": 1, "tile_n": 3, "threads": 192, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 614.32},
+{"m": 45, "n": 5, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 613.164},
+{"m": 45, "n": 5, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 256, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 622.314},
+{"m": 45, "n": 5, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 256, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 630.744},
+{"m": 45, "n": 5, "k": 45, "tile_m": 1, "tile_n": 1, "threads": 256, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 638.115},
+{"m": 45, "n": 7, "k": 4, "tile_m": 5, "tile_n": 1, "threads": 64, "grouping": 25, "minblocks": 14, "algorithm": "medium", "perf": 640.697},
+{"m": 45, "n": 7, "k": 5, "tile_m": 5, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 17, "algorithm": "medium", "perf": 669.324},
+{"m": 45, "n": 7, "k": 7, "tile_m": 6, "tile_n": 1, "threads": 64, "grouping": 32, "minblocks": 11, "algorithm": "medium", "perf": 712.064},
+{"m": 45, "n": 7, "k": 9, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 727.757},
+{"m": 45, "n": 7, "k": 13, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 24, "minblocks": 4, "algorithm": "medium", "perf": 753.039},
+{"m": 45, "n": 7, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 807.2},
+{"m": 45, "n": 7, "k": 26, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 815.315},
+{"m": 45, "n": 7, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 256, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 821.715},
+{"m": 45, "n": 7, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 256, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 837.239},
+{"m": 45, "n": 7, "k": 45, "tile_m": 1, "tile_n": 2, "w": 12, "v": 4, "threads": 192, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 833.545},
+{"m": 45, "n": 9, "k": 4, "tile_m": 3, "tile_n": 3, "threads": 64, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 735.448},
+{"m": 45, "n": 9, "k": 5, "tile_m": 3, "tile_n": 3, "threads": 64, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 771.229},
+{"m": 45, "n": 9, "k": 7, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 32, "minblocks": 12, "algorithm": "medium", "perf": 843.763},
+{"m": 45, "n": 9, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 32, "minblocks": 11, "algorithm": "medium", "perf": 864.971},
+{"m": 45, "n": 9, "k": 13, "tile_m": 1, "tile_n": 3, "threads": 160, "grouping": 5, "minblocks": 3, "algorithm": "medium", "perf": 908.669},
+{"m": 45, "n": 9, "k": 25, "tile_m": 1, "tile_n": 3, "threads": 256, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 980.24},
+{"m": 45, "n": 9, "k": 26, "tile_m": 1, "tile_n": 3, "threads": 256, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 988.361},
+{"m": 45, "n": 9, "k": 28, "tile_m": 1, "tile_n": 2, "threads": 256, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 997.761},
+{"m": 45, "n": 9, "k": 32, "tile_m": 1, "tile_n": 3, "threads": 160, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1009.32},
+{"m": 45, "n": 9, "k": 45, "tile_m": 1, "tile_n": 3, "threads": 256, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 1014.45},
+{"m": 45, "n": 13, "k": 4, "tile_m": 5, "tile_n": 2, "threads": 64, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 885.5},
+{"m": 45, "n": 13, "k": 5, "tile_m": 5, "tile_n": 1, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 912.85},
+{"m": 45, "n": 13, "k": 7, "tile_m": 5, "tile_n": 1, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 1016.11},
+{"m": 45, "n": 13, "k": 9, "tile_m": 5, "tile_n": 1, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 1076.14},
+{"m": 45, "n": 13, "k": 13, "tile_m": 1, "tile_n": 5, "threads": 192, "grouping": 5, "minblocks": 6, "algorithm": "medium", "perf": 1153.04},
+{"m": 45, "n": 13, "k": 25, "tile_m": 3, "tile_n": 4, "w": 8, "v": 10, "threads": 64, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 1237.7},
+{"m": 45, "n": 13, "k": 26, "tile_m": 3, "tile_n": 4, "w": 8, "v": 12, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1247.69},
+{"m": 45, "n": 13, "k": 28, "tile_m": 5, "tile_n": 2, "w": 14, "v": 12, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1268.39},
+{"m": 45, "n": 13, "k": 32, "tile_m": 5, "tile_n": 2, "w": 12, "v": 10, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1290.64},
+{"m": 45, "n": 13, "k": 45, "tile_m": 5, "tile_n": 2, "w": 12, "v": 12, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1334.66},
+{"m": 45, "n": 25, "k": 4, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 29, "minblocks": 4, "algorithm": "medium", "perf": 1027.95},
+{"m": 45, "n": 25, "k": 5, "tile_m": 5, "tile_n": 2, "threads": 128, "grouping": 24, "minblocks": 4, "algorithm": "medium", "perf": 1152.55},
+{"m": 45, "n": 25, "k": 7, "tile_m": 5, "tile_n": 3, "threads": 96, "grouping": 24, "minblocks": 1, "algorithm": "medium", "perf": 1310.14},
+{"m": 45, "n": 25, "k": 9, "tile_m": 5, "tile_n": 2, "threads": 128, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 1429.19},
+{"m": 45, "n": 25, "k": 13, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 24, "minblocks": 4, "algorithm": "medium", "perf": 1595.31},
+{"m": 45, "n": 25, "k": 25, "tile_m": 3, "tile_n": 7, "w": 10, "v": 14, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1830.75},
+{"m": 45, "n": 25, "k": 26, "tile_m": 5, "tile_n": 4, "w": 10, "v": 12, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1854.31},
+{"m": 45, "n": 25, "k": 28, "tile_m": 5, "tile_n": 4, "w": 12, "v": 22, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1879.95},
+{"m": 45, "n": 25, "k": 32, "tile_m": 5, "tile_n": 4, "w": 8, "v": 12, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1929.59},
+{"m": 45, "n": 25, "k": 45, "tile_m": 5, "tile_n": 4, "w": 12, "v": 16, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 2025.82},
+{"m": 45, "n": 26, "k": 4, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 29, "minblocks": 4, "algorithm": "medium", "perf": 1069.89},
+{"m": 45, "n": 26, "k": 5, "tile_m": 3, "tile_n": 3, "threads": 160, "grouping": 24, "minblocks": 4, "algorithm": "medium", "perf": 1144.5},
+{"m": 45, "n": 26, "k": 7, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 24, "minblocks": 4, "algorithm": "medium", "perf": 1348.87},
+{"m": 45, "n": 26, "k": 9, "tile_m": 5, "tile_n": 2, "threads": 128, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 1480.85},
+{"m": 45, "n": 26, "k": 13, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 24, "minblocks": 3, "algorithm": "medium", "perf": 1643.06},
+{"m": 45, "n": 26, "k": 25, "tile_m": 5, "tile_n": 4, "w": 12, "v": 26, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1877.75},
+{"m": 45, "n": 26, "k": 26, "tile_m": 5, "tile_n": 4, "w": 12, "v": 26, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1901.17},
+{"m": 45, "n": 26, "k": 28, "tile_m": 3, "tile_n": 7, "w": 8, "v": 16, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1935.75},
+{"m": 45, "n": 26, "k": 32, "tile_m": 5, "tile_n": 4, "w": 8, "v": 26, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1991.83},
+{"m": 45, "n": 26, "k": 45, "tile_m": 5, "tile_n": 4, "w": 12, "v": 26, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 2075.74},
+{"m": 45, "n": 28, "k": 4, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 29, "minblocks": 3, "algorithm": "medium", "perf": 1161.39},
+{"m": 45, "n": 28, "k": 5, "tile_m": 5, "tile_n": 2, "threads": 128, "grouping": 24, "minblocks": 4, "algorithm": "medium", "perf": 1229.89},
+{"m": 45, "n": 28, "k": 7, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 24, "minblocks": 4, "algorithm": "medium", "perf": 1432.27},
+{"m": 45, "n": 28, "k": 9, "tile_m": 5, "tile_n": 2, "threads": 128, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 1563.84},
+{"m": 45, "n": 28, "k": 13, "tile_m": 3, "tile_n": 5, "threads": 96, "grouping": 24, "minblocks": 4, "algorithm": "medium", "perf": 1719.62},
+{"m": 45, "n": 28, "k": 25, "tile_m": 5, "tile_n": 4, "w": 12, "v": 20, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1977.98},
+{"m": 45, "n": 28, "k": 26, "tile_m": 5, "tile_n": 4, "w": 12, "v": 28, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1994.7},
+{"m": 45, "n": 28, "k": 28, "tile_m": 3, "tile_n": 7, "w": 14, "v": 28, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 2029.85},
+{"m": 45, "n": 28, "k": 32, "tile_m": 5, "tile_n": 4, "w": 8, "v": 28, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 2089.27},
+{"m": 45, "n": 28, "k": 45, "tile_m": 3, "tile_n": 7, "w": 8, "v": 16, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 2179.89},
+{"m": 45, "n": 32, "k": 4, "tile_m": 6, "tile_n": 2, "threads": 192, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 1191.44},
+{"m": 45, "n": 32, "k": 5, "tile_m": 3, "tile_n": 4, "threads": 128, "grouping": 25, "minblocks": 2, "algorithm": "medium", "perf": 1315.4},
+{"m": 45, "n": 32, "k": 7, "tile_m": 3, "tile_n": 4, "threads": 128, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 1521.68},
+{"m": 45, "n": 32, "k": 9, "tile_m": 3, "tile_n": 4, "threads": 128, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 1691.63},
+{"m": 45, "n": 32, "k": 13, "tile_m": 3, "tile_n": 4, "threads": 128, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 1848.13},
+{"m": 45, "n": 32, "k": 25, "tile_m": 3, "tile_n": 4, "threads": 128, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 2107.65},
+{"m": 45, "n": 32, "k": 26, "tile_m": 3, "tile_n": 4, "threads": 128, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 2137},
+{"m": 45, "n": 32, "k": 28, "tile_m": 6, "tile_n": 4, "w": 8, "v": 8, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 2172},
+{"m": 45, "n": 32, "k": 32, "tile_m": 6, "tile_n": 4, "w": 8, "v": 16, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 2249.68},
+{"m": 45, "n": 32, "k": 45, "tile_m": 6, "tile_n": 4, "w": 8, "v": 16, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 2341.8},
+{"m": 45, "n": 45, "k": 4, "tile_m": 6, "tile_n": 2, "threads": 192, "grouping": 32, "minblocks": 2, "algorithm": "medium", "perf": 1271.92},
+{"m": 45, "n": 45, "k": 5, "tile_m": 6, "tile_n": 2, "threads": 256, "grouping": 29, "minblocks": 1, "algorithm": "medium", "perf": 1313.41},
+{"m": 45, "n": 45, "k": 7, "tile_m": 3, "tile_n": 4, "threads": 192, "grouping": 29, "minblocks": 1, "algorithm": "medium", "perf": 1559.15},
+{"m": 45, "n": 45, "k": 9, "tile_m": 3, "tile_n": 4, "threads": 192, "grouping": 29, "minblocks": 2, "algorithm": "medium", "perf": 1743.9},
+{"m": 45, "n": 45, "k": 13, "tile_m": 6, "tile_n": 6, "w": 6, "v": 28, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1951.48},
+{"m": 45, "n": 45, "k": 25, "tile_m": 6, "tile_n": 6, "w": 12, "v": 26, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 2366.95},
+{"m": 45, "n": 45, "k": 26, "tile_m": 6, "tile_n": 6, "w": 10, "v": 26, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 2409.7},
+{"m": 45, "n": 45, "k": 28, "tile_m": 7, "tile_n": 5, "w": 14, "v": 18, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 2479.64},
+{"m": 45, "n": 45, "k": 32, "tile_m": 7, "tile_n": 5, "w": 12, "v": 22, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 2550.51},
+{"m": 45, "n": 45, "k": 45, "tile_m": 6, "tile_n": 6, "w": 12, "v": 18, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 2690.9},
+{"m": 55, "n": 16, "k": 16, "tile_m": 1, "tile_n": 4, "threads": 256, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 1448.91},
+{"m": 55, "n": 16, "k": 29, "tile_m": 2, "tile_n": 8, "w": 8, "v": 8, "threads": 64, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 1544.22},
+{"m": 55, "n": 16, "k": 55, "tile_m": 2, "tile_n": 8, "w": 8, "v": 12, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1652.51},
+{"m": 55, "n": 29, "k": 16, "tile_m": 7, "tile_n": 4, "w": 8, "v": 22, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1916.32},
+{"m": 55, "n": 29, "k": 29, "tile_m": 3, "tile_n": 6, "w": 10, "v": 18, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 2161.11},
+{"m": 55, "n": 29, "k": 32, "tile_m": 7, "tile_n": 4, "w": 8, "v": 22, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 2241.72},
+{"m": 55, "n": 29, "k": 55, "tile_m": 3, "tile_n": 6, "w": 14, "v": 16, "threads": 96, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 2370.43},
+{"m": 55, "n": 32, "k": 29, "tile_m": 7, "tile_n": 4, "w": 14, "v": 20, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 2315.88},
+{"m": 55, "n": 32, "k": 32, "tile_m": 7, "tile_n": 4, "w": 8, "v": 24, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 2400.75},
+{"m": 55, "n": 32, "k": 55, "tile_m": 7, "tile_n": 4, "w": 6, "v": 12, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 2531.29},
+{"m": 55, "n": 55, "k": 16, "tile_m": 7, "tile_n": 4, "w": 8, "v": 32, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 2371.04},
+{"m": 55, "n": 55, "k": 29, "tile_m": 7, "tile_n": 7, "w": 10, "v": 28, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 2634.65},
+{"m": 55, "n": 55, "k": 32, "tile_m": 7, "tile_n": 7, "w": 10, "v": 28, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 2696.5},
+{"m": 55, "n": 55, "k": 55, "tile_m": 7, "tile_n": 7, "w": 10, "v": 24, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 2934.2},
+{"m": 64, "n": 64, "k": 64, "tile_m": 9, "tile_n": 4, "w": 22, "v": 32, "threads": 128, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 3072.53},
+{"m": 78, "n": 78, "k": 78, "tile_m": 10, "tile_n": 5, "w": 8, "v": 30, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB1", "perf": 3319.77},
+{"m": 10, "n": 12, "k": 12, "tile_m": 1, "tile_n": 2, "w": 6, "v": 12, "threads": 64, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 710.062},
+{"m": 11, "n": 20, "k": 20, "tile_m": 4, "tile_n": 1, "w": 10, "v": 8, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 900.568},
+{"m": 11, "n": 25, "k": 20, "tile_m": 2, "tile_n": 3, "w": 10, "v": 24, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 968.954},
+{"m": 11, "n": 25, "k": 25, "tile_m": 2, "tile_n": 3, "w": 10, "v": 22, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 972.814},
+{"m": 11, "n": 32, "k": 12, "tile_m": 6, "tile_n": 1, "w": 6, "v": 28, "threads": 64, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 971.263},
+{"m": 11, "n": 32, "k": 20, "tile_m": 3, "tile_n": 2, "w": 10, "v": 32, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 1040.31},
+{"m": 11, "n": 32, "k": 32, "tile_m": 2, "tile_n": 2, "w": 8, "v": 8, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1093.93},
+{"m": 12, "n": 10, "k": 12, "tile_m": 1, "tile_n": 2, "w": 6, "v": 10, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 707.143},
+{"m": 12, "n": 10, "k": 32, "tile_m": 1, "tile_n": 2, "w": 8, "v": 10, "threads": 64, "grouping": 16, "minblocks": 12, "algorithm": "largeDB2", "perf": 743.602},
+{"m": 12, "n": 20, "k": 20, "tile_m": 1, "tile_n": 3, "w": 10, "v": 12, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 960.877},
+{"m": 12, "n": 20, "k": 32, "tile_m": 2, "tile_n": 2, "w": 16, "v": 20, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1003.8},
+{"m": 12, "n": 25, "k": 20, "tile_m": 2, "tile_n": 3, "w": 10, "v": 24, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1028.48},
+{"m": 12, "n": 9, "k": 32, "tile_m": 1, "tile_n": 2, "w": 16, "v": 6, "threads": 64, "grouping": 16, "minblocks": 2, "algorithm": "largeDB2", "perf": 698.588},
+{"m": 20, "n": 11, "k": 20, "tile_m": 1, "tile_n": 2, "w": 10, "v": 8, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 904.021},
+{"m": 20, "n": 11, "k": 32, "tile_m": 1, "tile_n": 2, "w": 16, "v": 8, "threads": 128, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 944.417},
+{"m": 20, "n": 12, "k": 20, "tile_m": 1, "tile_n": 2, "w": 10, "v": 4, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 960.236},
+{"m": 20, "n": 12, "k": 32, "tile_m": 1, "tile_n": 2, "w": 16, "v": 12, "threads": 128, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1001.05},
+{"m": 20, "n": 25, "k": 12, "tile_m": 3, "tile_n": 3, "w": 6, "v": 18, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1244.17},
+{"m": 20, "n": 25, "k": 20, "tile_m": 3, "tile_n": 2, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1334.34},
+{"m": 20, "n": 25, "k": 25, "tile_m": 3, "tile_n": 3, "w": 10, "v": 22, "threads": 64, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 1361.83},
+{"m": 20, "n": 25, "k": 32, "tile_m": 3, "tile_n": 2, "w": 16, "v": 18, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1400.96},
+{"m": 25, "n": 11, "k": 20, "tile_m": 2, "tile_n": 3, "w": 10, "v": 8, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 956.932},
+{"m": 25, "n": 11, "k": 25, "tile_m": 2, "tile_n": 3, "w": 10, "v": 6, "threads": 64, "grouping": 16, "minblocks": 8, "algorithm": "largeDB2", "perf": 962.602},
+{"m": 25, "n": 11, "k": 32, "tile_m": 3, "tile_n": 2, "w": 16, "v": 6, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 996.876},
+{"m": 25, "n": 12, "k": 20, "tile_m": 3, "tile_n": 2, "w": 10, "v": 12, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1028.89},
+{"m": 25, "n": 12, "k": 32, "tile_m": 3, "tile_n": 2, "w": 16, "v": 12, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 1070.25},
+{"m": 25, "n": 20, "k": 12, "tile_m": 3, "tile_n": 3, "w": 6, "v": 20, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1253.35},
+{"m": 25, "n": 20, "k": 20, "tile_m": 3, "tile_n": 2, "w": 10, "v": 16, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1333.39},
+{"m": 25, "n": 20, "k": 25, "tile_m": 3, "tile_n": 3, "w": 10, "v": 16, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1355.68},
+{"m": 25, "n": 20, "k": 32, "tile_m": 3, "tile_n": 2, "w": 16, "v": 18, "threads": 96, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1408.81},
+{"m": 25, "n": 32, "k": 12, "tile_m": 7, "tile_n": 2, "w": 6, "v": 32, "threads": 64, "grouping": 16, "minblocks": 4, "algorithm": "largeDB2", "perf": 1481.41},
+{"m": 9, "n": 12, "k": 32, "tile_m": 1, "tile_n": 2, "w": 8, "v": 12, "threads": 64, "grouping": 16, "minblocks": 1, "algorithm": "largeDB2", "perf": 699.295},
+{"m": 10, "n": 10, "k": 11, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 6, "minblocks": 19, "algorithm": "medium", "perf": 649.449},
+{"m": 10, "n": 10, "k": 12, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 22, "minblocks": 3, "algorithm": "medium", "perf": 678.945},
+{"m": 10, "n": 10, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 3, "minblocks": 8, "algorithm": "medium", "perf": 692.008},
+{"m": 10, "n": 10, "k": 9, "tile_m": 1, "tile_n": 4, "threads": 32, "grouping": 19, "minblocks": 23, "algorithm": "medium", "perf": 645.292},
+{"m": 10, "n": 12, "k": 10, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 22, "minblocks": 6, "algorithm": "medium", "perf": 690.625},
+{"m": 10, "n": 12, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 749.015},
+{"m": 10, "n": 12, "k": 9, "tile_m": 1, "tile_n": 4, "threads": 32, "grouping": 13, "minblocks": 15, "algorithm": "medium", "perf": 669.43},
+{"m": 10, "n": 32, "k": 10, "tile_m": 1, "tile_n": 6, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 906.799},
+{"m": 10, "n": 32, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 938.098},
+{"m": 10, "n": 32, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1031.68},
+{"m": 10, "n": 32, "k": 9, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 905.73},
+{"m": 10, "n": 9, "k": 10, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 11, "minblocks": 6, "algorithm": "medium", "perf": 598.408},
+{"m": 10, "n": 9, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 12, "minblocks": 10, "algorithm": "medium", "perf": 630.235},
+{"m": 10, "n": 9, "k": 32, "tile_m": 1, "tile_n": 1, "threads": 96, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 654.862},
+{"m": 10, "n": 9, "k": 9, "tile_m": 1, "tile_n": 3, "threads": 32, "grouping": 16, "minblocks": 22, "algorithm": "medium", "perf": 617.477},
+{"m": 11, "n": 11, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 26, "minblocks": 7, "algorithm": "medium", "perf": 710.594},
+{"m": 11, "n": 11, "k": 20, "tile_m": 2, "tile_n": 2, "threads": 96, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 718.795},
+{"m": 11, "n": 11, "k": 25, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 32, "minblocks": 8, "algorithm": "medium", "perf": 723.132},
+{"m": 11, "n": 11, "k": 32, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 748.109},
+{"m": 11, "n": 12, "k": 11, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 6, "algorithm": "medium", "perf": 693.544},
+{"m": 11, "n": 12, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 26, "minblocks": 17, "algorithm": "medium", "perf": 710.581},
+{"m": 11, "n": 12, "k": 20, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 7, "minblocks": 13, "algorithm": "medium", "perf": 732.24},
+{"m": 11, "n": 12, "k": 25, "tile_m": 2, "tile_n": 1, "threads": 96, "grouping": 5, "minblocks": 8, "algorithm": "medium", "perf": 740.308},
+{"m": 11, "n": 12, "k": 32, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 766.012},
+{"m": 11, "n": 20, "k": 11, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 11, "algorithm": "medium", "perf": 859.155},
+{"m": 11, "n": 20, "k": 12, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 9, "algorithm": "medium", "perf": 859.574},
+{"m": 11, "n": 20, "k": 25, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 918.74},
+{"m": 11, "n": 20, "k": 32, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 948.189},
+{"m": 11, "n": 25, "k": 11, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 895.515},
+{"m": 11, "n": 25, "k": 12, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 32, "minblocks": 1, "algorithm": "medium", "perf": 894.023},
+{"m": 11, "n": 25, "k": 32, "tile_m": 2, "tile_n": 1, "threads": 192, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 1003.35},
+{"m": 11, "n": 32, "k": 11, "tile_m": 6, "tile_n": 1, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 967.416},
+{"m": 11, "n": 32, "k": 25, "tile_m": 2, "tile_n": 1, "threads": 192, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 1053.09},
+{"m": 12, "n": 10, "k": 10, "tile_m": 1, "tile_n": 2, "threads": 64, "grouping": 22, "minblocks": 12, "algorithm": "medium", "perf": 695.265},
+{"m": 12, "n": 10, "k": 9, "tile_m": 4, "tile_n": 1, "threads": 32, "grouping": 12, "minblocks": 10, "algorithm": "medium", "perf": 663.302},
+{"m": 12, "n": 11, "k": 11, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 26, "minblocks": 10, "algorithm": "medium", "perf": 707.91},
+{"m": 12, "n": 11, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 26, "minblocks": 18, "algorithm": "medium", "perf": 722.854},
+{"m": 12, "n": 11, "k": 20, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 6, "minblocks": 5, "algorithm": "medium", "perf": 748.533},
+{"m": 12, "n": 11, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 5, "minblocks": 6, "algorithm": "medium", "perf": 746.389},
+{"m": 12, "n": 11, "k": 32, "tile_m": 2, "tile_n": 1, "threads": 128, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 772.265},
+{"m": 12, "n": 12, "k": 10, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 22, "minblocks": 5, "algorithm": "medium", "perf": 782.428},
+{"m": 12, "n": 12, "k": 11, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 26, "minblocks": 1, "algorithm": "medium", "perf": 773.895},
+{"m": 12, "n": 12, "k": 16, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 32, "minblocks": 14, "algorithm": "medium", "perf": 797.978},
+{"m": 12, "n": 12, "k": 20, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 789.883},
+{"m": 12, "n": 16, "k": 12, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 26, "minblocks": 12, "algorithm": "medium", "perf": 850.387},
+{"m": 12, "n": 16, "k": 16, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 32, "minblocks": 7, "algorithm": "medium", "perf": 884.496},
+{"m": 12, "n": 16, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 928.761},
+{"m": 12, "n": 20, "k": 11, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 26, "minblocks": 11, "algorithm": "medium", "perf": 895.574},
+{"m": 12, "n": 20, "k": 12, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 26, "minblocks": 8, "algorithm": "medium", "perf": 908.586},
+{"m": 12, "n": 20, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 5, "minblocks": 4, "algorithm": "medium", "perf": 972.699},
+{"m": 12, "n": 25, "k": 11, "tile_m": 1, "tile_n": 5, "threads": 64, "grouping": 32, "minblocks": 7, "algorithm": "medium", "perf": 936.728},
+{"m": 12, "n": 25, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 1082.11},
+{"m": 12, "n": 32, "k": 10, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 1022.68},
+{"m": 12, "n": 32, "k": 11, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 1031.57},
+{"m": 12, "n": 32, "k": 16, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 4, "minblocks": 8, "algorithm": "medium", "perf": 1084.77},
+{"m": 12, "n": 32, "k": 20, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 1, "algorithm": "medium", "perf": 1106.6},
+{"m": 12, "n": 32, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 3, "algorithm": "medium", "perf": 1128.97},
+{"m": 12, "n": 32, "k": 9, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 1009.07},
+{"m": 12, "n": 9, "k": 10, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 18, "minblocks": 16, "algorithm": "medium", "perf": 645.924},
+{"m": 16, "n": 12, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 64, "grouping": 26, "minblocks": 15, "algorithm": "medium", "perf": 854.169},
+{"m": 16, "n": 12, "k": 16, "tile_m": 1, "tile_n": 2, "threads": 96, "grouping": 32, "minblocks": 11, "algorithm": "medium", "perf": 887.754},
+{"m": 16, "n": 12, "k": 32, "tile_m": 2, "tile_n": 1, "threads": 160, "grouping": 5, "minblocks": 3, "algorithm": "medium", "perf": 925.265},
+{"m": 16, "n": 16, "k": 12, "tile_m": 2, "tile_n": 2, "threads": 64, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 1009.93},
+{"m": 16, "n": 32, "k": 12, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 4, "minblocks": 8, "algorithm": "medium", "perf": 1231.07},
+{"m": 20, "n": 11, "k": 11, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 24, "minblocks": 1, "algorithm": "medium", "perf": 849.388},
+{"m": 20, "n": 11, "k": 12, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 24, "minblocks": 11, "algorithm": "medium", "perf": 853.531},
+{"m": 20, "n": 11, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 922.024},
+{"m": 20, "n": 12, "k": 11, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 26, "minblocks": 12, "algorithm": "medium", "perf": 897.705},
+{"m": 20, "n": 12, "k": 12, "tile_m": 1, "tile_n": 4, "threads": 64, "grouping": 29, "minblocks": 4, "algorithm": "medium", "perf": 906.799},
+{"m": 20, "n": 12, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 970.235},
+{"m": 20, "n": 20, "k": 11, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 32, "minblocks": 12, "algorithm": "medium", "perf": 1153.6},
+{"m": 20, "n": 20, "k": 12, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 4, "minblocks": 12, "algorithm": "medium", "perf": 1160.25},
+{"m": 20, "n": 20, "k": 25, "tile_m": 1, "tile_n": 4, "threads": 160, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 1275.85},
+{"m": 20, "n": 20, "k": 32, "tile_m": 1, "tile_n": 3, "threads": 160, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1309.2},
+{"m": 20, "n": 25, "k": 11, "tile_m": 3, "tile_n": 2, "threads": 96, "grouping": 29, "minblocks": 10, "algorithm": "medium", "perf": 1187.93},
+{"m": 20, "n": 32, "k": 11, "tile_m": 1, "tile_n": 6, "threads": 128, "grouping": 5, "minblocks": 8, "algorithm": "medium", "perf": 1336.45},
+{"m": 20, "n": 32, "k": 12, "tile_m": 1, "tile_n": 6, "threads": 128, "grouping": 4, "minblocks": 7, "algorithm": "medium", "perf": 1364.22},
+{"m": 20, "n": 32, "k": 20, "tile_m": 1, "tile_n": 4, "threads": 160, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 1493.29},
+{"m": 20, "n": 32, "k": 25, "tile_m": 1, "tile_n": 4, "threads": 160, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 1517.83},
+{"m": 20, "n": 32, "k": 32, "tile_m": 1, "tile_n": 4, "threads": 256, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 1557.15},
+{"m": 25, "n": 11, "k": 11, "tile_m": 1, "tile_n": 6, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 883.488},
+{"m": 25, "n": 11, "k": 12, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 895.478},
+{"m": 25, "n": 12, "k": 11, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 6, "minblocks": 13, "algorithm": "medium", "perf": 921.389},
+{"m": 25, "n": 20, "k": 11, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 6, "minblocks": 10, "algorithm": "medium", "perf": 1206.16},
+{"m": 25, "n": 25, "k": 11, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 1340.23},
+{"m": 25, "n": 25, "k": 20, "tile_m": 1, "tile_n": 5, "threads": 192, "grouping": 5, "minblocks": 6, "algorithm": "medium", "perf": 1480.51},
+{"m": 25, "n": 32, "k": 11, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 24, "minblocks": 6, "algorithm": "medium", "perf": 1423.93},
+{"m": 25, "n": 32, "k": 20, "tile_m": 3, "tile_n": 5, "threads": 64, "grouping": 3, "minblocks": 3, "algorithm": "medium", "perf": 1636.95},
+{"m": 32, "n": 10, "k": 10, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 915.443},
+{"m": 32, "n": 10, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 32, "minblocks": 9, "algorithm": "medium", "perf": 944.867},
+{"m": 32, "n": 10, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 1031.19},
+{"m": 32, "n": 10, "k": 9, "tile_m": 1, "tile_n": 5, "threads": 96, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 918.728},
+{"m": 32, "n": 11, "k": 11, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 4, "minblocks": 11, "algorithm": "medium", "perf": 978.001},
+{"m": 32, "n": 11, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 160, "grouping": 5, "minblocks": 9, "algorithm": "medium", "perf": 984.847},
+{"m": 32, "n": 11, "k": 20, "tile_m": 1, "tile_n": 3, "threads": 224, "grouping": 4, "minblocks": 6, "algorithm": "medium", "perf": 1051.13},
+{"m": 32, "n": 11, "k": 25, "tile_m": 1, "tile_n": 3, "threads": 160, "grouping": 3, "minblocks": 2, "algorithm": "medium", "perf": 1058.32},
+{"m": 32, "n": 11, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 3, "minblocks": 4, "algorithm": "medium", "perf": 1102.32},
+{"m": 32, "n": 12, "k": 10, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 32, "minblocks": 11, "algorithm": "medium", "perf": 1036.39},
+{"m": 32, "n": 12, "k": 11, "tile_m": 1, "tile_n": 4, "threads": 96, "grouping": 32, "minblocks": 11, "algorithm": "medium", "perf": 1023.16},
+{"m": 32, "n": 12, "k": 16, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 4, "minblocks": 2, "algorithm": "medium", "perf": 1090.93},
+{"m": 32, "n": 12, "k": 20, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 3, "minblocks": 6, "algorithm": "medium", "perf": 1116.25},
+{"m": 32, "n": 12, "k": 25, "tile_m": 1, "tile_n": 2, "threads": 192, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 1131.14},
+{"m": 32, "n": 12, "k": 9, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 32, "minblocks": 10, "algorithm": "medium", "perf": 1015.3},
+{"m": 32, "n": 16, "k": 12, "tile_m": 1, "tile_n": 4, "threads": 128, "grouping": 4, "minblocks": 10, "algorithm": "medium", "perf": 1235.03},
+{"m": 32, "n": 20, "k": 12, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 4, "minblocks": 8, "algorithm": "medium", "perf": 1367.22},
+{"m": 32, "n": 20, "k": 20, "tile_m": 1, "tile_n": 4, "threads": 192, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 1490.8},
+{"m": 32, "n": 20, "k": 25, "tile_m": 1, "tile_n": 4, "threads": 160, "grouping": 4, "minblocks": 4, "algorithm": "medium", "perf": 1527.53},
+{"m": 32, "n": 20, "k": 32, "tile_m": 1, "tile_n": 3, "threads": 224, "grouping": 3, "minblocks": 1, "algorithm": "medium", "perf": 1575.35},
+{"m": 32, "n": 25, "k": 11, "tile_m": 1, "tile_n": 5, "threads": 160, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1465.98},
+{"m": 32, "n": 25, "k": 12, "tile_m": 1, "tile_n": 5, "threads": 160, "grouping": 5, "minblocks": 7, "algorithm": "medium", "perf": 1501.64},
+{"m": 32, "n": 25, "k": 20, "tile_m": 1, "tile_n": 5, "threads": 224, "grouping": 4, "minblocks": 5, "algorithm": "medium", "perf": 1673.05},
+{"m": 32, "n": 32, "k": 10, "tile_m": 1, "tile_n": 6, "threads": 192, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1639.09},
+{"m": 32, "n": 32, "k": 11, "tile_m": 1, "tile_n": 6, "threads": 192, "grouping": 29, "minblocks": 5, "algorithm": "medium", "perf": 1658.37},
+{"m": 32, "n": 32, "k": 20, "tile_m": 1, "tile_n": 4, "threads": 256, "grouping": 5, "minblocks": 4, "algorithm": "medium", "perf": 1879.26},
+{"m": 32, "n": 9, "k": 10, "tile_m": 1, "tile_n": 3, "threads": 96, "grouping": 29, "minblocks": 10, "algorithm": "medium", "perf": 863.579},
+{"m": 32, "n": 9, "k": 12, "tile_m": 1, "tile_n": 3, "threads": 128, "grouping": 6, "minblocks": 11, "algorithm": "medium", "perf": 873.588},
+{"m": 9, "n": 10, "k": 10, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 11, "minblocks": 2, "algorithm": "medium", "perf": 590.348},
+{"m": 9, "n": 10, "k": 12, "tile_m": 3, "tile_n": 1, "threads": 64, "grouping": 22, "minblocks": 18, "algorithm": "medium", "perf": 616.887},
+{"m": 9, "n": 10, "k": 32, "tile_m": 1, "tile_n": 2, "threads": 128, "grouping": 4, "minblocks": 10, "algorithm": "medium", "perf": 649.51},
+{"m": 9, "n": 10, "k": 9, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 13, "minblocks": 16, "algorithm": "medium", "perf": 603.196},
+{"m": 9, "n": 12, "k": 10, "tile_m": 2, "tile_n": 2, "threads": 32, "grouping": 12, "minblocks": 17, "algorithm": "medium", "perf": 641.738},
+{"m": 9, "n": 32, "k": 10, "tile_m": 3, "tile_n": 1, "threads": 96, "grouping": 32, "minblocks": 3, "algorithm": "medium", "perf": 854.866},
+{"m": 9, "n": 32, "k": 12, "tile_m": 5, "tile_n": 1, "threads": 128, "grouping": 5, "minblocks": 10, "algorithm": "medium", "perf": 866.147},
+{"m": 9, "n": 9, "k": 10, "tile_m": 3, "tile_n": 1, "threads": 32, "grouping": 18, "minblocks": 5, "algorithm": "medium", "perf": 598.238},
+{"m": 32, "n": 20, "k": 11, "tile_m": 1, "tile_n": 5, "threads": 128, "grouping": 4, "minblocks": 9, "algorithm": "medium", "perf": 1342.48}
 ]
-
-#EOF

--- a/src/acc/libsmm_acc/libcusmm/submit.py
+++ b/src/acc/libsmm_acc/libcusmm/submit.py
@@ -18,28 +18,28 @@ def main():
 
 	n_submits = 0
 	for d in glob("tune_*"):
-		if(not path.isdir(d)):
+		if not path.isdir(d):
 			continue
 		
-		if(len(glob(d+"/slurm-*.out"))>0):
+		if len(glob(d+"/slurm-*.out"))>0:
 			print("%20s: Found slurm file(s)"%d)
 			continue
 
-		if(d in submitted):
+		if d in submitted:
 			print("%20s: Found submitted job"%d)
 			continue
 	
 		n_submits += 1
-		if(do_it):
+		if do_it:
 			print("%20s: Submitting"%d)
-			assert(os.system("cd %s; sbatch *.job"%d)==0)
+			assert os.system("cd %s; sbatch *.job"%d)==0
 		else:
 			print('%20s: Would submit, run with "doit!"'%d)
 
 	print("Number of jobs submitted: %d"%n_submits)
 
 #===============================================================================
-if(len(sys.argv)==2 and sys.argv[-1]=="--selftest"):
+if len(sys.argv)==2 and sys.argv[-1]=="--selftest":
     pass #TODO implement selftest
 else:
     main()

--- a/src/acc/libsmm_acc/libcusmm/tune.py
+++ b/src/acc/libsmm_acc/libcusmm/tune.py
@@ -13,7 +13,6 @@ from kernels.cusmm_dnt_largeDB2 import Kernel_dnt_largeDB2
 from kernels.cusmm_dnt_medium   import Kernel_dnt_medium
 from kernels.cusmm_dnt_small    import Kernel_dnt_small
 from kernels.cusmm_dnt_tiny     import Kernel_dnt_tiny
-from kernels.cusmm_dnt          import *
 
 kernel_algorithm = {
     'tiny': Kernel_dnt_tiny,
@@ -25,7 +24,7 @@ kernel_algorithm = {
 
 
 def get_kernel(**params):
-    return kernel_algorithm[params['algorithm']](**params)
+    return kernel_algorithm[params.pop('algorithm')](**params)
 
 
 ALL_KERNELS = (Kernel_dnt_tiny, Kernel_dnt_small, Kernel_dnt_medium, Kernel_dnt_largeDB1, Kernel_dnt_largeDB2,)

--- a/src/acc/libsmm_acc/libcusmm/tune.py
+++ b/src/acc/libsmm_acc/libcusmm/tune.py
@@ -3,10 +3,8 @@
 
 import sys
 import os
-from os import path
-from os.path import basename
 from glob import glob
-from itertools import product, chain
+from itertools import product
 from optparse import OptionParser
 
 from kernels.cusmm_dnt_largeDB1 import Kernel_dnt_largeDB1
@@ -59,7 +57,7 @@ def main():
             continue
 
         outdir = "tune_%dx%dx%d/"%(m,n,k)
-        if(path.exists(outdir)):
+        if(os.path.exists(outdir)):
             print("Directory %s exists already, skipping."%outdir)
             continue
         os.mkdir(outdir)
@@ -73,7 +71,7 @@ def main():
 #===============================================================================
 def format_params(params):
     output = []
-    order = ['m','n','k','tile_m', 'tile_n', 'w', 'v', 'split_thread', 'threads', 'blockdim', 'grouping']
+    order = ['m', 'n', 'k', 'tile_m', 'tile_n', 'w', 'v', 'split_thread', 'threads', 'blockdim', 'grouping']
     for k in order:
         if(params.has_key(k)):
             output.append("%s=%d"%(k, params[k]))
@@ -155,7 +153,7 @@ def gen_benchmark(outdir, m, n, k):
 #===============================================================================
 def gen_jobfile(outdir, m, n, k):
     t = "/tune_%dx%dx%d"%(m,n,k)
-    all_exe_src = [basename(fn) for fn in glob(outdir+t+"_*_main.cu")]
+    all_exe_src = [os.path.basename(fn) for fn in glob(outdir+t+"_*_main.cu")]
     all_exe = sorted([fn.replace("_main.cu", "") for fn in all_exe_src])
 
     output  = "#!/bin/bash -l\n"
@@ -199,7 +197,7 @@ def gen_jobfile(outdir, m, n, k):
 def gen_makefile(outdir, arch):
     output  = ".SECONDARY:\n"
     output += "vpath %.cu ../\n\n"
-    all_exe_src = sorted([basename(fn) for fn in glob(outdir+"/tune_*_main.cu")])
+    all_exe_src = sorted([os.path.basename(fn) for fn in glob(outdir+"/tune_*_main.cu")])
     build_targets = [fn.replace("_main.cu", "") for fn in all_exe_src]
 
     output += ".PHONY: do_nothing build_all \n\n"
@@ -215,7 +213,7 @@ def gen_makefile(outdir, arch):
 
     for exe_src in all_exe_src:
         absparts = sorted(glob(outdir+"/"+exe_src.replace("_main.cu", "_part*")))
-        parts = [basename(fn) for fn in absparts]
+        parts = [os.path.basename(fn) for fn in absparts]
         deps = [exe_src, "libcusmm_benchmark.cu"] + parts
         deps_obj = " ".join([fn.replace(".cu", ".o") for fn in deps])
         exe = exe_src.replace("_main.cu", "")

--- a/src/acc/libsmm_acc/libcusmm/tune.py
+++ b/src/acc/libsmm_acc/libcusmm/tune.py
@@ -34,7 +34,7 @@ def main():
         help="Default: %default")
 
     (options, args) = parser.parse_args(sys.argv)
-    if(len(sys.argv) < 2):
+    if len(sys.argv) < 2:
         print(usage)
         sys.exit(1)
 
@@ -46,19 +46,19 @@ def main():
     print("Libcusmm: Found %d existing parameter sets."%len(all_kernels))
 
     blocksizes = [int(i) for i in args[1:]]
-    assert(len(set(blocksizes)) == len(blocksizes))
+    assert len(set(blocksizes)) == len(blocksizes)
     blocksizes.sort()
 
     triples  = combinations(*blocksizes)
 
     for (m, n, k)  in triples:
         existing = [kern for kern in all_kernels if kern.can_handle(m,n,k)]
-        if(existing):
+        if existing:
             print("Found existing parameter set for %dx%dx%d, skipping."%(m,n,k))
             continue
 
         outdir = "tune_%dx%dx%d/"%(m,n,k)
-        if(os.path.exists(outdir)):
+        if os.path.exists(outdir):
             print("Directory %s exists already, skipping."%outdir)
             continue
         os.mkdir(outdir)
@@ -74,14 +74,14 @@ def format_params(params):
     output = []
     order = ['m', 'n', 'k', 'tile_m', 'tile_n', 'w', 'v', 'split_thread', 'threads', 'blockdim', 'grouping']
     for k in order:
-        if(params.has_key(k)):
+        if params.has_key(k):
             output.append("%s=%d"%(k, params[k]))
 
     for k in params.keys():
-        if(k not in order):
+        if k not in order:
             output.append("%s=%d"%(k, params[k]))
 
-    return("(" + ", ".join(output) +")")
+    return "(" + ", ".join(output) +")"
 
 
 
@@ -94,7 +94,7 @@ def gen_benchmark(outdir, m, n, k):
 
     for kernclass in ALL_KERNELS:
         params = kernclass.promising_parameters(m, n, k)
-        if(params == 0):
+        if params == 0:
             continue
 
         for p in params:
@@ -105,7 +105,7 @@ def gen_benchmark(outdir, m, n, k):
             kernel_descr.append(kernclass.__name__ + format_params(p))
 
     print("Found %d parameter sets for %dx%dx%d"%(len(launchers), m, n, k))
-    if(len(launchers)==0): return
+    if len(launchers)==0: return
     #assert(len(launchers)> 0)
 
     incl_output = '#include "../kernels/cusmm_common.h"\n'
@@ -238,11 +238,11 @@ def gen_collect(outdir, triples):
 
 #===============================================================================
 def writefile(fn, content):
-    if(path.exists(fn)):
+    if path.exists(fn):
         f = open(fn, "r")
         old_content = f.read()
         f.close()
-        if(old_content == content):
+        if old_content == content:
             return
 
     f = open(fn, "w")
@@ -253,7 +253,7 @@ def writefile(fn, content):
 
 #===============================================================================
 def combinations(*sizes):
-     return(list(product(sizes, sizes, sizes)))
+     return list(product(sizes, sizes, sizes))
 
 #===============================================================================
 if(len(sys.argv)==2 and sys.argv[-1]=="--selftest"):

--- a/src/acc/libsmm_acc/libcusmm/tune.py
+++ b/src/acc/libsmm_acc/libcusmm/tune.py
@@ -7,27 +7,14 @@ import json
 from glob import glob
 from itertools import product
 from optparse import OptionParser
-
-from kernels.cusmm_dnt_largeDB1 import Kernel_dnt_largeDB1
-from kernels.cusmm_dnt_largeDB2 import Kernel_dnt_largeDB2
-from kernels.cusmm_dnt_medium   import Kernel_dnt_medium
-from kernels.cusmm_dnt_small    import Kernel_dnt_small
-from kernels.cusmm_dnt_tiny     import Kernel_dnt_tiny
-
-kernel_algorithm = {
-    'tiny': Kernel_dnt_tiny,
-    'small': Kernel_dnt_small,
-    'medium': Kernel_dnt_medium,
-    'largeDB1': Kernel_dnt_largeDB1,
-    'largeDB2': Kernel_dnt_largeDB2
-}
+from kernels.cusmm_dnt import kernel_algorithm
 
 
 def get_kernel(**params):
     return kernel_algorithm[params.pop('algorithm')](**params)
 
 
-ALL_KERNELS = (Kernel_dnt_tiny, Kernel_dnt_small, Kernel_dnt_medium, Kernel_dnt_largeDB1, Kernel_dnt_largeDB2,)
+ALL_KERNELS = tuple(kernel_algorithm.values())
 
 #===============================================================================
 # Correspondance between CUDA compute versions and parameter_file

--- a/src/acc/libsmm_acc/libcusmm/tune.py
+++ b/src/acc/libsmm_acc/libcusmm/tune.py
@@ -3,6 +3,7 @@
 
 import sys
 import os
+import json
 from glob import glob
 from itertools import product
 from optparse import OptionParser
@@ -12,6 +13,20 @@ from kernels.cusmm_dnt_largeDB2 import Kernel_dnt_largeDB2
 from kernels.cusmm_dnt_medium   import Kernel_dnt_medium
 from kernels.cusmm_dnt_small    import Kernel_dnt_small
 from kernels.cusmm_dnt_tiny     import Kernel_dnt_tiny
+from kernels.cusmm_dnt          import *
+
+kernel_algorithm = {
+    'tiny': Kernel_dnt_tiny,
+    'small': Kernel_dnt_small,
+    'medium': Kernel_dnt_medium,
+    'largeDB1': Kernel_dnt_largeDB1,
+    'largeDB2': Kernel_dnt_largeDB2
+}
+
+
+def get_kernel(**params):
+    return kernel_algorithm[params['algorithm']](**params)
+
 
 ALL_KERNELS = (Kernel_dnt_tiny, Kernel_dnt_small, Kernel_dnt_medium, Kernel_dnt_largeDB1, Kernel_dnt_largeDB2,)
 
@@ -41,7 +56,7 @@ def main():
     param_fn = options.params
     assert param_fn in arch_number.keys(), "Cannot find compute version for file " + param_fn
     arch = arch_number[param_fn]
-    all_kernels = eval(open(param_fn).read())
+    all_kernels = [get_kernel(**params) for params in json.load(open(param_fn))]
     print("Libcusmm: Found %d existing parameter sets."%len(all_kernels))
 
     blocksizes = [int(i) for i in args[1:]]


### PR DESCRIPTION
- Change parameters_*.txt files to JSON format and subsequently adapt the autotuning infrastructure to this change. Using 'eval' in python is considered bad practice. 
- Introduce class hierarchy for Kernel_dnt_* classes to avoid code duplication and ease polymorphism  
