### PR TITLE
Fix build tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ endforeach ()
 set(DBCSR_TESTS
   dbcsr_unittest1
   dbcsr_unittest2
+  dbcsr_unittest3
   dbcsr_tensor_unittest
   dbcsr_test_csr_conversions
   )
@@ -47,6 +48,7 @@ set(dbcsr_unittest_common_SRCS
 # For each test, set a variable testname_SRCS defining the sources of that test
 set(dbcsr_unittest1_SRCS dbcsr_unittest1.F)
 set(dbcsr_unittest2_SRCS dbcsr_unittest2.F)
+set(dbcsr_unittest3_SRCS dbcsr_unittest3.F)
 set(dbcsr_tensor_unittest_SRCS dbcsr_tensor_unittest.F)
 set(dbcsr_test_csr_conversions_SRCS dbcsr_test_csr_conversions.F)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,9 +80,24 @@ if (USE_CUDA)
     libcusmm_timer_multiply
     )
 
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/libcusmm_unittest_multiply.cu
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/generate_libcusmm_unittest_multiply.py --base_folder ${CMAKE_CURRENT_SOURCE_DIR}/.. --gpu_version=${WITH_GPU}
+    DEPENDS libcusmm_unittest_multiply.template generate_libcusmm_unittest_multiply.py
+    COMMENT "Generate tests/libcusmm_unittest_multiply.cu"
+  )
+
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/libcusmm_timer_multiply.cu
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/generate_libcusmm_timer_multiply.py --base_folder ${CMAKE_CURRENT_SOURCE_DIR}/.. --gpu_version=${WITH_GPU}
+    DEPENDS libcusmm_timer_multiply.template generate_libcusmm_timer_multiply.py
+    COMMENT "Generate tests/libcusmm_timer_multiply.cu"
+  )
+
   foreach (libcusmm_test ${LIBCUSMM_TESTS})
-    add_executable(${libcusmm_test} ${libcusmm_test}.cu)
+    add_executable(${libcusmm_test} ${CMAKE_CURRENT_SOURCE_DIR}/${libcusmm_test}.cu)
     target_link_libraries(${libcusmm_test} dbcsr)
     add_test(NAME ${libcusmm_test} COMMAND ./${libcusmm_test})
   endforeach ()
+
 endif ()

--- a/tests/Makefile.inc
+++ b/tests/Makefile.inc
@@ -22,7 +22,7 @@ dbcsr_tensor_unittest: BIN_DEPS =
 ifneq ($(NVCC),)
 UNITTESTS += libcusmm_unittest_multiply libcusmm_unittest_transpose libcusmm_timer_multiply
 
-libcusmm_unittest_multiply.cu: $(DBCSRHOME)/tests/generate_libcusmm_unittest_multiply.py
+libcusmm_unittest_multiply.cu: $(DBCSRHOME)/tests/generate_libcusmm_unittest_multiply.py $(DBCSRHOME)/tests/libcusmm_unittest_multiply.template
 	$(DBCSRHOME)/tests/generate_libcusmm_unittest_multiply.py --base_folder $(DBCSRHOME) --gpu_version=$(GPUVER)
 
 libcusmm_unittest_multiply: libcusmm_unittest_multiply.cu
@@ -33,7 +33,7 @@ libcusmm_unittest_multiply: BIN_DEPS =
 SRC_TESTS += libcusmm_unittest_transpose.cu
 libcusmm_unittest_transpose: BIN_DEPS =
 
-libcusmm_timer_multiply.cu: $(DBCSRHOME)/tests/generate_libcusmm_timer_multiply.py 
+libcusmm_timer_multiply.cu: $(DBCSRHOME)/tests/generate_libcusmm_timer_multiply.py $(DBCSRHOME)/tests/libcusmm_timer_multiply.template
 	$(DBCSRHOME)/tests/generate_libcusmm_timer_multiply.py --base_folder $(DBCSRHOME) --gpu_version=$(GPUVER)
 
 libcusmm_timer_multiply: libcusmm_timer_multiply.cu

--- a/tests/dbcsr_unittest3.F
+++ b/tests/dbcsr_unittest3.F
@@ -93,35 +93,35 @@ PROGRAM dbcsr_unittest
 
    ! ...
    CALL dbcsr_test_multiplies("blocks_4_5_7", &
-                              group, mp_env, npdims, io_unit, matrix_sizes=(/496, 496, 496/), &
+                              group, mp_env, npdims, io_unit, matrix_sizes=(/496, 48, 48/), &
                               sparsities=(/0.5_dp, 0.5_dp, 0.5_dp/), retain_sparsity=.FALSE., &
                               alpha=CMPLX(1.0_dp, 0.0_dp, dp), beta=CMPLX(0.0_dp, 0.0_dp, dp), &
                               bs_m=(/1, 4, 1, 5, 1, 7/), bs_n=(/1, 4, 1, 5, 1, 7/), bs_k=(/1, 4, 1, 5, 1, 7/), &
-                              limits=(/1, 496, 1, 496, 1, 496/))
+                              limits=(/1, 496, 1, 48, 1, 48/))
    CALL dbcsr_test_multiplies("blocks_5_8_9", &
-                              group, mp_env, npdims, io_unit, matrix_sizes=(/506, 506, 506/), &
+                              group, mp_env, npdims, io_unit, matrix_sizes=(/506, 44, 44/), &
                               sparsities=(/0.5_dp, 0.5_dp, 0.5_dp/), retain_sparsity=.FALSE., &
                               alpha=CMPLX(1.0_dp, 0.0_dp, dp), beta=CMPLX(0.0_dp, 0.0_dp, dp), &
                               bs_m=(/1, 5, 1, 8, 1, 9/), bs_n=(/1, 5, 1, 8, 1, 9/), bs_k=(/1, 5, 1, 8, 1, 9/), &
-                              limits=(/1, 506, 1, 506, 1, 506/))
+                              limits=(/1, 506, 1, 44, 1, 44/))
    CALL dbcsr_test_multiplies("blocks_4_13_25", &
-                              group, mp_env, npdims, io_unit, matrix_sizes=(/504, 504, 504/), &
+                              group, mp_env, npdims, io_unit, matrix_sizes=(/504, 42, 42/), &
                               sparsities=(/0.5_dp, 0.5_dp, 0.5_dp/), retain_sparsity=.FALSE., &
                               alpha=CMPLX(1.0_dp, 0.0_dp, dp), beta=CMPLX(0.0_dp, 0.0_dp, dp), &
                               bs_m=(/1, 4, 1, 13, 1, 25/), bs_n=(/1, 4, 1, 13, 1, 25/), bs_k=(/1, 4, 1, 13, 1, 25/), &
-                              limits=(/1, 504, 1, 504, 1, 504/))
+                              limits=(/1, 504, 1, 42, 1, 42/))
    CALL dbcsr_test_multiplies("blocks_14_29_32", &
-                              group, mp_env, npdims, io_unit, matrix_sizes=(/525, 525, 525/), &
+                              group, mp_env, npdims, io_unit, matrix_sizes=(/525, 75, 75/), &
                               sparsities=(/0.5_dp, 0.5_dp, 0.5_dp/), retain_sparsity=.FALSE., &
                               alpha=CMPLX(1.0_dp, 0.0_dp, dp), beta=CMPLX(0.0_dp, 0.0_dp, dp), &
                               bs_m=(/1, 14, 1, 29, 1, 32/), bs_n=(/1, 14, 1, 29, 1, 32/), bs_k=(/1, 14, 1, 29, 1, 32/), &
-                              limits=(/1, 525, 1, 525, 1, 525/))
+                              limits=(/1, 525, 1, 75, 1, 75/))
    CALL dbcsr_test_multiplies("blocks_H2O", &
-                              group, mp_env, npdims, io_unit, matrix_sizes=(/552, 552, 552/), &
+                              group, mp_env, npdims, io_unit, matrix_sizes=(/552, 46, 46/), &
                               sparsities=(/0.5_dp, 0.5_dp, 0.5_dp/), retain_sparsity=.FALSE., &
                               alpha=CMPLX(1.0_dp, 0.0_dp, dp), beta=CMPLX(0.0_dp, 0.0_dp, dp), &
                               bs_m=(/1, 23/), bs_n=(/1, 23/), bs_k=(/1, 23/), &
-                              limits=(/1, 552, 1, 552, 1, 552/))
+                              limits=(/1, 552, 1, 46, 1, 46/))
 
    ! end of test cases ---------------------------------------------------------
 


### PR DESCRIPTION
Fixes to the building of tests

**cmake** 
- add `dbcsr_unittest3` to the DBCSR tests (really should have been done in PR #132 , where I updated the `Makefile` but forgot about `cmake` ... )
- add the generation of `libcusmm_unittest_multiply.cu` and `libcusmm_timer_multiply.cu` (really should have been done in PR #137 , but I again forgot about `cmake` ...)

**Makefile**
- add forgotten dependency on the template 