### PR TITLE
C-API to use void-signature for no-arg functions

### DIFF
--- a/src/acc/libsmm_acc/include/libsmm_acc.h
+++ b/src/acc/libsmm_acc/include/libsmm_acc.h
@@ -18,7 +18,7 @@ int libsmm_acc_process (void *param_stack, int stack_size,
 int libsmm_acc_transpose (void *trs_stack, int offset, int nblks,
     void *buffer, int datatype, int m, int n, void* stream);
 
-int libsmm_acc_libcusmm_is_thread_safe ();
+int libsmm_acc_libcusmm_is_thread_safe (void);
 
 #ifdef __cplusplus
  }

--- a/src/dbcsr.h
+++ b/src/dbcsr.h
@@ -24,7 +24,7 @@ extern "C" {
         c_dbcsr_init_lib_internal(&fcomm, io_unit);
     }
 
-    void c_dbcsr_finalize_lib();
+    void c_dbcsr_finalize_lib(void);
 
     void c_dbcsr_distribution_new_aux(void** dist, MPI_Fint* fcomm, int* row_dist, int row_dist_size,
                                       int* col_dist, int col_dist_size);


### PR DESCRIPTION
Adjusted C-API to rely on void-signature in case where no functions-argument is expected (C++ would ask for an ellipsis whereas C implicitly uses an ellipsis if the signature is non-void but empty).