### PR TITLE
Fix/207

### DIFF
--- a/src/acc/libsmm_acc/libcusmm/libcusmm.h
+++ b/src/acc/libsmm_acc/libcusmm/libcusmm.h
@@ -19,10 +19,6 @@
 #include <unordered_map>
 #include <vector>
 
-#if defined _OPENMP
-#include <omp.h>
-#endif
-
 // Macros for CUDA error handling
 // Wrap calls to CUDA NVRTC API
 #define NVRTC_SAFE_CALL(name, x)                                  \
@@ -51,9 +47,6 @@ struct kernel_launcher {
 };
 
 static std::unordered_map<Triplet, kernel_launcher> kernel_handles;
-#if defined _OPENMP
-static std::unordered_map<Triplet, omp_lock_t> kernel_locks;
-#endif
 
 int libcusmm_process_d(int *param_stack, int stack_size,
     CUstream stream, int m, int n, int k,


### PR DESCRIPTION
This PR fixes race conditions in libcusmm, in the JIT-ing of multiplication and transpose kernels. 

*Race condition*: an OpenMP thread could read from the lock-map `kernel_locks` while/after the lock-map is being modified.

*Solution*: This commit gets rid of the lock-map, instead just protecting the JIT-ing and the modify-ing of the kernel-handles-map with a critical section. This means that no two (m,n,k)-kernels (even different ones!) can be jit-ed in parallel by two OpenMP threads. Nevertheless, performance is improved because we get rid of locks.

Fix #207