### PR TITLE
Makefile change s.t. mod files are not recompiled unnecessarily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -422,10 +422,12 @@ vpath %.cpp   $(ALL_SRC_DIRS)
 
 FYPPFLAGS ?= -n
 
-%.o %.mod: %.F
-	@rm -f $*.mod
+%.o: %.F
 	$(FYPPEXE) $(FYPPFLAGS) $< $*.F90
 	$(FC) -c $(FCFLAGS) -D__SHORT_FILE__="\"$(notdir $<)\"" -I'$(dir $<)' -I'$(SRCDIR)' $*.F90 $(FCLOGPIPE)
+
+%.mod: %.o
+	@true
 
 %.o: %.c
 	$(CC) -c $(CFLAGS) $<


### PR DESCRIPTION
The proposed changes make sure that we do not recompile all modules using a.F if a.F has changed, recompilation only happens if a.mod has changed (gfortran does not update a .mod file if it does not change).

For more information: http://lagrange.mechse.illinois.edu/f90_mod_deps/

CP2K Makefile solves this in the same way.

Needed for cp2k/cp2k#86, in order to to recompile cp2k only if dbcsr_api.mod has changed.