### PR TITLE
Adjusted way to nullify output-pointers (IFORT)

### DIFF
--- a/src/tas/dbcsr_tas_mm.F
+++ b/src/tas/dbcsr_tas_mm.F
@@ -465,7 +465,7 @@ CONTAINS
    SUBROUTINE reshape_mm_compatible(matrix1_in, matrix2_in, matrix1_out, matrix2_out, new1, new2, trans1, trans2, &
                                     optimize_dist, nodata1, nodata2, move_data, comm_new, unit_nr)
       TYPE(dbcsr_tas_type), TARGET, INTENT(INOUT) :: matrix1_in, matrix2_in
-      TYPE(dbcsr_tas_type), POINTER, INTENT(OUT) :: matrix1_out => NULL(), matrix2_out => NULL()
+      TYPE(dbcsr_tas_type), POINTER, INTENT(OUT) :: matrix1_out, matrix2_out
       LOGICAL, INTENT(OUT) :: new1, new2
       CHARACTER(LEN=1), INTENT(INOUT) :: trans1, trans2
       LOGICAL, INTENT(IN), OPTIONAL :: optimize_dist
@@ -483,6 +483,7 @@ CONTAINS
       TYPE(dbcsr_tas_distribution_type) :: dist_1, dist_2
       TYPE(dbcsr_tas_create_split_info) :: split_info
 
+      NULLIFY(matrix1_out, matrix2_out)
       IF (PRESENT(unit_nr)) THEN
          io_unit = unit_nr
       ELSE

--- a/src/tensors/dbcsr_tensor.F
+++ b/src/tensors/dbcsr_tensor.F
@@ -700,7 +700,7 @@ CONTAINS
                                        optimize_dist, unit_nr)
          TYPE(dbcsr_t_type), TARGET, INTENT(INOUT)   :: tensor1
          TYPE(dbcsr_t_type), TARGET, INTENT(INOUT)   :: tensor2
-         TYPE(dbcsr_t_type), POINTER, INTENT(OUT)    :: tensor1_out => NULL(), tensor2_out => NULL()
+         TYPE(dbcsr_t_type), POINTER, INTENT(OUT)    :: tensor1_out, tensor2_out
          INTEGER, DIMENSION(:), INTENT(IN)           :: ind1_free, ind2_free
          INTEGER, DIMENSION(:), INTENT(IN)           :: ind1_linked, ind2_linked
          CHARACTER(LEN=1), INTENT(OUT)               :: trans1, trans2
@@ -716,6 +716,7 @@ CONTAINS
          INTEGER(KIND=int_8)                         :: nblkrows, nblkcols
          LOGICAL                                     :: optimize_dist_prv
 
+         NULLIFY(tensor1_out, tensor2_out)
          IF (PRESENT(unit_nr)) THEN
             io_unit = unit_nr
          ELSE
@@ -917,7 +918,7 @@ CONTAINS
       SUBROUTINE reshape_mm_small(tensor_in, ind1, ind2, tensor_out, trans, new, nodata, move_data, unit_nr)
          TYPE(dbcsr_t_type), TARGET, INTENT(INOUT)   :: tensor_in
          INTEGER, DIMENSION(:), INTENT(IN)           :: ind1, ind2
-         TYPE(dbcsr_t_type), POINTER, INTENT(OUT)    :: tensor_out => NULL()
+         TYPE(dbcsr_t_type), POINTER, INTENT(OUT)    :: tensor_out
          CHARACTER(LEN=1), INTENT(OUT)               :: trans
          LOGICAL, INTENT(OUT)                        :: new
          LOGICAL, INTENT(IN), OPTIONAL               :: nodata, move_data
@@ -925,6 +926,7 @@ CONTAINS
          INTEGER                                     :: compat1, compat2, compat1_old, compat2_old, io_unit
          LOGICAL                                     :: nodata_prv
 
+         NULLIFY(tensor_out)
          IF (PRESENT(nodata)) THEN
             nodata_prv = nodata
          ELSE


### PR DESCRIPTION
This fixes compilation errors saying that the initialization used is not applicable to the object (IFORT 18.0.5).