### PR TITLE
Require LIBXSMM v1.8.2 or later

### DIFF
--- a/src/base/dbcsr_base_uses.f90
+++ b/src/base/dbcsr_base_uses.f90
@@ -50,4 +50,7 @@
 ! Allows macro-toggles (in addition to parameters).
 #if defined(__LIBXSMM)
 #include <libxsmm_config.h>
+#if !defined(LIBXSMM_CONFIG_VERSION)
+#error LIBXSMM v1.8.2 or later is required!
+#endif
 #endif


### PR DESCRIPTION
Including libxsmm_config.h only works with LIBXSMM v1.8.2 and later. Otherwise, older versions of LIBXSMM still work if this header is not included (prior to v1.8.2 the header was not suitable for Fortran).