### PR TITLE
switch to F2008

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,11 +110,10 @@ if (Fortran_COMPILER_NAME MATCHES "^gfortran.*")
   set(CMAKE_CXX_FLAGS_RELEASE      "-O3 -funroll-loops")
   set(CMAKE_CXX_FLAGS_COVERAGE     "-O0 -fprofile-arcs -ftest-coverage")
   set(CMAKE_CXX_FLAGS_DEBUG        "-O0 -ggdb")
-  set(CMAKE_Fortran_FLAGS          "-ffree-form -ffree-line-length-none -std=f2008")
+  set(CMAKE_Fortran_FLAGS          "-ffree-form -ffree-line-length-none -std=f2008ts")
   set(CMAKE_Fortran_FLAGS_RELEASE  "-O3 -funroll-loops")
   set(CMAKE_Fortran_FLAGS_DEBUG    "-O0 -ggdb")
   set(CMAKE_Fortran_FLAGS_COVERAGE "-O0 -fprofile-arcs -ftest-coverage")
-  set(F2008_COMPILER_FLAGS         "-std=f2008ts")
 
   # on Apple we may compile with GCC Fortran, but build/link C/C++ code with Apple's clang, requiring special treatment
   if (APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
@@ -130,14 +129,12 @@ elseif (Fortran_COMPILER_NAME MATCHES "^ifort.*")
   # Disable the line-length-extension warning #5268
   set(CMAKE_Fortran_FLAGS_RELEASE  "-O3 -diag-disable=5268")
   set(CMAKE_Fortran_FLAGS_DEBUG    "-O0 -debug")
-  set(F2008_COMPILER_FLAGS         "")
 elseif (Fortran_COMPILER_NAME MATCHES "^pgf.*")
   set(CMAKE_CXX_FLAGS_RELEASE      "-fast")
   set(CMAKE_CXX_FLAGS_DEBUG        "-g")
   set(CMAKE_Fortran_FLAGS          "-Mfreeform -Mextend -Mallocatable=03")  # -Mallocatable=03: enable F2003+ assignment semantics
   set(CMAKE_Fortran_FLAGS_RELEASE  "-fast")
   set(CMAKE_Fortran_FLAGS_DEBUG    "-g")
-  set(F2008_COMPILER_FLAGS         "")
 else ()
   message(WARNING "\
 Unknown compiler, trying with just '-O2'/'-O0 -g'.\n\

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ if (Fortran_COMPILER_NAME MATCHES "^gfortran.*")
   set(CMAKE_CXX_FLAGS_RELEASE      "-O3 -funroll-loops")
   set(CMAKE_CXX_FLAGS_COVERAGE     "-O0 -fprofile-arcs -ftest-coverage")
   set(CMAKE_CXX_FLAGS_DEBUG        "-O0 -ggdb")
-  set(CMAKE_Fortran_FLAGS          "-ffree-form -ffree-line-length-none -std=f2003")
+  set(CMAKE_Fortran_FLAGS          "-ffree-form -ffree-line-length-none -std=f2008")
   set(CMAKE_Fortran_FLAGS_RELEASE  "-O3 -funroll-loops")
   set(CMAKE_Fortran_FLAGS_DEBUG    "-O0 -ggdb")
   set(CMAKE_Fortran_FLAGS_COVERAGE "-O0 -fprofile-arcs -ftest-coverage")
@@ -126,22 +126,22 @@ if (Fortran_COMPILER_NAME MATCHES "^gfortran.*")
 elseif (Fortran_COMPILER_NAME MATCHES "^ifort.*")
   set(CMAKE_CXX_FLAGS_RELEASE      "-O3")
   set(CMAKE_CXX_FLAGS_DEBUG        "-O0 -debug")
-  set(CMAKE_Fortran_FLAGS          "-free -stand f03 -fpp")
+  set(CMAKE_Fortran_FLAGS          "-free -stand f08 -fpp")
   # Disable the line-length-extension warning #5268
   set(CMAKE_Fortran_FLAGS_RELEASE  "-O3 -diag-disable=5268")
   set(CMAKE_Fortran_FLAGS_DEBUG    "-O0 -debug")
-  set(F2008_COMPILER_FLAGS         "-stand f08")
+  set(F2008_COMPILER_FLAGS         "")
 elseif (Fortran_COMPILER_NAME MATCHES "^pgf.*")
   set(CMAKE_CXX_FLAGS_RELEASE      "-fast")
   set(CMAKE_CXX_FLAGS_DEBUG        "-g")
-  set(CMAKE_Fortran_FLAGS          "-Mfreeform -Mextend -Mallocatable=03")
+  set(CMAKE_Fortran_FLAGS          "-Mfreeform -Mextend -Mallocatable=03")  # -Mallocatable=03: enable F2003+ assignment semantics
   set(CMAKE_Fortran_FLAGS_RELEASE  "-fast")
   set(CMAKE_Fortran_FLAGS_DEBUG    "-g")
   set(F2008_COMPILER_FLAGS         "")
 else ()
   message(WARNING "\
 Unknown compiler, trying with just '-O2'/'-O0 -g'.\n\
-You will most likely have to pass additonal options for free-form Fortran 2003/2008 for your compiler!\n\
+You will most likely have to pass additonal options for free-form Fortran 2008 for your compiler!\n\
 Please open an issue at https://github.com/cp2k/dbcsr/issues with the reported compiler name and the required flags.")
   message("-- Fortran_COMPILER_NAME: " ${Fortran_COMPILER_NAME})
   message("-- CMAKE_Fortran_COMPILER full path: " ${CMAKE_Fortran_COMPILER})
@@ -149,6 +149,8 @@ Please open an issue at https://github.com/cp2k/dbcsr/issues with the reported c
   set(CMAKE_Fortran_FLAGS_RELEASE  "-O2")
   set(CMAKE_Fortran_FLAGS_DEBUG    "-O0 -g")
 endif ()
+
+include(CheckCompilerSupport)
 
 file(STRINGS VERSION VERSION_INFO)
 foreach(line ${VERSION_INFO})

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It is MPI and OpenMP parallel and can exploit GPUs via CUDA.
 You absolutely need:
 
 * GNU make
-* a Fortran compiler which supports at least Fortran 2003 (respectively 2008+TS when using the C-bindings)
+* a Fortran compiler which supports at least Fortran 2008 (including the TS when using the C-bindings)
 * a LAPACK implementation (reference, OpenBLAS-bundled and MKL have been tested. Note: DBCSR linked to OpenBLAS 0.3.6 gives wrong results on Power9 architectures.)
 * a BLAS implementation (reference, OpenBLAS-bundled and MKL have been tested)
 * a Python version installed (2.7 or 3.6+ have been tested) with Numpy

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It is MPI and OpenMP parallel and can exploit GPUs via CUDA.
 You absolutely need:
 
 * GNU make
-* a Fortran compiler which supports at least Fortran 2008 (including the TS when using the C-bindings)
+* a Fortran compiler which supports at least Fortran 2008 (including the TS 29113 when using the C-bindings)
 * a LAPACK implementation (reference, OpenBLAS-bundled and MKL have been tested. Note: DBCSR linked to OpenBLAS 0.3.6 gives wrong results on Power9 architectures.)
 * a BLAS implementation (reference, OpenBLAS-bundled and MKL have been tested)
 * a Python version installed (2.7 or 3.6+ have been tested) with Numpy

--- a/cmake/CheckCompilerSupport.cmake
+++ b/cmake/CheckCompilerSupport.cmake
@@ -3,6 +3,8 @@ include(CheckFortranSourceCompiles)
 
 set(CHECK_PROGRAMS
   f2008-norm2.f90
+  f2008-block_construct.f90
+  f2008-contiguous.f90
   )
 
 foreach (prog ${CHECK_PROGRAMS})

--- a/cmake/CheckCompilerSupport.cmake
+++ b/cmake/CheckCompilerSupport.cmake
@@ -1,0 +1,18 @@
+
+include(CheckFortranSourceCompiles)
+
+set(CHECK_PROGRAMS
+  f2008-norm2.f90
+  )
+
+foreach (prog ${CHECK_PROGRAMS})
+  get_filename_component(prog_ext ${prog} EXT)  # get the src extension to pass along
+  get_filename_component(prog_name ${prog} NAME_WE)
+
+  file(READ "${CMAKE_CURRENT_LIST_DIR}/compiler-tests/${prog}" prog_src)
+  check_fortran_source_compiles("${prog_src}" "${prog_name}" SRC_EXT "${prog_ext}")
+
+  if (NOT ${prog_name})
+    message(FATAL_ERROR "Your compiler does not support all required F2008 features")
+  endif ()
+endforeach ()

--- a/cmake/compiler-tests/f2008-block_construct.f90
+++ b/cmake/compiler-tests/f2008-block_construct.f90
@@ -1,0 +1,14 @@
+!--------------------------------------------------------------------------------------------------!
+! Copyright (C) by the DBCSR developers group - All rights reserved                                !
+! This file is part of the DBCSR library.                                                          !
+!                                                                                                  !
+! For information on the license, see the LICENSE file.                                            !
+! For further information please visit https://dbcsr.cp2k.org                                      !
+! SPDX-License-Identifier: GPL-2.0+                                                                !
+!--------------------------------------------------------------------------------------------------!
+
+program main
+   try: block
+      exit try
+   end block try
+end program

--- a/cmake/compiler-tests/f2008-contiguous.f90
+++ b/cmake/compiler-tests/f2008-contiguous.f90
@@ -1,0 +1,22 @@
+!--------------------------------------------------------------------------------------------------!
+! Copyright (C) by the DBCSR developers group - All rights reserved                                !
+! This file is part of the DBCSR library.                                                          !
+!                                                                                                  !
+! For information on the license, see the LICENSE file.                                            !
+! For further information please visit https://dbcsr.cp2k.org                                      !
+! SPDX-License-Identifier: GPL-2.0+                                                                !
+!--------------------------------------------------------------------------------------------------!
+
+program main
+   implicit none
+
+   ! test whether the compiler supports the CONTIGUOUS keyword
+   integer, allocatable, target :: targ(:)
+   integer, contiguous, pointer :: ptr(:)
+
+   ! allocated data is always contiguous
+   allocate(targ(10))
+   ptr => targ
+
+   ! IS_CONTIGUOUS was implemented in gcc-9 and is therefore not tested for yet
+end program

--- a/cmake/compiler-tests/f2008-norm2.f90
+++ b/cmake/compiler-tests/f2008-norm2.f90
@@ -1,0 +1,14 @@
+!--------------------------------------------------------------------------------------------------!
+! Copyright (C) by the DBCSR developers group - All rights reserved                                !
+! This file is part of the DBCSR library.                                                          !
+!                                                                                                  !
+! For information on the license, see the LICENSE file.                                            !
+! For further information please visit https://dbcsr.cp2k.org                                      !
+! SPDX-License-Identifier: GPL-2.0+                                                                !
+!--------------------------------------------------------------------------------------------------!
+
+program main
+    implicit none
+    real :: x(2) = [ real :: 3, 4 ]
+    if (abs(norm2(x) - 5.) > 1.0D-5) stop 1
+end program

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -247,7 +247,7 @@ if (WITH_C_API)
   add_library(dbcsr_c ${DBCSR_C_SRCS})
   set_target_properties(dbcsr_c PROPERTIES
     LINKER_LANGUAGE Fortran
-    COMPILE_FLAGS "${F2008_COMPILER_FLAGS}")
+    )
   target_link_libraries(dbcsr_c PRIVATE dbcsr)
   target_link_libraries(dbcsr_c PUBLIC MPI::MPI_C)  # the C API always needs MPI
   target_include_directories(dbcsr_c PUBLIC


### PR DESCRIPTION
based on the discussion in #129, https://github.com/cp2k/cp2k/issues/142 and the fact that PR https://github.com/cp2k/cp2k/pull/158 was merged for CP2K this PR adds a check for F2008's `norm2` support in the compiler when using CMake.