### PR TITLE
Check the consistency between dbcsr and libcusmm when building with openmp

### DIFF
--- a/src/acc/libsmm_acc/include/libsmm_acc.h
+++ b/src/acc/libsmm_acc/include/libsmm_acc.h
@@ -18,6 +18,8 @@ int libsmm_acc_process (void *param_stack, int stack_size,
 int libsmm_acc_transpose (void *trs_stack, int offset, int nblks,
     void *buffer, int datatype, int m, int n, void* stream);
 
+bool libsmm_acc_libcusmm_is_thread_safe ();
+
 #ifdef __cplusplus
  }
 #endif

--- a/src/acc/libsmm_acc/include/libsmm_acc.h
+++ b/src/acc/libsmm_acc/include/libsmm_acc.h
@@ -18,7 +18,7 @@ int libsmm_acc_process (void *param_stack, int stack_size,
 int libsmm_acc_transpose (void *trs_stack, int offset, int nblks,
     void *buffer, int datatype, int m, int n, void* stream);
 
-bool libsmm_acc_libcusmm_is_thread_safe ();
+int libsmm_acc_libcusmm_is_thread_safe ();
 
 #ifdef __cplusplus
  }

--- a/src/acc/libsmm_acc/libcusmm/libcusmm.cpp
+++ b/src/acc/libsmm_acc/libcusmm/libcusmm.cpp
@@ -364,10 +364,10 @@ extern "C" int libsmm_acc_transpose (void *trs_stack, int offset, int nblks, voi
 
 
 //===========================================================================
-extern "C" bool libsmm_acc_libcusmm_is_thread_safe () {
+extern "C" int libsmm_acc_libcusmm_is_thread_safe () {
 #if defined _OPENMP
-    return true;
+    return 1;  // i.e. true, libcusmm is threaded
 #else
-    return false;
+    return 0;  // i.e. false, libcusmm is not threaded
 #endif
 }

--- a/src/acc/libsmm_acc/libcusmm/libcusmm.cpp
+++ b/src/acc/libsmm_acc/libcusmm/libcusmm.cpp
@@ -361,3 +361,13 @@ extern "C" int libsmm_acc_transpose (void *trs_stack, int offset, int nblks, voi
       return 0; // maximum size over any dimention
     return libcusmm_transpose_d((int *) trs_stack, offset, nblks, (double *) buffer, m, n, *((CUstream *) stream));
 }
+
+
+//===========================================================================
+extern "C" bool libsmm_acc_libcusmm_is_thread_safe () {
+#if defined _OPENMP
+    return true;
+#else
+    return false;
+#endif
+}

--- a/src/core/dbcsr_lib.F
+++ b/src/core/dbcsr_lib.F
@@ -77,6 +77,18 @@ MODULE dbcsr_lib
       MODULE PROCEDURE dbcsr_init_lib_hooks
    END INTERFACE
 
+#if defined (__DBCSR_ACC)
+   INTERFACE
+      FUNCTION libsmm_acc_libcusmm_is_thread_safe_cu() &
+         RESULT(thread_safe) &
+         BIND(C, name="libsmm_acc_libcusmm_is_thread_safe")
+         IMPORT
+         INTEGER                    :: thread_safe
+
+      END FUNCTION libsmm_acc_libcusmm_is_thread_safe_cu
+   END INTERFACE
+#endif
+
 CONTAINS
 
 ! **************************************************************************************************
@@ -152,7 +164,7 @@ CONTAINS
       INTEGER, INTENT(IN)  :: mp_comm
       INTEGER, INTENT(IN), OPTIONAL :: io_unit
 
-      INTEGER :: numnodes, mynode
+      INTEGER :: numnodes, mynode, thread_safe
 
       IF (PRESENT(io_unit)) THEN
          ext_io_unit = io_unit
@@ -164,6 +176,12 @@ CONTAINS
       CALL dbcsr_mp_make_env(mp_env, default_group, mp_comm)
 #if defined(__LIBXSMM)
       CALL libxsmm_init()
+#endif
+#if defined(__DBCSR_ACC)
+!$       thread_safe = libsmm_acc_libcusmm_is_thread_safe_cu()
+!$       IF (thread_safe /= 0) then
+!$          DBCSR_ABORT("libcusmm not compiled to be thread-safe. Recompile with OpenMP support")
+!$       endif
 #endif
    END SUBROUTINE dbcsr_init_lib_pre
 

--- a/src/core/dbcsr_lib.F
+++ b/src/core/dbcsr_lib.F
@@ -164,7 +164,11 @@ CONTAINS
       INTEGER, INTENT(IN)  :: mp_comm
       INTEGER, INTENT(IN), OPTIONAL :: io_unit
 
-      INTEGER :: numnodes, mynode, thread_safe
+      INTEGER :: numnodes, mynode
+
+#if defined(__DBCSR_ACC)
+!$    INTEGER :: thread_safe
+#endif
 
       IF (PRESENT(io_unit)) THEN
          ext_io_unit = io_unit

--- a/src/core/dbcsr_lib.F
+++ b/src/core/dbcsr_lib.F
@@ -58,6 +58,10 @@ MODULE dbcsr_lib
 
 !$ USE OMP_LIB, ONLY: omp_get_thread_num, omp_get_num_threads
 
+#if defined (__DBCSR_ACC)
+   USE ISO_C_BINDING, ONLY: C_INT
+#endif
+
    IMPLICIT NONE
    PRIVATE
 
@@ -83,7 +87,7 @@ MODULE dbcsr_lib
          RESULT(thread_safe) &
          BIND(C, name="libsmm_acc_libcusmm_is_thread_safe")
          IMPORT
-         INTEGER                    :: thread_safe
+         INTEGER(KIND=C_INT)        :: thread_safe
 
       END FUNCTION libsmm_acc_libcusmm_is_thread_safe_cu
    END INTERFACE
@@ -167,7 +171,7 @@ CONTAINS
       INTEGER :: numnodes, mynode
 
 #if defined(__DBCSR_ACC)
-!$    INTEGER :: thread_safe
+      INTEGER :: dbcsr_thread_safe, libcusmm_thread_safe
 #endif
 
       IF (PRESENT(io_unit)) THEN
@@ -181,11 +185,21 @@ CONTAINS
 #if defined(__LIBXSMM)
       CALL libxsmm_init()
 #endif
+
 #if defined(__DBCSR_ACC)
-!$       thread_safe = libsmm_acc_libcusmm_is_thread_safe_cu()
-!$       IF (thread_safe /= 0) then
-!$          DBCSR_ABORT("libcusmm not compiled to be thread-safe. Recompile with OpenMP support")
-!$       endif
+      libcusmm_thread_safe = libsmm_acc_libcusmm_is_thread_safe_cu()  ! 0: not threaded, 1: threaded
+      dbcsr_thread_safe = 0  ! not threaded
+!$    dbcsr_thread_safe = 1  ! if DBCSR is compiled with openmp, set to threaded
+      ! Check whether DBCSR and libcusmm (GPU backend) have the same level of threading
+       IF (dbcsr_thread_safe /= libcusmm_thread_safe) then
+          IF (dbcsr_thread_safe /= 0) then
+              DBCSR_ABORT("DBCSR's and libcusmm's threading levels do not match. DBCSR is compiled
+with threading support while libcusmm is compiled without threading support.")
+          ELSE
+              DBCSR_ABORT("DBCSR's and libcusmm's threading levels do not match. DBCSR is compiled
+without threading support while libcusmm is compiled with threading support.")
+          ENDIF
+       ENDIF
 #endif
    END SUBROUTINE dbcsr_init_lib_pre
 


### PR DESCRIPTION
In DBCSR's initialisation, if DBCSR is compiled with OpenMP support, add a call checking whether libcusmm was compiled with OpenMP support as well.

See [discussion](https://github.com/cp2k/cp2k/issues/338) in CP2K for the need behind such a check.

Fixes #180 