### PR TITLE
Makefile: fix compatibility issue with cp2k toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,10 @@ else
 endif
 
 ifneq ($(ARCH_NUMBER),)
+#if "-arch" has not yet been set in NVFLAGS
+ifeq ($(findstring "-arch", $(NVFLAGS)), '')
  NVFLAGS += -arch sm_$(ARCH_NUMBER)
+endif
 endif
 endif
 


### PR DESCRIPTION
- The Makefile variable `NVFLAGS` can already contain the correct gpu
architecture option depending on the variables included into the
makefile. If the option is set twice, compilation errors arise.
Therefore check whether the option is already set before setting
it in DBCSR Makefile.
- This fixes the following issue in cp2k repo: https://github.com/cp2k/cp2k/issues/128