### PR TITLE
Accommodate DBCSRv2 initialization flow

### DIFF
--- a/src/core/dbcsr_lib.F
+++ b/src/core/dbcsr_lib.F
@@ -138,6 +138,9 @@ CONTAINS
 !> \param io_unit ...
 ! **************************************************************************************************
    SUBROUTINE dbcsr_init_lib_pre(mp_comm, io_unit)
+#if defined(__LIBXSMM)
+      USE libxsmm, ONLY: libxsmm_init
+#endif
       INTEGER, INTENT(IN)  :: mp_comm
       INTEGER, INTENT(IN), OPTIONAL :: io_unit
 
@@ -151,6 +154,9 @@ CONTAINS
          IF (mynode .EQ. 0) ext_io_unit = default_output_unit
       ENDIF
       CALL dbcsr_mp_make_env(mp_env, default_group, mp_comm)
+#if defined(__LIBXSMM)
+      CALL libxsmm_init()
+#endif
    END SUBROUTINE dbcsr_init_lib_pre
 
 ! **************************************************************************************************
@@ -205,6 +211,9 @@ CONTAINS
 !> Cleans up after the DBCSR library.  Used to deallocate persistent objects.
 ! **************************************************************************************************
    SUBROUTINE dbcsr_finalize_lib()
+#if defined(__LIBXSMM)
+      USE libxsmm, ONLY: libxsmm_finalize
+#endif
       CHARACTER(len=*), PARAMETER :: routineN = 'dbcsr_finalize_lib', &
                                      routineP = moduleN//':'//routineN
 
@@ -247,11 +256,13 @@ CONTAINS
       ENDIF
       CALL dbcsr_mp_release(mp_env)
       CALL mp_comm_free(default_group)
+#if defined(__LIBXSMM)
+      CALL libxsmm_finalize()
+#endif
       NULLIFY(timeset_hook)
       NULLIFY(timestop_hook)
       NULLIFY(dbcsr_abort_hook)
       NULLIFY(dbcsr_warn_hook)
-
    END SUBROUTINE dbcsr_finalize_lib
 
 ! **************************************************************************************************

--- a/src/core/dbcsr_timings.F
+++ b/src/core/dbcsr_timings.F
@@ -160,7 +160,7 @@ CONTAINS
       IF (.NOT. ASSOCIATED(timer_env)) &
          DBCSR_ABORT("timer_env_retain: not associated")
       IF (timer_env%ref_count < 0) &
-         DBCSR_ABORT("timer_env_retain: negativ ref_count")
+         DBCSR_ABORT("timer_env_retain: negative ref_count")
       timer_env%ref_count = timer_env%ref_count + 1
    END SUBROUTINE timer_env_retain
 
@@ -180,7 +180,7 @@ CONTAINS
       IF (.NOT. ASSOCIATED(timer_env)) &
          DBCSR_ABORT("timer_env_release: not associated")
       IF (timer_env%ref_count < 0) &
-         DBCSR_ABORT("timer_env_release: negativ ref_count")
+         DBCSR_ABORT("timer_env_release: negative ref_count")
       timer_env%ref_count = timer_env%ref_count - 1
       IF (timer_env%ref_count > 0) RETURN
 
@@ -461,7 +461,7 @@ CONTAINS
    END SUBROUTINE print_stack
 
 ! **************************************************************************************************
-!> \brief Internal routine used by timestet and timings_setup_tracing.
+!> \brief Internal routine used by timeset_handler and timings_setup_tracing.
 !>        If no routine with given name is found in timer_env%routine_names
 !>        then a new entry is created.
 !> \param routineN ...

--- a/src/mm/dbcsr_mm_hostdrv.F
+++ b/src/mm/dbcsr_mm_hostdrv.F
@@ -75,13 +75,6 @@ CONTAINS
 !> \author Ole Schuett
 ! **************************************************************************************************
    SUBROUTINE dbcsr_mm_hostdrv_lib_init()
-#if defined(__LIBXSMM)
-      USE libxsmm, ONLY: libxsmm_init
-!$OMP     MASTER
-      CALL libxsmm_init()
-!$OMP     END MASTER
-!$OMP     BARRIER
-#endif
    END SUBROUTINE dbcsr_mm_hostdrv_lib_init
 
 ! **************************************************************************************************
@@ -89,13 +82,6 @@ CONTAINS
 !> \author Ole Schuett
 ! **************************************************************************************************
    SUBROUTINE dbcsr_mm_hostdrv_lib_finalize()
-#if defined(__LIBXSMM)
-      USE libxsmm, ONLY: libxsmm_finalize
-!$OMP     BARRIER
-!$OMP     MASTER
-      CALL libxsmm_finalize()
-!$OMP     END MASTER
-#endif
    END SUBROUTINE dbcsr_mm_hostdrv_lib_finalize
 
 ! **************************************************************************************************


### PR DESCRIPTION
Accommodate DBCSRv2 initialization flow:
* Moved libxsmm_init/libxsmm_finalize into dbcsr_init_lib_pre and dbcsr_finalize_lib respectively.
* init flow would fail as the timer facility is used before LIBXSMM is initialized;  
  Note: CP2K's timer hook may be based on LIBXSMM.
* LIBXSMM init-flow should not be limited to MM/host (dbcsr_mm_hostdrv_lib_init).
* Up-lifting the initialization location is self-contained and fwd./bwd. compatible.

This change may complement PR #171.