### PR TITLE
Use LIBXSMM (or MKL) for out-of-place and in-place transpose (block-ops).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
 env:
   global:
   # LIBXSMM: update to v1.10 or later
-  - LIBXSMM_VERSION=531c000d1218f5925aaf3ea34dca8eb3033d2dff
+  - LIBXSMM_VERSION=f1171cc08fbe8f65a2aad6d6d9af71ceb975ef91
 
 install:
   # Update cmake to the minimal required version (shamelessly copied from the boost travis config):

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 env:
   global:
   # LIBXSMM: update to v1.10 or later
-  - LIBXSMM_VERSION=531c000d1218f5925aaf3ea34dca8eb3033d2dff
+  - LIBXSMM_VERSION=eb4e85c6c7ef080658d1a8b36cc27be13afd9694
   - PKG_CONFIG_PATH=${TRAVIS_BUILD_DIR}/libxsmm-${LIBXSMM_VERSION}/lib
 
 install:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,11 @@ endif ()
 # PACKAGE DISCOVERY:
 
 find_package(BLAS REQUIRED)
+
+if (BLAS_VENDOR_FOUND MATCHES "Intel" OR BLAS_VENDOR MATCHES "Intel" OR BLAS_LIBRARIES MATCHES "mkl_")
+  add_definitions(-D__MKL)
+endif ()
+
 find_package(LAPACK REQUIRED)
 find_package(PkgConfig)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif ()
 
 find_package(BLAS REQUIRED)
 
-if (BLAS_VENDOR_FOUND MATCHES "Intel" OR BLAS_VENDOR MATCHES "Intel" OR BLAS_LIBRARIES MATCHES "mkl_")
+if (BLA_VENDOR_FOUND MATCHES "Intel" OR BLA_VENDOR MATCHES "Intel" OR BLAS_LIBRARIES MATCHES "mkl_")
   add_definitions(-D__MKL)
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,11 +43,6 @@ endif ()
 # PACKAGE DISCOVERY:
 
 find_package(BLAS REQUIRED)
-
-if (BLA_VENDOR MATCHES "Intel" OR BLAS_LIBRARIES MATCHES "mkl_")
-  add_definitions(-D__MKL)
-endif ()
-
 find_package(LAPACK REQUIRED)
 find_package(PkgConfig)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif ()
 
 find_package(BLAS REQUIRED)
 
-if (BLA_VENDOR_FOUND MATCHES "Intel" OR BLA_VENDOR MATCHES "Intel" OR BLAS_LIBRARIES MATCHES "mkl_")
+if (BLA_VENDOR MATCHES "Intel" OR BLAS_LIBRARIES MATCHES "mkl_")
   add_definitions(-D__MKL)
 endif ()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,6 +111,10 @@ if (USE_SMM MATCHES "libxsmm")
   target_compile_definitions(dbcsr PRIVATE __LIBXSMM)
 endif ()
 
+if (BLAS_LIBRARIES MATCHES "mkl_")
+  target_compile_definitions(dbcsr PRIVATE __MKL)
+endif ()
+
 if (USE_CUDA)
   set(CMAKE_CUDA_FLAGS "-arch=sm_${CUDA_ARCH_NUMBER} --cudart static")
   target_link_libraries(dbcsr PUBLIC ${CUDA_LIBRARY} cuda nvrtc)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,7 +148,7 @@ target_compile_definitions(dbcsr PRIVATE __STATM_TOTAL)
 set_target_properties(dbcsr PROPERTIES LINKER_LANGUAGE Fortran)
 
 if (MPI_FOUND)
-  # once built, a user of the dbcsr library can not influence anything anmore by setting those flags:
+  # once built, a user of the dbcsr library can not influence anything anymore by setting those flags:
   target_compile_definitions(dbcsr PRIVATE __parallel __MPI_VERSION=${MPI_Fortran_VERSION_MAJOR})
 
   # Instead of resetting the compiler for MPI, we are adding the compiler flags

--- a/src/base/dbcsr_base_uses.f90
+++ b/src/base/dbcsr_base_uses.f90
@@ -23,7 +23,7 @@
 #if defined(NDEBUG)
 # define DBCSR_ASSERT(cond)
 #else
-#define DBCSR_ASSERT(cond) IF(.NOT.(cond))CALL dbcsr__a(__SHORT_FILE__,__LINE__)
+# define DBCSR_ASSERT(cond) IF(.NOT.(cond))CALL dbcsr__a(__SHORT_FILE__,__LINE__)
 #endif
 
 ! The MARK_USED macro can be used to mark an argument/variable as used.

--- a/src/block/dbcsr_block_operations.F
+++ b/src/block/dbcsr_block_operations.F
@@ -44,9 +44,7 @@ MODULE dbcsr_block_operations
 #  define PURE_TCOPY PURE
 #  define PURE_TRANS PURE
 #else
-#  if defined(__MKL)
-#  include "mkl_trans.fi"
-#  endif
+! MKL: mkl_trans.fi header is obsolescent (use implicit "interface") 
 #  define PURE_TCOPY
 #  define PURE_TRANS
 #endif

--- a/src/block/dbcsr_block_operations.F
+++ b/src/block/dbcsr_block_operations.F
@@ -36,7 +36,10 @@ MODULE dbcsr_block_operations
 
 !$ USE OMP_LIB, ONLY: omp_get_max_threads, omp_get_thread_num, omp_get_num_threads
    IMPLICIT NONE
-#if !defined(__MKL) && !defined(__LIBXSMM)
+#if defined(__LIBXSMM) && TO_VERSION(1, 10, 0) <= TO_VERSION(LIBXSMM_CONFIG_VERSION_MAJOR, LIBXSMM_CONFIG_VERSION_MINOR, LIBXSMM_CONFIG_VERSION_UPDATE)
+# define __LIBXSMM_TRANS
+#endif
+#if !defined(__MKL) && !defined(__LIBXSMM_TRANS)
 !  MKL: routines are impure, LIBXSMM: C_LOC is impure (F-standard mistake)
 #  define PURE_TCOPY PURE
 #  define PURE_TRANS PURE

--- a/src/block/dbcsr_block_operations.F
+++ b/src/block/dbcsr_block_operations.F
@@ -36,6 +36,17 @@ MODULE dbcsr_block_operations
 
 !$ USE OMP_LIB, ONLY: omp_get_max_threads, omp_get_thread_num, omp_get_num_threads
    IMPLICIT NONE
+#if !defined(__MKL) && !defined(__LIBXSMM)
+!  MKL: routines are impure, LIBXSMM: C_LOC is impure (F-standard mistake)
+#  define PURE_TCOPY PURE
+#  define PURE_TRANS PURE
+#else
+#  if defined(__MKL)
+#  include "mkl_trans.fi"
+#  endif
+#  define PURE_TCOPY
+#  define PURE_TRANS
+#endif
    PRIVATE
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'dbcsr_block_operations'

--- a/src/block/dbcsr_block_operations.f90
+++ b/src/block/dbcsr_block_operations.f90
@@ -313,19 +313,33 @@
 !> \param[in] rows input matrix size
 !> \param[in] columns input matrix size
 ! **************************************************************************************************
-  PURE SUBROUTINE block_transpose_copy_${nametype1}$(extent_out, extent_in,&
+  PURE_TCOPY SUBROUTINE block_transpose_copy_${nametype1}$(extent_out, extent_in,&
        rows, columns)
+#if defined(__LIBXSMM)
+    USE libxsmm, ONLY: libxsmm_otrans
+    USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_LOC
+    ${type1}$, DIMENSION(:), INTENT(OUT), TARGET :: extent_out
+    ${type1}$, DIMENSION(:), INTENT(IN),  TARGET :: extent_in
+#else
     ${type1}$, DIMENSION(:), INTENT(OUT) :: extent_out
     ${type1}$, DIMENSION(:), INTENT(IN)  :: extent_in
-    INTEGER, INTENT(IN)                :: rows, columns
+#endif
+    INTEGER, INTENT(IN) :: rows, columns
 
     CHARACTER(len=*), PARAMETER :: routineN = 'block_transpose_copy_${nametype1}$', &
       routineP = moduleN//':'//routineN
 
 !   ---------------------------------------------------------------------------
 
+#if defined(__LIBXSMM)
+    CALL libxsmm_otrans(C_LOC(extent_out(1)), C_LOC(extent_in(1)), &
+                        ${typesize1[n]}$, rows, columns, rows, columns)
+#elif defined(__MKL)
+    CALL mkl_${nametype1}$omatcopy('C', 'T', rows, columns, ${one1[n]}$, extent_in, rows, extent_out, columns)
+#else
     extent_out(1:rows*columns) = RESHAPE(TRANSPOSE(&
          RESHAPE(extent_in(1:rows*columns), (/rows, columns/))), (/rows*columns/))
+#endif
   END SUBROUTINE block_transpose_copy_${nametype1}$
 
 ! **************************************************************************************************
@@ -337,7 +351,7 @@
 ! **************************************************************************************************
   PURE SUBROUTINE block_copy_2d1d_${nametype1}$(extent_out, extent_in,&
        rows, columns)
-    INTEGER, INTENT(IN)                           :: rows, columns
+    INTEGER, INTENT(IN)                             :: rows, columns
     ${type1}$, DIMENSION(rows,columns), INTENT(OUT) :: extent_out
     ${type1}$, DIMENSION(:), INTENT(IN)             :: extent_in
 
@@ -399,18 +413,32 @@
 !> \param[in] rows input matrix size
 !> \param[in] columns input matrix size
 ! **************************************************************************************************
-  PURE SUBROUTINE block_transpose_copy_2d1d_${nametype1}$(extent_out, extent_in,&
+  PURE_TCOPY SUBROUTINE block_transpose_copy_2d1d_${nametype1}$(extent_out, extent_in,&
        rows, columns)
-    INTEGER, INTENT(IN)                           :: rows, columns
-    ${type1}$, DIMENSION(columns,rows), INTENT(OUT) :: extent_out
-    ${type1}$, DIMENSION(:), INTENT(IN)             :: extent_in
-
+#if defined(__LIBXSMM)
+    USE libxsmm, ONLY: libxsmm_otrans
+    USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_LOC
+    INTEGER, INTENT(IN)                                     :: rows, columns
+    ${type1}$, DIMENSION(columns,rows), INTENT(OUT), TARGET :: extent_out
+    ${type1}$, DIMENSION(:), INTENT(IN), TARGET             :: extent_in
+#else
+    INTEGER, INTENT(IN)                                     :: rows, columns
+    ${type1}$, DIMENSION(columns,rows), INTENT(OUT)         :: extent_out
+    ${type1}$, DIMENSION(:), INTENT(IN)                     :: extent_in
+#endif
     CHARACTER(len=*), PARAMETER :: routineN = 'block_transpose_copy_2d1d_${nametype1}$', &
       routineP = moduleN//':'//routineN
 
 !   ---------------------------------------------------------------------------
 
+#if defined(__LIBXSMM)
+    CALL libxsmm_otrans(C_LOC(extent_out(1,1)), C_LOC(extent_in(1)), &
+                        ${typesize1[n]}$, rows, columns, rows, columns)
+#elif defined(__MKL)
+    CALL mkl_${nametype1}$omatcopy('C', 'T', rows, columns, ${one1[n]}$, extent_in, rows, extent_out, columns)
+#else
     extent_out = TRANSPOSE(RESHAPE(extent_in, (/rows, columns/)))
+#endif
   END SUBROUTINE block_transpose_copy_2d1d_${nametype1}$
 
 ! **************************************************************************************************
@@ -442,18 +470,32 @@
 !> \param[in] rows input matrix size
 !> \param[in] columns input matrix size
 ! **************************************************************************************************
-  PURE SUBROUTINE block_transpose_copy_1d2d_${nametype1}$(extent_out, extent_in,&
+  PURE_TCOPY SUBROUTINE block_transpose_copy_1d2d_${nametype1}$(extent_out, extent_in,&
        rows, columns)
-    ${type1}$, DIMENSION(:), INTENT(OUT)            :: extent_out
-    INTEGER, INTENT(IN)                           :: rows, columns
-    ${type1}$, DIMENSION(rows,columns), INTENT(IN)  :: extent_in
-
+#if defined(__LIBXSMM)
+    USE libxsmm, ONLY: libxsmm_otrans
+    USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_LOC
+    INTEGER, INTENT(IN)                                    :: rows, columns
+    ${type1}$, DIMENSION(:), INTENT(OUT), TARGET           :: extent_out
+    ${type1}$, DIMENSION(rows,columns), INTENT(IN), TARGET :: extent_in
+#else
+    INTEGER, INTENT(IN)                                    :: rows, columns
+    ${type1}$, DIMENSION(:), INTENT(OUT)                   :: extent_out
+    ${type1}$, DIMENSION(rows,columns), INTENT(IN)         :: extent_in
+#endif
     CHARACTER(len=*), PARAMETER :: routineN = 'block_transpose_copy_1d2d_${nametype1}$', &
       routineP = moduleN//':'//routineN
 
 !   ---------------------------------------------------------------------------
 
+#if defined(__LIBXSMM)
+    CALL libxsmm_otrans(C_LOC(extent_out(1)), C_LOC(extent_in(1,1)), &
+                        ${typesize1[n]}$, rows, columns, rows, columns)
+#elif defined(__MKL)
+    CALL mkl_${nametype1}$omatcopy('C', 'T', rows, columns, ${one1[n]}$, extent_in, rows, extent_out, columns)
+#else
     extent_out = RESHAPE(TRANSPOSE(extent_in), (/rows*columns/))
+#endif
   END SUBROUTINE block_transpose_copy_1d2d_${nametype1}$
 
 
@@ -463,11 +505,17 @@
 !> \param[in] rows input matrix size
 !> \param[in] columns input matrix size
 ! **************************************************************************************************
-  PURE SUBROUTINE block_transpose_inplace_${nametype1}$(extent, rows, columns)
-    INTEGER, INTENT(IN)                      :: rows, columns
-    ${type1}$, DIMENSION(rows*columns), &
-      INTENT(INOUT)                          :: extent
-    ${type1}$, DIMENSION(rows*columns)         :: extent_tr
+  PURE_TRANS SUBROUTINE block_transpose_inplace_${nametype1}$(extent, rows, columns)
+#if defined(__LIBXSMM)
+    USE libxsmm, ONLY: libxsmm_itrans
+    USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_LOC
+    INTEGER, INTENT(IN)                                       :: rows, columns
+    ${type1}$, DIMENSION(rows*columns), INTENT(INOUT), TARGET :: extent
+#else
+    INTEGER, INTENT(IN)                                       :: rows, columns
+    ${type1}$, DIMENSION(rows*columns), INTENT(INOUT)         :: extent
+#endif
+    ${type1}$, DIMENSION(rows*columns)                        :: extent_tr
 
     CHARACTER(len=*), PARAMETER :: routineN = 'block_transpose_inplace_${nametype1}$', &
       routineP = moduleN//':'//routineN
@@ -475,6 +523,11 @@
     INTEGER :: r, c
 !   ---------------------------------------------------------------------------
 
+#if defined(__LIBXSMM) && 0
+    CALL libxsmm_itrans(C_LOC(extent(1,1)), ${typesize1[n]}$, rows, columns, rows)
+#elif defined(__MKL)
+    CALL mkl_${nametype1}$imatcopy('C', 'T', rows, columns, ${one1[n]}$, extent, rows, columns)
+#else
     DO r = 1 , columns
       DO c = 1 , rows
        extent_tr(r + (c-1)*columns) = extent(c + (r-1)*rows)
@@ -485,6 +538,7 @@
        extent(r + (c-1)*columns) = extent_tr(r + (c-1)*columns)
       END DO
     END DO
+#endif
   END SUBROUTINE block_transpose_inplace_${nametype1}$
 
 
@@ -499,7 +553,7 @@
 !> \param[in] src        source data array
 !> \param[in] source_lb  (optional) lower bound of source
 ! **************************************************************************************************
-  SUBROUTINE dbcsr_data_set_a${nametype1}$ (dst, lb, data_size, src, source_lb)
+  SUBROUTINE dbcsr_data_set_a${nametype1}$(dst, lb, data_size, src, source_lb)
     TYPE(dbcsr_data_obj), INTENT(INOUT)      :: dst
     INTEGER, INTENT(IN)                      :: lb, data_size
     ${type1}$, DIMENSION(:), INTENT(IN)        :: src

--- a/src/block/dbcsr_block_operations.f90
+++ b/src/block/dbcsr_block_operations.f90
@@ -290,9 +290,9 @@
 !> \param[in] in_fe           first element of input
 ! **************************************************************************************************
   PURE SUBROUTINE block_copy_${nametype1}$(extent_out, extent_in, n, out_fe, in_fe)
-    INTEGER, INTENT(IN)                           :: n, out_fe, in_fe
-    ${type1}$, DIMENSION(*), INTENT(OUT)  :: extent_out
-    ${type1}$, DIMENSION(*), INTENT(IN)   :: extent_in
+    INTEGER, INTENT(IN) :: n, out_fe, in_fe
+    ${type1}$, DIMENSION(*), INTENT(OUT) :: extent_out
+    ${type1}$, DIMENSION(*), INTENT(IN)  :: extent_in
 
     CHARACTER(len=*), PARAMETER :: routineN = 'block_copy_${nametype1}$', &
       routineP = moduleN//':'//routineN
@@ -339,9 +339,9 @@
 ! **************************************************************************************************
   PURE SUBROUTINE block_copy_2d1d_${nametype1}$(extent_out, extent_in,&
        rows, columns)
+    INTEGER, INTENT(IN) :: rows, columns
     ${type1}$, DIMENSION(rows,columns), INTENT(OUT) :: extent_out
     ${type1}$, DIMENSION(:), INTENT(IN)             :: extent_in
-    INTEGER, INTENT(IN) :: rows, columns
 
     CHARACTER(len=*), PARAMETER :: routineN = 'block_copy_2d1d_${nametype1}$', &
       routineP = moduleN//':'//routineN
@@ -358,9 +358,9 @@
 ! **************************************************************************************************
   PURE SUBROUTINE block_copy_1d1d_${nametype1}$(extent_out, extent_in,&
        rows, columns)
+    INTEGER, INTENT(IN) :: rows, columns
     ${type1}$, DIMENSION(rows*columns), INTENT(OUT) :: extent_out
     ${type1}$, DIMENSION(rows*columns), INTENT(IN)  :: extent_in
-    INTEGER, INTENT(IN) :: rows, columns
 
     CHARACTER(len=*), PARAMETER :: routineN = 'block_copy_1d1d_${nametype1}$', &
       routineP = moduleN//':'//routineN
@@ -377,9 +377,9 @@
 ! **************************************************************************************************
   PURE SUBROUTINE block_copy_2d2d_${nametype1}$(extent_out, extent_in,&
        rows, columns)
+    INTEGER, INTENT(IN) :: rows, columns
     ${type1}$, DIMENSION(rows,columns), INTENT(OUT) :: extent_out
     ${type1}$, DIMENSION(rows,columns), INTENT(IN)  :: extent_in
-    INTEGER, INTENT(IN) :: rows, columns
 
     CHARACTER(len=*), PARAMETER :: routineN = 'block_copy_2d2d_${nametype1}$', &
       routineP = moduleN//':'//routineN
@@ -399,9 +399,9 @@
 #if defined(__LIBXSMM)
     USE libxsmm, ONLY: libxsmm_otrans, libxsmm_ptr1, libxsmm_ptr2
 #endif
+    INTEGER, INTENT(IN) :: rows, columns
     ${type1}$, DIMENSION(columns,rows), INTENT(OUT) :: extent_out
     ${type1}$, DIMENSION(:), INTENT(IN)             :: extent_in
-    INTEGER, INTENT(IN) :: rows, columns
 
     CHARACTER(len=*), PARAMETER :: routineN = 'block_transpose_copy_2d1d_${nametype1}$', &
       routineP = moduleN//':'//routineN
@@ -425,9 +425,9 @@
 ! **************************************************************************************************
   PURE SUBROUTINE block_copy_1d2d_${nametype1}$(extent_out, extent_in,&
        rows, columns)
+    INTEGER, INTENT(IN) :: rows, columns
     ${type1}$, DIMENSION(:), INTENT(OUT)           :: extent_out
     ${type1}$, DIMENSION(rows,columns), INTENT(IN) :: extent_in
-    INTEGER, INTENT(IN) :: rows, columns
 
     CHARACTER(len=*), PARAMETER :: routineN = 'block_copy_1d2d_${nametype1}$', &
       routineP = moduleN//':'//routineN
@@ -447,9 +447,9 @@
 #if defined(__LIBXSMM)
     USE libxsmm, ONLY: libxsmm_otrans, libxsmm_ptr1, libxsmm_ptr2
 #endif
+    INTEGER, INTENT(IN) :: rows, columns
     ${type1}$, DIMENSION(:), INTENT(OUT)           :: extent_out
     ${type1}$, DIMENSION(rows,columns), INTENT(IN) :: extent_in
-    INTEGER, INTENT(IN) :: rows, columns
 
     CHARACTER(len=*), PARAMETER :: routineN = 'block_transpose_copy_1d2d_${nametype1}$', &
       routineP = moduleN//':'//routineN
@@ -473,11 +473,12 @@
   PURE_TRANS SUBROUTINE block_transpose_inplace_${nametype1}$(extent, rows, columns)
 #if defined(__LIBXSMM) && 0
     USE libxsmm, ONLY: libxsmm_itrans, libxsmm_ptr1
+    INTEGER, INTENT(IN) :: rows, columns
 #else
-    ${type1}$, DIMENSION(rows*columns)                :: extent_tr
+    INTEGER, INTENT(IN) :: rows, columns
+    ${type1}$, DIMENSION(rows*columns) :: extent_tr
 #endif
     ${type1}$, DIMENSION(rows*columns), INTENT(INOUT) :: extent
-    INTEGER, INTENT(IN) :: rows, columns
 
     CHARACTER(len=*), PARAMETER :: routineN = 'block_transpose_inplace_${nametype1}$', &
       routineP = moduleN//':'//routineN

--- a/src/block/dbcsr_block_operations.f90
+++ b/src/block/dbcsr_block_operations.f90
@@ -309,7 +309,7 @@
 ! **************************************************************************************************
   PURE_TCOPY SUBROUTINE block_transpose_copy_${nametype1}$(extent_out, extent_in,&
        rows, columns)
-#if defined(__LIBXSMM)
+#if defined(__LIBXSMM_TRANS)
     USE libxsmm, ONLY: libxsmm_otrans, libxsmm_ptr1
 #endif
     ${type1}$, DIMENSION(:), INTENT(OUT) :: extent_out
@@ -319,7 +319,7 @@
     CHARACTER(len=*), PARAMETER :: routineN = 'block_transpose_copy_${nametype1}$', &
       routineP = moduleN//':'//routineN
 !   ---------------------------------------------------------------------------
-#if defined(__LIBXSMM)
+#if defined(__LIBXSMM_TRANS)
     CALL libxsmm_otrans(libxsmm_ptr1(extent_out), libxsmm_ptr1(extent_in), &
                         ${typesize1[n]}$, rows, columns, rows, columns)
 #elif defined(__MKL)
@@ -396,7 +396,7 @@
 ! **************************************************************************************************
   PURE_TCOPY SUBROUTINE block_transpose_copy_2d1d_${nametype1}$(extent_out, extent_in,&
        rows, columns)
-#if defined(__LIBXSMM)
+#if defined(__LIBXSMM_TRANS)
     USE libxsmm, ONLY: libxsmm_otrans, libxsmm_ptr1, libxsmm_ptr2
 #endif
     INTEGER, INTENT(IN) :: rows, columns
@@ -406,7 +406,7 @@
     CHARACTER(len=*), PARAMETER :: routineN = 'block_transpose_copy_2d1d_${nametype1}$', &
       routineP = moduleN//':'//routineN
 !   ---------------------------------------------------------------------------
-#if defined(__LIBXSMM)
+#if defined(__LIBXSMM_TRANS)
     CALL libxsmm_otrans(libxsmm_ptr2(extent_out), libxsmm_ptr1(extent_in), &
                         ${typesize1[n]}$, rows, columns, rows, columns)
 #elif defined(__MKL)
@@ -444,7 +444,7 @@
 ! **************************************************************************************************
   PURE_TCOPY SUBROUTINE block_transpose_copy_1d2d_${nametype1}$(extent_out, extent_in,&
        rows, columns)
-#if defined(__LIBXSMM)
+#if defined(__LIBXSMM_TRANS)
     USE libxsmm, ONLY: libxsmm_otrans, libxsmm_ptr1, libxsmm_ptr2
 #endif
     INTEGER, INTENT(IN) :: rows, columns
@@ -454,7 +454,7 @@
     CHARACTER(len=*), PARAMETER :: routineN = 'block_transpose_copy_1d2d_${nametype1}$', &
       routineP = moduleN//':'//routineN
 !   ---------------------------------------------------------------------------
-#if defined(__LIBXSMM)
+#if defined(__LIBXSMM_TRANS)
     CALL libxsmm_otrans(libxsmm_ptr1(extent_out), libxsmm_ptr2(extent_in), &
                         ${typesize1[n]}$, rows, columns, rows, columns)
 #elif defined(__MKL)
@@ -471,7 +471,7 @@
 !> \param[in] columns input matrix size
 ! **************************************************************************************************
   PURE_TRANS SUBROUTINE block_transpose_inplace_${nametype1}$(extent, rows, columns)
-#if defined(__LIBXSMM) && 0
+#if defined(__LIBXSMM_TRANS) && 0
     USE libxsmm, ONLY: libxsmm_itrans, libxsmm_ptr1
     INTEGER, INTENT(IN) :: rows, columns
 #else
@@ -485,7 +485,7 @@
 
     INTEGER :: r, c
 !   ---------------------------------------------------------------------------
-#if defined(__LIBXSMM) && 0
+#if defined(__LIBXSMM_TRANS) && 0
     CALL libxsmm_itrans(libxsmm_ptr1(extent), ${typesize1[n]}$, rows, columns, rows)
 #elif defined(__MKL)
     CALL mkl_${nametype1}$imatcopy('C', 'T', rows, columns, ${one1[n]}$, extent, rows, columns)

--- a/src/block/dbcsr_block_operations.f90
+++ b/src/block/dbcsr_block_operations.f90
@@ -549,9 +549,9 @@
 !> \param len ...
 ! **************************************************************************************************
   PURE SUBROUTINE block_add_${nametype1}$(block_a, block_b, len)
+    INTEGER, INTENT(IN) :: len
     ${type1}$, DIMENSION(len), INTENT(INOUT) :: block_a
     ${type1}$, DIMENSION(len), INTENT(IN)    :: block_b
-    INTEGER, INTENT(IN) :: len
     block_a(1:len) = block_a(1:len) + block_b(1:len)
   END SUBROUTINE block_add_${nametype1}$
 #:endfor

--- a/src/block/dbcsr_block_operations.f90
+++ b/src/block/dbcsr_block_operations.f90
@@ -315,7 +315,11 @@
 ! **************************************************************************************************
   PURE_TCOPY SUBROUTINE block_transpose_copy_${nametype1}$(extent_out, extent_in,&
        rows, columns)
+#:if nametype1=="s" or nametype1=="d"
 #if defined(__LIBXSMM)
+#:else
+#if 0
+#:endif
     USE libxsmm, ONLY: libxsmm_otrans
     USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_LOC
     ${type1}$, DIMENSION(:), INTENT(OUT), TARGET :: extent_out
@@ -331,7 +335,11 @@
 
 !   ---------------------------------------------------------------------------
 
+#:if nametype1=="s" or nametype1=="d"
 #if defined(__LIBXSMM)
+#:else
+#if 0
+#:endif
     CALL libxsmm_otrans(C_LOC(extent_out(1)), C_LOC(extent_in(1)), &
                         ${typesize1[n]}$, rows, columns, rows, columns)
 #elif defined(__MKL)
@@ -415,7 +423,11 @@
 ! **************************************************************************************************
   PURE_TCOPY SUBROUTINE block_transpose_copy_2d1d_${nametype1}$(extent_out, extent_in,&
        rows, columns)
+#:if nametype1=="s" or nametype1=="d"
 #if defined(__LIBXSMM)
+#:else
+#if 0
+#:endif
     USE libxsmm, ONLY: libxsmm_otrans
     USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_LOC
     INTEGER, INTENT(IN)                                     :: rows, columns
@@ -431,7 +443,11 @@
 
 !   ---------------------------------------------------------------------------
 
+#:if nametype1=="s" or nametype1=="d"
 #if defined(__LIBXSMM)
+#:else
+#if 0
+#:endif
     CALL libxsmm_otrans(C_LOC(extent_out(1,1)), C_LOC(extent_in(1)), &
                         ${typesize1[n]}$, rows, columns, rows, columns)
 #elif defined(__MKL)
@@ -472,7 +488,11 @@
 ! **************************************************************************************************
   PURE_TCOPY SUBROUTINE block_transpose_copy_1d2d_${nametype1}$(extent_out, extent_in,&
        rows, columns)
+#:if nametype1=="s" or nametype1=="d"
 #if defined(__LIBXSMM)
+#:else
+#if 0
+#:endif
     USE libxsmm, ONLY: libxsmm_otrans
     USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_LOC
     INTEGER, INTENT(IN)                                    :: rows, columns
@@ -488,7 +508,11 @@
 
 !   ---------------------------------------------------------------------------
 
+#:if nametype1=="s" or nametype1=="d"
 #if defined(__LIBXSMM)
+#:else
+#if 0
+#:endif
     CALL libxsmm_otrans(C_LOC(extent_out(1)), C_LOC(extent_in(1,1)), &
                         ${typesize1[n]}$, rows, columns, rows, columns)
 #elif defined(__MKL)
@@ -506,7 +530,7 @@
 !> \param[in] columns input matrix size
 ! **************************************************************************************************
   PURE_TRANS SUBROUTINE block_transpose_inplace_${nametype1}$(extent, rows, columns)
-#if defined(__LIBXSMM)
+#if defined(__LIBXSMM) && 0
     USE libxsmm, ONLY: libxsmm_itrans
     USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_LOC
     INTEGER, INTENT(IN)                                       :: rows, columns

--- a/src/block/dbcsr_block_operations.f90
+++ b/src/block/dbcsr_block_operations.f90
@@ -45,7 +45,6 @@
       routineP = moduleN//':'//routineN
 
     INTEGER                                  :: col, row
-
 !   ---------------------------------------------------------------------------
 ! Factors out the 4 combinations to remove branches from the inner loop.
 !  rs is the logical row size so it always remains the leading dimension.
@@ -116,7 +115,6 @@
       routineP = moduleN//':'//routineN
 
     INTEGER                                  :: col, row
-
 !   ---------------------------------------------------------------------------
 ! Factors out the 4 combinations to remove branches from the inner loop. rs is the logical row size so it always remains the leading dimension.
     IF (.NOT. dst_tr .AND. .NOT. src_tr) THEN
@@ -149,6 +147,7 @@
        END DO
     ENDIF
   END SUBROUTINE block_partial_copy_1d2d_${nametype1}$
+
 ! **************************************************************************************************
 !> \brief Copies a block subset
 !> \param dst ...
@@ -186,7 +185,6 @@
       routineP = moduleN//':'//routineN
 
     INTEGER                                  :: col, row
-
 !   ---------------------------------------------------------------------------
 ! Factors out the 4 combinations to remove branches from the inner loop. rs is the logical row size so it always remains the leading dimension.
     IF (.NOT. dst_tr .AND. .NOT. src_tr) THEN
@@ -219,6 +217,7 @@
        END DO
     ENDIF
   END SUBROUTINE block_partial_copy_2d1d_${nametype1}$
+
 ! **************************************************************************************************
 !> \brief Copies a block subset
 !> \param dst ...
@@ -249,7 +248,6 @@
       routineP = moduleN//':'//routineN
 
     INTEGER                                  :: col, row
-
 !   ---------------------------------------------------------------------------
 ! Factors out the 4 combinations to remove branches from the inner loop. rs is the logical row size so it always remains the leading dimension.
     IF (.NOT. dst_tr .AND. .NOT. src_tr) THEN
@@ -283,7 +281,6 @@
     ENDIF
   END SUBROUTINE block_partial_copy_2d2d_${nametype1}$
 
-
 ! **************************************************************************************************
 !> \brief Copy a block
 !> \param[out] extent_out     output data
@@ -299,12 +296,9 @@
 
     CHARACTER(len=*), PARAMETER :: routineN = 'block_copy_${nametype1}$', &
       routineP = moduleN//':'//routineN
-
 !   ---------------------------------------------------------------------------
-
     extent_out(out_fe : out_fe+n-1) = extent_in(in_fe : in_fe+n-1)
   END SUBROUTINE block_copy_${nametype1}$
-
 
 ! **************************************************************************************************
 !> \brief Copy and transpose block.
@@ -315,32 +309,18 @@
 ! **************************************************************************************************
   PURE_TCOPY SUBROUTINE block_transpose_copy_${nametype1}$(extent_out, extent_in,&
        rows, columns)
-#:if nametype1=="s" or nametype1=="d"
 #if defined(__LIBXSMM)
-#:else
-#if 0
-#:endif
-    USE libxsmm, ONLY: libxsmm_otrans
-    USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_LOC
-    ${type1}$, DIMENSION(:), INTENT(OUT), TARGET :: extent_out
-    ${type1}$, DIMENSION(:), INTENT(IN),  TARGET :: extent_in
-#else
+    USE libxsmm, ONLY: libxsmm_otrans, libxsmm_ptr1
+#endif
     ${type1}$, DIMENSION(:), INTENT(OUT) :: extent_out
     ${type1}$, DIMENSION(:), INTENT(IN)  :: extent_in
-#endif
     INTEGER, INTENT(IN) :: rows, columns
 
     CHARACTER(len=*), PARAMETER :: routineN = 'block_transpose_copy_${nametype1}$', &
       routineP = moduleN//':'//routineN
-
 !   ---------------------------------------------------------------------------
-
-#:if nametype1=="s" or nametype1=="d"
 #if defined(__LIBXSMM)
-#:else
-#if 0
-#:endif
-    CALL libxsmm_otrans(C_LOC(extent_out(1)), C_LOC(extent_in(1)), &
+    CALL libxsmm_otrans(libxsmm_ptr1(extent_out), libxsmm_ptr1(extent_in), &
                         ${typesize1[n]}$, rows, columns, rows, columns)
 #elif defined(__MKL)
     CALL mkl_${nametype1}$omatcopy('C', 'T', rows, columns, ${one1[n]}$, extent_in, rows, extent_out, columns)
@@ -359,15 +339,13 @@
 ! **************************************************************************************************
   PURE SUBROUTINE block_copy_2d1d_${nametype1}$(extent_out, extent_in,&
        rows, columns)
-    INTEGER, INTENT(IN)                             :: rows, columns
     ${type1}$, DIMENSION(rows,columns), INTENT(OUT) :: extent_out
     ${type1}$, DIMENSION(:), INTENT(IN)             :: extent_in
+    INTEGER, INTENT(IN) :: rows, columns
 
     CHARACTER(len=*), PARAMETER :: routineN = 'block_copy_2d1d_${nametype1}$', &
       routineP = moduleN//':'//routineN
-
 !   ---------------------------------------------------------------------------
-
     extent_out = RESHAPE(extent_in, (/rows, columns/))
   END SUBROUTINE block_copy_2d1d_${nametype1}$
 
@@ -380,15 +358,13 @@
 ! **************************************************************************************************
   PURE SUBROUTINE block_copy_1d1d_${nametype1}$(extent_out, extent_in,&
        rows, columns)
-    INTEGER, INTENT(IN)                           :: rows, columns
     ${type1}$, DIMENSION(rows*columns), INTENT(OUT) :: extent_out
     ${type1}$, DIMENSION(rows*columns), INTENT(IN)  :: extent_in
+    INTEGER, INTENT(IN) :: rows, columns
 
     CHARACTER(len=*), PARAMETER :: routineN = 'block_copy_1d1d_${nametype1}$', &
       routineP = moduleN//':'//routineN
-
 !   ---------------------------------------------------------------------------
-
     extent_out(:) = extent_in(:)
   END SUBROUTINE block_copy_1d1d_${nametype1}$
 
@@ -401,18 +377,15 @@
 ! **************************************************************************************************
   PURE SUBROUTINE block_copy_2d2d_${nametype1}$(extent_out, extent_in,&
        rows, columns)
-    INTEGER, INTENT(IN)                           :: rows, columns
     ${type1}$, DIMENSION(rows,columns), INTENT(OUT) :: extent_out
     ${type1}$, DIMENSION(rows,columns), INTENT(IN)  :: extent_in
+    INTEGER, INTENT(IN) :: rows, columns
 
     CHARACTER(len=*), PARAMETER :: routineN = 'block_copy_2d2d_${nametype1}$', &
       routineP = moduleN//':'//routineN
-
 !   ---------------------------------------------------------------------------
-
     extent_out(:,:) = extent_in(:,:)
   END SUBROUTINE block_copy_2d2d_${nametype1}$
-
 
 ! **************************************************************************************************
 !> \brief Copy and transpose block.
@@ -423,32 +396,18 @@
 ! **************************************************************************************************
   PURE_TCOPY SUBROUTINE block_transpose_copy_2d1d_${nametype1}$(extent_out, extent_in,&
        rows, columns)
-#:if nametype1=="s" or nametype1=="d"
 #if defined(__LIBXSMM)
-#:else
-#if 0
-#:endif
-    USE libxsmm, ONLY: libxsmm_otrans
-    USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_LOC
-    INTEGER, INTENT(IN)                                     :: rows, columns
-    ${type1}$, DIMENSION(columns,rows), INTENT(OUT), TARGET :: extent_out
-    ${type1}$, DIMENSION(:), INTENT(IN), TARGET             :: extent_in
-#else
-    INTEGER, INTENT(IN)                                     :: rows, columns
-    ${type1}$, DIMENSION(columns,rows), INTENT(OUT)         :: extent_out
-    ${type1}$, DIMENSION(:), INTENT(IN)                     :: extent_in
+    USE libxsmm, ONLY: libxsmm_otrans, libxsmm_ptr1, libxsmm_ptr2
 #endif
+    ${type1}$, DIMENSION(columns,rows), INTENT(OUT) :: extent_out
+    ${type1}$, DIMENSION(:), INTENT(IN)             :: extent_in
+    INTEGER, INTENT(IN) :: rows, columns
+
     CHARACTER(len=*), PARAMETER :: routineN = 'block_transpose_copy_2d1d_${nametype1}$', &
       routineP = moduleN//':'//routineN
-
 !   ---------------------------------------------------------------------------
-
-#:if nametype1=="s" or nametype1=="d"
 #if defined(__LIBXSMM)
-#:else
-#if 0
-#:endif
-    CALL libxsmm_otrans(C_LOC(extent_out(1,1)), C_LOC(extent_in(1)), &
+    CALL libxsmm_otrans(libxsmm_ptr2(extent_out), libxsmm_ptr1(extent_in), &
                         ${typesize1[n]}$, rows, columns, rows, columns)
 #elif defined(__MKL)
     CALL mkl_${nametype1}$omatcopy('C', 'T', rows, columns, ${one1[n]}$, extent_in, rows, extent_out, columns)
@@ -466,18 +425,15 @@
 ! **************************************************************************************************
   PURE SUBROUTINE block_copy_1d2d_${nametype1}$(extent_out, extent_in,&
        rows, columns)
-    ${type1}$, DIMENSION(:), INTENT(OUT)            :: extent_out
-    INTEGER, INTENT(IN)                           :: rows, columns
-    ${type1}$, DIMENSION(rows,columns), INTENT(IN)  :: extent_in
+    ${type1}$, DIMENSION(:), INTENT(OUT)           :: extent_out
+    ${type1}$, DIMENSION(rows,columns), INTENT(IN) :: extent_in
+    INTEGER, INTENT(IN) :: rows, columns
 
     CHARACTER(len=*), PARAMETER :: routineN = 'block_copy_1d2d_${nametype1}$', &
       routineP = moduleN//':'//routineN
-
 !   ---------------------------------------------------------------------------
-
     extent_out = RESHAPE(extent_in, (/rows*columns/))
   END SUBROUTINE block_copy_1d2d_${nametype1}$
-
 
 ! **************************************************************************************************
 !> \brief Copy and transpose block.
@@ -488,32 +444,18 @@
 ! **************************************************************************************************
   PURE_TCOPY SUBROUTINE block_transpose_copy_1d2d_${nametype1}$(extent_out, extent_in,&
        rows, columns)
-#:if nametype1=="s" or nametype1=="d"
 #if defined(__LIBXSMM)
-#:else
-#if 0
-#:endif
-    USE libxsmm, ONLY: libxsmm_otrans
-    USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_LOC
-    INTEGER, INTENT(IN)                                    :: rows, columns
-    ${type1}$, DIMENSION(:), INTENT(OUT), TARGET           :: extent_out
-    ${type1}$, DIMENSION(rows,columns), INTENT(IN), TARGET :: extent_in
-#else
-    INTEGER, INTENT(IN)                                    :: rows, columns
-    ${type1}$, DIMENSION(:), INTENT(OUT)                   :: extent_out
-    ${type1}$, DIMENSION(rows,columns), INTENT(IN)         :: extent_in
+    USE libxsmm, ONLY: libxsmm_otrans, libxsmm_ptr1, libxsmm_ptr2
 #endif
+    ${type1}$, DIMENSION(:), INTENT(OUT)           :: extent_out
+    ${type1}$, DIMENSION(rows,columns), INTENT(IN) :: extent_in
+    INTEGER, INTENT(IN) :: rows, columns
+
     CHARACTER(len=*), PARAMETER :: routineN = 'block_transpose_copy_1d2d_${nametype1}$', &
       routineP = moduleN//':'//routineN
-
 !   ---------------------------------------------------------------------------
-
-#:if nametype1=="s" or nametype1=="d"
 #if defined(__LIBXSMM)
-#:else
-#if 0
-#:endif
-    CALL libxsmm_otrans(C_LOC(extent_out(1)), C_LOC(extent_in(1,1)), &
+    CALL libxsmm_otrans(libxsmm_ptr1(extent_out), libxsmm_ptr2(extent_in), &
                         ${typesize1[n]}$, rows, columns, rows, columns)
 #elif defined(__MKL)
     CALL mkl_${nametype1}$omatcopy('C', 'T', rows, columns, ${one1[n]}$, extent_in, rows, extent_out, columns)
@@ -521,7 +463,6 @@
     extent_out = RESHAPE(TRANSPOSE(extent_in), (/rows*columns/))
 #endif
   END SUBROUTINE block_transpose_copy_1d2d_${nametype1}$
-
 
 ! **************************************************************************************************
 !> \brief In-place block transpose.
@@ -531,24 +472,20 @@
 ! **************************************************************************************************
   PURE_TRANS SUBROUTINE block_transpose_inplace_${nametype1}$(extent, rows, columns)
 #if defined(__LIBXSMM) && 0
-    USE libxsmm, ONLY: libxsmm_itrans
-    USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_LOC
-    INTEGER, INTENT(IN)                                       :: rows, columns
-    ${type1}$, DIMENSION(rows*columns), INTENT(INOUT), TARGET :: extent
+    USE libxsmm, ONLY: libxsmm_itrans, libxsmm_ptr1
 #else
-    INTEGER, INTENT(IN)                                       :: rows, columns
-    ${type1}$, DIMENSION(rows*columns), INTENT(INOUT)         :: extent
+    ${type1}$, DIMENSION(rows*columns)                :: extent_tr
 #endif
-    ${type1}$, DIMENSION(rows*columns)                        :: extent_tr
+    ${type1}$, DIMENSION(rows*columns), INTENT(INOUT) :: extent
+    INTEGER, INTENT(IN) :: rows, columns
 
     CHARACTER(len=*), PARAMETER :: routineN = 'block_transpose_inplace_${nametype1}$', &
       routineP = moduleN//':'//routineN
 
     INTEGER :: r, c
 !   ---------------------------------------------------------------------------
-
 #if defined(__LIBXSMM) && 0
-    CALL libxsmm_itrans(C_LOC(extent(1,1)), ${typesize1[n]}$, rows, columns, rows)
+    CALL libxsmm_itrans(libxsmm_ptr1(extent), ${typesize1[n]}$, rows, columns, rows)
 #elif defined(__MKL)
     CALL mkl_${nametype1}$imatcopy('C', 'T', rows, columns, ${one1[n]}$, extent, rows, columns)
 #else
@@ -564,7 +501,6 @@
     END DO
 #endif
   END SUBROUTINE block_transpose_inplace_${nametype1}$
-
 
 ! **************************************************************************************************
 !> \brief Copy data from a double real array to a data area
@@ -612,9 +548,9 @@
 !> \param len ...
 ! **************************************************************************************************
   PURE SUBROUTINE block_add_${nametype1}$(block_a, block_b, len)
-    INTEGER, INTENT(IN)                    :: len
     ${type1}$, DIMENSION(len), INTENT(INOUT) :: block_a
     ${type1}$, DIMENSION(len), INTENT(IN)    :: block_b
+    INTEGER, INTENT(IN) :: len
     block_a(1:len) = block_a(1:len) + block_b(1:len)
   END SUBROUTINE block_add_${nametype1}$
 #:endfor

--- a/src/data/dbcsr.fypp
+++ b/src/data/dbcsr.fypp
@@ -9,6 +9,7 @@
 #:set n_inst = [0, 1, 2, 3]
 
 #:set nametype1 = ['d','s','z','c']
+#:set typesize1 = ['8','4','16','8']
 #:set base1 = ['r', 'r', 'c', 'c']
 #:set prec1 = ['dp','sp','dp','sp']
 #:set kind1 = ['real_8', 'real_4', 'real_8', 'real_4']


### PR DESCRIPTION
* Functionality becomes available with LIBXSMM v1.10 although the actual interface was there forever. The version barrier was necessary because of portability issues with C_LOC (worked around with libxsmm_ptr1 and libxsmm_ptr2). 
* If LIBXSMM is not used (or because of insufficient version), MKL's omatcopy and imatcopy functions are used (this could be ported to OpenBLAS as well). Note that mkl_trans.fi is not used as the header is obolescent; use an implicit "interface" instead (link-time).
* CMake infrastructure is extended to add __MKL to the list of preprocessor symbols (depends on BLA_VENDOR or list of BLAS_LIBRARIES); this check is done in a backward compatible fashion (older CMake).