### PR TITLE
dbcsr.h: make functions static, drop C++ aliases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
     - cd build
     # C++ example fails with this ancient version of MPI,
     # we see all system CPUs, but can use only 1, causing nproc auto-detection to fail
-    - cmake -DCMAKE_BUILD_TYPE=Coverage -DWITH_EXAMPLES=OFF -DTEST_MPI_RANKS=1 ..
+    - cmake -DCMAKE_BUILD_TYPE=Coverage -DTEST_MPI_RANKS=1 ..
     - make -j
     - make CTEST_OUTPUT_ON_FAILURE=1 test
   - # run this in parallel with the other builds
@@ -67,7 +67,7 @@ jobs:
     - mkdir -p build
     - cd build
     # all examples need MPI atm
-    - cmake -DCMAKE_BUILD_TYPE=Coverage -DUSE_MPI=OFF -DWITH_EXAMPLES=OFF ..
+    - cmake -DCMAKE_BUILD_TYPE=Coverage -DUSE_MPI=OFF ..
     - make -j
     - make CTEST_OUTPUT_ON_FAILURE=1 test
   - # run this in parallel with the other builds
@@ -76,7 +76,7 @@ jobs:
     - mkdir -p build
     - cd build
     # all examples need MPI atm
-    - cmake -DCMAKE_BUILD_TYPE=Coverage -DUSE_MPI=OFF -DWITH_EXAMPLES=OFF -DUSE_SMM=libxsmm ..
+    - cmake -DCMAKE_BUILD_TYPE=Coverage -DUSE_MPI=OFF -DUSE_SMM=libxsmm ..
     - make -j
     - make CTEST_OUTPUT_ON_FAILURE=1 test
   - # run this in parallel with the other builds
@@ -85,7 +85,7 @@ jobs:
     - mkdir -p build
     - cd build
     # all examples need MPI atm
-    - cmake -DCMAKE_BUILD_TYPE=Coverage -DUSE_OPENMP=OFF -DWITH_EXAMPLES=OFF -DTEST_MPI_RANKS=1 ..
+    - cmake -DCMAKE_BUILD_TYPE=Coverage -DUSE_OPENMP=OFF -DTEST_MPI_RANKS=1 ..
     - make -j
     - make CTEST_OUTPUT_ON_FAILURE=1 test
   - stage: GitHub Release

--- a/examples/dbcsr_example_3.cpp
+++ b/examples/dbcsr_example_3.cpp
@@ -50,7 +50,7 @@ int main(int argc, char* argv[])
         << ", (" << coord[0] << ", " << coord[1] << ") in the 2D grid"
         << std::endl;
 
-    dbcsr::init_lib();
+    c_dbcsr_init_lib();
 
     // Total number of blocks
     int nblkrows_total = 4;
@@ -64,7 +64,7 @@ int main(int argc, char* argv[])
 
     void* dist = nullptr;
 
-    dbcsr::distribution_new(&dist, group,
+    c_dbcsr_distribution_new(&dist, group,
         row_dist.data(), row_dist.size(),
         col_dist.data(), col_dist.size());
 
@@ -83,13 +83,13 @@ int main(int argc, char* argv[])
             for(int j = 0; j < nblkcols_total; j++)
             {
                 int blk_proc = -1;
-                dbcsr::get_stored_coordinates(matrix, i, j, &blk_proc);
+                c_dbcsr_get_stored_coordinates(matrix, i, j, &blk_proc);
 
                 if(blk_proc == mpi_rank)
                 {
                     block.resize(row_blk_sizes[i] * col_blk_sizes[j]);
                     std::generate(block.begin(), block.end(), [&](){ return static_cast<double>(std::rand())/RAND_MAX; });
-                    dbcsr::put_block_d(matrix, i, j, block.data(), block.size());
+                    c_dbcsr_put_block_d(matrix, i, j, block.data(), block.size());
                 }
             }
         }
@@ -97,41 +97,41 @@ int main(int argc, char* argv[])
 
     // create and fill matrix a
     void* matrix_a = nullptr;
-    dbcsr::create_new_d(&matrix_a, "this is my matrix a", dist, 'N',
+    c_dbcsr_create_new_d(&matrix_a, "this is my matrix a", dist, 'N',
         row_blk_sizes.data(), row_blk_sizes.size(),
         col_blk_sizes.data(), col_blk_sizes.size());
     fill_matrix(matrix_a);
-    dbcsr::finalize(matrix_a);
+    c_dbcsr_finalize(matrix_a);
 
     // create and fill matrix b
     void* matrix_b = nullptr;
-    dbcsr::create_new_d(&matrix_b, "this is my matrix b", dist, 'N',
+    c_dbcsr_create_new_d(&matrix_b, "this is my matrix b", dist, 'N',
         row_blk_sizes.data(), row_blk_sizes.size(),
         col_blk_sizes.data(), col_blk_sizes.size());
     fill_matrix(matrix_b);
-    dbcsr::finalize(matrix_b);
+    c_dbcsr_finalize(matrix_b);
 
     // create matrix c, empty
     void* matrix_c = nullptr;
-    dbcsr::create_new_d(&matrix_c, "matrix c", dist, 'N',
+    c_dbcsr_create_new_d(&matrix_c, "matrix c", dist, 'N',
         row_blk_sizes.data(), row_blk_sizes.size(),
         col_blk_sizes.data(), col_blk_sizes.size());
-    dbcsr::finalize(matrix_c);
+    c_dbcsr_finalize(matrix_c);
 
     // multiply the matrices
-    dbcsr::multiply_d('N', 'N', 1.0, &matrix_a, &matrix_b, 0.0, &matrix_c, nullptr);
+    c_dbcsr_multiply_d('N', 'N', 1.0, &matrix_a, &matrix_b, 0.0, &matrix_c, nullptr);
 
-    dbcsr::print(matrix_a);
-    dbcsr::print(matrix_b);
-    dbcsr::print(matrix_c);
+    c_dbcsr_print(matrix_a);
+    c_dbcsr_print(matrix_b);
+    c_dbcsr_print(matrix_c);
 
-    dbcsr::release(&matrix_a);
-    dbcsr::release(&matrix_b);
-    dbcsr::release(&matrix_c);
+    c_dbcsr_release(&matrix_a);
+    c_dbcsr_release(&matrix_b);
+    c_dbcsr_release(&matrix_c);
 
-    dbcsr::distribution_release(&dist);
+    c_dbcsr_distribution_release(&dist);
 
-    dbcsr::finalize_lib(group);
+    c_dbcsr_finalize_lib(group);
 
     MPI_Comm_free(&group);
     MPI_Finalize();

--- a/examples/dbcsr_example_3.cpp
+++ b/examples/dbcsr_example_3.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* argv[])
     // Make 2D grid
     int dims[2] = {0};
     MPI_Dims_create(mpi_size, 2, dims);
-    const int periods[2] = {1};
+    int periods[2] = {1};
     int reorder = 0;
     MPI_Comm group;
     MPI_Cart_create(MPI_COMM_WORLD, 2, dims, periods, reorder, &group);

--- a/src/dbcsr.h
+++ b/src/dbcsr.h
@@ -2,7 +2,7 @@
 #define DBCSR_H
 
 #include <mpi.h>
-#include <stdbool.h> /* we need bool introduce in C99 */
+#include <stdbool.h> /* we need bool from C99 */
 
 #ifdef __cplusplus
 extern "C" {
@@ -11,7 +11,7 @@ extern "C" {
     
     void c_dbcsr_finalize_lib_aux(MPI_Fint* fcomm);
     
-    void c_dbcsr_finalize_lib(MPI_Comm comm)
+    static void c_dbcsr_finalize_lib(MPI_Comm comm)
     {
         MPI_Fint fcomm = MPI_Comm_c2f(comm);
         c_dbcsr_finalize_lib_aux(&fcomm);
@@ -20,8 +20,8 @@ extern "C" {
     void c_dbcsr_distribution_new_aux(void** dist, MPI_Fint* fcomm, int* row_dist, int row_dist_size,
                                       int* col_dist, int col_dist_size);
     
-    void c_dbcsr_distribution_new(void** dist, MPI_Comm comm, int* row_dist, int row_dist_size,
-                                              int* col_dist, int col_dist_size)
+    static void c_dbcsr_distribution_new(void** dist, MPI_Comm comm, int* row_dist, int row_dist_size,
+                                         int* col_dist, int col_dist_size)
     {
         MPI_Fint fcomm = MPI_Comm_c2f(comm);
         c_dbcsr_distribution_new_aux(dist, &fcomm, row_dist, row_dist_size, col_dist, col_dist_size);
@@ -31,7 +31,6 @@ extern "C" {
 
     void c_dbcsr_create_new_d(void** matrix, const char* name, void* dist, char matrix_type, int* row_blk_sizes,
                               int row_blk_sizes_length, int* col_blk_sizes, int col_blk_sizes_length);
-
 
     void c_dbcsr_finalize(void* matrix);
     
@@ -47,23 +46,6 @@ extern "C" {
                             double beta, void** c_matrix_c, bool* retain_sparsity);
 #ifdef __cplusplus
 }
-
-
-namespace dbcsr {
-    constexpr auto& init_lib = c_dbcsr_init_lib;
-    constexpr auto& finalize_lib = c_dbcsr_finalize_lib;
-    constexpr auto& distribution_new = c_dbcsr_distribution_new;
-    constexpr auto& distribution_release = c_dbcsr_distribution_release;
-    constexpr auto& create_new_d = c_dbcsr_create_new_d;
-    constexpr auto& finalize = c_dbcsr_finalize;
-    constexpr auto& release = c_dbcsr_release;
-    constexpr auto& print = c_dbcsr_print;
-    constexpr auto& get_stored_coordinates = c_dbcsr_get_stored_coordinates;
-    constexpr auto& put_block_d = c_dbcsr_put_block_d;
-    constexpr auto& multiply_d = c_dbcsr_multiply_d;
-}
-
 #endif
-
 
 #endif // DBCSR_H


### PR DESCRIPTION
Following the discussion on #65 and in consideration of PR #64 which
adds a fully OO C++ interface, I consider it to be safer to drop the
aliased C++ functions for now to avoid that people start relying on an
interface we are going to change later on.

fixes: #65