### PR TITLE
Removed padded data

### DIFF
--- a/src/data/dbcsr_data_methods.F
+++ b/src/data/dbcsr_data_methods.F
@@ -282,12 +282,14 @@ CONTAINS
             DBCSR_ABORT("Cannot use memory pool with previous data area.")
       ENDIF
 
+#if defined(__HAS_smm_dnn) && defined(__HAS_smm_vec)
       ! allocate some more as padding for libsmm kernels which read over the end.
       IF (data_size .GT. 0) THEN
          wanted_size = data_size + 10
       ELSE
          wanted_size = data_size
       ENDIF
+#endif
 
       !IF(area%d%memory_type%acc_devalloc) THEN
       !    IF(current_size==acc_devmem_size(area%d%acc_devmem)) &

--- a/src/data/dbcsr_data_methods.F
+++ b/src/data/dbcsr_data_methods.F
@@ -282,12 +282,11 @@ CONTAINS
             DBCSR_ABORT("Cannot use memory pool with previous data area.")
       ENDIF
 
+      wanted_size = data_size
 #if defined(__HAS_smm_dnn) && defined(__HAS_smm_vec)
       ! allocate some more as padding for libsmm kernels which read over the end.
       IF (data_size .GT. 0) THEN
          wanted_size = data_size + 10
-      ELSE
-         wanted_size = data_size
       ENDIF
 #endif
 


### PR DESCRIPTION
Removed padded data (over-allocation) for MATMUL, BLAS, and LIBXSMM code path. The SMM-layer is supposed to never cause OOBs (unless padding is clearly specified/determined). Previously, the +10-pad was cumbersome.