### PR TITLE
Rely on mpi_comm_set_errhandler instead of mpi_errhandler_set

### DIFF
--- a/src/mpi/dbcsr_mpiwrap.F
+++ b/src/mpi/dbcsr_mpiwrap.F
@@ -690,7 +690,7 @@ MODULE dbcsr_mpiwrap
       TYPE(mp_perf_env_type), POINTER         :: mp_perf_env => Null()
    END TYPE mp_perf_env_p_type
 
-   ! introduce a stack of mp_perfs, first index is the stack pointer, for convience is replacing
+   ! introduce a stack of mp_perfs, first index is the stack pointer, for convenience is replacing
    INTEGER, PARAMETER :: max_stack_size = 10
    INTEGER            :: stack_pointer = 0
    ! target attribute needed as a hack around ifc 7.1 bug
@@ -760,7 +760,11 @@ CONTAINS
 !$       ENDIF
 !$OMP END MASTER
 !$    ENDIF
+#if __MPI_VERSION > 2
+      CALL mpi_comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN, ierr)
+#else
       CALL mpi_errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN, ierr)
+#endif
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_errhandler_set @ mp_world_init")
       mp_comm = MPI_COMM_WORLD
       debug_comm_count = 1
@@ -2014,7 +2018,7 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief splits the given communicator in group in subgroups trying to organize
 !>      them in a way that the communication within each subgroup is
-!>      efficent (but not necessarily the communication between subgroups)
+!>      efficient (but not necessarily the communication between subgroups)
 !> \param comm the mpi communicator that you want to split
 !> \param sub_comm the communicator for the subgroup (created, needs to be freed later)
 !> \param ngroups actual number of groups


### PR DESCRIPTION
Rely on `mpi_comm_set_errhandler` instead of `mpi_errhandler_set`. The conditional compilation checks for MPIv3 (`__MPI_VERSION`) which is reasonable but may be not exactly related. This so far fixes linker errors with OpenMPI 4.x (see [here](https://www.open-mpi.org/faq/?category=mpi-removed) for a list of removed [legacy] functions). It is reasonable to assume that MPI function names are standardized since MPIv3 (portable ABI between different implementations of MPI). In addition, this changes also fixes source code comments (typos).