### PR TITLE
utils/dbcsr_toollib: follow USE/ONLY convention

### DIFF
--- a/src/utils/dbcsr_toollib.F
+++ b/src/utils/dbcsr_toollib.F
@@ -205,7 +205,7 @@ CONTAINS
    FUNCTION joaat_hash(key) RESULT(hash_index)
       ! LIBXSMM: at least v1.9.0-6 is required
 #if defined(__LIBXSMM) && TO_VERSION(1, 10, 0) <= TO_VERSION(LIBXSMM_CONFIG_VERSION_MAJOR, LIBXSMM_CONFIG_VERSION_MINOR, LIBXSMM_CONFIG_VERSION_UPDATE)
-      USE libxsmm
+      USE libxsmm, ONLY: libxsmm_hash
       INTEGER, PARAMETER                                 :: seed = 0
       INTEGER, DIMENSION(:), INTENT(IN)                  :: key
       INTEGER                                            :: hash_index


### PR DESCRIPTION
fixes #133