### PR TITLE
Potentially accelerate MPI-only operation by using OpenMP based libxsmm_gemm_batch

### DIFF
--- a/src/mm/dbcsr_mm_hostdrv.f90
+++ b/src/mm/dbcsr_mm_hostdrv.f90
@@ -163,10 +163,13 @@
   SUBROUTINE xsmm_process_mm_batch_${nametype1}$ (stack_descr, params, &
                                                   stack_size, a_data, b_data, c_data, used_smm)
 #if ${xsmm_supported[n]}$
+#if !defined(DBCSR_LIBXSMM_GEMM_BATCH)
+#define DBCSR_LIBXSMM_GEMM_BATCH libxsmm_gemm_batch
+#endif
      ! Caution: This dependency is ignored by makedep.py, because libxsmm.F is kinda empty.
      USE libxsmm, ONLY: LIBXSMM_GEMM_PRECISION => ${'LIBXSMM_GEMM_PRECISION_F'+bits1[n]}$, &
                         libxsmm_gemm => libxsmm_${nametype1}$gemm, &
-                        libxsmm_gemm_batch, &
+                        libxsmm_gemm_batch => DBCSR_LIBXSMM_GEMM_BATCH, &
                         libxsmm_ptr0
      REAL(${kind1}$), PARAMETER :: one = 1.0_${kind1}$
      INTEGER :: sp


### PR DESCRIPTION
A user of the DBCSR-library can chose to define DBCSR_LIBXSMM_GEMM_BATCH as `libxsmm_gemm_batch_omp`, and additionally link against libxsmmext (on top of libxsmm and libxsmmf). This change allows to speedup the runtime when relying on POPT-builds (e.g., CP2K).

The symbol DBCSR_LIBXSMM_GEMM_BATCH allows to switch from between `libxsmm_gemm_batch` to `libxsmm_gemm_batch_omp`. This is a minimal change with no complementary adjustment of the build systems; it does not introduce potentially complicated build-logic (Make and CMake).

Note: `libxsmm_gemm_batch_omp` safely operates on a batch of SMMs even if there are duplicated C-indexes (synchronization).