### PR TITLE
libcusmm/notebooks: update requirements

### DIFF
--- a/src/acc/libsmm_acc/libcusmm/notebooks/README.md
+++ b/src/acc/libsmm_acc/libcusmm/notebooks/README.md
@@ -3,6 +3,7 @@
 Notebooks for exploring data generated from autotuning and prediction.
 
 **Requirements**
+Python version required: python 3.6
 
 Install all python packages required (if you do not want this project's requirements to interfere with your other Python projects, consider doing so in a [virtual environment](https://docs.python.org/3/tutorial/venv.html)), using
 

--- a/src/acc/libsmm_acc/libcusmm/notebooks/requirements.txt
+++ b/src/acc/libsmm_acc/libcusmm/notebooks/requirements.txt
@@ -12,7 +12,7 @@ Pillow==5.4.1
 pyparsing==2.3.1
 python-dateutil==2.7.5
 pytz==2018.9
-PyYAML==3.13
+PyYAML==4.2b1
 scipy==1.2.0
 seaborn==0.9.0
 six==1.12.0


### PR DESCRIPTION
- Update PyYAML version requirement to resolve security vulnerability
- Specify that notebooks require py3, just like the autotuning and predicting scripts