### PR TITLE
ACC interface cleanup

### DIFF
--- a/src/acc/include/acc.h
+++ b/src/acc/include/acc.h
@@ -6,46 +6,51 @@
  * For further information please visit https://dbcsr.cp2k.org                                    *
  * SPDX-License-Identifier: GPL-2.0+                                                              *
  *------------------------------------------------------------------------------------------------*/
-
 #include <stddef.h>
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
-// cuda driver initialization and finalization
-int acc_init();
-int acc_finalize();
+/** types */
+typedef void* acc_stream_t;
+typedef void* acc_event_t;
 
-// devices
+/** initialization and finalization */
+int acc_init(void);
+int acc_finalize(void);
+int acc_clear_errors(void);
+
+/** devices */
 int acc_get_ndevices(int* n_devices);
 int acc_set_active_device(int device_id);
 
-// streams
+/** streams */
 int acc_stream_priority_range(int* least, int* greatest);
-int acc_stream_create(void** stream_p, const char* name, int priority);
-int acc_stream_destroy(void* stream);
-int acc_stream_sync(void* stream);
-int acc_stream_wait_event(void* stream, void* event);
+int acc_stream_create(acc_stream_t* stream_p, const char* name, int priority);
+int acc_stream_destroy(acc_stream_t stream);
+int acc_stream_sync(acc_stream_t stream);
+int acc_stream_wait_event(acc_stream_t stream, acc_event_t event);
 
-// events
-int acc_event_create(void** event_p);
-int acc_event_destroy(void* event);
-int acc_event_record(void* event, void* stream);
-int acc_event_query(void* event, int* has_occurred);
-int acc_event_synchronize(void* event);
+/** events */
+int acc_event_create(acc_event_t* event_p);
+int acc_event_destroy(acc_event_t event);
+int acc_event_record(acc_event_t event, acc_stream_t stream);
+int acc_event_query(acc_event_t event, int* has_occurred);
+int acc_event_synchronize(acc_event_t event);
 
-// memory
+/** memory */
 int acc_dev_mem_allocate(void** dev_mem, size_t n);
 int acc_dev_mem_deallocate(void* dev_mem);
-int acc_host_mem_allocate(void** host_mem, size_t n, void* stream);
-int acc_host_mem_deallocate(void* host_mem, void* stream);
-int acc_memcpy_h2d(const void* host_mem, void* dev_mem, size_t count, void* stream);
-int acc_memcpy_d2h(const void* dev_mem, void* host_mem, size_t count, void* stream);
-int acc_memcpy_d2d(const void* devmem_src, void* devmem_dst, size_t count, void* stream);
-int acc_memset_zero(void* dev_mem, size_t offset, size_t length, void* stream);
-int acc_dev_mem_info(size_t* free, size_t* avail);
+int acc_dev_mem_set_ptr(void** dev_mem, void* other, size_t lb);
+int acc_host_mem_allocate(void** host_mem, size_t n, acc_stream_t stream);
+int acc_host_mem_deallocate(void* host_mem, acc_stream_t stream);
+int acc_memcpy_h2d(const void* host_mem, void* dev_mem, size_t count, acc_stream_t stream);
+int acc_memcpy_d2h(const void* dev_mem, void* host_mem, size_t count, acc_stream_t stream);
+int acc_memcpy_d2d(const void* devmem_src, void* devmem_dst, size_t count, acc_stream_t stream);
+int acc_memset_zero(void* dev_mem, size_t offset, size_t length, acc_stream_t stream);
+int acc_dev_mem_info(size_t* mem_free, size_t* mem_avail);
 
 #ifdef __cplusplus
- }
+}
 #endif


### PR DESCRIPTION
Introduced typedefs for void* (acc_stream_t, acc_event_t). Ensure void-signatures in cases where no argument is expected. Added ACC interface bits (acc_clear_errors, acc_dev_mem_set_ptr). Turned C++-style comments into C-style comments (C89 compatibility). This change is related to issue #212.