### PR TITLE
Workaround race condition on ORNL's Summit

### DIFF
--- a/src/acc/dbcsr_acc_hostmem.F
+++ b/src/acc/dbcsr_acc_hostmem.F
@@ -129,6 +129,9 @@ CONTAINS
       INTEGER                                            :: istat
       TYPE(C_PTR)                                        :: stream_cptr
 
+! Workaround for a segmentation fault on ORNL's Summit
+!$OMP CRITICAL
+
       IF (.NOT. acc_stream_associated(stream)) &
          DBCSR_ABORT("acc_hostmem_dealloc_raw: stream not associated")
 
@@ -137,6 +140,7 @@ CONTAINS
       istat = cuda_host_mem_dealloc_cu(host_mem_c_ptr, stream_cptr)
       IF (istat /= 0) &
          DBCSR_ABORT("acc_hostmem_dealloc_raw: Could not deallocate host pinned memory")
+!$OMP END CRITICAL
    END SUBROUTINE acc_hostmem_dealloc_raw
 #endif
 


### PR DESCRIPTION
Occurs when running tests/dbcsr_tensor_unittest built with MPI, OpenMP and CUDA support.

Credit goes to Joost VandeVondele @vondele