### PR TITLE
Makefile: remove superfluous variable CXXOMPFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -497,7 +497,7 @@ FYPPFLAGS ?= -n
 	$(CXX) -c $(CXXFLAGS) $<
 
 libcusmm.o: libcusmm.cpp parameters.h cusmm_kernels.h
-	$(CXX) -c $(CXXFLAGS) $(CXXOMPFLAGS) -DARCH_NUMBER=$(ARCH_NUMBER) $<
+	$(CXX) -c $(CXXFLAGS) -DARCH_NUMBER=$(ARCH_NUMBER) $<
 
 %.o: %.cu
 	$(NVCC) -c $(NVFLAGS) -I'$(SRCDIR)' $<

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -147,7 +147,7 @@ else
 endif
 
 ifneq (0,$(OMP)) # using OpenMP
-  CXXOMPFLAGS = -fopenmp
+  CXXFLAGS += -fopenmp
   FCFLAGS  += -fopenmp
 endif
 


### PR DESCRIPTION
Remove the superfluous variable `CXXOMPFLAGS`, and instead, add OpenMP flags to the variable `CXXFLAGS` directly.
This simplifies the Makefile and reduces the risk of issues such as https://github.com/cp2k/cp2k/issues/338 occurring.