### PR TITLE
libcusmm: remove non-ascii character

### DIFF
--- a/src/acc/libsmm_acc/libcusmm/libcusmm_benchmark.cu
+++ b/src/acc/libsmm_acc/libcusmm/libcusmm_benchmark.cu
@@ -481,4 +481,4 @@ int libcusmm_benchmark_transpose(libcusmm_benchmark_t* handle,
 
 }
 
-//EOF§
+//EOF


### PR DESCRIPTION
This non-ascii character prevented the file from being read when running `makedep.py` with Python 3 instead of Python 2. 