### PR TITLE
Fixed dbcsr_finalize_lib when initialized per dbcsr_finalize_lib

### DIFF
--- a/src/core/dbcsr_lib.F
+++ b/src/core/dbcsr_lib.F
@@ -87,14 +87,18 @@ CONTAINS
       INTEGER, INTENT(IN), OPTIONAL :: io_unit
 
       CALL dbcsr_init_lib_pre(mp_comm, io_unit)
-      ! Declare loggers and timers
+      !
+      ! Declare loggers
       CALL dbcsr_logger_create(logger, mp_env=mp_env, &
                                default_global_unit_nr=ext_io_unit, &
                                close_global_unit_on_dealloc=.FALSE.)
       CALL dbcsr_add_default_logger(logger)
       CALL dbcsr_logger_release(logger)
+      ! abort/warn hooks
       CALL dbcsr_error_handling_setup()
+      ! timeset/timestop hooks
       CALL timings_register_hooks()
+      ! timer environment
       CALL add_mp_perf_env()
       CALL add_timer_env()
       !
@@ -121,11 +125,13 @@ CONTAINS
       INTEGER, INTENT(IN), OPTIONAL :: io_unit
 
       CALL dbcsr_init_lib_pre(mp_comm, io_unit)
-      !
-      timeset_hook => in_timeset_hook
-      timestop_hook => in_timestop_hook
+      ! abort/warn hooks
       dbcsr_abort_hook => in_abort_hook
       dbcsr_warn_hook => in_warn_hook
+      ! timeset/timestop hooks
+      timeset_hook => in_timeset_hook
+      timestop_hook => in_timestop_hook
+      ! timer environment is assumed
       !
       CALL dbcsr_init_lib_low()
    END SUBROUTINE dbcsr_init_lib_hooks
@@ -244,15 +250,15 @@ CONTAINS
 
       is_initialized = .FALSE.
 
-      CALL dbcsr_print_timers()
-
-      CALL timestop(error_handle)
-
       IF (ASSOCIATED(logger)) THEN
+         CALL dbcsr_print_timers()
+         CALL timestop(error_handle)
          CALL dbcsr_rm_default_logger()
          CALL rm_mp_perf_env()
          CALL rm_timer_env()
          NULLIFY(logger)
+      ELSE
+         CALL timestop(error_handle)
       ENDIF
       CALL dbcsr_mp_release(mp_env)
       CALL mp_comm_free(default_group)

--- a/src/core/dbcsr_timings.F
+++ b/src/core/dbcsr_timings.F
@@ -232,7 +232,7 @@ CONTAINS
       cs_entry%walltime_start = -HUGE(1.0_dp)
       cs_entry%energy_start = -HUGE(1.0_dp)
       !
-      routine_name_dsl = routineN ! converte to default_string_length
+      routine_name_dsl = routineN ! converts to default_string_length
       routine_id = routine_name2id(routine_name_dsl)
       !
       ! Take timings when the timings_level is appropriated


### PR DESCRIPTION
Fixed crash in dbcsr_finalize_lib when initialized per dbcsr_init_lib_hooks (tested with CP2K+PR330). The root cause of the issue was following flow (stacktrace):

> dbcsr_finalize_lib  
dbcsr_print_timers  
timings_report_print  
collect_reports_from_ranks  
-> "timer_env => get_timer_env()".

In get_timer_env, "timer_env => list_peek(timers_stack)" fails due to the "timers_stack" not being setup/allocated. The only function that does that i.e., initializing an internal private SAVE variable is "add_timer_env".

PR #171 seems to intent to explicitly omit add_timer_env in case of a hook-based initialization (dbcsr_init_lib_hooks), likely assuming this is controlled externally. This leaves the conclusion that "dbcsr_print_timers" can only be called in dbcsr_finalize_lib in case of the non-hook initialization. The existing "test" of non-hook initialization has been reused (ASSOCIATED(logger)).

Please carefully review and revise this change.