### PR TITLE
Joaat hash to produce CRC32 hashes

### DIFF
--- a/src/base/dbcsr_base_uses.f90
+++ b/src/base/dbcsr_base_uses.f90
@@ -36,3 +36,9 @@
 ! Calculate version number from 3-components. Can be used for comparison e.g.,
 ! TO_VERSION(4, 9, 0) <= TO_VERSION(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
 #define TO_VERSION(MAJOR, MINOR, UPDATE) ((MAJOR) * 10000 + (MINOR) * 100 + (UPDATE))
+
+! LIBXSMM has a FORTRAN-suitable header with macro/version definitions (since v1.8.2).
+! Allows macro-toggles (in addition to parameters).
+#if defined(__LIBXSMM)
+#include <libxsmm_config.h>
+#endif

--- a/src/utils/dbcsr_toollib.F
+++ b/src/utils/dbcsr_toollib.F
@@ -218,7 +218,8 @@ CONTAINS
 !>       we return already the index in the table as a final result
 ! **************************************************************************************************
    FUNCTION joaat_hash(key) RESULT(hash_index)
-#if defined(__LIBXSMM) ! requires at least v1.9.0.6
+      ! LIBXSMM: at least v1.9.0.6 is required
+#if defined(__LIBXSMM)
       USE libxsmm
       INTEGER, DIMENSION(:), INTENT(IN)                  :: key
       INTEGER                                            :: hash_index

--- a/src/utils/dbcsr_toollib.F
+++ b/src/utils/dbcsr_toollib.F
@@ -218,9 +218,7 @@ CONTAINS
 !>       we return already the index in the table as a final result
 ! **************************************************************************************************
    FUNCTION joaat_hash(key) RESULT(hash_index)
-#if defined(__LIBXSMM) && CP_VERSION4(1, 9, 0, 6) <= \
-  CP_VERSION4(LIBXSMM_CONFIG_VERSION_MAJOR,  LIBXSMM_CONFIG_VERSION_MINOR, \
-              LIBXSMM_CONFIG_VERSION_UPDATE, LIBXSMM_CONFIG_VERSION_PATCH)
+#if defined(__LIBXSMM) ! requires at least v1.9.0.6
       USE libxsmm
       INTEGER, DIMENSION(:), INTENT(IN)                  :: key
       INTEGER                                            :: hash_index

--- a/src/utils/dbcsr_toollib.F
+++ b/src/utils/dbcsr_toollib.F
@@ -218,6 +218,15 @@ CONTAINS
 !>       we return already the index in the table as a final result
 ! **************************************************************************************************
    FUNCTION joaat_hash(key) RESULT(hash_index)
+#if defined(__LIBXSMM) && CP_VERSION4(1, 9, 0, 6) <= \
+  CP_VERSION4(LIBXSMM_CONFIG_VERSION_MAJOR,  LIBXSMM_CONFIG_VERSION_MINOR, \
+              LIBXSMM_CONFIG_VERSION_UPDATE, LIBXSMM_CONFIG_VERSION_PATCH)
+      USE libxsmm
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: key
+      INTEGER                                            :: hash_index
+      INTEGER, PARAMETER                                 :: seed = 0
+      hash_index = libxsmm_hash(key, seed)
+#else
       INTEGER, DIMENSION(:), INTENT(IN)                  :: key
       INTEGER                                            :: hash_index
 
@@ -241,6 +250,7 @@ CONTAINS
       ! In fortran 4-byte-integers have only 31 bits because they are signed
       ! In fortran the rightmost (least significant) bit is in position 0
       hash_index = INT(IBCLR(hash, 31))
+#endif
    END FUNCTION joaat_hash
 
 ! **************************************************************************************************

--- a/src/utils/dbcsr_toollib.F
+++ b/src/utils/dbcsr_toollib.F
@@ -21,6 +21,7 @@ MODULE dbcsr_toollib
    USE dbcsr_kinds,                     ONLY: int_4,&
                                               int_8,&
                                               real_8
+#include "../base/dbcsr_base_uses.f90"
 
 !$ USE OMP_LIB, ONLY: omp_get_max_threads, omp_get_thread_num, omp_get_num_threads
 
@@ -219,7 +220,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION joaat_hash(key) RESULT(hash_index)
       ! LIBXSMM: at least v1.9.0.6 is required
-#if defined(__LIBXSMM) && TO_VERSION(1, 10, 0) <= VERSION4(LIBXSMM_CONFIG_VERSION_MAJOR, LIBXSMM_CONFIG_VERSION_MINOR, LIBXSMM_CONFIG_VERSION_UPDATE)
+#if defined(__LIBXSMM) && TO_VERSION(1, 10, 0) <= TO_VERSION(LIBXSMM_CONFIG_VERSION_MAJOR, LIBXSMM_CONFIG_VERSION_MINOR, LIBXSMM_CONFIG_VERSION_UPDATE)
       USE libxsmm
       INTEGER, DIMENSION(:), INTENT(IN)                  :: key
       INTEGER                                            :: hash_index

--- a/src/utils/dbcsr_toollib.F
+++ b/src/utils/dbcsr_toollib.F
@@ -222,9 +222,9 @@ CONTAINS
       ! LIBXSMM: at least v1.9.0.6 is required
 #if defined(__LIBXSMM) && TO_VERSION(1, 10, 0) <= TO_VERSION(LIBXSMM_CONFIG_VERSION_MAJOR, LIBXSMM_CONFIG_VERSION_MINOR, LIBXSMM_CONFIG_VERSION_UPDATE)
       USE libxsmm
+      INTEGER, PARAMETER                                 :: seed = 0
       INTEGER, DIMENSION(:), INTENT(IN)                  :: key
       INTEGER                                            :: hash_index
-      INTEGER, PARAMETER                                 :: seed = 0
       hash_index = libxsmm_hash(key, seed)
 #else
       INTEGER, DIMENSION(:), INTENT(IN)                  :: key

--- a/src/utils/dbcsr_toollib.F
+++ b/src/utils/dbcsr_toollib.F
@@ -219,7 +219,7 @@ CONTAINS
 !>       we return already the index in the table as a final result
 ! **************************************************************************************************
    FUNCTION joaat_hash(key) RESULT(hash_index)
-      ! LIBXSMM: at least v1.9.0.6 is required
+      ! LIBXSMM: at least v1.9.0-6 is required
 #if defined(__LIBXSMM) && TO_VERSION(1, 10, 0) <= TO_VERSION(LIBXSMM_CONFIG_VERSION_MAJOR, LIBXSMM_CONFIG_VERSION_MINOR, LIBXSMM_CONFIG_VERSION_UPDATE)
       USE libxsmm
       INTEGER, PARAMETER                                 :: seed = 0

--- a/src/utils/dbcsr_toollib.F
+++ b/src/utils/dbcsr_toollib.F
@@ -219,7 +219,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION joaat_hash(key) RESULT(hash_index)
       ! LIBXSMM: at least v1.9.0.6 is required
-#if defined(__LIBXSMM)
+#if defined(__LIBXSMM) && TO_VERSION(1, 10, 0) <= VERSION4(LIBXSMM_CONFIG_VERSION_MAJOR, LIBXSMM_CONFIG_VERSION_MINOR, LIBXSMM_CONFIG_VERSION_UPDATE)
       USE libxsmm
       INTEGER, DIMENSION(:), INTENT(IN)                  :: key
       INTEGER                                            :: hash_index


### PR DESCRIPTION
Call libxsmm_hash to implement joaat_hash. This function produces CRC32 hashes and leverages specific CPU instructions. The CRC32 hash may also improve the hash quality and distribution. LIBXSMM provides this function since v1.9.0-6 as part of the Fortran interface (tested in CP2K/intel fork since then). LIBXSMM v.1.10 will be the first release with the Fortran interface for libxsmm_hash.