### PR TITLE
DBCSR_ASSERT to be elided (NDEBUG). Introduced TO_VERSION macro.

### DIFF
--- a/src/base/dbcsr_base_uses.f90
+++ b/src/base/dbcsr_base_uses.f90
@@ -18,7 +18,13 @@
 #define __LOCATION__ dbcsr__l(__SHORT_FILE__,__LINE__)
 #define DBCSR_WARN(msg) CALL dbcsr__w(__SHORT_FILE__,__LINE__,msg)
 #define DBCSR_ABORT(msg) CALL dbcsr__b(__SHORT_FILE__,__LINE__,msg)
+
+! DBCSR_ASSERT can be elided if NDEBUG is defined.
+#if defined(NDEBUG)
+# define DBCSR_ASSERT(cond)
+#else
 #define DBCSR_ASSERT(cond) IF(.NOT.(cond))CALL dbcsr__a(__SHORT_FILE__,__LINE__)
+#endif
 
 ! The MARK_USED macro can be used to mark an argument/variable as used.
 ! It is intended to make it possible to switch on -Werror=unused-dummy-argument,
@@ -26,3 +32,7 @@
 ! This code should be valid for any Fortran variable, is always standard conforming,
 ! and will be optimized away completely by the compiler
 #define MARK_USED(foo) IF(.FALSE.)THEN; DO ; IF(SIZE(SHAPE(foo))==-1) EXIT ;  END DO ; ENDIF
+
+! Calculate version number from 3-components. Can be used for comparison e.g.,
+! TO_VERSION(4, 9, 0) <= TO_VERSION(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
+#define TO_VERSION(MAJOR, MINOR, UPDATE) ((MAJOR) * 10000 + (MINOR) * 100 + (UPDATE))


### PR DESCRIPTION
Allow DBCSR_ASSERT to be elided if NDEBUG is defined. Introduced TO_VERSION macro.