### PR TITLE
Fix/perf issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,14 @@ endif ()
 
 get_filename_component(Fortran_COMPILER_NAME ${CMAKE_Fortran_COMPILER} NAME)
 
+# if the fortran compiler command is a CRAY wrapper, find out what the underlying compiler is
+if (Fortran_COMPILER_NAME MATCHES "ftn")
+  execute_process(COMMAND ftn -craype-verbose OUTPUT_VARIABLE ftn_verbose_OUT ERROR_QUIET)
+  separate_arguments(ftn_verbose_OUT NATIVE_COMMAND "${ftn_verbose_OUT}")
+  list(GET ftn_verbose_OUT 0 Fortran_COMPILER_NAME)
+endif ()
+
+# Depending on the fortran compiler, set the appropriate compiler flags
 if (Fortran_COMPILER_NAME MATCHES "gfortran.*")
   set(CMAKE_CXX_FLAGS              "-std=c++11")
   set(CMAKE_CXX_FLAGS_RELEASE      "-O3 -funroll-loops")

--- a/Makefile
+++ b/Makefile
@@ -486,7 +486,7 @@ FYPPFLAGS ?= -n
 	$(CXX) -c $(CXXFLAGS) $<
 
 libcusmm.o: libcusmm.cpp parameters.h cusmm_kernels.h
-	$(CXX) -c $(CXXFLAGS) -fopenmp -DARCH_NUMBER=$(ARCH_NUMBER) $<
+	$(CXX) -c $(CXXFLAGS) $(CXXOMPFLAGS) -DARCH_NUMBER=$(ARCH_NUMBER) $<
 
 %.o: %.cu
 	$(NVCC) -c $(NVFLAGS) -I'$(SRCDIR)' $<

--- a/Makefile
+++ b/Makefile
@@ -486,7 +486,7 @@ FYPPFLAGS ?= -n
 	$(CXX) -c $(CXXFLAGS) $<
 
 libcusmm.o: libcusmm.cpp parameters.h cusmm_kernels.h
-	$(CXX) -c $(CXXFLAGS) -DARCH_NUMBER=$(ARCH_NUMBER) $<
+	$(CXX) -c $(CXXFLAGS) -fopenmp -DARCH_NUMBER=$(ARCH_NUMBER) $<
 
 %.o: %.cu
 	$(NVCC) -c $(NVFLAGS) -I'$(SRCDIR)' $<

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -34,11 +34,12 @@
 #
 # For convenience, some variables can be set during compilation,
 # e.g. make `VARIABLE=value` (multiple variables are possible):
-# 1) MPI=0    : disable MPI compilation
-# 2) GNU=0    : disable GNU compiler compilation and enable Intel compiler compilation
-# 3) CHECKS=1 : enable GNU compiler checks and DBCSR asserts
-# 4) CINT=1   : generate the C interface
-# 5) GPU=1    : enable GPU support
+# 1) OMP=0    : disable OpenMP compilation
+# 2) MPI=0    : disable MPI compilation
+# 3) GNU=0    : disable GNU compiler compilation and enable Intel compiler compilation
+# 4) CHECKS=1 : enable GNU compiler checks and DBCSR asserts
+# 5) CINT=1   : generate the C interface
+# 6) GPU=1    : enable GPU support
 #
 
 #######################################################################################
@@ -136,15 +137,18 @@ endif
 
 ifneq (0,$(GNU)) # DEFAULT, just edit...
   CXXFLAGS += -std=c++11
-  CXXOMPFLAGS += -fopenmp
-  FCFLAGS  += -fopenmp -std=f2003 -ffree-form -fimplicit-none -ffree-line-length-512
+  FCFLAGS  += -std=f2003 -ffree-form -fimplicit-none -ffree-line-length-512
   OPTFLAGS += -O3 -g -fno-omit-frame-pointer -funroll-loops
 else
  # Intel compiler flags
   CXXFLAGS += -std=c++11
-  CXXOMPFLAGS += -fopenmp
-  FCFLAGS  += -fopenmp -free
+  FCFLAGS  += -free
   OPTFLAGS += -O2 -g
+endif
+
+ifneq (0,$(OMP)) # using OpenMP
+  CXXOMPFLAGS = -fopenmp
+  FCFLAGS  += -fopenmp
 endif
 
 OPTFLAGS    +=

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -136,11 +136,13 @@ endif
 
 ifneq (0,$(GNU)) # DEFAULT, just edit...
   CXXFLAGS += -std=c++11
+  CXXOMPFLAGS += -fopenmp
   FCFLAGS  += -fopenmp -std=f2003 -ffree-form -fimplicit-none -ffree-line-length-512
   OPTFLAGS += -O3 -g -fno-omit-frame-pointer -funroll-loops
 else
  # Intel compiler flags
   CXXFLAGS += -std=c++11
+  CXXOMPFLAGS += -fopenmp
   FCFLAGS  += -fopenmp -free
   OPTFLAGS += -O2 -g
 endif

--- a/src/acc/libsmm_acc/libcusmm/libcusmm.cpp
+++ b/src/acc/libsmm_acc/libcusmm/libcusmm.cpp
@@ -209,6 +209,7 @@ int libcusmm_process_d(int *param_stack, int stack_size, CUstream stream, int m,
 
         // Add lock to table of locks and initialize it
         // (Some serialization here)
+#if defined _OPENMP
         #pragma omp critical 
         {
             if(kernel_locks.find(h_mnk) == kernel_locks.end()){
@@ -225,7 +226,9 @@ int libcusmm_process_d(int *param_stack, int stack_size, CUstream stream, int m,
 
         // JIT the kernel using a single thread
         if(kernel_handles.find(h_mnk) == kernel_handles.end()){
+#endif
             add_kernel_handle_to_jitted_kernels(kern_func, stream, h_mnk, threads, grouping, cpu_fallback); 
+#if defined _OPENMP
         }
 
         // Unset lock and destroy
@@ -241,6 +244,7 @@ int libcusmm_process_d(int *param_stack, int stack_size, CUstream stream, int m,
                 kernel_locks.erase(it);
             }
         }
+#endif
 
         if(cpu_fallback)
             return -2; // fall back to CPU

--- a/src/acc/libsmm_acc/libcusmm/libcusmm.h
+++ b/src/acc/libsmm_acc/libcusmm/libcusmm.h
@@ -16,9 +16,12 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <nvrtc.h>
-#include <omp.h>
 #include <unordered_map>
 #include <vector>
+
+#if defined _OPENMP
+#include <omp.h>
+#endif
 
 // Macros for CUDA error handling
 // Wrap calls to CUDA NVRTC API
@@ -48,7 +51,9 @@ struct kernel_launcher {
 };
 
 static std::unordered_map<Triplet, kernel_launcher> kernel_handles;
+#if defined _OPENMP
 static std::unordered_map<Triplet, omp_lock_t> kernel_locks;
+#endif
 
 int libcusmm_process_d(int *param_stack, int stack_size,
     CUstream stream, int m, int n, int k,

--- a/src/acc/libsmm_acc/libcusmm/libcusmm.h
+++ b/src/acc/libsmm_acc/libcusmm/libcusmm.h
@@ -16,6 +16,7 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <nvrtc.h>
+#include <omp.h>
 #include <unordered_map>
 #include <vector>
 
@@ -47,6 +48,7 @@ struct kernel_launcher {
 };
 
 static std::unordered_map<Triplet, kernel_launcher> kernel_handles;
+static std::unordered_map<Triplet, omp_lock_t> kernel_locks;
 
 int libcusmm_process_d(int *param_stack, int stack_size,
     CUstream stream, int m, int n, int k,

--- a/tests/inputs/test_H2O.perf
+++ b/tests/inputs/test_H2O.perf
@@ -1,0 +1,60 @@
+# npcols MPI grid, 0 leaves MPI to find the best grid.
+# Note that the total number of processors must be divisible per npcols
+0
+# operation
+dbcsr_multiply
+# matrix sizes (M, N, K)
+2208
+2208
+2208
+# sparsity (A, B, C)
+0.2d0
+0.2d0
+0.2d0
+# transposes
+N
+N
+# symmetries
+N
+N
+N
+# data type
+3
+# alpha (real, imag)
+1.0d0
+0.0d0
+# beta (real, imag)
+1.0d0
+0.0d0          
+# limits (0 means full size)
+# row
+0
+0
+# col
+0
+0
+# k
+0
+0
+# retain sparsity (T/F)
+F
+# number of repetitions
+3
+# number of different blocks to read (m, n, k)
+1
+1
+1
+# the m blocks (multiplicity, block size, ...)
+1
+23
+# the n blocks (multiplicity, block size, ...)
+1
+23
+# the k blocks (multiplicity, block size, ...)
+1
+23
+# checksum (check, threshold, references)
+F
+0.
+0.
+0.


### PR DESCRIPTION
### Motivation
Investigate libcusmm's performance following a [performance issue in CP2K](https://github.com/cp2k/cp2k/issues/155).

----------------------
### PR changes
- Add a performance test loosely corresponding to H2O simulations in CP2K (commit
 94326fb, file `tests/inputs/test_H2O.perf`) 

- Fix a performance issue in libcusmm (see commit 7b808c09 for description of the fix)

----------------------
### JIT-ing kernels 

is performed only once per node for each (m,n,k)-multiplication triplet or each (m,n)-transpose pair which occurs in the program. This can be verified by running a test with [nvprof](https://devblogs.nvidia.com/cuda-pro-tip-nvprof-your-handy-universal-gpu-profiler/) as in the following example:

Sample output of `nvprof` for DBCSR's performance driver with `tests/inputs/test_H2O.perf` on 1 node, 12 threads: 

```
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   50.13%  26.574ms        73  364.02us  14.368us  469.85us  void cusmm_dnt_medium<int=23, int=23, int=23, int=3, int=2, int=96, int=4, int=4>(int const *, int, double const *, double const *, double*)
                   32.09%  17.009ms        84  202.49us  1.0230us  2.5687ms  [CUDA memcpy HtoD]
                   16.99%  9.0034ms        37  243.33us  3.8400us  254.11us  [CUDA memcpy DtoH]
                    0.73%  384.73us         3  128.24us  127.39us  129.02us  void transpose_d<int=23, int=23>(int*, double*)
                    0.07%  35.424us        37     957ns     768ns  2.4320us  [CUDA memset]
      API calls:   19.70%  273.86ms        36  7.6073ms  3.0762ms  9.3789ms  cudaStreamSynchronize
...
                    3.08%  42.758ms         2  21.379ms  17.946ms  24.812ms  cuModuleLoadDataEx
```

- The [NVRTC](https://docs.nvidia.com/cuda/nvrtc/index.html) API function `cuModuleLoadDataEx`, which is the longest function to execute as part of the JITting, (see `src/acc/libsmm_acc/libcusmm/libcusmm.cpp`) is called only twice (once for (23,23,23)-multiplication and once for (23,23)-transpose), though transposition (`transpose_d`) is called `3` times and multiplication (`cusmm_dnt_medium`) is called `73` times.
- JIT-ing kernels rather than generating them and compiling them at DBCSR's compile time (as was the case before PR #15) is therefore a one-off cost at runtime.
- The overhead of JIT-ing a single kernel is about `300-400 ms`, a negligible overhead for long runs. 

----------------------

### Performance numbers in DBCSR 
**Running performance driver with `tests/inputs/test_H2O.perf` on 1 node, 12 threads (cscs-daint-gpu)**

| commit | mean [s] | minmin [s] | maxmax [s] |
| ------------- |-------------:|-------------:|-------------:|
| `7b808c09` (this PR) | 0.311 | 0.035 | 0.860 |
| `78a915c2` (JIT-PR #15) | 1.45 | 0.036 | 4.29 |
| `5844932` (before JIT-PR #15) | 0.133 | 0.036 | 0.325 |

(each cell value is averaged over 3 runs of the performance driver) 

- The "minmin" values are very similar in all three DBCSR versions, in alignment with the fact that kernel-JITing incurs a one-off cost.
- Comparing the maxmax values, we see that the JIT overhead difference between `7b808c09` and `5844932` is of about `530 ms` for 2 kernels ((23,23,23)-multiplication and (23,23)-transpose), i.e. about `270 ms` per kernel in this case. These numbers are to be taken with a grain of salt though, since the first kernels launched on the GPU come with some GPU-startup overhead that is difficult to estimate. 
- This overhead is reduced between `7b808c09` and `78a915c2` as explained in commit 7b808c09.

----------------------

### Performance numbers in CP2K 
**Running CP2K with `tests/QS/benchmark_DM_LS/H2O-dft-ls.inp` with `NREP=1` on 1 node, 1 rank, 12 threads (cscs-daint-gpu)**

| CP2K commit | DBCSR commit | runtime [s] | 
| ------------- | ------------- |-------------:|
| `53314e2` (DBCSR separate from CP2K) | `7b808c09` (this PR) | 5.38 |
| `53314e2` (DBCSR separate from CP2K) | `78a915c2` (JIT-PR #15) | 7.45 |
| `e9292bad5` (DBCSR not yet separated from CP2K) | `5844932` (no JIT)| 4.82 | 

(values averaged over 6 runs)

**Running CP2K with `tests/QS/benchmark_DM_LS/H2O-dft-ls.inp` with `NREP=3` on 8 nodes, 2 ranks/node, 12 threads/rank (same config as `CRAY_XC50_gpu (Performance)` on the [dashboard](https://dashboard.cp2k.org/), cscs-daint-gpu)**

| CP2K commit | DBCSR commit | runtime [s] | 
| ------------- | ------------- |-------------:|
| `53314e2` (DBCSR separate from CP2K) | `7b808c09` (this PR) | 112.77 |
| `53314e2` (DBCSR separate from CP2K) | `78a915c2` (JIT-PR #15) | 119.16 |
| `e9292bad5` (DBCSR not yet separated from CP2K) | `5844932` (no JIT)| 109.27 | 

(values averaged over 3 runs)