### PR TITLE
Modernized original LIBXSMM integration and use explicit batch interface

### DIFF
--- a/src/data/dbcsr.fypp
+++ b/src/data/dbcsr.fypp
@@ -16,6 +16,7 @@
 #:set typesize1 = ['8','4','16','8']
 #:set base1 = ['r', 'r', 'c', 'c']
 #:set prec1 = ['dp','sp','dp','sp']
+#:set bits1 = ['64','32','64','32']
 #:set kind1 = ['real_8', 'real_4', 'real_8', 'real_4']
 #:set type1 = ['REAL(kind=real_8)', 'REAL(kind=real_4)', 'COMPLEX(kind=real_8)', 'COMPLEX(kind=real_4)']
 #:set dkind1 = ['dbcsr_type_real_8', 'dbcsr_type_real_4', 'dbcsr_type_complex_8', 'dbcsr_type_complex_4']

--- a/src/mm/dbcsr_mm_hostdrv.F
+++ b/src/mm/dbcsr_mm_hostdrv.F
@@ -218,9 +218,23 @@ CONTAINS
          CASE default
             DBCSR_ABORT("Invalid data type")
          END SELECT
-
+#if defined(__LIBXSMM)
       CASE (mm_driver_xsmm)
          SELECT CASE (this%data_area%d%data_type)
+#if TO_VERSION(1, 10, 0) < TO_VERSION(LIBXSMM_CONFIG_VERSION_MAJOR, LIBXSMM_CONFIG_VERSION_MINOR, LIBXSMM_CONFIG_VERSION_UPDATE)
+         CASE (dbcsr_type_real_4)
+            CALL xsmm_process_mm_batch_s(stack_descr, params, stack_size, &
+                                         left%data_area%d%r_sp, right%data_area%d%r_sp, this%data_area%d%r_sp, used_smm)
+         CASE (dbcsr_type_real_8)
+            CALL xsmm_process_mm_batch_d(stack_descr, params, stack_size, &
+                                         left%data_area%d%r_dp, right%data_area%d%r_dp, this%data_area%d%r_dp, used_smm)
+         CASE (dbcsr_type_complex_4)
+            CALL xsmm_process_mm_batch_c(stack_descr, params, stack_size, &
+                                         left%data_area%d%c_sp, right%data_area%d%c_sp, this%data_area%d%c_sp, used_smm)
+         CASE (dbcsr_type_complex_8)
+            CALL xsmm_process_mm_batch_z(stack_descr, params, stack_size, &
+                                         left%data_area%d%c_dp, right%data_area%d%c_dp, this%data_area%d%c_dp, used_smm)
+#else
          CASE (dbcsr_type_real_4)
             CALL xsmm_process_mm_stack_s(stack_descr, params, stack_size, &
                                          left%data_area%d%r_sp, right%data_area%d%r_sp, this%data_area%d%r_sp, used_smm)
@@ -233,10 +247,11 @@ CONTAINS
          CASE (dbcsr_type_complex_8)
             CALL xsmm_process_mm_stack_z(stack_descr, params, stack_size, &
                                          left%data_area%d%c_dp, right%data_area%d%c_dp, this%data_area%d%c_dp, used_smm)
+#endif
          CASE default
             DBCSR_ABORT("Invalid data type")
          END SELECT
-
+#endif
       CASE (mm_driver_blas)
          SELECT CASE (this%data_area%d%data_type)
          CASE (dbcsr_type_real_4)


### PR DESCRIPTION
Alternative code-path using LIBXSMM's explicit batch interface (hosted by xsmm_process_mm_batch routine). Modernized the original integration with LIBXSMM (xsmm_process_mm_stack routine). For the latter, e.g. conditions are adjusted by likelihood of taking the IF-branch. The explicit batch interface internalizes the loop which processes a stack of matrices (this enables future tuning without touching the integration). The explicit batch interface is used if the LIBXSMM version is sufficient (upcoming v1.11).