### PR TITLE
travis: update and cache homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,13 @@ addons:
     - gcc
     - cmake
     - openmpi
+    update: true
 
 cache:
   pip: true
   directories:
   - $HOME/deps
+  - $HOME/Library/Caches/Homebrew
 
 env:
   global:


### PR DESCRIPTION
fixes build on Travis/macOS
upstream "bug report" here:
https://travis-ci.community/t/issue-brew-formula-installation-fails-due-to-being-outdated/3872