### PR TITLE
Tensors: better heuristics for parameters affecting parallelism

### DIFF
--- a/src/tas/dbcsr_tas_base.F
+++ b/src/tas/dbcsr_tas_base.F
@@ -416,7 +416,7 @@ CONTAINS
          split_info_prv = split_info
       ELSE
          ! default split heuristic: split into submatrices that have roughly same block dimensions
-         IF(row_dist%nmrowcol >= col_dist%nmrowcol) THEN
+         IF (row_dist%nmrowcol >= col_dist%nmrowcol) THEN
             split_rowcol = rowsplit
             nsplit = INT((row_dist%nmrowcol - 1)/col_dist%nmrowcol + 1)
          ELSE
@@ -424,8 +424,8 @@ CONTAINS
             nsplit = INT((col_dist%nmrowcol - 1)/row_dist%nmrowcol + 1)
          ENDIF
          opt_nsplit = .TRUE.
-         IF(PRESENT(nosplit)) THEN
-            IF(nosplit) THEN
+         IF (PRESENT(nosplit)) THEN
+            IF (nosplit) THEN
                nsplit = 1
                opt_nsplit = .FALSE.
             ENDIF

--- a/src/tas/dbcsr_tas_base.F
+++ b/src/tas/dbcsr_tas_base.F
@@ -39,38 +39,26 @@ MODULE dbcsr_tas_base
       dbcsr_distribution_release, dbcsr_get_data_type, dbcsr_mp_release, dbcsr_nblkcols_total, &
       dbcsr_nblkrows_total, dbcsr_nfullrows_total, dbcsr_nfullcols_total, dbcsr_release, &
       dbcsr_get_data_size, dbcsr_get_num_blocks, dbcsr_get_nze
-   USE dbcsr_operations, ONLY: dbcsr_get_info, &
-                               dbcsr_set, &
-                               dbcsr_filter, &
-                               dbcsr_clear
-   USE dbcsr_tas_types, ONLY: dbcsr_tas_distribution_type, &
-                              dbcsr_tas_iterator, &
-                              dbcsr_tas_create_split_info, &
-                              dbcsr_tas_type
-   USE dbcsr_tas_global, ONLY: dbcsr_tas_blk_size_arb, &
-                               dbcsr_tas_dist_arb, &
-                               dbcsr_tas_distribution, &
-                               dbcsr_tas_rowcol_data
+   USE dbcsr_operations, ONLY: &
+      dbcsr_get_info, dbcsr_set, dbcsr_filter, dbcsr_clear
+   USE dbcsr_tas_types, ONLY: &
+      dbcsr_tas_distribution_type, dbcsr_tas_iterator, dbcsr_tas_split_info, dbcsr_tas_type
+   USE dbcsr_tas_global, ONLY: &
+      dbcsr_tas_blk_size_arb, dbcsr_tas_dist_arb, dbcsr_tas_distribution, dbcsr_tas_rowcol_data
    USE dbcsr_tas_split, ONLY: &
       block_index_global_to_local, block_index_local_to_global, colsplit, &
       dbcsr_tas_info_hold, dbcsr_tas_release_info, dbcsr_tas_create_split, &
       group_to_mrowcol, rowsplit, dbcsr_tas_get_split_info
-   USE dbcsr_tas_util, ONLY: dbcsr_mp_environ, &
-                             index_unique
-   USE dbcsr_types, ONLY: dbcsr_distribution_obj, &
-                          dbcsr_iterator, &
-                          dbcsr_mp_obj, &
-                          dbcsr_type
-   USE dbcsr_work_operations, ONLY: dbcsr_create, &
-                                    dbcsr_finalize
-   USE dbcsr_kinds, ONLY: default_string_length, &
-                          int_8, &
-                          real_8, &
-                          real_4
-   USE dbcsr_mpiwrap, ONLY: mp_cart_rank, &
-                            mp_environ, &
-                            mp_sum, &
-                            mp_max
+   USE dbcsr_tas_util, ONLY: &
+      dbcsr_mp_environ, index_unique
+   USE dbcsr_types, ONLY: &
+      dbcsr_distribution_obj, dbcsr_iterator, dbcsr_mp_obj, dbcsr_type
+   USE dbcsr_work_operations, ONLY: &
+      dbcsr_create, dbcsr_finalize
+   USE dbcsr_kinds, ONLY: &
+      default_string_length, int_8, real_8, real_4
+   USE dbcsr_mpiwrap, ONLY: &
+      mp_cart_rank, mp_environ, mp_sum, mp_max
 #include "../base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -186,14 +174,14 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE dbcsr_tas_create_new(matrix, name, dist, data_type, &
                                    row_blk_size, col_blk_size, own_dist)
-      TYPE(dbcsr_tas_type), INTENT(OUT)                :: matrix
+      TYPE(dbcsr_tas_type), INTENT(OUT)              :: matrix
       CHARACTER(len=*), INTENT(IN)                   :: name
       TYPE(dbcsr_tas_distribution_type), INTENT(INOUT) :: dist
       INTEGER, INTENT(IN)                            :: data_type
-      CLASS(dbcsr_tas_rowcol_data), INTENT(IN)         :: row_blk_size, col_blk_size
+      CLASS(dbcsr_tas_rowcol_data), INTENT(IN)       :: row_blk_size, col_blk_size
       LOGICAL, INTENT(IN), OPTIONAL                  :: own_dist
 
-      TYPE(dbcsr_tas_create_split_info)                       :: info
+      TYPE(dbcsr_tas_split_info)                     :: info
 
       INTEGER, DIMENSION(:), POINTER                 :: row_blk_size_vec => NULL(), col_blk_size_vec => NULL()
       INTEGER                                        :: nrows, ncols, irow, col, icol, row
@@ -411,17 +399,18 @@ CONTAINS
    SUBROUTINE dbcsr_tas_distribution_new(dist, mp_comm, &
                                          row_dist, col_dist, split_info, nosplit)
       TYPE(dbcsr_tas_distribution_type), INTENT(OUT)   :: dist
-      INTEGER, INTENT(IN)                            :: mp_comm
+      INTEGER, INTENT(IN)                              :: mp_comm
       CLASS(dbcsr_tas_distribution), INTENT(IN)        :: row_dist, col_dist
-      TYPE(dbcsr_tas_create_split_info), INTENT(IN), OPTIONAL :: split_info
-      LOGICAL, INTENT(IN), OPTIONAL                  :: nosplit
+      TYPE(dbcsr_tas_split_info), INTENT(IN), OPTIONAL :: split_info
+      LOGICAL, INTENT(IN), OPTIONAL                    :: nosplit
 
-      TYPE(dbcsr_tas_create_split_info)                           :: split_info_prv
+      TYPE(dbcsr_tas_split_info)                       :: split_info_prv
 
-      INTEGER, DIMENSION(:), POINTER :: row_dist_vec => NULL()
-      INTEGER, DIMENSION(:), POINTER :: col_dist_vec => NULL()
-      TYPE(dbcsr_mp_obj) :: mp_environ_tmp
-      INTEGER :: nrows, ncols, irow, col, icol, row
+      INTEGER, DIMENSION(:), POINTER                   :: row_dist_vec => NULL()
+      INTEGER, DIMENSION(:), POINTER                   :: col_dist_vec => NULL()
+      TYPE(dbcsr_mp_obj)                               :: mp_environ_tmp
+      INTEGER                                          :: nrows, ncols, irow, col, icol, row, &
+                                                          split_rowcol, nsplit
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_tas_distribution_new', &
                                      routineP = moduleN//':'//routineN
@@ -432,7 +421,18 @@ CONTAINS
          CALL dbcsr_tas_info_hold(split_info)
          split_info_prv = split_info
       ELSE
-         CALL dbcsr_tas_create_split(split_info_prv, mp_comm, row_dist%nmrowcol, col_dist%nmrowcol, nosplit=nosplit)
+         ! default split heuristic: split into submatrices that have roughly same block dimensions
+         IF(row_dist%nmrowcol >= col_dist%nmrowcol) THEN
+            split_rowcol = rowsplit
+            nsplit = INT((row_dist%nmrowcol - 1)/col_dist%nmrowcol + 1)
+         ELSE
+            split_rowcol = colsplit
+            nsplit = INT((col_dist%nmrowcol - 1)/row_dist%nmrowcol + 1)
+         ENDIF
+         IF(PRESENT(nosplit)) THEN
+            IF(nosplit) nsplit=0
+         ENDIF
+         CALL dbcsr_tas_create_split(split_info_prv, mp_comm, split_rowcol, nsplit=nsplit)
       ENDIF
 
       SELECT CASE (split_info_prv%split_rowcol)
@@ -502,12 +502,12 @@ CONTAINS
 !> \param processor process ID
 ! **************************************************************************************************
    SUBROUTINE dbcsr_tas_get_stored_coordinates(matrix, row, column, processor)
-      TYPE(dbcsr_tas_type), INTENT(IN)                     :: matrix
+      TYPE(dbcsr_tas_type), INTENT(IN)                   :: matrix
       INTEGER(KIND=int_8), INTENT(IN)                    :: row, column
       INTEGER, INTENT(OUT)                               :: processor
 
       INTEGER, DIMENSION(2)                              :: pcoord
-      TYPE(dbcsr_tas_create_split_info)                           :: info
+      TYPE(dbcsr_tas_split_info)                         :: info
 
       pcoord(1) = matrix%dist%row_dist%dist(row)
       pcoord(2) = matrix%dist%col_dist%dist(column)
@@ -532,7 +532,7 @@ CONTAINS
       INTEGER                                            :: igroup
       INTEGER(KIND=int_8)                                :: col_s, row_s
       INTEGER, DIMENSION(2)                              :: pcoord
-      TYPE(dbcsr_tas_create_split_info)                           :: info
+      TYPE(dbcsr_tas_split_info)                         :: info
 
       row_s = INT(row, KIND=int_8); col_s = INT(column, KIND=int_8)
 
@@ -574,8 +574,8 @@ CONTAINS
       TYPE(dbcsr_data_obj)                               :: block
       TYPE(dbcsr_distribution_obj)                       :: dist
       TYPE(dbcsr_mp_obj)                                 :: mp_environ_tmp
-      TYPE(dbcsr_tas_iterator)                             :: iter
-      TYPE(dbcsr_tas_create_split_info)                           :: info
+      TYPE(dbcsr_tas_iterator)                           :: iter
+      TYPE(dbcsr_tas_split_info)                         :: info
       INTEGER                                            :: block_number, rb_count, nblks_local
       INTEGER, DIMENSION(:), ALLOCATABLE                 :: nz_rows, nz_cols
 
@@ -652,9 +652,9 @@ CONTAINS
 !> \param matrix_dbcsr ...
 ! **************************************************************************************************
    SUBROUTINE dbcsr_tas_convert_to_tas(info, matrix_rect, matrix_dbcsr)
-      TYPE(dbcsr_tas_create_split_info), INTENT(IN)               :: info
+      TYPE(dbcsr_tas_split_info), INTENT(IN)               :: info
       TYPE(dbcsr_tas_type), INTENT(OUT)                    :: matrix_rect
-      TYPE(dbcsr_type), INTENT(IN)                       :: matrix_dbcsr
+      TYPE(dbcsr_type), INTENT(IN)                         :: matrix_dbcsr
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_tas_convert_to_tas', &
                                      routineP = moduleN//':'//routineN
@@ -976,7 +976,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION dbcsr_tas_info(matrix)
       TYPE(dbcsr_tas_type), INTENT(IN)                     :: matrix
-      TYPE(dbcsr_tas_create_split_info)                           :: dbcsr_tas_info
+      TYPE(dbcsr_tas_split_info)                           :: dbcsr_tas_info
 
       dbcsr_tas_info = matrix%dist%info
    END FUNCTION
@@ -1107,8 +1107,8 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION dbcsr_tas_get_num_blocks_total(matrix) RESULT(num_blocks)
       TYPE(dbcsr_tas_type), INTENT(IN) :: matrix
-      INTEGER(KIND=int_8)            :: num_blocks
-      TYPE(dbcsr_tas_create_split_info) :: info
+      INTEGER(KIND=int_8)              :: num_blocks
+      TYPE(dbcsr_tas_split_info)       :: info
 
       info = dbcsr_tas_info(matrix)
       num_blocks = dbcsr_tas_get_num_blocks(matrix)
@@ -1136,8 +1136,8 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION dbcsr_tas_get_nze_total(matrix)
       TYPE(dbcsr_tas_type), INTENT(IN) :: matrix
-      INTEGER(KIND=int_8) :: dbcsr_tas_get_nze_total
-      TYPE(dbcsr_tas_create_split_info) :: info
+      INTEGER(KIND=int_8)              :: dbcsr_tas_get_nze_total
+      TYPE(dbcsr_tas_split_info)       :: info
 
       dbcsr_tas_get_nze_total = dbcsr_tas_get_nze(matrix)
       info = dbcsr_tas_info(matrix)
@@ -1151,7 +1151,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION dbcsr_tas_get_data_size(matrix) RESULT(data_size)
       TYPE(dbcsr_tas_type), INTENT(IN) :: matrix
-      INTEGER                        :: data_size
+      INTEGER                          :: data_size
 
       data_size = dbcsr_get_data_size(matrix%matrix)
    END FUNCTION
@@ -1202,21 +1202,23 @@ CONTAINS
                                  row_blk_size, col_blk_size, distribution, name, data_area, &
                                  matrix_type, data_type)
 
-      TYPE(dbcsr_tas_type), INTENT(IN)                                  :: matrix
+      TYPE(dbcsr_tas_type), INTENT(IN)                                :: matrix
       INTEGER(KIND=int_8), INTENT(OUT), OPTIONAL                      :: nblkrows_total, nblkcols_total, nfullrows_total, &
                                                                          nfullcols_total
       INTEGER, INTENT(OUT), OPTIONAL                                  :: nblkrows_local, nblkcols_local, nfullrows_local, &
                                                                          nfullcols_local, nprow, npcol, my_prow, my_pcol
       INTEGER(KIND=int_8), DIMENSION(:), OPTIONAL, ALLOCATABLE        :: local_rows, local_cols
-      CLASS(dbcsr_tas_distribution), ALLOCATABLE, OPTIONAL, INTENT(OUT) :: proc_row_dist, proc_col_dist
-      CLASS(dbcsr_tas_rowcol_data), ALLOCATABLE, OPTIONAL, INTENT(OUT)  :: row_blk_size, col_blk_size
-      TYPE(dbcsr_tas_distribution_type), OPTIONAL                       :: distribution
+      CLASS(dbcsr_tas_distribution), ALLOCATABLE, OPTIONAL, &
+         INTENT(OUT)                                                  :: proc_row_dist, proc_col_dist
+      CLASS(dbcsr_tas_rowcol_data), ALLOCATABLE, OPTIONAL, &
+         INTENT(OUT)                                                  :: row_blk_size, col_blk_size
+      TYPE(dbcsr_tas_distribution_type), OPTIONAL                     :: distribution
       CHARACTER(len=*), INTENT(OUT), OPTIONAL                         :: name
       TYPE(dbcsr_data_obj), INTENT(OUT), OPTIONAL                     :: data_area
       CHARACTER, OPTIONAL                                             :: matrix_type
       INTEGER, OPTIONAL                                               :: data_type
 
-      TYPE(dbcsr_tas_create_split_info)                                        :: info
+      TYPE(dbcsr_tas_split_info)                                      :: info
       INTEGER                                                         :: numnodes, irow, icol
       INTEGER, DIMENSION(2)                                           :: pdims, pcoord
       INTEGER, DIMENSION(:), POINTER                                  :: local_rows_local => NULL(), local_cols_local => NULL()

--- a/src/tas/dbcsr_tas_base.F
+++ b/src/tas/dbcsr_tas_base.F
@@ -17,24 +17,18 @@
 MODULE dbcsr_tas_base
 #:include "dbcsr_tas.fypp"
 
-   USE dbcsr_block_access, ONLY: dbcsr_get_block_p, &
-                                 dbcsr_put_block, &
-                                 dbcsr_reserve_blocks
-   USE dbcsr_data_methods, ONLY: dbcsr_data_new, &
-                                 dbcsr_data_release, &
-                                 dbcsr_type_1d_to_2d
-   USE dbcsr_data_methods_low, ONLY: dbcsr_data_clear_pointer, &
-                                     dbcsr_data_init
-   USE dbcsr_data_types, ONLY: dbcsr_data_obj, &
-                               dbcsr_scalar_type
-   USE dbcsr_dist_methods, ONLY: dbcsr_distribution_col_dist, &
-                                 dbcsr_distribution_new, &
-                                 dbcsr_distribution_row_dist, &
-                                 dbcsr_distribution_hold
-   USE dbcsr_iterator_operations, ONLY: dbcsr_iterator_blocks_left, &
-                                        dbcsr_iterator_next_block, &
-                                        dbcsr_iterator_start, &
-                                        dbcsr_iterator_stop
+   USE dbcsr_block_access, ONLY: &
+      dbcsr_get_block_p, dbcsr_put_block, dbcsr_reserve_blocks
+   USE dbcsr_data_methods, ONLY: &
+      dbcsr_data_new, dbcsr_data_release, dbcsr_type_1d_to_2d
+   USE dbcsr_data_methods_low, ONLY: &
+      dbcsr_data_clear_pointer, dbcsr_data_init
+   USE dbcsr_data_types, ONLY: &
+      dbcsr_data_obj, dbcsr_scalar_type
+   USE dbcsr_dist_methods, ONLY: &
+      dbcsr_distribution_col_dist, dbcsr_distribution_new, dbcsr_distribution_row_dist, dbcsr_distribution_hold
+   USE dbcsr_iterator_operations, ONLY: &
+      dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, dbcsr_iterator_start, dbcsr_iterator_stop
    USE dbcsr_methods, ONLY: &
       dbcsr_distribution_release, dbcsr_get_data_type, dbcsr_mp_release, dbcsr_nblkcols_total, &
       dbcsr_nblkrows_total, dbcsr_nfullrows_total, dbcsr_nfullcols_total, dbcsr_release, &
@@ -403,6 +397,7 @@ CONTAINS
       CLASS(dbcsr_tas_distribution), INTENT(IN)        :: row_dist, col_dist
       TYPE(dbcsr_tas_split_info), INTENT(IN), OPTIONAL :: split_info
       LOGICAL, INTENT(IN), OPTIONAL                    :: nosplit
+      !LOGICAL, INTENT(IN), OPTIONAL                    :: strict_split
 
       TYPE(dbcsr_tas_split_info)                       :: split_info_prv
 
@@ -410,11 +405,10 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                   :: col_dist_vec => NULL()
       TYPE(dbcsr_mp_obj)                               :: mp_environ_tmp
       INTEGER                                          :: nrows, ncols, irow, col, icol, row, &
-                                                          split_rowcol, nsplit
-
+                                                          split_rowcol, nsplit, handle
+      LOGICAL                                          :: opt_nsplit
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_tas_distribution_new', &
                                      routineP = moduleN//':'//routineN
-      INTEGER :: handle
 
       CALL timeset(routineN, handle)
       IF (PRESENT(split_info)) THEN
@@ -429,10 +423,14 @@ CONTAINS
             split_rowcol = colsplit
             nsplit = INT((col_dist%nmrowcol - 1)/row_dist%nmrowcol + 1)
          ENDIF
+         opt_nsplit = .TRUE.
          IF(PRESENT(nosplit)) THEN
-            IF(nosplit) nsplit=0
+            IF(nosplit) THEN
+               nsplit = 1
+               opt_nsplit = .FALSE.
+            ENDIF
          ENDIF
-         CALL dbcsr_tas_create_split(split_info_prv, mp_comm, split_rowcol, nsplit=nsplit)
+         CALL dbcsr_tas_create_split(split_info_prv, mp_comm, split_rowcol, nsplit=nsplit, opt_nsplit=opt_nsplit)
       ENDIF
 
       SELECT CASE (split_info_prv%split_rowcol)
@@ -470,6 +468,8 @@ CONTAINS
       ALLOCATE (dist%row_dist, source=row_dist)
       ALLOCATE (dist%col_dist, source=col_dist)
       CALL dbcsr_mp_release(mp_environ_tmp)
+
+      !IF(PRESENT(strict_split)) dist%strict_split = strict_split
 
       CALL timestop(handle)
    END SUBROUTINE

--- a/src/tas/dbcsr_tas_global.F
+++ b/src/tas/dbcsr_tas_global.F
@@ -31,12 +31,14 @@ MODULE dbcsr_tas_global
    PUBLIC :: &
       dbcsr_tas_blk_size_arb, &
       dbcsr_tas_blk_size_repl, &
+      dbcsr_tas_blk_size_one, &
       dbcsr_tas_dist_arb, &
       dbcsr_tas_dist_arb_default, &
       dbcsr_tas_dist_cyclic, &
       dbcsr_tas_dist_repl, &
       dbcsr_tas_distribution, &
-      dbcsr_tas_rowcol_data
+      dbcsr_tas_rowcol_data, &
+      cyclic_weighted_dist
 
    ! abstract type for distribution vectors along one dimension
    TYPE, ABSTRACT :: dbcsr_tas_distribution
@@ -114,6 +116,13 @@ MODULE dbcsr_tas_global
       PROCEDURE :: DATA => blk_size_repl
    END TYPE
 
+   ! type for blocks of size one
+   ! - memory efficient for large dimensions
+   TYPE, EXTENDS(dbcsr_tas_rowcol_data) :: dbcsr_tas_blk_size_one
+   CONTAINS
+      PROCEDURE :: DATA => blk_size_one
+   END TYPE
+
    ABSTRACT INTERFACE
 ! **************************************************************************************************
 !> \brief map matrix rows/cols to distribution rows/cols:
@@ -176,6 +185,10 @@ MODULE dbcsr_tas_global
       MODULE PROCEDURE new_dbcsr_tas_blk_size_repl
    END INTERFACE
 
+   INTERFACE dbcsr_tas_blk_size_one
+      MODULE PROCEDURE new_dbcsr_tas_blk_size_one
+   END INTERFACE
+
 CONTAINS
 ! **************************************************************************************************
 !> \brief ...
@@ -211,6 +224,22 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
+!> \param t ...
+!> \param rowcol ...
+!> \return ...
+! **************************************************************************************************
+   FUNCTION blk_size_one(t, rowcol)
+      CLASS(dbcsr_tas_blk_size_one), INTENT(IN) :: t
+      INTEGER(KIND=int_8), INTENT(IN) :: rowcol
+      INTEGER :: blk_size_one
+
+      MARK_USED(t)
+      MARK_USED(rowcol)
+      blk_size_one = 1
+   END FUNCTION
+
+! **************************************************************************************************
+!> \brief ...
 !> \param blk_size_vec ...
 !> \return ...
 ! **************************************************************************************************
@@ -240,6 +269,19 @@ CONTAINS
       new_dbcsr_tas_blk_size_repl%blk_size_vec(:) = blk_size_vec(:)
       new_dbcsr_tas_blk_size_repl%nmrowcol = new_dbcsr_tas_blk_size_repl%nmrowcol_local*n_repl
       new_dbcsr_tas_blk_size_repl%nfullrowcol = SUM(blk_size_vec)*n_repl
+   END FUNCTION
+
+! **************************************************************************************************
+!> \brief ...
+!> \param nrowcol ...
+!> \return ...
+! **************************************************************************************************
+   FUNCTION new_dbcsr_tas_blk_size_one(nrowcol)
+      INTEGER(KIND=int_8), INTENT(IN)      :: nrowcol
+      TYPE(dbcsr_tas_blk_size_one)         :: new_dbcsr_tas_blk_size_one
+
+      new_dbcsr_tas_blk_size_one%nmrowcol = nrowcol
+      new_dbcsr_tas_blk_size_one%nfullrowcol = nrowcol
    END FUNCTION
 
 ! **************************************************************************************************
@@ -399,7 +441,9 @@ CONTAINS
 
       CALL cyclic_weighted_dist(INT(nmrowcol), nprowcol, bsize_vec, dist_vec)
       dbcsr_tas_dist_arb_default = dbcsr_tas_dist_arb(dist_vec, nprowcol, nmrowcol)
-   CONTAINS
+
+   END FUNCTION
+
 ! **************************************************************************************************
 !> \brief ...
 !> \param nel ...
@@ -407,32 +451,30 @@ CONTAINS
 !> \param weights ...
 !> \param dist ...
 ! **************************************************************************************************
-      SUBROUTINE cyclic_weighted_dist(nel, nbin, weights, dist)
-         INTEGER, INTENT(IN) :: nel
-         INTEGER, INTENT(IN) :: nbin
-         INTEGER, DIMENSION(nel), INTENT(IN)            :: weights
-         INTEGER, DIMENSION(nel), INTENT(OUT)            :: dist
-         INTEGER, DIMENSION(nbin)                        :: occup
-         INTEGER                :: iel, ibin
-         INTEGER                :: niter
+   SUBROUTINE cyclic_weighted_dist(nel, nbin, weights, dist)
+      INTEGER, INTENT(IN) :: nel
+      INTEGER, INTENT(IN) :: nbin
+      INTEGER, DIMENSION(nel), INTENT(IN)            :: weights
+      INTEGER, DIMENSION(nel), INTENT(OUT)            :: dist
+      INTEGER, DIMENSION(nbin)                        :: occup
+      INTEGER                :: iel, ibin
+      INTEGER                :: niter
 
-         occup(:) = 0
-         ibin = 0
-         DO iel = 1, nel
-            niter = 0
+      occup(:) = 0
+      ibin = 0
+      DO iel = 1, nel
+         niter = 0
+         ibin = MOD(ibin + 1, nbin)
+         DO WHILE (occup(ibin + 1) + weights(iel) .GE. MAXVAL(occup))
+            IF (MINLOC(occup, DIM=1) == ibin + 1) EXIT
             ibin = MOD(ibin + 1, nbin)
-            DO WHILE (occup(ibin + 1) + weights(iel) .GE. MAXVAL(occup))
-               IF (MINLOC(occup, DIM=1) == ibin + 1) EXIT
-               ibin = MOD(ibin + 1, nbin)
-               niter = niter + 1
-            ENDDO
-            dist(iel) = ibin
-            occup(ibin + 1) = occup(ibin + 1) + weights(iel)
+            niter = niter + 1
          ENDDO
+         dist(iel) = ibin
+         occup(ibin + 1) = occup(ibin + 1) + weights(iel)
+      ENDDO
 
-      END SUBROUTINE
-
-   END FUNCTION
+   END SUBROUTINE
 
 ! **************************************************************************************************
 !> \brief ...

--- a/src/tas/dbcsr_tas_io.F
+++ b/src/tas/dbcsr_tas_io.F
@@ -15,7 +15,7 @@
 
 MODULE dbcsr_tas_io
    USE dbcsr_tas_types, ONLY: &
-      dbcsr_tas_type, dbcsr_tas_create_split_info
+      dbcsr_tas_type, dbcsr_tas_split_info
    USE dbcsr_tas_global, ONLY: &
       dbcsr_tas_rowcol_data, dbcsr_tas_distribution
    USE dbcsr_kinds, ONLY: &
@@ -189,18 +189,25 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief Print info on how matrix is split
 !> \param info ...
-!> \param name ...
 !> \param io_unit ...
+!> \param name ...
 ! **************************************************************************************************
-   SUBROUTINE dbcsr_tas_write_split_info(info, name, io_unit)
-      TYPE(dbcsr_tas_create_split_info), INTENT(IN)               :: info
-      CHARACTER(len=*), INTENT(IN)                       :: name
+   SUBROUTINE dbcsr_tas_write_split_info(info, io_unit, name)
+      TYPE(dbcsr_tas_split_info), INTENT(IN)             :: info
       INTEGER, INTENT(IN) :: io_unit
+      CHARACTER(len=*), INTENT(IN), OPTIONAL             :: name
       INTEGER                                            :: groupsize, igroup, mp_comm, &
                                                             mp_comm_group, mynode, nsplit, &
                                                             numnodes, split_rowcol
       INTEGER, DIMENSION(2)                              :: coord, dims, groupcoord, groupdims, &
                                                             pgrid_offset
+      CHARACTER(len=:), ALLOCATABLE                      :: name_prv
+
+      IF(PRESENT(name)) THEN
+         ALLOCATE(name_prv, SOURCE=TRIM(name))
+      ELSE
+         ALLOCATE(name_prv, SOURCE="")
+      ENDIF
 
       CALL dbcsr_tas_get_split_info(info, mp_comm, nsplit, igroup, mp_comm_group, split_rowcol, pgrid_offset)
       CALL mp_environ(numnodes, mynode, mp_comm)
@@ -210,16 +217,16 @@ CONTAINS
       IF (io_unit > 0) THEN
          SELECT CASE (split_rowcol)
          CASE (rowsplit)
-            WRITE (io_unit, "(T4,A,I4,1X,A,I4)") TRIM(name)//" splitting rows by factor", nsplit
+            WRITE (io_unit, "(T4,A,I4,1X,A,I4)") name_prv//"splitting rows by factor", nsplit
          CASE (colsplit)
-            WRITE (io_unit, "(T4,A,I4,1X,A,I4)") TRIM(name)//" splitting columns by factor", nsplit
+            WRITE (io_unit, "(T4,A,I4,1X,A,I4)") name_prv//"splitting columns by factor", nsplit
          END SELECT
-         WRITE (io_unit, "(T4,A, I4,A1,I4)") TRIM(name)//" global grid sizes:", dims(1), "x", dims(2)
+         WRITE (io_unit, "(T4,A,I4,A1,I4)") name_prv//"global grid sizes:", dims(1), "x", dims(2)
       ENDIF
 
       IF (io_unit > 0) THEN
          WRITE (io_unit, "(T4,A,I4,A1,I4)") &
-            TRIM(name)//" grid sizes on subgroups:", &
+            name_prv//"grid sizes on subgroups:", &
             groupdims(1), "x", groupdims(2)
       ENDIF
 

--- a/src/tas/dbcsr_tas_io.F
+++ b/src/tas/dbcsr_tas_io.F
@@ -205,10 +205,10 @@ CONTAINS
                                                             pgrid_offset
       CHARACTER(len=:), ALLOCATABLE                      :: name_prv
 
-      IF(PRESENT(name)) THEN
-         ALLOCATE(name_prv, SOURCE=TRIM(name))
+      IF (PRESENT(name)) THEN
+         ALLOCATE (name_prv, SOURCE=TRIM(name))
       ELSE
-         ALLOCATE(name_prv, SOURCE="")
+         ALLOCATE (name_prv, SOURCE="")
       ENDIF
 
       CALL dbcsr_tas_get_split_info(info, mp_comm, nsplit, igroup, mp_comm_group, split_rowcol, pgrid_offset)

--- a/src/tas/dbcsr_tas_io.F
+++ b/src/tas/dbcsr_tas_io.F
@@ -110,16 +110,18 @@ CONTAINS
 !> \param full_info Whether to print subgroup DBCSR distribution
 ! **************************************************************************************************
    SUBROUTINE dbcsr_tas_write_dist(matrix, output_unit, full_info)
-      TYPE(dbcsr_tas_type), INTENT(IN)   :: matrix
+      TYPE(dbcsr_tas_type), INTENT(IN) :: matrix
       INTEGER, INTENT(IN)              :: output_unit
       LOGICAL, INTENT(IN), OPTIONAL    :: full_info
 
       CHARACTER(default_string_length) :: name
       INTEGER                          :: mp_comm, ngroup, igroup, mp_comm_group, nproc, iproc, &
-                                          nblock_p_max, nelement_p_max, nblock_s, nelement_s, &
-                                          nblock_s_max, nelement_s_max, nblock, nelement
+                                          nblock_p_max, nelement_p_max, &
+                                          nblock, nelement
+      INTEGER(KIND=int_8), DIMENSION(2) :: tmp_i8
       INTEGER, DIMENSION(2)            :: tmp
-      INTEGER(KIND=int_8)              :: nblock_tot, nblock_p_sum, nelement_p_sum
+      INTEGER(KIND=int_8)              :: nblock_tot, nblock_p_sum, nelement_p_sum, nelement_s_max, &
+                                          nblock_s, nelement_s, nblock_s_max
       REAL(KIND=real_8)                :: occupation
       INTEGER, DIMENSION(:), POINTER   :: rowdist => NULL(), coldist => NULL()
       INTEGER                          :: split_rowcol, icol, irow
@@ -144,9 +146,9 @@ CONTAINS
       CALL mp_sum(nblock_s, mp_comm_group)
       CALL mp_sum(nelement_s, mp_comm_group)
 
-      tmp = (/nblock_s, nelement_s/)
-      CALL mp_max(tmp, mp_comm)
-      nblock_s_max = tmp(1); nelement_s_max = tmp(2)
+      tmp_i8 = (/nblock_s, nelement_s/)
+      CALL mp_max(tmp_i8, mp_comm)
+      nblock_s_max = tmp_i8(1); nelement_s_max = tmp_i8(2)
 
       nblock_tot = dbcsr_tas_nblkrows_total(matrix)*dbcsr_tas_nblkcols_total(matrix)
       occupation = -1.0_real_8

--- a/src/tas/dbcsr_tas_mm.F
+++ b/src/tas/dbcsr_tas_mm.F
@@ -126,7 +126,7 @@ CONTAINS
       TYPE(dbcsr_scalar_type)                    :: zero
       LOGICAL                                    :: new_a, new_b, new_c, simple_split_prv, opt_pgrid,&
                                                     move_a, move_b
-      TYPE(dbcsr_tas_split_info)                 :: info
+      TYPE(dbcsr_tas_split_info)                 :: info, info_a, info_b, info_c
       CHARACTER(LEN=*), PARAMETER                :: routineN = 'dbcsr_tas_multiply', &
                                                     routineP = moduleN//':'//routineN
       INTEGER(KIND=int_8)                        :: nze_a, nze_b, nze_c
@@ -146,6 +146,9 @@ CONTAINS
          simple_split_prv = simple_split
       ELSE
          simple_split_prv = .FALSE.
+
+         info_a = dbcsr_tas_info(matrix_a); info_b = dbcsr_tas_info(matrix_b); info_c = dbcsr_tas_info(matrix_c)
+         IF(info_a%strict_split .OR. info_b%strict_split .OR. info_c%strict_split) simple_split_prv = .TRUE.
       ENDIF
 
       IF(simple_split_prv .AND. PRESENT(split_opt)) THEN
@@ -534,8 +537,7 @@ CONTAINS
 
       IF(PRESENT(split_opt)) THEN
          ! ideally we should rederive the split factor from the actual sparsity of C, but
-         ! due to parameter beta, we can not actually get the sparsity of AxB from DBCSR if
-         ! not new_c
+         ! due to parameter beta, we can not get the sparsity of AxB from DBCSR if not new_c
          mp_comm_opt = dbcsr_tas_mp_comm(mp_comm, split_rc, nsplit_opt)
          CALL dbcsr_tas_create_split(split_opt, mp_comm_opt, split_rc, nsplit_opt, own_comm=.TRUE.)
       ENDIF

--- a/src/tas/dbcsr_tas_mm.F
+++ b/src/tas/dbcsr_tas_mm.F
@@ -173,7 +173,7 @@ CONTAINS
       IF (PRESENT(io_unit)) THEN
          IF (io_unit_prv .GT. 0) THEN
             WRITE (io_unit_prv, '(A)') repeat("-", 80)
-            WRITE (io_unit_prv, '(A,1X,A,1X,A,1X,A,1X,A,1X,A)') "DBCSR TALL-AND-SKINNY MATRIX MULTIPLICATION:", &
+            WRITE (io_unit_prv, '(A,1X,A,1X,A,1X,A,1X,A,1X,A)') "DBCSR TAS MATRIX MULTIPLICATION:", &
                TRIM(matrix_a%matrix%name), 'x', TRIM(matrix_b%matrix%name), '=', TRIM(matrix_c%matrix%name)
             WRITE (io_unit_prv, '(A)') repeat("-", 80)
          ENDIF
@@ -228,7 +228,6 @@ CONTAINS
          nsplit = 0
          max_mm_dim = MAXLOC(dims, 1)
       ENDIF
-
 
       ! reshape matrices to the optimal layout and split factor
       split_a = rowsplit; split_b=rowsplit; split_c=rowsplit
@@ -560,7 +559,7 @@ CONTAINS
       ENDIF
       IF (io_unit_prv > 0) THEN
          WRITE (io_unit_prv, '(A)') repeat("-", 80)
-         WRITE (io_unit_prv, '(A,1X,A,1X,A,1X,A,1X,A,1X,A)') "TALL-AND-SKINNY MATRIX MULTIPLICATION DONE"
+         WRITE (io_unit_prv, '(A,1X,A,1X,A,1X,A,1X,A,1X,A)') "TAS MATRIX MULTIPLICATION DONE"
          WRITE (io_unit_prv, '(A)') repeat("-", 80)
       ENDIF
 

--- a/src/tas/dbcsr_tas_mm.F
+++ b/src/tas/dbcsr_tas_mm.F
@@ -20,44 +20,46 @@
 ! **************************************************************************************************
 
 MODULE dbcsr_tas_mm
+#:include "dbcsr_tas.fypp"
 
-   USE dbcsr_data_methods, ONLY: dbcsr_scalar_zero
-   USE dbcsr_data_types, ONLY: dbcsr_scalar_type
+   USE dbcsr_data_methods, ONLY: &
+      dbcsr_scalar_zero, dbcsr_scalar
+   USE dbcsr_data_types, ONLY: &
+      dbcsr_scalar_type, dbcsr_type_real_8, dbcsr_type_real_4, dbcsr_type_complex_8, dbcsr_type_complex_4
    USE dbcsr_multiply_api, ONLY: dbcsr_multiply
    USE dbcsr_tas_base, ONLY: &
       dbcsr_tas_create, dbcsr_tas_destroy, dbcsr_tas_distribution_destroy, dbcsr_tas_distribution_new, &
       dbcsr_tas_get_data_type, dbcsr_tas_info, dbcsr_tas_nblkcols_total, &
-      dbcsr_tas_nblkrows_total, dbcsr_tas_filter
-   USE dbcsr_tas_types, ONLY: dbcsr_tas_distribution_type, &
-                              dbcsr_tas_create_split_info, &
-                              dbcsr_tas_type
-   USE dbcsr_tas_global, ONLY: dbcsr_tas_dist_cyclic, &
-                               dbcsr_tas_dist_arb, &
-                               dbcsr_tas_distribution, &
-                               dbcsr_tas_dist_arb_default
-   USE dbcsr_tas_reshape_ops, ONLY: dbcsr_tas_merge, &
-                                    dbcsr_tas_replicate, &
-                                    dbcsr_tas_reshape
-   USE dbcsr_tas_split, ONLY: colsplit, &
-                              dbcsr_tas_get_split_info, &
-                              dbcsr_tas_create_split, &
-                              dbcsr_tas_mp_comm, &
-                              dbcsr_tas_release_info
-   USE dbcsr_tas_util, ONLY: swap, &
-                             invert_transpose_flag, &
-                             array_eq_i8
-   USE dbcsr_types, ONLY: dbcsr_no_transpose, &
-                          dbcsr_transpose
-   USE dbcsr_kinds, ONLY: int_8, &
-                          real_8
-   USE dbcsr_mpiwrap, ONLY: mp_comm_compare, &
-                            mp_environ, &
-                            mp_sum, &
-                            mp_comm_free
-   USE dbcsr_operations, ONLY: dbcsr_scale
-   USE dbcsr_tas_io, ONLY: dbcsr_tas_write_dist, &
-                           dbcsr_tas_write_matrix_info, &
-                           dbcsr_tas_write_split_info
+      dbcsr_tas_nblkrows_total, dbcsr_tas_filter, dbcsr_tas_get_info, dbcsr_tas_iterator_blocks_left, &
+      dbcsr_tas_get_nze_total, dbcsr_tas_reserve_blocks, dbcsr_tas_iterator_start, dbcsr_tas_iterator_next_block, &
+      dbcsr_tas_iterator_stop, dbcsr_tas_copy, dbcsr_tas_get_block_p, dbcsr_tas_clear
+   USE dbcsr_tas_types, ONLY: &
+      dbcsr_tas_distribution_type, dbcsr_tas_split_info, dbcsr_tas_type, dbcsr_tas_iterator
+   USE dbcsr_tas_global, ONLY: &
+      dbcsr_tas_dist_cyclic, dbcsr_tas_dist_arb, dbcsr_tas_distribution, dbcsr_tas_dist_arb_default, &
+      dbcsr_tas_rowcol_data, dbcsr_tas_blk_size_one, cyclic_weighted_dist
+   USE dbcsr_tas_reshape_ops, ONLY: &
+      dbcsr_tas_merge, dbcsr_tas_replicate, dbcsr_tas_reshape
+   USE dbcsr_tas_split, ONLY: &
+      rowsplit, colsplit, dbcsr_tas_get_split_info, dbcsr_tas_create_split, dbcsr_tas_mp_comm, &
+      dbcsr_tas_release_info, accept_pgrid_dims, dbcsr_tas_info_hold, default_nsplit_accept_ratio_1
+   USE dbcsr_tas_util, ONLY: &
+      swap, invert_transpose_flag, array_eq_i8, dbcsr_mp_environ
+   USE dbcsr_types, ONLY: &
+      dbcsr_no_transpose, dbcsr_transpose, dbcsr_type, dbcsr_distribution_obj, dbcsr_mp_obj
+   USE dbcsr_kinds, ONLY: &
+      int_8, real_8, real_4, default_string_length
+   USE dbcsr_mpiwrap, ONLY: &
+      mp_comm_compare, mp_environ, mp_sum, mp_comm_free, mp_cart_create
+   USE dbcsr_operations, ONLY: &
+      dbcsr_scale, dbcsr_get_info, dbcsr_copy, dbcsr_clear, dbcsr_add
+   USE dbcsr_tas_io, ONLY: &
+      dbcsr_tas_write_dist, dbcsr_tas_write_matrix_info, dbcsr_tas_write_split_info
+   USE dbcsr_work_operations, ONLY: dbcsr_create, dbcsr_finalize
+   USE dbcsr_transformations, ONLY: dbcsr_redistribute
+   USE dbcsr_dist_methods, ONLY: dbcsr_distribution_new
+   USE dbcsr_methods, ONLY: &
+      dbcsr_mp_release, dbcsr_release, dbcsr_distribution_release, dbcsr_get_nze
 #include "../base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -80,44 +82,59 @@ CONTAINS
 !> \param matrix_b ...
 !> \param beta ...
 !> \param matrix_c ...
-!> \param optimize_dist Whether distribution should be optimized internally. Experimental and should
-!> be used for dense matrices only.
+!> \param optimize_dist Whether distribution should be optimized internally. In the current implementation
+!>                      this guarantees optimal parameters only for dense matrices.
+!> \param split_opt optionally return split info containing optimal grid and split parameters. This
+!>                  can be used to choose optimal process grids for subsequent matrix multiplications
+!>                  with matrices of similar shape and sparsity.
 !> \param filter_eps ...
 !> \param flop ...
-!> \param move_data memory optimization: move data to matrix_c such that matrix_a and matrix_b are
-!> empty on return
+!> \param move_data_a memory optimization: move data to matrix_c such that matrix_a is empty on return
+!> \param move_data_b memory optimization: move data to matrix_c such that matrix_b is empty on return
+!> \param simple_split for internal use only
 !> \param io_unit unit number for logging output
 !> \param log_verbose only for testing: verbose output
 ! **************************************************************************************************
    SUBROUTINE dbcsr_tas_multiply(transa, transb, transc, alpha, matrix_a, matrix_b, beta, matrix_c, &
-                                 optimize_dist, filter_eps, flop, move_data, io_unit, log_verbose)
+                                 optimize_dist, split_opt, filter_eps, flop, move_data_a, &
+                                 move_data_b, simple_split, io_unit, log_verbose)
       CHARACTER(LEN=1), INTENT(IN)               :: transa, transb, transc
       TYPE(dbcsr_scalar_type), INTENT(IN)        :: alpha, beta
-      TYPE(dbcsr_tas_type), TARGET, INTENT(INOUT)  :: matrix_a, matrix_b, matrix_c
+      TYPE(dbcsr_tas_type), TARGET, &
+         INTENT(INOUT)                           :: matrix_a, matrix_b, matrix_c
       LOGICAL, INTENT(IN), OPTIONAL              :: optimize_dist
+      TYPE(dbcsr_tas_split_info), INTENT(OUT), &
+         OPTIONAL                                :: split_opt
       REAL(KIND=real_8), INTENT(IN), OPTIONAL    :: filter_eps
       INTEGER(KIND=int_8), INTENT(OUT), OPTIONAL :: flop
-      LOGICAL, INTENT(IN), OPTIONAL              :: move_data
+      LOGICAL, INTENT(IN), OPTIONAL              :: move_data_a, move_data_b, simple_split
       INTEGER, OPTIONAL, INTENT(IN)              :: io_unit
       LOGICAL, OPTIONAL, INTENT(IN)              :: log_verbose
 
-      TYPE(dbcsr_tas_type), POINTER                :: matrix_b_rs => NULL(), matrix_a_rs => NULL(), matrix_c_rs => NULL()
-      TYPE(dbcsr_tas_type)                         :: matrix_c_rep, matrix_b_rep, matrix_a_rep
+      TYPE(dbcsr_tas_type), POINTER              :: matrix_b_rs, matrix_a_rs, matrix_c_rs
+      TYPE(dbcsr_tas_type)                       :: matrix_c_rep, matrix_b_rep, matrix_a_rep
 
       REAL(KIND=real_8)                          :: filter_eps_prv
       INTEGER(KIND=int_8), DIMENSION(2)          :: dims_a, dims_b, dims_c
-      INTEGER, DIMENSION(2) :: pdims, pcoord
+      INTEGER, DIMENSION(2)                      :: pdims, pcoord, pcoord_sub, pdims_sub
       INTEGER(KIND=int_8), DIMENSION(3)          :: dims
-      INTEGER                                    :: max_mm_dim, data_type, numnodes, mp_comm, comm_tmp, &
-                                                    handle, handle2, io_unit_prv, nsplit
+      INTEGER                                    :: max_mm_dim, data_type, mp_comm, comm_tmp, &
+                                                    handle, handle2, io_unit_prv, nsplit, nsplit_opt, numproc, numproc_sub, iproc, &
+                                                    mp_comm_group, mp_comm_mm, split_rc, split_a, split_b, split_c, &
+                                                    mp_comm_opt
       CHARACTER(LEN=1)                           :: tr_case, transa_prv, transb_prv, transc_prv
       TYPE(dbcsr_scalar_type)                    :: zero
-      LOGICAL                                    :: new_a, new_b, new_c, move_prv
-      TYPE(dbcsr_tas_create_split_info)                   :: info
+      LOGICAL                                    :: new_a, new_b, new_c, simple_split_prv, opt_pgrid,&
+                                                    move_a, move_b
+      TYPE(dbcsr_tas_split_info)                 :: info
       CHARACTER(LEN=*), PARAMETER                :: routineN = 'dbcsr_tas_multiply', &
                                                     routineP = moduleN//':'//routineN
+      INTEGER(KIND=int_8)                        :: nze_a, nze_b, nze_c
+      TYPE(dbcsr_type), POINTER                  :: matrix_a_mm, matrix_b_mm, matrix_c_mm
 
       CALL timeset(routineN, handle)
+
+      NULLIFY(matrix_b_rs, matrix_a_rs, matrix_c_rs, matrix_a_mm, matrix_b_mm, matrix_c_mm)
 
       IF (PRESENT(io_unit)) THEN
          io_unit_prv = io_unit
@@ -125,11 +142,21 @@ CONTAINS
          io_unit_prv = 0
       ENDIF
 
-      IF (PRESENT(move_data)) THEN
-         move_prv = move_data
+      IF (PRESENT(simple_split)) THEN
+         simple_split_prv = simple_split
       ELSE
-         move_prv = .FALSE.
+         simple_split_prv = .FALSE.
       ENDIF
+
+      IF(simple_split_prv .AND. PRESENT(split_opt)) THEN
+         DBCSR_ABORT("incompatible dummy arguments split_opt and simple_split")
+      ENDIF
+
+      move_a = .FALSE.
+      move_b = .FALSE.
+
+      IF(PRESENT(move_data_a)) move_a = move_data_a
+      IF(PRESENT(move_data_b)) move_b = move_data_b
 
       IF (.NOT. dbcsr_tas_get_data_type(matrix_a) .EQ. dbcsr_tas_get_data_type(matrix_b)) THEN
          DBCSR_ABORT("matrices must have same datatype")
@@ -169,29 +196,58 @@ CONTAINS
 
       dims(:) = [dims_a(1), dims_a(2), dims_b(2)]
 
-      max_mm_dim = MAXLOC(dims, 1)
-
       tr_case = ''
 
       IF (io_unit_prv > 0) THEN
          WRITE (io_unit_prv, "(T2,A, 1X, I12, 1X, I12, 1X, I12)") "mm dims:", dims(1), dims(2), dims(3)
       ENDIF
 
-      ! ideally decision which matrix to reshape should be based on occupancy not on size
-      ! but since we don't know occupancy of result matrix, heuristics is based on size
+      CALL dbcsr_tas_get_split_info(dbcsr_tas_info(matrix_a), mp_comm=mp_comm)
+      CALL mp_environ(numproc, iproc, mp_comm)
 
+      ! derive optimal matrix layout and split factor from occupancies
+      IF (.NOT. simple_split_prv) THEN
+         nze_a = dbcsr_tas_get_nze_total(matrix_a)
+         nze_b = dbcsr_tas_get_nze_total(matrix_b)
+         nze_c = result_sparsity_estimate(transa, transb, transc, matrix_a, matrix_b, matrix_c, filter_eps)
+
+         nsplit = split_factor_estimate(nze_a, nze_b, nze_c, numproc)
+         nsplit_opt = nsplit
+         max_mm_dim = MINLOC([nze_b, nze_c, nze_a], 1)
+
+         IF (io_unit_prv > 0) THEN
+            WRITE (io_unit_prv, "(T2,A)") &
+               "MM PARAMETERS"
+            WRITE (io_unit_prv, "(T4,A,T68,I13)") "Est. number of matrix elements per CPU of result matrix:", &
+               (nze_c + numproc - 1)/numproc
+
+            WRITE (io_unit_prv, "(T4,A,T68,I13)") "Est. optimal split factor:", nsplit
+         ENDIF
+
+      ELSE
+         nsplit = 0
+         max_mm_dim = MAXLOC(dims, 1)
+      ENDIF
+
+
+      ! reshape matrices to the optimal layout and split factor
+      split_a = rowsplit; split_b=rowsplit; split_c=rowsplit
       SELECT CASE (max_mm_dim)
       CASE (1)
 
+         split_a = rowsplit; split_c = rowsplit
          CALL reshape_mm_compatible(matrix_a, matrix_c, matrix_a_rs, matrix_c_rs, &
                                     new_a, new_c, transa_prv, transc_prv, optimize_dist=optimize_dist, &
+                                    nsplit=nsplit, &
+                                    split_rc_1=split_a, split_rc_2=split_c, &
                                     nodata2=.TRUE., comm_new=comm_tmp, &
-                                    move_data=move_data, unit_nr=io_unit)
+                                    move_data_1=move_a, unit_nr=io_unit)
 
-         CALL dbcsr_tas_get_split_info(dbcsr_tas_info(matrix_a_rs), mp_comm=mp_comm)
+         info = dbcsr_tas_info(matrix_a_rs)
+         CALL dbcsr_tas_get_split_info(info, split_rowcol=split_rc, mp_comm=mp_comm)
 
          ALLOCATE (matrix_b_rs)
-         CALL reshape_mm_small(mp_comm, matrix_b, matrix_b_rs, transb_prv == dbcsr_transpose, transb_prv, move_data=move_data)
+         CALL reshape_mm_small(mp_comm, matrix_b, matrix_b_rs, transb_prv == dbcsr_transpose, transb_prv, move_data=move_b)
          new_b = .TRUE.
          tr_case = transa_prv
 
@@ -205,11 +261,16 @@ CONTAINS
 
       CASE (2)
 
+         split_a = colsplit; split_b=rowsplit
          CALL reshape_mm_compatible(matrix_a, matrix_b, matrix_a_rs, matrix_b_rs, new_a, new_b, transa_prv, transb_prv, &
-                                    optimize_dist=optimize_dist, comm_new=comm_tmp, &
-                                    move_data=move_data, unit_nr=io_unit)
+                                    optimize_dist=optimize_dist, &
+                                    nsplit=nsplit, &
+                                    split_rc_1 = split_a, split_rc_2=split_b, &
+                                    comm_new=comm_tmp, &
+                                    move_data_1=move_a, move_data_2=move_b, unit_nr=io_unit)
 
-         CALL dbcsr_tas_get_split_info(dbcsr_tas_info(matrix_a_rs), mp_comm=mp_comm)
+         info = dbcsr_tas_info(matrix_a_rs)
+         CALL dbcsr_tas_get_split_info(info, split_rowcol=split_rc, mp_comm=mp_comm)
 
          ALLOCATE (matrix_c_rs)
          CALL reshape_mm_small(mp_comm, matrix_c, matrix_c_rs, transc_prv == dbcsr_transpose, transc_prv, nodata=.TRUE.)
@@ -226,14 +287,18 @@ CONTAINS
 
       CASE (3)
 
+         split_b=colsplit; split_c=colsplit
          CALL reshape_mm_compatible(matrix_b, matrix_c, matrix_b_rs, matrix_c_rs, new_b, new_c, transb_prv, &
-                                    transc_prv, optimize_dist=optimize_dist, nodata2=.TRUE., comm_new=comm_tmp, &
-                                    move_data=move_data, unit_nr=io_unit)
-
-         CALL dbcsr_tas_get_split_info(dbcsr_tas_info(matrix_b_rs), mp_comm=mp_comm)
+                                    transc_prv, optimize_dist=optimize_dist, &
+                                    nsplit=nsplit, &
+                                    split_rc_1=split_b, split_rc_2=split_c, &
+                                    nodata2=.TRUE., comm_new=comm_tmp, &
+                                    move_data_1=move_b, unit_nr=io_unit)
+         info = dbcsr_tas_info(matrix_b_rs)
+         CALL dbcsr_tas_get_split_info(info, split_rowcol=split_rc, mp_comm=mp_comm)
 
          ALLOCATE (matrix_a_rs)
-         CALL reshape_mm_small(mp_comm, matrix_a, matrix_a_rs, transa_prv == dbcsr_transpose, transa_prv, move_data=move_data)
+         CALL reshape_mm_small(mp_comm, matrix_a, matrix_a_rs, transa_prv == dbcsr_transpose, transa_prv, move_data=move_a)
          new_a = .TRUE.
          tr_case = transb_prv
 
@@ -247,9 +312,16 @@ CONTAINS
 
       END SELECT
 
-      info = dbcsr_tas_info(matrix_a_rs)
-      CALL dbcsr_tas_get_split_info(info, nsplit=nsplit, mp_comm=mp_comm)
-      CALL mp_environ(numnodes, pdims, pcoord, mp_comm)
+      CALL dbcsr_tas_get_split_info(info, nsplit=nsplit, mp_comm=mp_comm, mp_comm_group=mp_comm_group)
+
+      CALL mp_environ(numproc, pdims, pcoord, mp_comm)
+      CALL mp_environ(numproc_sub, pdims_sub, pcoord_sub, mp_comm_group)
+
+      IF (.NOT. simple_split_prv) THEN
+         opt_pgrid = .NOT. accept_pgrid_dims(pdims_sub, relative=.TRUE.)
+      ELSE
+         opt_pgrid = .FALSE.
+      ENDIF
 
       IF (PRESENT(filter_eps)) THEN
          filter_eps_prv = filter_eps
@@ -259,104 +331,228 @@ CONTAINS
 
       IF (PRESENT(io_unit)) THEN
          IF (io_unit_prv > 0) THEN
-            WRITE (io_unit_prv, "(T2, A)") "SPLIT INFO"
+            WRITE (io_unit_prv, "(T2, A)") "SPLIT / PARALLELIZATION INFO"
          ENDIF
-         CALL dbcsr_tas_write_split_info(info, "Split info:", io_unit_prv)
+         CALL dbcsr_tas_write_split_info(info, io_unit_prv)
          CALL dbcsr_tas_write_matrix_info(matrix_a_rs, io_unit_prv, full_info=log_verbose)
          CALL dbcsr_tas_write_matrix_info(matrix_b_rs, io_unit_prv, full_info=log_verbose)
          CALL dbcsr_tas_write_matrix_info(matrix_c_rs, io_unit_prv, full_info=log_verbose)
+         IF (io_unit_prv > 0) THEN
+            IF(opt_pgrid) THEN
+               WRITE (io_unit_prv, "(T4, A, 1X, A)") "Change process grid:", "Yes"
+            ELSE
+               WRITE (io_unit_prv, "(T4, A, 1X, A)") "Change process grid:", "No"
+            ENDIF
+         ENDIF
       ENDIF
 
       zero = dbcsr_scalar_zero(data_type)
+
+      pdims = 0
+      CALL mp_cart_create(mp_comm_group, 2, pdims, pcoord, mp_comm_mm)
+
+      ! Convert DBCSR submatrices to optimized process grids and multiply
       SELECT CASE (max_mm_dim)
       CASE (1)
          CALL dbcsr_tas_replicate(matrix_b_rs%matrix, dbcsr_tas_info(matrix_a_rs), matrix_b_rep, move_data=.TRUE.)
+         IF (new_b) THEN
+            CALL dbcsr_tas_destroy(matrix_b_rs)
+            DEALLOCATE (matrix_b_rs)
+         ENDIF
+         IF (PRESENT(io_unit)) THEN
+            CALL dbcsr_tas_write_dist(matrix_a_rs, io_unit)
+            CALL dbcsr_tas_write_dist(matrix_b_rep, io_unit, full_info=log_verbose)
+         ENDIF
+
+         CALL convert_to_new_pgrid(mp_comm_mm, matrix_a_rs%matrix, matrix_a_mm, optimize_pgrid=opt_pgrid, move_data=move_a)
+
+         IF (new_a .AND. opt_pgrid) THEN
+            CALL dbcsr_tas_destroy(matrix_a_rs)
+            DEALLOCATE (matrix_a_rs)
+         ENDIF
+         CALL convert_to_new_pgrid(mp_comm_mm, matrix_b_rep%matrix, matrix_b_mm, optimize_pgrid=opt_pgrid, move_data=.TRUE.)
+
+         IF(opt_pgrid) CALL dbcsr_tas_destroy(matrix_b_rep)
+
+         CALL convert_to_new_pgrid(mp_comm_mm, matrix_c_rs%matrix, matrix_c_mm, nodata=.TRUE., optimize_pgrid=opt_pgrid)
+
          SELECT CASE (tr_case)
          CASE (dbcsr_no_transpose)
-            CALL timeset(routineN//"_dbcsr_mm_1N", handle2)
+            CALL timeset(routineN//"_mm_1N", handle2)
 
             CALL dbcsr_multiply(transa=dbcsr_no_transpose, transb=dbcsr_no_transpose, alpha=alpha, &
-                                matrix_a=matrix_a_rs%matrix, matrix_b=matrix_b_rep%matrix, beta=beta, matrix_c=matrix_c_rs%matrix, &
+                                matrix_a=matrix_a_mm, matrix_b=matrix_b_mm, beta=beta, matrix_c=matrix_c_mm, &
                                 filter_eps=filter_eps_prv, flop=flop)
             CALL timestop(handle2)
          CASE (dbcsr_transpose)
-            CALL timeset(routineN//"_dbcsr_mm_1T", handle2)
+            CALL timeset(routineN//"_mm_1T", handle2)
             CALL dbcsr_multiply(transa=dbcsr_transpose, transb=dbcsr_no_transpose, alpha=alpha, &
-                                matrix_a=matrix_b_rep%matrix, matrix_b=matrix_a_rs%matrix, beta=beta, matrix_c=matrix_c_rs%matrix, &
+                                matrix_a=matrix_b_mm, matrix_b=matrix_a_mm, beta=beta, matrix_c=matrix_c_mm, &
                                 filter_eps=filter_eps_prv, flop=flop)
 
             CALL timestop(handle2)
          END SELECT
+
+         IF (opt_pgrid) THEN
+            CALL dbcsr_release(matrix_a_mm)
+            CALL dbcsr_release(matrix_b_mm)
+            IF (.NOT. new_c) THEN
+               CALL redistribute_and_sum(matrix_c_mm, matrix_c_rs%matrix, alpha=beta)
+            ELSE
+               CALL redistribute_and_sum(matrix_c_mm, matrix_c_rs%matrix)
+            ENDIF
+
+            CALL dbcsr_release(matrix_c_mm)
+
+            DEALLOCATE(matrix_a_mm, matrix_b_mm, matrix_c_mm)
+         ELSE
+            IF(new_a) CALL dbcsr_tas_destroy(matrix_a_rs)
+            IF(new_a) DEALLOCATE(matrix_a_rs)
+            CALL dbcsr_tas_destroy(matrix_b_rep)
+         ENDIF
+
+         IF(PRESENT(filter_eps)) CALL dbcsr_tas_filter(matrix_c_rs, filter_eps)
+
          IF (PRESENT(io_unit)) THEN
-            CALL dbcsr_tas_write_dist(matrix_a_rs, io_unit)
-            CALL dbcsr_tas_write_dist(matrix_b_rep, io_unit, full_info=log_verbose)
             CALL dbcsr_tas_write_dist(matrix_c_rs, io_unit)
          ENDIF
-         CALL dbcsr_tas_distribution_destroy(matrix_b_rep%dist)
-         CALL dbcsr_tas_destroy(matrix_b_rep)
+
       CASE (2)
          CALL dbcsr_tas_replicate(matrix_c_rs%matrix, dbcsr_tas_info(matrix_a_rs), matrix_c_rep, nodata=.TRUE.)
-
-         CALL timeset(routineN//"_dbcsr_mm_2", handle2)
-         CALL dbcsr_multiply(transa=transa_prv, transb=transb_prv, alpha=alpha, matrix_a=matrix_a_rs%matrix, &
-                             matrix_b=matrix_b_rs%matrix, beta=beta, matrix_c=matrix_c_rep%matrix, &
-                             filter_eps=filter_eps_prv/REAL(nsplit, KIND=real_8), flop=flop)
-         CALL timestop(handle2)
          IF (PRESENT(io_unit)) THEN
             CALL dbcsr_tas_write_dist(matrix_a_rs, io_unit)
             CALL dbcsr_tas_write_dist(matrix_b_rs, io_unit)
+         ENDIF
+
+         CALL convert_to_new_pgrid(mp_comm_mm, matrix_a_rs%matrix, matrix_a_mm, optimize_pgrid=opt_pgrid, move_data=move_a)
+         IF (new_a .AND. opt_pgrid) THEN
+            CALL dbcsr_tas_destroy(matrix_a_rs)
+            DEALLOCATE (matrix_a_rs)
+         ENDIF
+
+         CALL convert_to_new_pgrid(mp_comm_mm, matrix_b_rs%matrix, matrix_b_mm, optimize_pgrid=opt_pgrid, move_data=move_b)
+         IF (new_b .AND. opt_pgrid) THEN
+            CALL dbcsr_tas_destroy(matrix_b_rs)
+            DEALLOCATE (matrix_b_rs)
+         ENDIF
+
+         CALL convert_to_new_pgrid(mp_comm_mm, matrix_c_rep%matrix, matrix_c_mm, nodata=.TRUE., optimize_pgrid=opt_pgrid)
+
+         CALL timeset(routineN//"_mm_2", handle2)
+         CALL dbcsr_multiply(transa=transa_prv, transb=transb_prv, alpha=alpha, matrix_a=matrix_a_mm, &
+                             matrix_b=matrix_b_mm, beta=beta, matrix_c=matrix_c_mm, &
+                             filter_eps=filter_eps_prv/REAL(nsplit, KIND=real_8), flop=flop)
+         CALL timestop(handle2)
+
+         IF (opt_pgrid) THEN
+            CALL dbcsr_release(matrix_a_mm)
+            CALL dbcsr_release(matrix_b_mm)
+            CALL dbcsr_redistribute(matrix_c_mm, matrix_c_rep%matrix)
+            CALL dbcsr_release(matrix_c_mm)
+
+            DEALLOCATE(matrix_a_mm, matrix_b_mm, matrix_c_mm)
+         ELSE
+            IF(new_a) CALL dbcsr_tas_destroy(matrix_a_rs)
+            IF(new_a) DEALLOCATE(matrix_a_rs)
+            IF(new_b) CALL dbcsr_tas_destroy(matrix_b_rs)
+            IF(new_b) DEALLOCATE(matrix_b_rs)
+         ENDIF
+
+         IF (PRESENT(io_unit)) THEN
             CALL dbcsr_tas_write_dist(matrix_c_rep, io_unit, full_info=log_verbose)
          ENDIF
 
          CALL dbcsr_tas_merge(matrix_c_rs%matrix, matrix_c_rep, move_data=.TRUE.)
-         CALL dbcsr_tas_filter(matrix_c_rs, filter_eps_prv)
-         CALL dbcsr_tas_distribution_destroy(matrix_c_rep%dist)
          CALL dbcsr_tas_destroy(matrix_c_rep)
+         IF(PRESENT(filter_eps)) CALL dbcsr_tas_filter(matrix_c_rs, filter_eps)
       CASE (3)
          CALL dbcsr_tas_replicate(matrix_a_rs%matrix, dbcsr_tas_info(matrix_b_rs), matrix_a_rep, move_data=.TRUE.)
-         SELECT CASE (tr_case)
-         CASE (dbcsr_no_transpose)
-            CALL timeset(routineN//"_dbcsr_mm_3N", handle2)
-            CALL dbcsr_multiply(transa=dbcsr_no_transpose, transb=dbcsr_no_transpose, alpha=alpha, &
-                                matrix_a=matrix_a_rep%matrix, matrix_b=matrix_b_rs%matrix, beta=beta, matrix_c=matrix_c_rs%matrix, &
-                                filter_eps=filter_eps_prv, flop=flop)
-            CALL timestop(handle2)
-         CASE (dbcsr_transpose)
-            CALL timeset(routineN//"_dbcsr_mm_3T", handle2)
-            CALL dbcsr_multiply(transa=dbcsr_no_transpose, transb=dbcsr_transpose, alpha=alpha, &
-                                matrix_a=matrix_b_rs%matrix, matrix_b=matrix_a_rep%matrix, beta=beta, matrix_c=matrix_c_rs%matrix, &
-                                filter_eps=filter_eps_prv, flop=flop)
-            CALL timestop(handle2)
-         END SELECT
+         IF (new_a) THEN
+            CALL dbcsr_tas_destroy(matrix_a_rs)
+            DEALLOCATE (matrix_a_rs)
+         ENDIF
          IF (PRESENT(io_unit)) THEN
             CALL dbcsr_tas_write_dist(matrix_a_rep, io_unit, full_info=log_verbose)
             CALL dbcsr_tas_write_dist(matrix_b_rs, io_unit)
+         ENDIF
+
+         CALL convert_to_new_pgrid(mp_comm_mm, matrix_a_rep%matrix, matrix_a_mm, optimize_pgrid=opt_pgrid, move_data=.TRUE.)
+
+         IF(opt_pgrid) CALL dbcsr_tas_destroy(matrix_a_rep)
+
+         CALL convert_to_new_pgrid(mp_comm_mm, matrix_b_rs%matrix, matrix_b_mm, optimize_pgrid=opt_pgrid, move_data=move_b)
+
+         IF (new_b .AND. opt_pgrid) THEN
+            CALL dbcsr_tas_destroy(matrix_b_rs)
+            DEALLOCATE (matrix_b_rs)
+         ENDIF
+         CALL convert_to_new_pgrid(mp_comm_mm, matrix_c_rs%matrix, matrix_c_mm, nodata=.TRUE., optimize_pgrid=opt_pgrid)
+
+         SELECT CASE (tr_case)
+         CASE (dbcsr_no_transpose)
+            CALL timeset(routineN//"_mm_3N", handle2)
+            CALL dbcsr_multiply(transa=dbcsr_no_transpose, transb=dbcsr_no_transpose, alpha=alpha, &
+                                matrix_a=matrix_a_mm, matrix_b=matrix_b_mm, beta=beta, matrix_c=matrix_c_mm, &
+                                filter_eps=filter_eps_prv, flop=flop)
+            CALL timestop(handle2)
+         CASE (dbcsr_transpose)
+            CALL timeset(routineN//"_mm_3T", handle2)
+            CALL dbcsr_multiply(transa=dbcsr_no_transpose, transb=dbcsr_transpose, alpha=alpha, &
+                                matrix_a=matrix_b_mm, matrix_b=matrix_a_mm, beta=beta, matrix_c=matrix_c_mm, &
+                                filter_eps=filter_eps_prv, flop=flop)
+            CALL timestop(handle2)
+         END SELECT
+
+         IF (opt_pgrid) THEN
+            CALL dbcsr_release(matrix_a_mm)
+            CALL dbcsr_release(matrix_b_mm)
+
+            IF (.NOT. new_c) THEN
+               CALL redistribute_and_sum(matrix_c_mm, matrix_c_rs%matrix, alpha=beta)
+            ELSE
+               CALL redistribute_and_sum(matrix_c_mm, matrix_c_rs%matrix)
+            ENDIF
+
+            CALL dbcsr_release(matrix_c_mm)
+
+            DEALLOCATE(matrix_a_mm, matrix_b_mm, matrix_c_mm)
+         ELSE
+            IF(new_b) CALL dbcsr_tas_destroy(matrix_b_rs)
+            IF(new_b) DEALLOCATE(matrix_b_rs)
+            CALL dbcsr_tas_destroy(matrix_a_rep)
+         ENDIF
+
+         IF(PRESENT(filter_eps)) CALL dbcsr_tas_filter(matrix_c_rs, filter_eps)
+
+         IF (PRESENT(io_unit)) THEN
             CALL dbcsr_tas_write_dist(matrix_c_rs, io_unit)
          ENDIF
-         CALL dbcsr_tas_distribution_destroy(matrix_a_rep%dist)
-         CALL dbcsr_tas_destroy(matrix_a_rep)
       END SELECT
 
-      IF (new_a) THEN
-         CALL dbcsr_tas_destroy(matrix_a_rs)
-         DEALLOCATE (matrix_a_rs)
+      CALL mp_comm_free(mp_comm_mm)
+
+      CALL dbcsr_tas_get_split_info(dbcsr_tas_info(matrix_c), mp_comm=mp_comm)
+
+      IF(PRESENT(split_opt)) THEN
+         ! ideally we should rederive the split factor from the actual sparsity of C, but
+         ! due to parameter beta, we can not actually get the sparsity of AxB from DBCSR if
+         ! not new_c
+         mp_comm_opt = dbcsr_tas_mp_comm(mp_comm, split_rc, nsplit_opt)
+         CALL dbcsr_tas_create_split(split_opt, mp_comm_opt, split_rc, nsplit_opt, own_comm=.TRUE.)
       ENDIF
-      IF (new_b) THEN
-         CALL dbcsr_tas_destroy(matrix_b_rs)
-         DEALLOCATE (matrix_b_rs)
-      ENDIF
+
       IF (new_c) THEN
          CALL dbcsr_scale(matrix_c%matrix, beta)
          CALL dbcsr_tas_reshape(matrix_c_rs, matrix_c, summation=.TRUE., transposed=transc_prv /= transc, &
                                 move_data=.TRUE.)
-         IF (PRESENT(filter_eps)) CALL dbcsr_tas_filter(matrix_c, filter_eps)
          CALL dbcsr_tas_destroy(matrix_c_rs)
          DEALLOCATE (matrix_c_rs)
+         IF (PRESENT(filter_eps)) CALL dbcsr_tas_filter(matrix_c, filter_eps)
       ENDIF
 
       IF (PRESENT(flop)) THEN
          CALL mp_sum(flop, mp_comm)
-         flop = (flop + numnodes - 1)/numnodes
+         flop = (flop + numproc - 1)/numproc
       ENDIF
 
       IF (PRESENT(optimize_dist)) THEN
@@ -369,6 +565,19 @@ CONTAINS
       ENDIF
 
       CALL timestop(handle)
+
+   END SUBROUTINE
+
+   SUBROUTINE redistribute_and_sum(matrix_in, matrix_out, alpha)
+      TYPE(dbcsr_type), INTENT(IN) :: matrix_in
+      TYPE(dbcsr_type), INTENT(INOUT) :: matrix_out
+      TYPE(dbcsr_scalar_type), INTENT(IN), OPTIONAL :: alpha
+      TYPE(dbcsr_type) :: matrix_tmp
+
+      CALL dbcsr_create(matrix_tmp, matrix_out)
+      CALL dbcsr_redistribute(matrix_in, matrix_tmp)
+      CALL dbcsr_add(matrix_out, matrix_tmp, alpha_scalar=alpha)
+      CALL dbcsr_release(matrix_tmp)
 
    END SUBROUTINE
 
@@ -456,32 +665,60 @@ CONTAINS
 !> \param trans1 transpose flag of matrix1_in for multiplication
 !> \param trans2 transpose flag of matrix2_in for multiplication
 !> \param optimize_dist experimental: optimize matrix splitting and distribution
+!> \param nsplit Optimal split factor (set to 0 if split factor should not be changed)
+!> \param split_rc_1 Whether to split rows or columns for matrix 1
+!> \param split_rc_2 Whether to split rows or columns for matrix 2
 !> \param nodata1 Don't copy matrix data from matrix1_in to matrix1_out
 !> \param nodata2 Don't copy matrix data from matrix2_in to matrix2_out
-!> \param move_data memory optimization: move data such that matrix*_in are empty on return.
+!> \param move_data_1 memory optimization: move data such that matrix1_in may be empty on return.
+!> \param move_data_2 memory optimization: move data such that matrix2_in may be empty on return.
 !> \param comm_new returns the new communicator only if optimize_dist
 !> \param unit_nr output unit
 ! **************************************************************************************************
    SUBROUTINE reshape_mm_compatible(matrix1_in, matrix2_in, matrix1_out, matrix2_out, new1, new2, trans1, trans2, &
-                                    optimize_dist, nodata1, nodata2, move_data, comm_new, unit_nr)
-      TYPE(dbcsr_tas_type), TARGET, INTENT(INOUT) :: matrix1_in, matrix2_in
+                                    optimize_dist, nsplit, split_rc_1, split_rc_2, nodata1, nodata2, &
+                                    move_data_1, move_data_2, comm_new, unit_nr)
+      TYPE(dbcsr_tas_type), TARGET, &
+         INTENT(INOUT)                           :: matrix1_in, matrix2_in
       TYPE(dbcsr_tas_type), POINTER, INTENT(OUT) :: matrix1_out, matrix2_out
-      LOGICAL, INTENT(OUT) :: new1, new2
-      CHARACTER(LEN=1), INTENT(INOUT) :: trans1, trans2
-      LOGICAL, INTENT(IN), OPTIONAL :: optimize_dist
-      INTEGER, INTENT(OUT), OPTIONAL :: comm_new
-      LOGICAL, OPTIONAL, INTENT(IN) :: nodata1, nodata2, move_data
-      INTEGER, INTENT(IN), OPTIONAL :: unit_nr
+      LOGICAL, INTENT(OUT)                       :: new1, new2
+      CHARACTER(LEN=1), INTENT(INOUT)            :: trans1, trans2
+      LOGICAL, INTENT(IN), OPTIONAL              :: optimize_dist
+      INTEGER, INTENT(IN), OPTIONAL              :: nsplit
+      INTEGER, INTENT(INOUT)                     :: split_rc_1, split_rc_2
+      INTEGER, INTENT(OUT), OPTIONAL             :: comm_new
+      LOGICAL, OPTIONAL, INTENT(IN)              :: nodata1, nodata2
+      LOGICAL, OPTIONAL, INTENT(INOUT)           :: move_data_1, move_data_2
+      INTEGER, INTENT(IN), OPTIONAL              :: unit_nr
 
-      INTEGER(KIND=int_8), DIMENSION(2) :: dims1, dims2
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'reshape_mm_compatible', &
-                                     routineP = moduleN//':'//routineN
-      INTEGER :: handle, mp_comm, numnodes, split_rc_1, split_rc_2, io_unit
-      INTEGER, DIMENSION(2) :: pcoord, pdims
-      LOGICAL :: optimize_dist_prv, trans1_newdist, trans2_newdist
-      TYPE(dbcsr_tas_dist_cyclic) :: row_dist_1, col_dist_1, row_dist_2, col_dist_2
-      TYPE(dbcsr_tas_distribution_type) :: dist_1, dist_2
-      TYPE(dbcsr_tas_create_split_info) :: split_info
+      INTEGER(KIND=int_8), DIMENSION(2)          :: dims1, dims2, dims_ref
+      INTEGER(KIND=int_8)                        :: d1, d2
+      CHARACTER(LEN=*), PARAMETER                :: routineN = 'reshape_mm_compatible', &
+                                                    routineP = moduleN//':'//routineN
+      INTEGER                                    :: handle, mp_comm, numnodes, io_unit, &
+                                                    nsplit_prv, ref, split_rc_ref
+      INTEGER, DIMENSION(2)                      :: pcoord, pdims
+      LOGICAL                                    :: optimize_dist_prv, trans1_newdist, trans2_newdist
+      TYPE(dbcsr_tas_dist_cyclic)                :: row_dist_1, col_dist_1, row_dist_2, col_dist_2
+      TYPE(dbcsr_tas_distribution_type)          :: dist_1, dist_2
+      TYPE(dbcsr_tas_split_info)                 :: split_info
+      INTEGER(KIND=int_8)                        :: nze1, nze2
+      LOGICAL                                    :: nodata1_prv, nodata2_prv
+
+      CALL timeset(routineN, handle)
+      new1 = .FALSE.; new2 = .FALSE.
+
+      IF (PRESENT(nodata1)) THEN
+         nodata1_prv = nodata1
+      ELSE
+         nodata1_prv = .FALSE.
+      ENDIF
+
+      IF (PRESENT(nodata2)) THEN
+         nodata2_prv = nodata2
+      ELSE
+         nodata2_prv = .FALSE.
+      ENDIF
 
       NULLIFY(matrix1_out, matrix2_out)
       IF (PRESENT(unit_nr)) THEN
@@ -496,32 +733,61 @@ CONTAINS
          optimize_dist_prv = .FALSE.
       ENDIF
 
+      dims1 = [dbcsr_tas_nblkrows_total(matrix1_in), dbcsr_tas_nblkcols_total(matrix1_in)]
+      dims2 = [dbcsr_tas_nblkrows_total(matrix2_in), dbcsr_tas_nblkcols_total(matrix2_in)]
+      nze1 = dbcsr_tas_get_nze_total(matrix1_in)
+      nze2 = dbcsr_tas_get_nze_total(matrix2_in)
+
+      IF(trans1 == dbcsr_transpose) split_rc_1 = MOD(split_rc_1, 2) + 1
+
+      IF(trans2 == dbcsr_transpose) split_rc_2 = MOD(split_rc_2, 2) + 1
+
+      IF(nze1 >= nze2) THEN
+         ref=1
+         split_rc_ref = split_rc_1
+         dims_ref=dims1
+      ELSE
+         ref=2
+         split_rc_ref = split_rc_2
+         dims_ref=dims2
+      ENDIF
+
+      IF(PRESENT(nsplit)) THEN
+         nsplit_prv = nsplit
+      ELSE
+         nsplit_prv = 0
+      ENDIF
+
       IF (optimize_dist_prv) THEN
          DBCSR_ASSERT(PRESENT(comm_new))
       ENDIF
 
-      CALL timeset(routineN, handle)
-      new1 = .FALSE.; new2 = .FALSE.
-
       IF ((.NOT. optimize_dist_prv) .AND. dist_compatible(matrix1_in, matrix2_in)) THEN
-         matrix1_out => matrix1_in
-         matrix2_out => matrix2_in
+         CALL change_split(matrix1_in, matrix1_out, nsplit_prv, split_rc_1, new1, &
+                           move_data=move_data_1, nodata=nodata1)
+         CALL change_split(matrix2_in, matrix2_out, nsplit_prv, split_rc_2, new2, &
+                           move_data=move_data_2, nodata=nodata2)
          IF (io_unit > 0) THEN
             WRITE (io_unit, "(T2,A,1X,A,1X,A,1X,A)") "No redistribution of", TRIM(matrix1_in%matrix%name), &
                "and", TRIM(matrix2_in%matrix%name)
+            IF(new1) THEN
+               WRITE (io_unit, "(T2,A,1X,A,1X,A)") "Change split factor of", TRIM(matrix1_in%matrix%name), ": Yes"
+            ELSE
+               WRITE (io_unit, "(T2,A,1X,A,1X,A)") "Change split factor of", TRIM(matrix1_in%matrix%name), ": No"
+            ENDIF
+            IF(new2) THEN
+               WRITE (io_unit, "(T2,A,1X,A,1X,A)") "Change split factor of", TRIM(matrix2_in%matrix%name), ": Yes"
+            ELSE
+               WRITE (io_unit, "(T2,A,1X,A,1X,A)") "Change split factor of", TRIM(matrix2_in%matrix%name), ": No"
+            ENDIF
          ENDIF
       ELSE
-
-         dims1 = [dbcsr_tas_nblkrows_total(matrix1_in), dbcsr_tas_nblkcols_total(matrix1_in)]
-         dims2 = [dbcsr_tas_nblkrows_total(matrix2_in), dbcsr_tas_nblkcols_total(matrix2_in)]
 
          IF (optimize_dist_prv) THEN
             IF (io_unit > 0) THEN
                WRITE (io_unit, "(T2,A,1X,A,1X,A,1X,A)") "Optimizing distribution of", TRIM(matrix1_in%matrix%name), &
                   "and", TRIM(matrix2_in%matrix%name)
             ENDIF
-            CALL dbcsr_tas_get_split_info(dbcsr_tas_info(matrix1_in), mp_comm=mp_comm, split_rowcol=split_rc_1)
-            CALL dbcsr_tas_get_split_info(dbcsr_tas_info(matrix2_in), split_rowcol=split_rc_2)
 
             trans1_newdist = (split_rc_1 == colsplit)
             trans2_newdist = (split_rc_2 == colsplit)
@@ -536,13 +802,23 @@ CONTAINS
                CALL invert_transpose_flag(trans2)
             ENDIF
 
-            IF (PRODUCT(dims1) .GE. PRODUCT(dims2)) THEN
-               comm_new = dbcsr_tas_mp_comm(mp_comm, dims1(1), dims1(2))
-               CALL dbcsr_tas_create_split(split_info, comm_new, dims1(1), dims1(2))
-            ELSE
-               comm_new = dbcsr_tas_mp_comm(mp_comm, dims2(1), dims2(2))
-               CALL dbcsr_tas_create_split(split_info, comm_new, dims2(1), dims2(2))
+            IF(nsplit_prv == 0) THEN
+               SELECT CASE(split_rc_ref)
+               CASE(rowsplit)
+                  d1 = dims_ref(1)
+                  d2 = dims_ref(2)
+               CASE(colsplit)
+                  d1 = dims_ref(2)
+                  d2 = dims_ref(1)
+               END SELECT
+               nsplit_prv = INT((d1 - 1)/d2 + 1)
             ENDIF
+
+            DBCSR_ASSERT(nsplit_prv > 0)
+
+            CALL dbcsr_tas_get_split_info(dbcsr_tas_info(matrix1_in), mp_comm=mp_comm)
+            comm_new = dbcsr_tas_mp_comm(mp_comm, rowsplit, nsplit_prv)
+            CALL dbcsr_tas_create_split(split_info, comm_new, rowsplit, nsplit_prv)
 
             CALL mp_environ(numnodes, pdims, pcoord, comm_new)
 
@@ -579,35 +855,131 @@ CONTAINS
                                      matrix2_in%col_blk_size, matrix2_in%row_blk_size, own_dist=.TRUE.)
             ENDIF
 
-            CALL dbcsr_tas_reshape(matrix1_in, matrix1_out, transposed=trans1_newdist, move_data=move_data)
-            CALL dbcsr_tas_reshape(matrix2_in, matrix2_out, transposed=trans2_newdist, move_data=move_data)
+            IF(.NOT. nodata1_prv) CALL dbcsr_tas_reshape(matrix1_in, matrix1_out, transposed=trans1_newdist, move_data=move_data_1)
+            IF(.NOT. nodata2_prv) CALL dbcsr_tas_reshape(matrix2_in, matrix2_out, transposed=trans2_newdist, move_data=move_data_2)
             new1 = .TRUE.
             new2 = .TRUE.
 
          ELSE
-            IF (PRODUCT(dims1) .GE. PRODUCT(dims2)) THEN
+            SELECT CASE(ref)
+            CASE(1)
                IF (io_unit > 0) THEN
                   WRITE (io_unit, "(T2,A,1X,A)") "Redistribution of", TRIM(matrix2_in%matrix%name)
                ENDIF
 
+               CALL change_split(matrix1_in, matrix1_out, nsplit_prv, split_rc_1, new1, &
+                                 move_data=move_data_1, nodata=nodata1)
+
                ALLOCATE (matrix2_out)
-               CALL reshape_mm_template(matrix1_in, matrix2_in, matrix2_out, trans2, nodata=nodata2, move_data=move_data)
+               CALL reshape_mm_template(matrix1_out, matrix2_in, matrix2_out, trans2, nodata=nodata2, move_data=move_data_2)
                new2 = .TRUE.
-               matrix1_out => matrix1_in
-            ELSE
+            CASE(2)
                IF (io_unit > 0) THEN
                   WRITE (io_unit, "(T2,A,1X,A)") "Redistribution of", TRIM(matrix1_in%matrix%name)
                ENDIF
+
+               CALL change_split(matrix2_in, matrix2_out, nsplit_prv, split_rc_2, new2, &
+                                 move_data=move_data_2, nodata=nodata2)
+
                ALLOCATE (matrix1_out)
-               CALL reshape_mm_template(matrix2_in, matrix1_in, matrix1_out, trans1, nodata=nodata1, move_data=move_data)
+               CALL reshape_mm_template(matrix2_out, matrix1_in, matrix1_out, trans1, nodata=nodata1, move_data=move_data_1)
                new1 = .TRUE.
-               matrix2_out => matrix2_in
-            ENDIF
+            END SELECT
+         ENDIF
+      ENDIF
+
+      IF(PRESENT(move_data_1) .AND. new1) move_data_1 = .TRUE.
+      IF(PRESENT(move_data_2) .AND. new2) move_data_2 = .TRUE.
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief Change split factor without redistribution
+!> \param matrix_in ...
+!> \param matrix_out ...
+!> \param nsplit new split factor, set to 0 to not split factor
+!> \param split_rowcol split rows or columns
+!> \param is_new whether matrix_out is new or a pointer to matrix_in
+!> \param move_data memory optimization: move data such that matrix_in is empty on return.
+!> \param nodata Data of matrix_in should not be copied to matrix_out
+! **************************************************************************************************
+
+   SUBROUTINE change_split(matrix_in, matrix_out, nsplit, split_rowcol, is_new, move_data, nodata)
+      TYPE(dbcsr_tas_type), TARGET, &
+         INTENT(INOUT)                           :: matrix_in
+      TYPE(dbcsr_tas_type), POINTER, INTENT(OUT) :: matrix_out
+      INTEGER, INTENT(IN)                        :: nsplit
+      INTEGER, INTENT(IN)                        :: split_rowcol
+      LOGICAL, INTENT(OUT)                       :: is_new
+      LOGICAL, INTENT(IN), OPTIONAL              :: nodata
+      LOGICAL, INTENT(INOUT), OPTIONAL           :: move_data
+
+      INTEGER                                    :: &
+         mp_comm, split_rc, nsplit_old, handle, data_type, nsplit_new
+      TYPE(dbcsr_tas_split_info)                 :: split_info
+      CHARACTER(len=default_string_length)       :: name
+      TYPE(dbcsr_tas_distribution_type)          :: dist
+      LOGICAL                                    :: nodata_prv
+      CLASS(dbcsr_tas_distribution), ALLOCATABLE :: rdist, cdist
+      CLASS(dbcsr_tas_rowcol_data), ALLOCATABLE  :: rbsize, cbsize
+      CHARACTER(LEN=*), PARAMETER                :: routineN = 'change_split', &
+                                                    routineP = moduleN//':'//routineN
+      NULLIFY(matrix_out)
+
+      is_new = .TRUE.
+
+      IF(nsplit == 0) THEN
+         matrix_out => matrix_in
+         is_new = .FALSE.
+         RETURN
+      ENDIF
+
+      CALL timeset(routineN, handle)
+
+      nodata_prv = .FALSE.
+      IF(PRESENT(nodata)) nodata_prv = nodata
+
+      CALL dbcsr_tas_get_split_info(dbcsr_tas_info(matrix_in), mp_comm=mp_comm, &
+                                    split_rowcol=split_rc, nsplit=nsplit_old)
+
+      CALL dbcsr_tas_get_info(matrix_in, data_type=data_type, name=name, &
+                              row_blk_size=rbsize, col_blk_size=cbsize, &
+                              proc_row_dist=rdist, proc_col_dist=cdist)
+
+      CALL dbcsr_tas_create_split(split_info, mp_comm, split_rowcol, nsplit)
+
+      CALL dbcsr_tas_get_split_info(split_info, nsplit=nsplit_new)
+
+      IF(nsplit_old == nsplit_new .AND. split_rc == split_rowcol) THEN
+         matrix_out => matrix_in
+         is_new = .FALSE.
+         CALL dbcsr_tas_release_info(split_info)
+         CALL timestop(handle)
+         RETURN
+      ENDIF
+
+      CALL dbcsr_tas_distribution_new(dist, mp_comm, rdist, cdist, &
+                                      split_info=split_info)
+
+      CALL dbcsr_tas_release_info(split_info)
+
+      ALLOCATE(matrix_out)
+      CALL dbcsr_tas_create(matrix_out, name, dist, &
+                            data_type, &
+                            rbsize, cbsize, own_dist=.TRUE.)
+
+      IF(.NOT. nodata_prv) CALL dbcsr_tas_copy(matrix_out, matrix_in)
+
+      IF(PRESENT(move_data)) THEN
+         IF (.NOT. nodata_prv) THEN
+            IF (move_data) CALL dbcsr_tas_clear(matrix_in)
+            move_data = .TRUE.
          ENDIF
       ENDIF
 
       CALL timestop(handle)
-
    END SUBROUTINE
 
 ! **************************************************************************************************
@@ -618,13 +990,13 @@ CONTAINS
 !> \return ...
 ! **************************************************************************************************
    FUNCTION dist_compatible(mat_a, mat_b, io_unit)
-      TYPE(dbcsr_tas_type), INTENT(IN)                     :: mat_a, mat_b
+      TYPE(dbcsr_tas_type), INTENT(IN)           :: mat_a, mat_b
       INTEGER, INTENT(IN), OPTIONAL :: io_unit
-      LOGICAL                                            :: dist_compatible
+      LOGICAL                                    :: dist_compatible
 
-      INTEGER                                            :: res, same_local_rowcols
-      TYPE(dbcsr_tas_create_split_info)                           :: info_a, info_b
-      INTEGER :: io_unit_prv, numproc, iproc
+      INTEGER                                    :: res, same_local_rowcols
+      TYPE(dbcsr_tas_split_info)                 :: info_a, info_b
+      INTEGER                                    :: io_unit_prv, numproc, iproc
 
       IF (PRESENT(io_unit)) THEN
          io_unit_prv = io_unit
@@ -677,7 +1049,7 @@ CONTAINS
    END FUNCTION
 
 ! **************************************************************************************************
-!> \brief Reshape matrix_in s.t. it has same process grid, distribution and split as matrix_in
+!> \brief Reshape matrix_in s.t. it has same process grid, distribution and split as template
 !> \param template ...
 !> \param matrix_in ...
 !> \param matrix_out ...
@@ -686,21 +1058,19 @@ CONTAINS
 !> \param move_data ...
 ! **************************************************************************************************
    SUBROUTINE reshape_mm_template(template, matrix_in, matrix_out, trans, nodata, move_data)
-      TYPE(dbcsr_tas_type), INTENT(IN) :: template
-      TYPE(dbcsr_tas_type), INTENT(INOUT) :: matrix_in
-      TYPE(dbcsr_tas_type), INTENT(OUT) :: matrix_out
-      CHARACTER(LEN=1), INTENT(INOUT) :: trans
-      LOGICAL, INTENT(IN), OPTIONAL :: nodata, move_data
+      TYPE(dbcsr_tas_type), INTENT(IN)           :: template
+      TYPE(dbcsr_tas_type), INTENT(INOUT)        :: matrix_in
+      TYPE(dbcsr_tas_type), INTENT(OUT)          :: matrix_out
+      CHARACTER(LEN=1), INTENT(INOUT)            :: trans
+      LOGICAL, INTENT(IN), OPTIONAL              :: nodata, move_data
       CLASS(dbcsr_tas_distribution), ALLOCATABLE :: row_dist, col_dist
 
-      TYPE(dbcsr_tas_distribution_type) :: dist_new
-      TYPE(dbcsr_tas_create_split_info) :: info_template, info_matrix
-      INTEGER :: mp_comm, dim_split_template, dim_split_matrix
-      LOGICAL :: nodata_prv
-      INTEGER, DIMENSION(2)                              :: pcoord, pdims
-      INTEGER :: numnodes, handle
-      LOGICAL :: transposed
-
+      TYPE(dbcsr_tas_distribution_type)          :: dist_new
+      TYPE(dbcsr_tas_split_info)                 :: info_template, info_matrix
+      INTEGER                                    :: mp_comm, dim_split_template, dim_split_matrix, &
+                                                    numnodes, handle
+      INTEGER, DIMENSION(2)                      :: pcoord, pdims
+      LOGICAL                                    :: nodata_prv, transposed
       CHARACTER(LEN=*), PARAMETER :: routineN = 'reshape_mm_template', &
                                      routineP = moduleN//':'//routineN
 
@@ -763,6 +1133,229 @@ CONTAINS
 
       CALL timestop(handle)
 
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief Estimate sparsity pattern of C resulting from A x B = C by multiplying the block norms of A and B
+!>        Same dummy arguments as dbcsr_tas_multiply
+!> \param transa ...
+!> \param transb ...
+!> \param transc ...
+!> \param matrix_a ...
+!> \param matrix_b ...
+!> \param matrix_c ...
+!> \param filter_eps ...
+! **************************************************************************************************
+   FUNCTION result_sparsity_estimate(transa, transb, transc, matrix_a, matrix_b, matrix_c, filter_eps) RESULT(nze)
+      CHARACTER(LEN=1), INTENT(IN)               :: transa, transb, transc
+      TYPE(dbcsr_tas_type), INTENT(INOUT)        :: matrix_a, matrix_b, matrix_c
+      TYPE(dbcsr_tas_type)                       :: matrix_a_bnorm, matrix_b_bnorm, matrix_c_bnorm
+      REAL(KIND=real_8), INTENT(IN), OPTIONAL    :: filter_eps
+      INTEGER(KIND=int_8)                        :: row, col, nze
+      INTEGER                                    :: bn, row_size, col_size, mp_comm, handle
+      TYPE(dbcsr_tas_iterator)                   :: iter
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'result_sparsity_estimate', &
+                                     routineP = moduleN//':'//routineN
+
+      CALL timeset(routineN, handle)
+
+      CALL create_block_norms_matrix(matrix_a, matrix_a_bnorm)
+      CALL create_block_norms_matrix(matrix_b, matrix_b_bnorm)
+      CALL create_block_norms_matrix(matrix_c, matrix_c_bnorm, nodata=.TRUE.)
+
+      CALL dbcsr_tas_multiply(transa, transb, transc, dbcsr_scalar(1.0_real_8), matrix_a_bnorm, &
+                              matrix_b_bnorm, dbcsr_scalar(0.0_real_8), matrix_c_bnorm, &
+                              filter_eps=filter_eps, move_data_a=.TRUE., move_data_b=.TRUE., &
+                              simple_split=.TRUE.)
+
+      CALL dbcsr_tas_iterator_start(iter, matrix_c_bnorm)
+      nze = 0
+      DO WHILE (dbcsr_tas_iterator_blocks_left(iter))
+         CALL dbcsr_tas_iterator_next_block(iter, row, col, bn)
+         row_size = matrix_c%row_blk_size%data(row)
+         col_size = matrix_c%col_blk_size%data(col)
+         nze=nze+row_size*col_size
+      ENDDO
+      CALL dbcsr_tas_iterator_stop(iter)
+
+      CALL dbcsr_tas_get_split_info(dbcsr_tas_info(matrix_a), mp_comm=mp_comm)
+      CALL mp_sum(nze, mp_comm)
+
+      CALL dbcsr_tas_destroy(matrix_a_bnorm)
+      CALL dbcsr_tas_destroy(matrix_b_bnorm)
+      CALL dbcsr_tas_destroy(matrix_c_bnorm)
+      CALL timestop(handle)
+
+   END FUNCTION
+
+! **************************************************************************************************
+!> \brief Estimate optimal split factor for AxB=C from occupancies (number of non-zero elements)
+!>
+!>        This estimate is based on the minimization of communication volume whereby
+!>        the communication of CARMA n-split step and CANNON-multiplication of submatrices are
+!>        considered.
+!> \param nze_a number of non-zeroes in A
+!> \param nze_b number of non-zeroes in B
+!> \param nze_c number of non-zeroes in C
+!> \param numnodes number of MPI ranks
+!> \result estimated split factor
+! **************************************************************************************************
+   FUNCTION split_factor_estimate(nze_a, nze_b, nze_c, numnodes) RESULT(nsplit)
+      INTEGER(KIND=int_8), INTENT(IN)             :: nze_a, nze_b, nze_c
+      INTEGER, INTENT(IN)                         :: numnodes
+      INTEGER                                     :: nsplit, nsplit_comm, nsplit_memory
+      INTEGER(KIND=int_8)                         :: max_nze, min_nze
+
+      min_nze = MAX(MINVAL([nze_a, nze_b, nze_c]),1_int_8)
+      max_nze = MAX(MAXVAL([nze_a, nze_b, nze_c]),1_int_8)
+      nsplit_comm = NINT((REAL(nze_a + nze_b, real_8)/(2*min_nze))**(2._real_8/3)*REAL(numnodes, real_8)**(1._real_8/3))
+
+      ! nsplit_memory protects against excess memory usage
+      ! actual split factor may be up to default_nsplit_accept_ratio_1 times larger, so the largest nsplit
+      ! that fits into memory used by A or B needs to be divided by this factor
+      nsplit_memory = CEILING(REAL((max_nze - 1)/min_nze + 1, real_8)/default_nsplit_accept_ratio_1)
+
+      nsplit = MIN(nsplit_comm, nsplit_memory)
+
+   END FUNCTION
+
+! **************************************************************************************************
+!> \brief Create a matrix with block sizes one that contains the block norms of matrix_in
+!>
+!> \param matrix_in ...
+!> \param matrix_out ...
+!> \param nodata ...
+! **************************************************************************************************
+   SUBROUTINE create_block_norms_matrix(matrix_in, matrix_out, nodata)
+      TYPE(dbcsr_tas_type), INTENT(INOUT)        :: matrix_in
+      TYPE(dbcsr_tas_type), INTENT(OUT)          :: matrix_out
+      LOGICAL, INTENT(IN), OPTIONAL              :: nodata
+      TYPE(dbcsr_tas_blk_size_one)               :: row_blk_size, col_blk_size
+      TYPE(dbcsr_tas_iterator)                   :: iter
+      INTEGER(KIND=int_8)                        :: row, column, nblkrows, nblkcols
+      CHARACTER(len=default_string_length)       :: name
+      INTEGER                                    :: data_type
+
+#:for dparam, dtype, dsuffix in dtype_float_list
+      ${dtype}$, DIMENSION(:, :), POINTER        :: block_get_${dsuffix}$
+      ${dtype}$, DIMENSION(:, :), POINTER        :: block_put_${dsuffix}$
+#:endfor
+      LOGICAL                                    :: tr, nodata_prv, found
+
+      DBCSR_ASSERT(matrix_in%valid)
+
+      IF(PRESENT(nodata)) THEN
+         nodata_prv = nodata
+      ELSE
+         nodata_prv = .FALSE.
+      ENDIF
+
+      CALL dbcsr_tas_get_info(matrix_in, data_type=data_type, name=name, &
+                              nblkrows_total=nblkrows, nblkcols_total=nblkcols)
+
+      row_blk_size = dbcsr_tas_blk_size_one(nblkrows)
+      col_blk_size = dbcsr_tas_blk_size_one(nblkcols)
+
+      ! not sure if assumption that same distribution can be taken still holds
+      CALL dbcsr_tas_create(matrix_out, name, matrix_in%dist, &
+                            data_type, &
+                            row_blk_size, col_blk_size)
+
+      IF (.NOT. nodata_prv) THEN
+         CALL dbcsr_tas_reserve_blocks(matrix_in, matrix_out)
+
+         CALL dbcsr_tas_iterator_start(iter, matrix_in)
+
+         DO WHILE (dbcsr_tas_iterator_blocks_left(iter))
+
+#:for dparam, dtype, dsuffix in dtype_float_list
+            IF (data_type == ${dparam}$) THEN
+               CALL dbcsr_tas_iterator_next_block(iter, row, column, block_get_${dsuffix}$, tr)
+               CALL dbcsr_tas_get_block_p(matrix_out, row, column, block_put_${dsuffix}$, tr, found)
+               DBCSR_ASSERT(found)
+               block_put_${dsuffix}$ (1, 1) = SQRT(SUM(block_get_${dsuffix}$**2)) ! norm2 works only for real
+            ENDIF
+#:endfor
+         ENDDO
+         CALL dbcsr_tas_iterator_stop(iter)
+      ENDIF
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief Convert a DBCSR matrix to a new process grid
+!> \param mp_comm_cart new process grid
+!> \param matrix_in ...
+!> \param matrix_out ...
+!> \param move_data memory optimization: move data such that matrix_in is empty on return.
+!> \param nodata Data of matrix_in should not be copied to matrix_out
+!> \param optimize_pgrid Whether to change process grid
+! **************************************************************************************************
+   SUBROUTINE convert_to_new_pgrid(mp_comm_cart, matrix_in, matrix_out, move_data, nodata, optimize_pgrid)
+      INTEGER, INTENT(IN)                        :: mp_comm_cart
+      TYPE(dbcsr_type), INTENT(INOUT), TARGET    :: matrix_in
+      TYPE(dbcsr_type), INTENT(OUT), POINTER     :: matrix_out
+      LOGICAL, INTENT(IN), OPTIONAL              :: move_data, nodata
+      LOGICAL, INTENT(IN), OPTIONAL              :: optimize_pgrid
+
+      INTEGER                                    :: &
+         nbrows, nbcols, data_type, nproc, handle
+      INTEGER, DIMENSION(2)                      :: pdims, pcoord
+      INTEGER, DIMENSION(:), POINTER             :: row_dist, col_dist, rbsize, rcsize
+      TYPE(dbcsr_distribution_obj)               :: dist, dist_old
+      TYPE(dbcsr_mp_obj)                         :: mp_obj
+      CHARACTER(len=default_string_length)       :: name
+      LOGICAL                                    :: nodata_prv, optimize_pgrid_prv
+      CHARACTER(LEN=*), PARAMETER                :: routineN = 'convert_to_new_pgrid', &
+                                                    routineP = moduleN//':'//routineN
+
+      NULLIFY(row_dist, col_dist, rbsize, rcsize)
+
+      IF(PRESENT(optimize_pgrid)) THEN
+         optimize_pgrid_prv = optimize_pgrid
+      ELSE
+         optimize_pgrid_prv = .TRUE.
+      ENDIF
+
+      IF(.NOT. optimize_pgrid_prv) THEN
+         matrix_out => matrix_in
+         RETURN
+      ENDIF
+
+      CALL timeset(routineN, handle)
+
+      IF(PRESENT(nodata)) THEN
+         nodata_prv = nodata
+      ELSE
+         nodata_prv = .FALSE.
+      ENDIF
+
+      ALLOCATE(matrix_out)
+
+      CALL dbcsr_get_info(matrix_in, nblkrows_total=nbrows, nblkcols_total=nbcols, &
+                          row_blk_size=rbsize, col_blk_size=rcsize, &
+                          data_type=data_type, distribution=dist_old, name=name)
+      CALL mp_environ(nproc, pdims, pcoord, mp_comm_cart)
+
+      ALLOCATE(row_dist(nbrows), col_dist(nbcols))
+      CALL cyclic_weighted_dist(nbrows, pdims(1), rbsize, row_dist)
+      CALL cyclic_weighted_dist(nbcols, pdims(2), rcsize, col_dist)
+
+      mp_obj = dbcsr_mp_environ(mp_comm_cart)
+      CALL dbcsr_distribution_new(dist, mp_obj, row_dist, col_dist, reuse_arrays=.TRUE.)
+      CALL dbcsr_mp_release(mp_obj)
+
+      CALL dbcsr_create(matrix_out, name, dist, 'N', rbsize, rcsize, data_type=data_type)
+      CALL dbcsr_distribution_release(dist)
+
+      IF(.NOT. nodata_prv) THEN
+         CALL dbcsr_redistribute(matrix_in, matrix_out)
+         IF(PRESENT(move_data)) THEN
+            IF(move_data) CALL dbcsr_clear(matrix_in)
+         ENDIF
+      ENDIF
+
+      CALL timestop(handle)
    END SUBROUTINE
 
 END MODULE

--- a/src/tas/dbcsr_tas_mm.F
+++ b/src/tas/dbcsr_tas_mm.F
@@ -126,7 +126,7 @@ CONTAINS
                                                     mp_comm_opt
       CHARACTER(LEN=1)                           :: tr_case, transa_prv, transb_prv, transc_prv
       TYPE(dbcsr_scalar_type)                    :: zero
-      LOGICAL                                    :: new_a, new_b, new_c, simple_split_prv, opt_pgrid,&
+      LOGICAL                                    :: new_a, new_b, new_c, simple_split_prv, opt_pgrid, &
                                                     move_a, move_b
       TYPE(dbcsr_tas_split_info)                 :: info, info_a, info_b, info_c
       CHARACTER(LEN=*), PARAMETER                :: routineN = 'dbcsr_tas_multiply', &
@@ -136,7 +136,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      NULLIFY(matrix_b_rs, matrix_a_rs, matrix_c_rs, matrix_a_mm, matrix_b_mm, matrix_c_mm)
+      NULLIFY (matrix_b_rs, matrix_a_rs, matrix_c_rs, matrix_a_mm, matrix_b_mm, matrix_c_mm)
 
       IF (PRESENT(io_unit)) THEN
          io_unit_prv = io_unit
@@ -150,15 +150,14 @@ CONTAINS
          simple_split_prv = .FALSE.
 
          info_a = dbcsr_tas_info(matrix_a); info_b = dbcsr_tas_info(matrix_b); info_c = dbcsr_tas_info(matrix_c)
-         IF(info_a%strict_split .OR. info_b%strict_split .OR. info_c%strict_split) simple_split_prv = .TRUE.
+         IF (info_a%strict_split .OR. info_b%strict_split .OR. info_c%strict_split) simple_split_prv = .TRUE.
       ENDIF
-
 
       move_a = .FALSE.
       move_b = .FALSE.
 
-      IF(PRESENT(move_data_a)) move_a = move_data_a
-      IF(PRESENT(move_data_b)) move_b = move_data_b
+      IF (PRESENT(move_data_a)) move_a = move_data_a
+      IF (PRESENT(move_data_b)) move_b = move_data_b
 
       IF (.NOT. dbcsr_tas_get_data_type(matrix_a) .EQ. dbcsr_tas_get_data_type(matrix_b)) THEN
          DBCSR_ABORT("matrices must have same datatype")
@@ -232,7 +231,7 @@ CONTAINS
       ENDIF
 
       ! reshape matrices to the optimal layout and split factor
-      split_a = rowsplit; split_b=rowsplit; split_c=rowsplit
+      split_a = rowsplit; split_b = rowsplit; split_c = rowsplit
       SELECT CASE (max_mm_dim)
       CASE (1)
 
@@ -262,11 +261,11 @@ CONTAINS
 
       CASE (2)
 
-         split_a = colsplit; split_b=rowsplit
+         split_a = colsplit; split_b = rowsplit
          CALL reshape_mm_compatible(matrix_a, matrix_b, matrix_a_rs, matrix_b_rs, new_a, new_b, transa_prv, transb_prv, &
                                     optimize_dist=optimize_dist, &
                                     nsplit=nsplit, &
-                                    split_rc_1 = split_a, split_rc_2=split_b, &
+                                    split_rc_1=split_a, split_rc_2=split_b, &
                                     comm_new=comm_tmp, &
                                     move_data_1=move_a, move_data_2=move_b, unit_nr=io_unit)
 
@@ -288,7 +287,7 @@ CONTAINS
 
       CASE (3)
 
-         split_b=colsplit; split_c=colsplit
+         split_b = colsplit; split_c = colsplit
          CALL reshape_mm_compatible(matrix_b, matrix_c, matrix_b_rs, matrix_c_rs, new_b, new_c, transb_prv, &
                                     transc_prv, optimize_dist=optimize_dist, &
                                     nsplit=nsplit, &
@@ -339,7 +338,7 @@ CONTAINS
          CALL dbcsr_tas_write_matrix_info(matrix_b_rs, io_unit_prv, full_info=log_verbose)
          CALL dbcsr_tas_write_matrix_info(matrix_c_rs, io_unit_prv, full_info=log_verbose)
          IF (io_unit_prv > 0) THEN
-            IF(opt_pgrid) THEN
+            IF (opt_pgrid) THEN
                WRITE (io_unit_prv, "(T4, A, 1X, A)") "Change process grid:", "Yes"
             ELSE
                WRITE (io_unit_prv, "(T4, A, 1X, A)") "Change process grid:", "No"
@@ -373,7 +372,7 @@ CONTAINS
          ENDIF
          CALL convert_to_new_pgrid(mp_comm_mm, matrix_b_rep%matrix, matrix_b_mm, optimize_pgrid=opt_pgrid, move_data=.TRUE.)
 
-         IF(opt_pgrid) CALL dbcsr_tas_destroy(matrix_b_rep)
+         IF (opt_pgrid) CALL dbcsr_tas_destroy(matrix_b_rep)
 
          CALL convert_to_new_pgrid(mp_comm_mm, matrix_c_rs%matrix, matrix_c_mm, nodata=.TRUE., optimize_pgrid=opt_pgrid)
 
@@ -405,14 +404,14 @@ CONTAINS
 
             CALL dbcsr_release(matrix_c_mm)
 
-            DEALLOCATE(matrix_a_mm, matrix_b_mm, matrix_c_mm)
+            DEALLOCATE (matrix_a_mm, matrix_b_mm, matrix_c_mm)
          ELSE
-            IF(new_a) CALL dbcsr_tas_destroy(matrix_a_rs)
-            IF(new_a) DEALLOCATE(matrix_a_rs)
+            IF (new_a) CALL dbcsr_tas_destroy(matrix_a_rs)
+            IF (new_a) DEALLOCATE (matrix_a_rs)
             CALL dbcsr_tas_destroy(matrix_b_rep)
          ENDIF
 
-         IF(PRESENT(filter_eps)) CALL dbcsr_tas_filter(matrix_c_rs, filter_eps)
+         IF (PRESENT(filter_eps)) CALL dbcsr_tas_filter(matrix_c_rs, filter_eps)
 
          IF (PRESENT(io_unit)) THEN
             CALL dbcsr_tas_write_dist(matrix_c_rs, io_unit)
@@ -451,12 +450,12 @@ CONTAINS
             CALL dbcsr_redistribute(matrix_c_mm, matrix_c_rep%matrix)
             CALL dbcsr_release(matrix_c_mm)
 
-            DEALLOCATE(matrix_a_mm, matrix_b_mm, matrix_c_mm)
+            DEALLOCATE (matrix_a_mm, matrix_b_mm, matrix_c_mm)
          ELSE
-            IF(new_a) CALL dbcsr_tas_destroy(matrix_a_rs)
-            IF(new_a) DEALLOCATE(matrix_a_rs)
-            IF(new_b) CALL dbcsr_tas_destroy(matrix_b_rs)
-            IF(new_b) DEALLOCATE(matrix_b_rs)
+            IF (new_a) CALL dbcsr_tas_destroy(matrix_a_rs)
+            IF (new_a) DEALLOCATE (matrix_a_rs)
+            IF (new_b) CALL dbcsr_tas_destroy(matrix_b_rs)
+            IF (new_b) DEALLOCATE (matrix_b_rs)
          ENDIF
 
          IF (PRESENT(io_unit)) THEN
@@ -465,7 +464,7 @@ CONTAINS
 
          CALL dbcsr_tas_merge(matrix_c_rs%matrix, matrix_c_rep, move_data=.TRUE.)
          CALL dbcsr_tas_destroy(matrix_c_rep)
-         IF(PRESENT(filter_eps)) CALL dbcsr_tas_filter(matrix_c_rs, filter_eps)
+         IF (PRESENT(filter_eps)) CALL dbcsr_tas_filter(matrix_c_rs, filter_eps)
       CASE (3)
          CALL dbcsr_tas_replicate(matrix_a_rs%matrix, dbcsr_tas_info(matrix_b_rs), matrix_a_rep, move_data=.TRUE.)
          IF (new_a) THEN
@@ -479,7 +478,7 @@ CONTAINS
 
          CALL convert_to_new_pgrid(mp_comm_mm, matrix_a_rep%matrix, matrix_a_mm, optimize_pgrid=opt_pgrid, move_data=.TRUE.)
 
-         IF(opt_pgrid) CALL dbcsr_tas_destroy(matrix_a_rep)
+         IF (opt_pgrid) CALL dbcsr_tas_destroy(matrix_a_rep)
 
          CALL convert_to_new_pgrid(mp_comm_mm, matrix_b_rs%matrix, matrix_b_mm, optimize_pgrid=opt_pgrid, move_data=move_b)
 
@@ -516,14 +515,14 @@ CONTAINS
 
             CALL dbcsr_release(matrix_c_mm)
 
-            DEALLOCATE(matrix_a_mm, matrix_b_mm, matrix_c_mm)
+            DEALLOCATE (matrix_a_mm, matrix_b_mm, matrix_c_mm)
          ELSE
-            IF(new_b) CALL dbcsr_tas_destroy(matrix_b_rs)
-            IF(new_b) DEALLOCATE(matrix_b_rs)
+            IF (new_b) CALL dbcsr_tas_destroy(matrix_b_rs)
+            IF (new_b) DEALLOCATE (matrix_b_rs)
             CALL dbcsr_tas_destroy(matrix_a_rep)
          ENDIF
 
-         IF(PRESENT(filter_eps)) CALL dbcsr_tas_filter(matrix_c_rs, filter_eps)
+         IF (PRESENT(filter_eps)) CALL dbcsr_tas_filter(matrix_c_rs, filter_eps)
 
          IF (PRESENT(io_unit)) THEN
             CALL dbcsr_tas_write_dist(matrix_c_rs, io_unit)
@@ -534,10 +533,10 @@ CONTAINS
 
       CALL dbcsr_tas_get_split_info(dbcsr_tas_info(matrix_c), mp_comm=mp_comm)
 
-      IF(PRESENT(split_opt) .AND. .NOT. simple_split_prv) THEN
+      IF (PRESENT(split_opt) .AND. .NOT. simple_split_prv) THEN
          ! ideally we should rederive the split factor from the actual sparsity of C, but
          ! due to parameter beta, we can not get the sparsity of AxB from DBCSR if not new_c
-         ALLOCATE(split_opt)
+         ALLOCATE (split_opt)
          mp_comm_opt = dbcsr_tas_mp_comm(mp_comm, split_rc, nsplit_opt)
          CALL dbcsr_tas_create_split(split_opt, mp_comm_opt, split_rc, nsplit_opt, own_comm=.TRUE.)
       ENDIF
@@ -721,7 +720,7 @@ CONTAINS
          nodata2_prv = .FALSE.
       ENDIF
 
-      NULLIFY(matrix1_out, matrix2_out)
+      NULLIFY (matrix1_out, matrix2_out)
       IF (PRESENT(unit_nr)) THEN
          io_unit = unit_nr
       ELSE
@@ -739,21 +738,21 @@ CONTAINS
       nze1 = dbcsr_tas_get_nze_total(matrix1_in)
       nze2 = dbcsr_tas_get_nze_total(matrix2_in)
 
-      IF(trans1 == dbcsr_transpose) split_rc_1 = MOD(split_rc_1, 2) + 1
+      IF (trans1 == dbcsr_transpose) split_rc_1 = MOD(split_rc_1, 2) + 1
 
-      IF(trans2 == dbcsr_transpose) split_rc_2 = MOD(split_rc_2, 2) + 1
+      IF (trans2 == dbcsr_transpose) split_rc_2 = MOD(split_rc_2, 2) + 1
 
-      IF(nze1 >= nze2) THEN
-         ref=1
+      IF (nze1 >= nze2) THEN
+         ref = 1
          split_rc_ref = split_rc_1
-         dims_ref=dims1
+         dims_ref = dims1
       ELSE
-         ref=2
+         ref = 2
          split_rc_ref = split_rc_2
-         dims_ref=dims2
+         dims_ref = dims2
       ENDIF
 
-      IF(PRESENT(nsplit)) THEN
+      IF (PRESENT(nsplit)) THEN
          nsplit_prv = nsplit
       ELSE
          nsplit_prv = 0
@@ -771,12 +770,12 @@ CONTAINS
          IF (io_unit > 0) THEN
             WRITE (io_unit, "(T2,A,1X,A,1X,A,1X,A)") "No redistribution of", TRIM(matrix1_in%matrix%name), &
                "and", TRIM(matrix2_in%matrix%name)
-            IF(new1) THEN
+            IF (new1) THEN
                WRITE (io_unit, "(T2,A,1X,A,1X,A)") "Change split factor of", TRIM(matrix1_in%matrix%name), ": Yes"
             ELSE
                WRITE (io_unit, "(T2,A,1X,A,1X,A)") "Change split factor of", TRIM(matrix1_in%matrix%name), ": No"
             ENDIF
-            IF(new2) THEN
+            IF (new2) THEN
                WRITE (io_unit, "(T2,A,1X,A,1X,A)") "Change split factor of", TRIM(matrix2_in%matrix%name), ": Yes"
             ELSE
                WRITE (io_unit, "(T2,A,1X,A,1X,A)") "Change split factor of", TRIM(matrix2_in%matrix%name), ": No"
@@ -803,12 +802,12 @@ CONTAINS
                CALL invert_transpose_flag(trans2)
             ENDIF
 
-            IF(nsplit_prv == 0) THEN
-               SELECT CASE(split_rc_ref)
-               CASE(rowsplit)
+            IF (nsplit_prv == 0) THEN
+               SELECT CASE (split_rc_ref)
+               CASE (rowsplit)
                   d1 = dims_ref(1)
                   d2 = dims_ref(2)
-               CASE(colsplit)
+               CASE (colsplit)
                   d1 = dims_ref(2)
                   d2 = dims_ref(1)
                END SELECT
@@ -856,14 +855,14 @@ CONTAINS
                                      matrix2_in%col_blk_size, matrix2_in%row_blk_size, own_dist=.TRUE.)
             ENDIF
 
-            IF(.NOT. nodata1_prv) CALL dbcsr_tas_reshape(matrix1_in, matrix1_out, transposed=trans1_newdist, move_data=move_data_1)
-            IF(.NOT. nodata2_prv) CALL dbcsr_tas_reshape(matrix2_in, matrix2_out, transposed=trans2_newdist, move_data=move_data_2)
+            IF (.NOT. nodata1_prv) CALL dbcsr_tas_reshape(matrix1_in, matrix1_out, transposed=trans1_newdist, move_data=move_data_1)
+            IF (.NOT. nodata2_prv) CALL dbcsr_tas_reshape(matrix2_in, matrix2_out, transposed=trans2_newdist, move_data=move_data_2)
             new1 = .TRUE.
             new2 = .TRUE.
 
          ELSE
-            SELECT CASE(ref)
-            CASE(1)
+            SELECT CASE (ref)
+            CASE (1)
                IF (io_unit > 0) THEN
                   WRITE (io_unit, "(T2,A,1X,A)") "Redistribution of", TRIM(matrix2_in%matrix%name)
                ENDIF
@@ -874,7 +873,7 @@ CONTAINS
                ALLOCATE (matrix2_out)
                CALL reshape_mm_template(matrix1_out, matrix2_in, matrix2_out, trans2, nodata=nodata2, move_data=move_data_2)
                new2 = .TRUE.
-            CASE(2)
+            CASE (2)
                IF (io_unit > 0) THEN
                   WRITE (io_unit, "(T2,A,1X,A)") "Redistribution of", TRIM(matrix1_in%matrix%name)
                ENDIF
@@ -889,8 +888,8 @@ CONTAINS
          ENDIF
       ENDIF
 
-      IF(PRESENT(move_data_1) .AND. new1) move_data_1 = .TRUE.
-      IF(PRESENT(move_data_2) .AND. new2) move_data_2 = .TRUE.
+      IF (PRESENT(move_data_1) .AND. new1) move_data_1 = .TRUE.
+      IF (PRESENT(move_data_2) .AND. new2) move_data_2 = .TRUE.
 
       CALL timestop(handle)
 
@@ -927,11 +926,11 @@ CONTAINS
       CLASS(dbcsr_tas_rowcol_data), ALLOCATABLE  :: rbsize, cbsize
       CHARACTER(LEN=*), PARAMETER                :: routineN = 'change_split', &
                                                     routineP = moduleN//':'//routineN
-      NULLIFY(matrix_out)
+      NULLIFY (matrix_out)
 
       is_new = .TRUE.
 
-      IF(nsplit == 0) THEN
+      IF (nsplit == 0) THEN
          matrix_out => matrix_in
          is_new = .FALSE.
          RETURN
@@ -940,7 +939,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       nodata_prv = .FALSE.
-      IF(PRESENT(nodata)) nodata_prv = nodata
+      IF (PRESENT(nodata)) nodata_prv = nodata
 
       CALL dbcsr_tas_get_split_info(dbcsr_tas_info(matrix_in), mp_comm=mp_comm, &
                                     split_rowcol=split_rc, nsplit=nsplit_old)
@@ -953,7 +952,7 @@ CONTAINS
 
       CALL dbcsr_tas_get_split_info(split_info, nsplit=nsplit_new)
 
-      IF(nsplit_old == nsplit_new .AND. split_rc == split_rowcol) THEN
+      IF (nsplit_old == nsplit_new .AND. split_rc == split_rowcol) THEN
          matrix_out => matrix_in
          is_new = .FALSE.
          CALL dbcsr_tas_release_info(split_info)
@@ -966,14 +965,14 @@ CONTAINS
 
       CALL dbcsr_tas_release_info(split_info)
 
-      ALLOCATE(matrix_out)
+      ALLOCATE (matrix_out)
       CALL dbcsr_tas_create(matrix_out, name, dist, &
                             data_type, &
                             rbsize, cbsize, own_dist=.TRUE.)
 
-      IF(.NOT. nodata_prv) CALL dbcsr_tas_copy(matrix_out, matrix_in)
+      IF (.NOT. nodata_prv) CALL dbcsr_tas_copy(matrix_out, matrix_in)
 
-      IF(PRESENT(move_data)) THEN
+      IF (PRESENT(move_data)) THEN
          IF (.NOT. nodata_prv) THEN
             IF (move_data) CALL dbcsr_tas_clear(matrix_in)
             move_data = .TRUE.
@@ -1175,7 +1174,7 @@ CONTAINS
          CALL dbcsr_tas_iterator_next_block(iter, row, col, bn)
          row_size = matrix_c%row_blk_size%data(row)
          col_size = matrix_c%col_blk_size%data(col)
-         nze=nze+row_size*col_size
+         nze = nze + row_size*col_size
       ENDDO
       CALL dbcsr_tas_iterator_stop(iter)
 
@@ -1207,8 +1206,8 @@ CONTAINS
       INTEGER                                     :: nsplit, nsplit_comm, nsplit_memory
       INTEGER(KIND=int_8)                         :: max_nze, min_nze
 
-      min_nze = MAX(MINVAL([nze_a, nze_b, nze_c]),1_int_8)
-      max_nze = MAX(MAXVAL([nze_a, nze_b, nze_c]),1_int_8)
+      min_nze = MAX(MINVAL([nze_a, nze_b, nze_c]), 1_int_8)
+      max_nze = MAX(MAXVAL([nze_a, nze_b, nze_c]), 1_int_8)
       nsplit_comm = NINT((REAL(nze_a + nze_b, real_8)/(2*min_nze))**(2._real_8/3)*REAL(numnodes, real_8)**(1._real_8/3))
 
       ! nsplit_memory protects against excess memory usage
@@ -1245,7 +1244,7 @@ CONTAINS
 
       DBCSR_ASSERT(matrix_in%valid)
 
-      IF(PRESENT(nodata)) THEN
+      IF (PRESENT(nodata)) THEN
          nodata_prv = nodata
       ELSE
          nodata_prv = .FALSE.
@@ -1310,35 +1309,35 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER                :: routineN = 'convert_to_new_pgrid', &
                                                     routineP = moduleN//':'//routineN
 
-      NULLIFY(row_dist, col_dist, rbsize, rcsize)
+      NULLIFY (row_dist, col_dist, rbsize, rcsize)
 
-      IF(PRESENT(optimize_pgrid)) THEN
+      IF (PRESENT(optimize_pgrid)) THEN
          optimize_pgrid_prv = optimize_pgrid
       ELSE
          optimize_pgrid_prv = .TRUE.
       ENDIF
 
-      IF(.NOT. optimize_pgrid_prv) THEN
+      IF (.NOT. optimize_pgrid_prv) THEN
          matrix_out => matrix_in
          RETURN
       ENDIF
 
       CALL timeset(routineN, handle)
 
-      IF(PRESENT(nodata)) THEN
+      IF (PRESENT(nodata)) THEN
          nodata_prv = nodata
       ELSE
          nodata_prv = .FALSE.
       ENDIF
 
-      ALLOCATE(matrix_out)
+      ALLOCATE (matrix_out)
 
       CALL dbcsr_get_info(matrix_in, nblkrows_total=nbrows, nblkcols_total=nbcols, &
                           row_blk_size=rbsize, col_blk_size=rcsize, &
                           data_type=data_type, distribution=dist_old, name=name)
       CALL mp_environ(nproc, pdims, pcoord, mp_comm_cart)
 
-      ALLOCATE(row_dist(nbrows), col_dist(nbcols))
+      ALLOCATE (row_dist(nbrows), col_dist(nbcols))
       CALL cyclic_weighted_dist(nbrows, pdims(1), rbsize, row_dist)
       CALL cyclic_weighted_dist(nbcols, pdims(2), rcsize, col_dist)
 
@@ -1349,10 +1348,10 @@ CONTAINS
       CALL dbcsr_create(matrix_out, name, dist, 'N', rbsize, rcsize, data_type=data_type)
       CALL dbcsr_distribution_release(dist)
 
-      IF(.NOT. nodata_prv) THEN
+      IF (.NOT. nodata_prv) THEN
          CALL dbcsr_redistribute(matrix_in, matrix_out)
-         IF(PRESENT(move_data)) THEN
-            IF(move_data) CALL dbcsr_clear(matrix_in)
+         IF (PRESENT(move_data)) THEN
+            IF (move_data) CALL dbcsr_clear(matrix_in)
          ENDIF
       ENDIF
 

--- a/src/tas/dbcsr_tas_mm.F
+++ b/src/tas/dbcsr_tas_mm.F
@@ -84,9 +84,11 @@ CONTAINS
 !> \param matrix_c ...
 !> \param optimize_dist Whether distribution should be optimized internally. In the current implementation
 !>                      this guarantees optimal parameters only for dense matrices.
-!> \param split_opt optionally return split info containing optimal grid and split parameters. This
-!>                  can be used to choose optimal process grids for subsequent matrix multiplications
+!> \param split_opt optionally return split info containing optimal grid and split parameters.
+!>                  This can be used to choose optimal process grids for subsequent matrix multiplications
 !>                  with matrices of similar shape and sparsity.
+!>                  under some conditions, split_opt can not be returned, in this case the pointer is
+!>                  not associated
 !> \param filter_eps ...
 !> \param flop ...
 !> \param move_data_a memory optimization: move data to matrix_c such that matrix_a is empty on return
@@ -104,7 +106,7 @@ CONTAINS
          INTENT(INOUT)                           :: matrix_a, matrix_b, matrix_c
       LOGICAL, INTENT(IN), OPTIONAL              :: optimize_dist
       TYPE(dbcsr_tas_split_info), INTENT(OUT), &
-         OPTIONAL                                :: split_opt
+         POINTER, OPTIONAL                       :: split_opt
       REAL(KIND=real_8), INTENT(IN), OPTIONAL    :: filter_eps
       INTEGER(KIND=int_8), INTENT(OUT), OPTIONAL :: flop
       LOGICAL, INTENT(IN), OPTIONAL              :: move_data_a, move_data_b, simple_split
@@ -151,9 +153,6 @@ CONTAINS
          IF(info_a%strict_split .OR. info_b%strict_split .OR. info_c%strict_split) simple_split_prv = .TRUE.
       ENDIF
 
-      IF(simple_split_prv .AND. PRESENT(split_opt)) THEN
-         DBCSR_ABORT("incompatible dummy arguments split_opt and simple_split")
-      ENDIF
 
       move_a = .FALSE.
       move_b = .FALSE.
@@ -535,9 +534,10 @@ CONTAINS
 
       CALL dbcsr_tas_get_split_info(dbcsr_tas_info(matrix_c), mp_comm=mp_comm)
 
-      IF(PRESENT(split_opt)) THEN
+      IF(PRESENT(split_opt) .AND. .NOT. simple_split_prv) THEN
          ! ideally we should rederive the split factor from the actual sparsity of C, but
          ! due to parameter beta, we can not get the sparsity of AxB from DBCSR if not new_c
+         ALLOCATE(split_opt)
          mp_comm_opt = dbcsr_tas_mp_comm(mp_comm, split_rc, nsplit_opt)
          CALL dbcsr_tas_create_split(split_opt, mp_comm_opt, split_rc, nsplit_opt, own_comm=.TRUE.)
       ENDIF

--- a/src/tas/dbcsr_tas_reshape_ops.F
+++ b/src/tas/dbcsr_tas_reshape_ops.F
@@ -14,70 +14,49 @@
 MODULE dbcsr_tas_reshape_ops
 #:include "dbcsr_tas.fypp"
 
-   USE dbcsr_block_access, ONLY: dbcsr_put_block, &
-                                 dbcsr_reserve_blocks
-   USE dbcsr_data_methods, ONLY: dbcsr_data_clear_pointer, &
-                                 dbcsr_data_init, &
-                                 dbcsr_data_new, &
-                                 dbcsr_data_release, &
-                                 dbcsr_type_1d_to_2d, &
-                                 dbcsr_data_get_sizes, &
-                                 dbcsr_data_set_pointer
-   USE dbcsr_data_methods_low, ONLY: internal_data_allocate, &
-                                     internal_data_deallocate, &
-                                     dbcsr_get_data_p_2d_d, &
-                                     dbcsr_get_data_p_2d_s, &
-                                     dbcsr_get_data_p_2d_z, &
-                                     dbcsr_get_data_p_2d_c
-   USE dbcsr_data_types, ONLY: dbcsr_data_obj, &
-                               dbcsr_type_real_8, &
-                               dbcsr_type_real_4, &
-                               dbcsr_type_complex_8, &
-                               dbcsr_type_complex_4
-   USE dbcsr_dist_methods, ONLY: dbcsr_distribution_col_dist, &
-                                 dbcsr_distribution_row_dist
-   USE dbcsr_dist_operations, ONLY: dbcsr_get_stored_coordinates
-   USE dbcsr_iterator_operations, ONLY: dbcsr_iterator_blocks_left, &
-                                        dbcsr_iterator_next_block, &
-                                        dbcsr_iterator_start, &
-                                        dbcsr_iterator_stop
-   USE dbcsr_methods, ONLY: dbcsr_blk_column_size, &
-                            dbcsr_blk_row_size
-   USE dbcsr_operations, ONLY: dbcsr_get_info, &
-                               dbcsr_clear
+   USE dbcsr_block_access, ONLY: &
+      dbcsr_put_block, dbcsr_reserve_blocks
+   USE dbcsr_data_methods, ONLY: &
+      dbcsr_data_clear_pointer, dbcsr_data_init, dbcsr_data_new, dbcsr_data_release, &
+      dbcsr_type_1d_to_2d, dbcsr_data_get_sizes, dbcsr_data_set_pointer
+   USE dbcsr_data_methods_low, ONLY: &
+      internal_data_allocate, internal_data_deallocate, dbcsr_get_data_p_2d_d, dbcsr_get_data_p_2d_s, &
+      dbcsr_get_data_p_2d_z, dbcsr_get_data_p_2d_c
+   USE dbcsr_data_types, ONLY: &
+      dbcsr_data_obj, dbcsr_type_real_8, dbcsr_type_real_4, dbcsr_type_complex_8, dbcsr_type_complex_4
+   USE dbcsr_dist_methods, ONLY: &
+      dbcsr_distribution_col_dist, dbcsr_distribution_row_dist
+   USE dbcsr_dist_operations, ONLY: &
+      dbcsr_get_stored_coordinates
+   USE dbcsr_iterator_operations, ONLY: &
+      dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, dbcsr_iterator_start, dbcsr_iterator_stop
+   USE dbcsr_methods, ONLY: &
+      dbcsr_blk_column_size, dbcsr_blk_row_size
+   USE dbcsr_operations, ONLY: &
+      dbcsr_get_info, dbcsr_clear
    USE dbcsr_tas_base, ONLY: &
       dbcsr_tas_blk_sizes, dbcsr_tas_create, dbcsr_tas_distribution_new, dbcsr_tas_finalize, &
       dbcsr_tas_get_data_type, dbcsr_tas_get_stored_coordinates, dbcsr_tas_info, &
       dbcsr_tas_iterator_blocks_left, dbcsr_tas_iterator_next_block, dbcsr_tas_iterator_start, &
       dbcsr_tas_iterator_stop, dbcsr_tas_put_block, dbcsr_tas_reserve_blocks, &
       dbcsr_repl_get_stored_coordinates, dbcsr_tas_clear
-   USE dbcsr_tas_types, ONLY: dbcsr_tas_distribution_type, &
-                              dbcsr_tas_iterator, &
-                              dbcsr_tas_create_split_info, &
-                              dbcsr_tas_type
-   USE dbcsr_tas_global, ONLY: dbcsr_tas_blk_size_arb, &
-                               dbcsr_tas_blk_size_repl, &
-                               dbcsr_tas_dist_arb, &
-                               dbcsr_tas_dist_repl, &
-                               dbcsr_tas_distribution, &
-                               dbcsr_tas_rowcol_data
-   USE dbcsr_tas_split, ONLY: colsplit, &
-                              dbcsr_tas_get_split_info, &
-                              rowsplit
-   USE dbcsr_types, ONLY: dbcsr_distribution_obj, &
-                          dbcsr_iterator, &
-                          dbcsr_type
-   USE dbcsr_work_operations, ONLY: dbcsr_finalize
-   USE dbcsr_kinds, ONLY: int_8, &
-                          real_8, &
-                          real_4
-   USE dbcsr_mpiwrap, ONLY: mp_alltoall, &
-                            mp_environ, &
-                            mp_isend, &
-                            mp_irecv, &
-                            mp_waitall
-
-   USE dbcsr_tas_util, ONLY: swap, index_unique
+   USE dbcsr_tas_types, ONLY: &
+      dbcsr_tas_distribution_type, dbcsr_tas_iterator, dbcsr_tas_split_info, dbcsr_tas_type
+   USE dbcsr_tas_global, ONLY: &
+      dbcsr_tas_blk_size_arb, dbcsr_tas_blk_size_repl, dbcsr_tas_dist_arb, dbcsr_tas_dist_repl, &
+      dbcsr_tas_distribution, dbcsr_tas_rowcol_data
+   USE dbcsr_tas_split, ONLY: &
+      colsplit, dbcsr_tas_get_split_info, rowsplit
+   USE dbcsr_types, ONLY: &
+      dbcsr_distribution_obj, dbcsr_iterator, dbcsr_type
+   USE dbcsr_work_operations, ONLY: &
+      dbcsr_finalize
+   USE dbcsr_kinds, ONLY: &
+      int_8, real_8, real_4
+   USE dbcsr_mpiwrap, ONLY: &
+      mp_alltoall, mp_environ, mp_isend, mp_irecv, mp_waitall
+   USE dbcsr_tas_util, ONLY: &
+      swap, index_unique
 #include "../base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -145,8 +124,8 @@ CONTAINS
       LOGICAL                                            :: tr, tr_in, move_prv
       TYPE(block_buffer_type), ALLOCATABLE, DIMENSION(:) :: buffer_recv, buffer_send
       TYPE(dbcsr_data_obj)                               :: block
-      TYPE(dbcsr_tas_iterator)                             :: iter
-      TYPE(dbcsr_tas_create_split_info)                           :: info
+      TYPE(dbcsr_tas_iterator)                           :: iter
+      TYPE(dbcsr_tas_split_info)                         :: info
 
       CALL timeset(routineN, handle)
 
@@ -303,8 +282,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE dbcsr_tas_replicate(matrix_in, info, matrix_out, nodata, move_data)
       TYPE(dbcsr_type), INTENT(INOUT)                    :: matrix_in
-      TYPE(dbcsr_tas_create_split_info), INTENT(IN)               :: info
-      TYPE(dbcsr_tas_type), INTENT(OUT)                    :: matrix_out
+      TYPE(dbcsr_tas_split_info), INTENT(IN)             :: info
+      TYPE(dbcsr_tas_type), INTENT(OUT)                  :: matrix_out
       LOGICAL, INTENT(IN), OPTIONAL                      :: nodata
       LOGICAL, INTENT(IN), OPTIONAL                      :: move_data
 
@@ -392,7 +371,7 @@ CONTAINS
 
       CALL dbcsr_tas_distribution_new(dist, mp_comm, row_dist_obj, col_dist_obj, split_info=info)
       CALL dbcsr_tas_create(matrix_out, TRIM(matrix_in%name)//" replicated", &
-                            dist, data_type, row_bsize_obj, col_bsize_obj)
+                            dist, data_type, row_bsize_obj, col_bsize_obj, own_dist=.TRUE.)
 
       IF (nodata_prv) THEN
          CALL dbcsr_tas_finalize(matrix_out)
@@ -529,7 +508,7 @@ CONTAINS
       TYPE(block_buffer_type), ALLOCATABLE, DIMENSION(:) :: buffer_recv, buffer_send
       TYPE(dbcsr_data_obj)                               :: block
       TYPE(dbcsr_iterator)                               :: iter
-      TYPE(dbcsr_tas_create_split_info)                           :: info
+      TYPE(dbcsr_tas_split_info)                         :: info
 
       CALL timeset(routineN, handle)
 

--- a/src/tas/dbcsr_tas_split.F
+++ b/src/tas/dbcsr_tas_split.F
@@ -195,7 +195,7 @@ CONTAINS
       INTEGER                                            :: group_size
       INTEGER, DIMENSION(2)                              :: group_dims
 
-      nsplit_opt = opt_nsplit(numproc, nsplit, split_pgrid = .FALSE.)
+      nsplit_opt = get_opt_nsplit(numproc, nsplit, split_pgrid = .FALSE.)
 
       group_size = numproc/nsplit_opt
       group_dims(:) = 0
@@ -228,13 +228,13 @@ CONTAINS
 !> \param pdim_nonsplit if split_pgrid: other process grid dimension
 !> \return split factor consistent with process grid or number of processes
 ! **************************************************************************************************
-   FUNCTION opt_nsplit(numproc, nsplit, split_pgrid, pdim_nonsplit)
+   FUNCTION get_opt_nsplit(numproc, nsplit, split_pgrid, pdim_nonsplit)
       INTEGER, INTENT(IN)                        :: numproc, nsplit
       LOGICAL, INTENT(IN)                        :: split_pgrid
       INTEGER, INTENT(IN), OPTIONAL              :: pdim_nonsplit
       INTEGER, ALLOCATABLE, DIMENSION(:)         :: nsplit_list, nsplit_list_square, nsplit_list_accept
       INTEGER                                    :: lb, ub, count, count_square, count_accept, split, &
-                                                    minpos, opt_nsplit
+                                                    minpos, get_opt_nsplit
       INTEGER, DIMENSION(2)                      :: dims_sub
       REAL(KIND=real_8)                          :: nsplit_accept_ratio
 
@@ -290,17 +290,17 @@ CONTAINS
 
       IF(count_square > 0) THEN
          minpos = MINLOC(ABS(nsplit_list_square(1:count_square) - nsplit), DIM=1)
-         opt_nsplit = nsplit_list_square(minpos)
+         get_opt_nsplit = nsplit_list_square(minpos)
       ELSEIF(count_accept > 0) THEN
          minpos = MINLOC(ABS(nsplit_list_accept(1:count_accept) - nsplit), DIM=1)
-         opt_nsplit = nsplit_list_accept(minpos)
+         get_opt_nsplit = nsplit_list_accept(minpos)
       ELSEIF(count > 0) THEN
          minpos = MINLOC(ABS(nsplit_list(1:count) - nsplit), DIM=1)
-         opt_nsplit = nsplit_list(minpos)
+         get_opt_nsplit = nsplit_list(minpos)
       ELSE
-         opt_nsplit = nsplit
-         DO WHILE (MOD(numproc, opt_nsplit) .NE. 0)
-            opt_nsplit = opt_nsplit - 1
+         get_opt_nsplit = nsplit
+         DO WHILE (MOD(numproc, get_opt_nsplit) .NE. 0)
+            get_opt_nsplit = get_opt_nsplit - 1
          ENDDO
       ENDIF
 
@@ -338,13 +338,15 @@ CONTAINS
 !> \param split_rowcol split rows or columns
 !> \param nsplit desired split factor, set to 0 if split factor of exactly 1 is required
 !> \param own_comm whether split_info should own communicator
+!> \param opt_nsplit ...
 ! **************************************************************************************************
-   SUBROUTINE dbcsr_tas_create_split(split_info, mp_comm, split_rowcol, nsplit, own_comm)
+   SUBROUTINE dbcsr_tas_create_split(split_info, mp_comm, split_rowcol, nsplit, own_comm, opt_nsplit)
       TYPE(dbcsr_tas_split_info), INTENT(OUT)            :: split_info
       INTEGER, INTENT(IN)                                :: mp_comm
       INTEGER, INTENT(IN)                                :: split_rowcol
       INTEGER, INTENT(IN)                                :: nsplit
       LOGICAL, INTENT(IN), OPTIONAL                      :: own_comm
+      LOGICAL, INTENT(IN), OPTIONAL                      :: opt_nsplit
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'dbcsr_tas_create_split', &
                                                             routineP = moduleN//':'//routineN
@@ -352,8 +354,17 @@ CONTAINS
       INTEGER                                            :: &
          handle, iproc, numproc, igroup, nsplit_opt, pdim_split, pdim_nonsplit
       INTEGER, DIMENSION(2)                              :: pcoord, pdims, pdims_group
+      LOGICAL                                            :: opt_nsplit_prv
 
       CALL timeset(routineN, handle)
+
+      IF(PRESENT(opt_nsplit)) THEN
+         opt_nsplit_prv = opt_nsplit
+      ELSE
+         opt_nsplit_prv = .TRUE.
+      ENDIF
+
+      DBCSR_ASSERT(nsplit > 0)
 
       CALL mp_environ(numproc, iproc, mp_comm)
       CALL mp_environ(numproc, pdims, pcoord, mp_comm)
@@ -367,22 +378,22 @@ CONTAINS
          pdim_nonsplit = pdims(1)
       END SELECT
 
-      IF (nsplit > 0) THEN
-         nsplit_opt = opt_nsplit(pdim_split, nsplit, split_pgrid=.TRUE., pdim_nonsplit=pdim_nonsplit)
+      IF (opt_nsplit_prv) THEN
+         nsplit_opt = get_opt_nsplit(pdim_split, nsplit, split_pgrid=.TRUE., pdim_nonsplit=pdim_nonsplit)
       ELSE
-         nsplit_opt = 1
+         IF(MOD(pdims(split_rowcol), nsplit) .NE. 0) THEN
+            DBCSR_ABORT("Split factor does not divide process grid dimension")
+         ENDIF
+         nsplit_opt = nsplit
       ENDIF
 
-      SELECT CASE (split_rowcol)
-      CASE (rowsplit)
-         pdims_group = [pdims(1)/nsplit_opt, pdims(2)]
-      CASE (colsplit)
-         pdims_group = [pdims(1), pdims(2)/nsplit_opt]
-      END SELECT
+      pdims_group = pdims
+      pdims_group(split_rowcol) = pdims_group(split_rowcol)/nsplit_opt
 
       igroup = pcoord(split_rowcol)/pdims_group(split_rowcol)
 
       CALL dbcsr_tas_create_split_rows_or_cols(split_info, mp_comm, nsplit_opt, igroup, split_rowcol, own_comm=own_comm)
+      IF(.NOT. opt_nsplit_prv) split_info%strict_split = .TRUE.
 
       CALL timestop(handle)
 

--- a/src/tas/dbcsr_tas_split.F
+++ b/src/tas/dbcsr_tas_split.F
@@ -93,13 +93,13 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      IF(PRESENT(own_comm)) THEN
+      IF (PRESENT(own_comm)) THEN
          own_comm_prv = own_comm
       ELSE
          own_comm_prv = .FALSE.
       ENDIF
 
-      IF(own_comm_prv) THEN
+      IF (own_comm_prv) THEN
          split_info%mp_comm = mp_comm
       ELSE
          CALL mp_comm_dup(mp_comm, split_info%mp_comm)
@@ -195,7 +195,7 @@ CONTAINS
       INTEGER                                            :: group_size
       INTEGER, DIMENSION(2)                              :: group_dims
 
-      nsplit_opt = get_opt_nsplit(numproc, nsplit, split_pgrid = .FALSE.)
+      nsplit_opt = get_opt_nsplit(numproc, nsplit, split_pgrid=.FALSE.)
 
       group_size = numproc/nsplit_opt
       group_dims(:) = 0
@@ -204,10 +204,10 @@ CONTAINS
 
       ! here we choose order of group dims s.t. a split factor < nsplit_opt is favoured w.r.t.
       ! optimal subgrid dimensions
-      SELECT CASE(split_rowcol)
-      CASE(rowsplit)
+      SELECT CASE (split_rowcol)
+      CASE (rowsplit)
          group_dims = [MINVAL(group_dims), MAXVAL(group_dims)]
-      CASE(colsplit)
+      CASE (colsplit)
          group_dims = [MAXVAL(group_dims), MINVAL(group_dims)]
       END SELECT
 
@@ -240,11 +240,11 @@ CONTAINS
 
       DBCSR_ASSERT(nsplit > 0)
 
-      IF(split_pgrid) THEN
+      IF (split_pgrid) THEN
          DBCSR_ASSERT(PRESENT(pdim_nonsplit))
       ENDIF
 
-      IF(split_pgrid) THEN
+      IF (split_pgrid) THEN
          ! if process grid dimensions are fixed, we need more flexibility in split factor in order
          ! to obtain balanced grid dimensions --> larger accept ratio
          nsplit_accept_ratio = default_nsplit_accept_ratio_2
@@ -257,9 +257,9 @@ CONTAINS
       lb = CEILING(REAL(nsplit, real_8)/nsplit_accept_ratio)
       ub = FLOOR(REAL(nsplit, real_8)*nsplit_accept_ratio)
 
-      IF(ub < lb) ub = lb
+      IF (ub < lb) ub = lb
 
-      ALLOCATE(nsplit_list(1:ub-lb+1), nsplit_list_square(1:ub-lb+1), nsplit_list_accept(1:ub-lb+1))
+      ALLOCATE (nsplit_list(1:ub - lb + 1), nsplit_list_square(1:ub - lb + 1), nsplit_list_accept(1:ub - lb + 1))
       count = 0
       count_square = 0
       count_accept = 0
@@ -280,7 +280,7 @@ CONTAINS
                nsplit_list_square(count_square) = split
                count_accept = count_accept + 1
                nsplit_list_accept(count_accept) = split
-            ELSEIF(accept_pgrid_dims(dims_sub, relative=.FALSE.)) THEN
+            ELSEIF (accept_pgrid_dims(dims_sub, relative=.FALSE.)) THEN
                count_accept = count_accept + 1
                nsplit_list_accept(count_accept) = split
             ENDIF
@@ -288,13 +288,13 @@ CONTAINS
          ENDIF
       ENDDO
 
-      IF(count_square > 0) THEN
+      IF (count_square > 0) THEN
          minpos = MINLOC(ABS(nsplit_list_square(1:count_square) - nsplit), DIM=1)
          get_opt_nsplit = nsplit_list_square(minpos)
-      ELSEIF(count_accept > 0) THEN
+      ELSEIF (count_accept > 0) THEN
          minpos = MINLOC(ABS(nsplit_list_accept(1:count_accept) - nsplit), DIM=1)
          get_opt_nsplit = nsplit_list_accept(minpos)
-      ELSEIF(count > 0) THEN
+      ELSEIF (count > 0) THEN
          minpos = MINLOC(ABS(nsplit_list(1:count) - nsplit), DIM=1)
          get_opt_nsplit = nsplit_list(minpos)
       ELSE
@@ -320,7 +320,7 @@ CONTAINS
       INTEGER                                            :: nsplit, split_rowcol
       INTEGER                                            :: mp_comm_new
 
-      IF(nblkrows >= nblkcols) THEN
+      IF (nblkrows >= nblkcols) THEN
          split_rowcol = rowsplit
          nsplit = INT((nblkrows - 1)/nblkcols + 1)
       ELSE
@@ -358,7 +358,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      IF(PRESENT(opt_nsplit)) THEN
+      IF (PRESENT(opt_nsplit)) THEN
          opt_nsplit_prv = opt_nsplit
       ELSE
          opt_nsplit_prv = .TRUE.
@@ -381,7 +381,7 @@ CONTAINS
       IF (opt_nsplit_prv) THEN
          nsplit_opt = get_opt_nsplit(pdim_split, nsplit, split_pgrid=.TRUE., pdim_nonsplit=pdim_nonsplit)
       ELSE
-         IF(MOD(pdims(split_rowcol), nsplit) .NE. 0) THEN
+         IF (MOD(pdims(split_rowcol), nsplit) .NE. 0) THEN
             DBCSR_ABORT("Split factor does not divide process grid dimension")
          ENDIF
          nsplit_opt = nsplit
@@ -393,7 +393,7 @@ CONTAINS
       igroup = pcoord(split_rowcol)/pdims_group(split_rowcol)
 
       CALL dbcsr_tas_create_split_rows_or_cols(split_info, mp_comm, nsplit_opt, igroup, split_rowcol, own_comm=own_comm)
-      IF(.NOT. opt_nsplit_prv) split_info%strict_split = .TRUE.
+      IF (.NOT. opt_nsplit_prv) split_info%strict_split = .TRUE.
 
       CALL timestop(handle)
 
@@ -411,7 +411,7 @@ CONTAINS
       INTEGER, DIMENSION(2)                      :: dims_opt
       LOGICAL                                    :: accept_pgrid_dims
 
-      IF(relative) THEN
+      IF (relative) THEN
          dims_opt = 0
          CALL mp_dims_create(PRODUCT(dims), dims_opt)
          accept_pgrid_dims = (MAXVAL(REAL(dims, real_8))/MAXVAL(dims_opt) .LT. default_pdims_accept_ratio)

--- a/src/tas/dbcsr_tas_split.F
+++ b/src/tas/dbcsr_tas_split.F
@@ -15,19 +15,20 @@
 ! **************************************************************************************************
 MODULE dbcsr_tas_split
 
-   USE dbcsr_tas_types, ONLY: dbcsr_tas_distribution_type, &
-                              dbcsr_tas_create_split_info
-   USE dbcsr_tas_global, ONLY: dbcsr_tas_distribution
-   USE dbcsr_tas_util, ONLY: swap
-   USE dbcsr_toollib, ONLY: sort
-   USE dbcsr_kinds, ONLY: int_8
-   USE dbcsr_mpiwrap, ONLY: mp_bcast, &
-                            mp_cart_create, &
-                            mp_comm_dup, &
-                            mp_comm_free, &
-                            mp_comm_split_direct, &
-                            mp_dims_create, &
-                            mp_environ
+   USE dbcsr_tas_types, ONLY: &
+      dbcsr_tas_distribution_type, dbcsr_tas_split_info
+   USE dbcsr_tas_global, ONLY: &
+      dbcsr_tas_distribution
+   USE dbcsr_tas_util, ONLY: &
+      swap
+   USE dbcsr_toollib, ONLY: &
+      sort
+   USE dbcsr_kinds, ONLY: &
+      int_8
+   USE dbcsr_mpiwrap, ONLY: &
+      mp_bcast, mp_cart_create, mp_comm_dup, mp_comm_free, mp_comm_split_direct, mp_dims_create, mp_environ
+   USE dbcsr_kinds, ONLY: &
+      real_8
 #include "../base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -40,6 +41,7 @@ MODULE dbcsr_tas_split
       dbcsr_tas_get_split_info, &
       dbcsr_tas_info_hold, &
       dbcsr_tas_mp_comm, &
+      dbcsr_tas_mp_dims, &
       dbcsr_tas_release_info, &
       dbcsr_tas_create_split, &
       dbcsr_tas_create_split_rows_or_cols, &
@@ -47,11 +49,21 @@ MODULE dbcsr_tas_split
       group_to_world_proc_map, &
       mrowcol_to_group, &
       rowsplit, &
-      world_to_group_proc_map
+      world_to_group_proc_map, &
+      accept_pgrid_dims, &
+      default_nsplit_accept_ratio_1
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'dbcsr_tas_split'
 
    INTEGER, PARAMETER :: rowsplit = 1, colsplit = 2
+   REAL(real_8), PARAMETER :: default_pdims_accept_ratio = 1.2_real_8
+   REAL(real_8), PARAMETER :: default_nsplit_accept_ratio_1 = 1.5_real_8
+   REAL(real_8), PARAMETER :: default_nsplit_accept_ratio_2 = 2.5_real_8
+
+   INTERFACE dbcsr_tas_mp_comm
+      MODULE PROCEDURE dbcsr_tas_mp_comm
+      MODULE PROCEDURE dbcsr_tas_mp_comm_from_matrix_sizes
+   END INTERFACE
 
 CONTAINS
 
@@ -59,28 +71,40 @@ CONTAINS
 !> \brief split mpi grid by rows or columns
 !> \param split_info ...
 !> \param mp_comm global mpi communicator with a 2d cartesian grid
-!> \param ngroup number of groups. Note: this number may be diminished on out in order to have a
-!>        distribution where all groups have the same number of processes
+!> \param ngroup number of groups
 !> \param igroup my group ID
 !> \param split_rowcol split rows or columns
+!> \param own_comm Whether split_info should own communicator
 ! **************************************************************************************************
-   SUBROUTINE dbcsr_tas_create_split_rows_or_cols(split_info, mp_comm, ngroup, igroup, split_rowcol)
-      TYPE(dbcsr_tas_create_split_info), INTENT(OUT)              :: split_info
+   SUBROUTINE dbcsr_tas_create_split_rows_or_cols(split_info, mp_comm, ngroup, igroup, split_rowcol, own_comm)
+      TYPE(dbcsr_tas_split_info), INTENT(OUT)            :: split_info
       INTEGER, INTENT(IN)                                :: mp_comm
       INTEGER, INTENT(INOUT)                             :: ngroup
       INTEGER, INTENT(IN)                                :: igroup, split_rowcol
+      LOGICAL, INTENT(IN), OPTIONAL                      :: own_comm
 
       INTEGER :: &
          igroup_check, iproc, iproc_group, iproc_group_check, mp_comm_group, numproc, &
          numproc_group, numproc_group_check, handle
       INTEGER, DIMENSION(2)                              :: pcoord, pcoord_group, pdims, pdims_group
-      LOGICAL                                            :: to_assert
+      LOGICAL                                            :: to_assert, own_comm_prv
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_tas_create_split_rows_or_cols', &
                                      routineP = moduleN//':'//routineN
 
       CALL timeset(routineN, handle)
 
-      CALL mp_comm_dup(mp_comm, split_info%mp_comm)
+      IF(PRESENT(own_comm)) THEN
+         own_comm_prv = own_comm
+      ELSE
+         own_comm_prv = .FALSE.
+      ENDIF
+
+      IF(own_comm_prv) THEN
+         split_info%mp_comm = mp_comm
+      ELSE
+         CALL mp_comm_dup(mp_comm, split_info%mp_comm)
+      ENDIF
+
       split_info%igroup = igroup
       split_info%split_rowcol = split_rowcol
 
@@ -124,69 +148,30 @@ CONTAINS
    END SUBROUTINE
 
 ! **************************************************************************************************
-!> \brief Create default cartesian grid that is consistent with default split heuristic of dbcsr_tas_create_split
-!>        This is experimental and should be used for testing purposes only!
+!> \brief Create default cartesian process grid that is consistent with default split heuristic
+!>        of dbcsr_tas_create_split
 !> \param mp_comm ...
-!> \param nblkrows_total ...
-!> \param nblkcols_total ...
+!> \param split_rowcol ...
+!> \param nsplit ...
 !> \return new communicator
 ! **************************************************************************************************
-   FUNCTION dbcsr_tas_mp_comm(mp_comm, nblkrows_total, nblkcols_total)
+   FUNCTION dbcsr_tas_mp_comm(mp_comm, split_rowcol, nsplit)
       INTEGER, INTENT(IN)                                :: mp_comm
-      INTEGER(KIND=int_8), INTENT(IN)                    :: nblkrows_total, nblkcols_total
+      INTEGER, INTENT(IN)                                :: split_rowcol
+      INTEGER, INTENT(INOUT)                             :: nsplit
       INTEGER                                            :: dbcsr_tas_mp_comm
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_tas_mp_comm', &
                                      routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: group_size, handle, iproc, numproc, s, &
-                                                            split_rowcol
-      INTEGER(KIND=int_8)                                :: d_max, d_min
-      INTEGER, DIMENSION(2)                              :: group_dims, mdims_group, myploc, npdims, &
-                                                            sort_indices
+      INTEGER                                            :: handle, iproc, numproc
+      INTEGER, DIMENSION(2)                              :: myploc, npdims
 
       CALL timeset(routineN, handle)
 
-      d_max = MAX(nblkrows_total, nblkcols_total)
-      d_min = MIN(nblkrows_total, nblkcols_total)
-
-      s = INT((d_max - 1)/d_min + 1)
-
       CALL mp_environ(numproc, iproc, mp_comm)
 
-      DO WHILE (MOD(numproc, s) .NE. 0)
-         s = s - 1
-      ENDDO
-
-      group_size = numproc/s
-      group_dims(:) = 0
-
-      CALL mp_dims_create(group_size, group_dims)
-      CALL sort(group_dims, 2, sort_indices)
-
-      IF (d_max == nblkrows_total) THEN
-         split_rowcol = rowsplit
-      ELSE
-         split_rowcol = colsplit
-      ENDIF
-
-      SELECT CASE (split_rowcol)
-      CASE (rowsplit)
-         mdims_group = [INT(nblkrows_total/s), INT(nblkcols_total)]
-      CASE (colsplit)
-         mdims_group = [INT(nblkrows_total), INT(nblkcols_total/s)]
-      END SELECT
-
-      IF (mdims_group(1) .GT. mdims_group(2)) THEN
-         CALL swap(group_dims)
-      ENDIF
-
-      SELECT CASE (split_rowcol)
-      CASE (rowsplit)
-         npdims(:) = [group_dims(1)*s, group_dims(2)]
-      CASE (colsplit)
-         npdims(:) = [group_dims(1), group_dims(2)*s]
-      END SELECT
+      npdims = dbcsr_tas_mp_dims(numproc, split_rowcol, nsplit)
 
       CALL mp_cart_create(mp_comm, 2, npdims, myploc, dbcsr_tas_mp_comm)
 
@@ -194,76 +179,235 @@ CONTAINS
    END FUNCTION
 
 ! **************************************************************************************************
-!> \brief Split Cartesian process grid using a default split heuristic. The split factor may not be
-!>        ideal.
-!> \param split_info object storing all data corresponding to split, submatrices and parallelization
-!> \param mp_comm ...
-!> \param nblkrows_total ...
-!> \param nblkcols_total ...
-!> \param nosplit Matrix should not be split
+!> \brief Get optimal process grid dimensions consistent with dbcsr_tas_create_split
+!> \param numproc ...
+!> \param split_rowcol ...
+!> \param nsplit ...
+!> \return ...
 ! **************************************************************************************************
-   SUBROUTINE dbcsr_tas_create_split(split_info, mp_comm, nblkrows_total, nblkcols_total, nosplit)
-      TYPE(dbcsr_tas_create_split_info), INTENT(OUT)              :: split_info
+   FUNCTION dbcsr_tas_mp_dims(numproc, split_rowcol, nsplit)
+      INTEGER, INTENT(IN)                                :: numproc
+      INTEGER, INTENT(IN)                                :: split_rowcol
+      INTEGER, INTENT(IN)                                :: nsplit
+      INTEGER, DIMENSION(2)                              :: dbcsr_tas_mp_dims
+
+      INTEGER                                            :: dbcsr_tas_mp_comm, nsplit_opt
+      INTEGER                                            :: group_size
+      INTEGER, DIMENSION(2)                              :: group_dims
+
+      nsplit_opt = opt_nsplit(numproc, nsplit, split_pgrid = .FALSE.)
+
+      group_size = numproc/nsplit_opt
+      group_dims(:) = 0
+
+      CALL mp_dims_create(group_size, group_dims)
+
+      ! here we choose order of group dims s.t. a split factor < nsplit_opt is favoured w.r.t.
+      ! optimal subgrid dimensions
+      SELECT CASE(split_rowcol)
+      CASE(rowsplit)
+         group_dims = [MINVAL(group_dims), MAXVAL(group_dims)]
+      CASE(colsplit)
+         group_dims = [MAXVAL(group_dims), MINVAL(group_dims)]
+      END SELECT
+
+      SELECT CASE (split_rowcol)
+      CASE (rowsplit)
+         dbcsr_tas_mp_dims(:) = [group_dims(1)*nsplit_opt, group_dims(2)]
+      CASE (colsplit)
+         dbcsr_tas_mp_dims(:) = [group_dims(1), group_dims(2)*nsplit_opt]
+      END SELECT
+
+   END FUNCTION
+
+! **************************************************************************************************
+!> \brief Heuristic to get good split factor for a given process grid OR a given number of processes
+!> \param numproc total number of processes or (if split_pgrid) process grid dimension to split
+!> \param nsplit Desired split factor
+!> \param split_pgrid whether to split process grid
+!> \param pdim_nonsplit if split_pgrid: other process grid dimension
+!> \return split factor consistent with process grid or number of processes
+! **************************************************************************************************
+   FUNCTION opt_nsplit(numproc, nsplit, split_pgrid, pdim_nonsplit)
+      INTEGER, INTENT(IN)                        :: numproc, nsplit
+      LOGICAL, INTENT(IN)                        :: split_pgrid
+      INTEGER, INTENT(IN), OPTIONAL              :: pdim_nonsplit
+      INTEGER, ALLOCATABLE, DIMENSION(:)         :: nsplit_list, nsplit_list_square, nsplit_list_accept
+      INTEGER                                    :: lb, ub, count, count_square, count_accept, split, &
+                                                    minpos, opt_nsplit
+      INTEGER, DIMENSION(2)                      :: dims_sub
+      REAL(KIND=real_8)                          :: nsplit_accept_ratio
+
+      DBCSR_ASSERT(nsplit > 0)
+
+      IF(split_pgrid) THEN
+         DBCSR_ASSERT(PRESENT(pdim_nonsplit))
+      ENDIF
+
+      IF(split_pgrid) THEN
+         ! if process grid dimensions are fixed, we need more flexibility in split factor in order
+         ! to obtain balanced grid dimensions --> larger accept ratio
+         nsplit_accept_ratio = default_nsplit_accept_ratio_2
+      ELSE
+         ! if process grid dimensions are flexible, less flexibility in split factor sufficient in
+         ! order to obtain balanced grid dimensions --> smaller accept ratio
+         nsplit_accept_ratio = default_nsplit_accept_ratio_1
+      ENDIF
+
+      lb = CEILING(REAL(nsplit, real_8)/nsplit_accept_ratio)
+      ub = FLOOR(REAL(nsplit, real_8)*nsplit_accept_ratio)
+
+      IF(ub < lb) ub = lb
+
+      ALLOCATE(nsplit_list(1:ub-lb+1), nsplit_list_square(1:ub-lb+1), nsplit_list_accept(1:ub-lb+1))
+      count = 0
+      count_square = 0
+      count_accept = 0
+      DO split = lb, ub
+         IF (MOD(numproc, split) == 0) THEN
+            count = count + 1
+            nsplit_list(count) = split
+
+            dims_sub = 0
+            IF (.NOT. split_pgrid) THEN
+               CALL mp_dims_create(numproc/split, dims_sub)
+            ELSE
+               dims_sub = [numproc/split, pdim_nonsplit]
+            ENDIF
+
+            IF (dims_sub(1) == dims_sub(2)) THEN
+               count_square = count_square + 1
+               nsplit_list_square(count_square) = split
+               count_accept = count_accept + 1
+               nsplit_list_accept(count_accept) = split
+            ELSEIF(accept_pgrid_dims(dims_sub, relative=.FALSE.)) THEN
+               count_accept = count_accept + 1
+               nsplit_list_accept(count_accept) = split
+            ENDIF
+
+         ENDIF
+      ENDDO
+
+      IF(count_square > 0) THEN
+         minpos = MINLOC(ABS(nsplit_list_square(1:count_square) - nsplit), DIM=1)
+         opt_nsplit = nsplit_list_square(minpos)
+      ELSEIF(count_accept > 0) THEN
+         minpos = MINLOC(ABS(nsplit_list_accept(1:count_accept) - nsplit), DIM=1)
+         opt_nsplit = nsplit_list_accept(minpos)
+      ELSEIF(count > 0) THEN
+         minpos = MINLOC(ABS(nsplit_list(1:count) - nsplit), DIM=1)
+         opt_nsplit = nsplit_list(minpos)
+      ELSE
+         opt_nsplit = nsplit
+         DO WHILE (MOD(numproc, opt_nsplit) .NE. 0)
+            opt_nsplit = opt_nsplit - 1
+         ENDDO
+      ENDIF
+
+   END FUNCTION
+
+! **************************************************************************************************
+!> \brief Derive optimal cartesian process grid from matrix sizes. This ensures optimality for
+!>        dense matrices only
+!> \param mp_comm ...
+!> \param nblkrows total number of block rows
+!> \param nblkcols total number of block columns
+!> \return MPI communicator
+! **************************************************************************************************
+   FUNCTION dbcsr_tas_mp_comm_from_matrix_sizes(mp_comm, nblkrows, nblkcols) RESULT(mp_comm_new)
       INTEGER, INTENT(IN)                                :: mp_comm
-      INTEGER(KIND=int_8), INTENT(IN)                    :: nblkrows_total, nblkcols_total
-      LOGICAL, INTENT(IN), OPTIONAL                      :: nosplit
+      INTEGER(KIND=int_8), INTENT(IN)                    :: nblkrows, nblkcols
+      INTEGER                                            :: nsplit, split_rowcol
+      INTEGER                                            :: mp_comm_new
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_tas_create_split', routineP = moduleN//':'//routineN
+      IF(nblkrows >= nblkcols) THEN
+         split_rowcol = rowsplit
+         nsplit = INT((nblkrows - 1)/nblkcols + 1)
+      ELSE
+         split_rowcol = colsplit
+         nsplit = INT((nblkcols - 1)/nblkrows + 1)
+      ENDIF
 
-      INTEGER                                            :: handle, igroup, iproc, numproc, s, &
-                                                            split_rowcol
-      INTEGER(KIND=int_8)                                :: d_max, d_min
+      mp_comm_new = dbcsr_tas_mp_comm(mp_comm, split_rowcol, nsplit)
+   END FUNCTION
+
+! **************************************************************************************************
+!> \brief Split Cartesian process grid using a default split heuristic.
+!> \param split_info object storing all data corresponding to split, submatrices and parallelization
+!> \param mp_comm MPI communicator with associated cartesian grid
+!> \param split_rowcol split rows or columns
+!> \param nsplit desired split factor, set to 0 if split factor of exactly 1 is required
+!> \param own_comm whether split_info should own communicator
+! **************************************************************************************************
+   SUBROUTINE dbcsr_tas_create_split(split_info, mp_comm, split_rowcol, nsplit, own_comm)
+      TYPE(dbcsr_tas_split_info), INTENT(OUT)            :: split_info
+      INTEGER, INTENT(IN)                                :: mp_comm
+      INTEGER, INTENT(IN)                                :: split_rowcol
+      INTEGER, INTENT(IN)                                :: nsplit
+      LOGICAL, INTENT(IN), OPTIONAL                      :: own_comm
+
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'dbcsr_tas_create_split', &
+                                                            routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: &
+         handle, iproc, numproc, igroup, nsplit_opt, pdim_split, pdim_nonsplit
       INTEGER, DIMENSION(2)                              :: pcoord, pdims, pdims_group
-      LOGICAL                                            :: nosplit_prv
 
       CALL timeset(routineN, handle)
 
-      IF (PRESENT(nosplit)) THEN
-         nosplit_prv = nosplit
+      CALL mp_environ(numproc, iproc, mp_comm)
+      CALL mp_environ(numproc, pdims, pcoord, mp_comm)
+
+      SELECT CASE (split_rowcol)
+      CASE (rowsplit)
+         pdim_split = pdims(1)
+         pdim_nonsplit = pdims(2)
+      CASE (colsplit)
+         pdim_split = pdims(2)
+         pdim_nonsplit = pdims(1)
+      END SELECT
+
+      IF (nsplit > 0) THEN
+         nsplit_opt = opt_nsplit(pdim_split, nsplit, split_pgrid=.TRUE., pdim_nonsplit=pdim_nonsplit)
       ELSE
-         nosplit_prv = .FALSE.
+         nsplit_opt = 1
       ENDIF
 
-      IF (nosplit_prv) THEN
-         s = 1
-         igroup = 0
-         split_rowcol = rowsplit
+      SELECT CASE (split_rowcol)
+      CASE (rowsplit)
+         pdims_group = [pdims(1)/nsplit_opt, pdims(2)]
+      CASE (colsplit)
+         pdims_group = [pdims(1), pdims(2)/nsplit_opt]
+      END SELECT
 
-      ELSE
+      igroup = pcoord(split_rowcol)/pdims_group(split_rowcol)
 
-         d_max = MAX(nblkrows_total, nblkcols_total)
-         d_min = MIN(nblkrows_total, nblkcols_total)
-
-         s = INT((d_max - 1)/d_min + 1)
-
-         CALL mp_environ(numproc, iproc, mp_comm)
-         CALL mp_environ(numproc, pdims, pcoord, mp_comm)
-
-         IF (d_max == nblkrows_total) THEN
-            split_rowcol = rowsplit
-         ELSE
-            split_rowcol = colsplit
-         ENDIF
-
-         DO WHILE (MOD(pdims(split_rowcol), s) .NE. 0)
-            s = s - 1
-         ENDDO
-
-         SELECT CASE (split_rowcol)
-         CASE (rowsplit)
-            pdims_group = [pdims(1)/s, pdims(2)]
-         CASE (colsplit)
-            pdims_group = [pdims(1), pdims(2)/s]
-         END SELECT
-
-         igroup = pcoord(split_rowcol)/pdims_group(split_rowcol)
-
-      ENDIF
-      CALL dbcsr_tas_create_split_rows_or_cols(split_info, mp_comm, s, igroup, split_rowcol)
+      CALL dbcsr_tas_create_split_rows_or_cols(split_info, mp_comm, nsplit_opt, igroup, split_rowcol, own_comm=own_comm)
 
       CALL timestop(handle)
 
    END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief Whether to accept proposed process grid dimensions (based on ratio of dimensions)
+!> \param dims ...
+!> \param relative ...
+!> \return ...
+! **************************************************************************************************
+   FUNCTION accept_pgrid_dims(dims, relative)
+      INTEGER, DIMENSION(2), INTENT(IN)          :: dims
+      LOGICAL, INTENT(IN)                        :: relative
+      INTEGER, DIMENSION(2)                      :: dims_opt
+      LOGICAL                                    :: accept_pgrid_dims
+
+      IF(relative) THEN
+         dims_opt = 0
+         CALL mp_dims_create(PRODUCT(dims), dims_opt)
+         accept_pgrid_dims = (MAXVAL(REAL(dims, real_8))/MAXVAL(dims_opt) .LT. default_pdims_accept_ratio)
+      ELSE
+         accept_pgrid_dims = (MAXVAL(REAL(dims, real_8))/MINVAL(dims) .LT. default_pdims_accept_ratio**2)
+      ENDIF
+   END FUNCTION
 
 ! **************************************************************************************************
 !> \brief Get info on split
@@ -276,7 +420,7 @@ CONTAINS
 !> \param pgrid_offset group-local offset in process grid
 ! **************************************************************************************************
    SUBROUTINE dbcsr_tas_get_split_info(info, mp_comm, nsplit, igroup, mp_comm_group, split_rowcol, pgrid_offset)
-      TYPE(dbcsr_tas_create_split_info), INTENT(IN)               :: info
+      TYPE(dbcsr_tas_split_info), INTENT(IN)             :: info
       INTEGER, INTENT(OUT), OPTIONAL                     :: mp_comm, nsplit, igroup, mp_comm_group, &
                                                             split_rowcol
       INTEGER, DIMENSION(2), INTENT(OUT), OPTIONAL       :: pgrid_offset
@@ -303,7 +447,7 @@ CONTAINS
 !> \param split_info ...
 ! **************************************************************************************************
    SUBROUTINE dbcsr_tas_release_info(split_info)
-      TYPE(dbcsr_tas_create_split_info), INTENT(INOUT)            :: split_info
+      TYPE(dbcsr_tas_split_info), INTENT(INOUT)          :: split_info
       LOGICAL                                            :: abort
 
       abort = .FALSE.
@@ -332,7 +476,7 @@ CONTAINS
 !> \param split_info ...
 ! **************************************************************************************************
    SUBROUTINE dbcsr_tas_info_hold(split_info)
-      TYPE(dbcsr_tas_create_split_info), INTENT(IN)               :: split_info
+      TYPE(dbcsr_tas_split_info), INTENT(IN)             :: split_info
 
       INTEGER, POINTER                                   :: ref => NULL()
 
@@ -430,8 +574,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE block_index_local_to_global(info, dist, row_group, column_group, &
                                           row, column)
-      TYPE(dbcsr_tas_create_split_info), INTENT(IN)               :: info
-      TYPE(dbcsr_tas_distribution_type), INTENT(IN)        :: dist
+      TYPE(dbcsr_tas_split_info), INTENT(IN)             :: info
+      TYPE(dbcsr_tas_distribution_type), INTENT(IN)      :: dist
       INTEGER, INTENT(IN), OPTIONAL                      :: row_group, column_group
       INTEGER(KIND=int_8), INTENT(OUT), OPTIONAL         :: row, column
 
@@ -466,7 +610,7 @@ CONTAINS
 !> \param column_group ...
 ! **************************************************************************************************
    SUBROUTINE block_index_global_to_local(info, dist, row, column, row_group, column_group)
-      TYPE(dbcsr_tas_create_split_info), INTENT(IN)               :: info
+      TYPE(dbcsr_tas_split_info), INTENT(IN)               :: info
       TYPE(dbcsr_tas_distribution_type), INTENT(IN)        :: dist
       INTEGER(KIND=int_8), INTENT(IN), OPTIONAL          :: row, column
       INTEGER, INTENT(OUT), OPTIONAL                     :: row_group, column_group
@@ -550,8 +694,8 @@ CONTAINS
 !> \param rowcols rows/ columns on this group
 ! **************************************************************************************************
    SUBROUTINE group_to_mrowcol(info, rowcol_dist, igroup, rowcols)
-      TYPE(dbcsr_tas_create_split_info), INTENT(IN)                        :: info
-      CLASS(dbcsr_tas_distribution), INTENT(IN)                     :: rowcol_dist
+      TYPE(dbcsr_tas_split_info), INTENT(IN)                      :: info
+      CLASS(dbcsr_tas_distribution), INTENT(IN)                   :: rowcol_dist
       INTEGER, INTENT(IN)                                         :: igroup
       INTEGER(KIND=int_8), DIMENSION(:), ALLOCATABLE, INTENT(OUT) :: rowcols
       INTEGER, DIMENSION(0:info%pgrid_split_size - 1)             :: nrowcols_group

--- a/src/tas/dbcsr_tas_types.F
+++ b/src/tas/dbcsr_tas_types.F
@@ -44,6 +44,7 @@ MODULE dbcsr_tas_types
       INTEGER :: pgrid_split_size ! how many process rows/cols in subgroups
       INTEGER :: group_size ! group size (how many cores) of subgroups
       INTEGER :: mp_comm_group ! sub communicator
+      LOGICAL :: strict_split = .FALSE. ! if .true., split factor should not be modified (for testing only)
       INTEGER, POINTER :: refcount => NULL() ! lightweight reference counting for communicators
    END TYPE
 

--- a/src/tas/dbcsr_tas_types.F
+++ b/src/tas/dbcsr_tas_types.F
@@ -16,11 +16,10 @@
 
 MODULE dbcsr_tas_types
 
-   USE dbcsr_tas_global, ONLY: dbcsr_tas_distribution, &
-                               dbcsr_tas_rowcol_data
-   USE dbcsr_types, ONLY: dbcsr_distribution_obj, &
-                          dbcsr_iterator, &
-                          dbcsr_type
+   USE dbcsr_tas_global, ONLY: &
+      dbcsr_tas_distribution, dbcsr_tas_rowcol_data
+   USE dbcsr_types, ONLY: &
+      dbcsr_distribution_obj, dbcsr_iterator, dbcsr_type
    USE dbcsr_kinds, ONLY: int_8
 #include "../base/dbcsr_base_uses.f90"
 
@@ -32,12 +31,12 @@ MODULE dbcsr_tas_types
    PUBLIC :: &
       dbcsr_tas_distribution_type, &
       dbcsr_tas_iterator, &
-      dbcsr_tas_create_split_info, &
+      dbcsr_tas_split_info, &
       dbcsr_tas_type
 
    ! info on MPI Cartesian grid that is split on MPI subgroups.
    ! info on distribution of matrix rows / columns to different subgroups.
-   TYPE dbcsr_tas_create_split_info
+   TYPE dbcsr_tas_split_info
       INTEGER :: mp_comm ! global communicator
       INTEGER :: igroup ! which subgroup do I belong to
       INTEGER :: ngroup ! how many groups in total
@@ -49,7 +48,7 @@ MODULE dbcsr_tas_types
    END TYPE
 
    TYPE dbcsr_tas_distribution_type
-      TYPE(dbcsr_tas_create_split_info) :: info
+      TYPE(dbcsr_tas_split_info) :: info
       TYPE(dbcsr_distribution_obj) :: dbcsr_dist
       CLASS(dbcsr_tas_distribution), ALLOCATABLE :: row_dist
       CLASS(dbcsr_tas_distribution), ALLOCATABLE :: col_dist
@@ -72,7 +71,7 @@ MODULE dbcsr_tas_types
    END TYPE
 
    TYPE dbcsr_tas_iterator
-      TYPE(dbcsr_tas_create_split_info) :: info
+      TYPE(dbcsr_tas_split_info) :: info
       TYPE(dbcsr_tas_distribution_type) :: dist
       TYPE(dbcsr_iterator) :: iter
    END TYPE dbcsr_tas_iterator

--- a/src/tensors/dbcsr_tensor.F
+++ b/src/tensors/dbcsr_tensor.F
@@ -1520,7 +1520,6 @@ CONTAINS
       LOGICAL, INTENT(OUT), OPTIONAL                 :: do_crop_1, do_crop_2
       LOGICAL, DIMENSION(2)                          :: do_crop
 
-      !do_crop_1 = .FALSE.; do_crop_2 = .FALSE.
       do_crop = .FALSE.
 
       bounds_t1(1, :) = 1

--- a/src/tensors/dbcsr_tensor.F
+++ b/src/tensors/dbcsr_tensor.F
@@ -349,7 +349,8 @@ CONTAINS
 !>                      this guarantees optimal parameters only for dense matrices.
 !> \param pgrid_opt_1 Optionally return optimal process grid for tensor_1. This can be used to choose
 !>                    optimal process grids for subsequent tensor contractions with tensors of similar
-!>                    shape and sparsity.
+!>                    shape and sparsity. Under some conditions, pgrid_opt_1 can not be returned, in this
+!>                    case the pointer is not associated.
 !> \param pgrid_opt_2 Optionally return optimal process grid for tensor_2.
 !> \param pgrid_opt_3 Optionally return optimal process grid for tensor_3.
 !> \param filter_eps As in DBCSR mm
@@ -368,7 +369,7 @@ CONTAINS
                                filter_eps, flop, move_data, unit_nr, log_verbose)
       TYPE(dbcsr_scalar_type), INTENT(IN)            :: alpha
       TYPE(dbcsr_t_type), INTENT(INOUT), TARGET      :: tensor_1, tensor_2
-      TYPE(dbcsr_scalar_type), INTENT(IN) :: beta
+      TYPE(dbcsr_scalar_type), INTENT(IN)            :: beta
       INTEGER, DIMENSION(:), INTENT(IN)              :: contract_1, contract_2, map_1, map_2
       INTEGER, DIMENSION(:), INTENT(IN)              :: notcontract_1, notcontract_2
       TYPE(dbcsr_t_type), INTENT(INOUT), TARGET      :: tensor_3
@@ -380,14 +381,14 @@ CONTAINS
          INTENT(IN), OPTIONAL                        :: bounds_3
       LOGICAL, INTENT(IN), OPTIONAL                  :: optimize_dist
       TYPE(dbcsr_t_pgrid_type), INTENT(OUT), &
-         OPTIONAL                                    :: pgrid_opt_1, pgrid_opt_2, pgrid_opt_3
+         POINTER, OPTIONAL                           :: pgrid_opt_1, pgrid_opt_2, pgrid_opt_3
       REAL(KIND=real_8), INTENT(IN), OPTIONAL        :: filter_eps
       INTEGER(KIND=int_8), INTENT(OUT), OPTIONAL     :: flop
       LOGICAL, INTENT(IN), OPTIONAL                  :: move_data
       INTEGER, OPTIONAL, INTENT(IN)                  :: unit_nr
       LOGICAL, INTENT(IN), OPTIONAL                  :: log_verbose
 
-      TYPE(dbcsr_t_type), POINTER                    :: tensor_contr_1 => NULL(), tensor_contr_2 => NULL(), tensor_contr_3 => NULL()
+      TYPE(dbcsr_t_type), POINTER                    :: tensor_contr_1, tensor_contr_2, tensor_contr_3
       TYPE(dbcsr_t_type)                             :: tensor_algn_1, tensor_algn_2, tensor_algn_3
       TYPE(dbcsr_t_type), POINTER                    :: tensor_crop_1, tensor_crop_2
       LOGICAL                                        :: assert_stmt
@@ -406,16 +407,18 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_contract', &
                                      routineP = moduleN//':'//routineN
-      CHARACTER(LEN=1), DIMENSION(:), ALLOCATABLE :: indchar1, indchar2, indchar3, indchar1_mod, &
-                                                     indchar2_mod, indchar3_mod
+      CHARACTER(LEN=1), DIMENSION(:), ALLOCATABLE    :: indchar1, indchar2, indchar3, indchar1_mod, &
+                                                        indchar2_mod, indchar3_mod
       CHARACTER(LEN=1), DIMENSION(15) :: alph = &
                                          ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o']
       INTEGER, DIMENSION(2, dbcsr_t_ndims(tensor_1)) :: bounds_t1
       INTEGER, DIMENSION(2, dbcsr_t_ndims(tensor_2)) :: bounds_t2
-      LOGICAL :: do_crop_1, do_crop_2
-      TYPE(dbcsr_tas_split_info) :: split_opt
+      LOGICAL                                        :: do_crop_1, do_crop_2
+      TYPE(dbcsr_tas_split_info), POINTER            :: split_opt
 
       CALL timeset(routineN, handle)
+
+      NULLIFY(tensor_contr_1, tensor_contr_2, tensor_contr_3, tensor_crop_1, tensor_crop_2, split_opt)
 
       DBCSR_ASSERT(tensor_1%valid)
       DBCSR_ASSERT(tensor_2%valid)
@@ -667,34 +670,31 @@ CONTAINS
                               split_opt=split_opt, &
                               move_data_a=move_data_1, move_data_b=move_data_2)
 
-      IF(PRESENT(pgrid_opt_1)) THEN
-         IF(new_1) THEN
-            CALL dbcsr_abort(__LOCATION__, &
-                             "pgrid_opt_1 can not be returned because tensor_1 not in matrix multiplication compatible layout")
-         ELSE
+      IF(PRESENT(pgrid_opt_1) .AND. ASSOCIATED(split_opt)) THEN
+         IF(.NOT. new_1) THEN
+            ALLOCATE(pgrid_opt_1)
             pgrid_opt_1 = opt_pgrid(tensor_1, split_opt)
          ENDIF
       ENDIF
 
-      IF(PRESENT(pgrid_opt_2)) THEN
-         IF(new_2) THEN
-            CALL dbcsr_abort(__LOCATION__, &
-                             "pgrid_opt_2 can not be returned because tensor_2 not in matrix multiplication compatible layout")
-         ELSE
+      IF(PRESENT(pgrid_opt_2) .AND. ASSOCIATED(split_opt)) THEN
+         IF(.NOT. new_2) THEN
+            ALLOCATE(pgrid_opt_2)
             pgrid_opt_2 = opt_pgrid(tensor_2, split_opt)
          ENDIF
       ENDIF
 
-      IF(PRESENT(pgrid_opt_3)) THEN
-         IF(new_3) THEN
-            CALL dbcsr_abort(__LOCATION__, &
-                             "pgrid_opt_3 can not be returned because tensor_3 not in matrix multiplication compatible layout")
-         ELSE
+      IF(PRESENT(pgrid_opt_3) .AND. ASSOCIATED(split_opt)) THEN
+         IF(.NOT. new_3) THEN
+            ALLOCATE(pgrid_opt_3)
             pgrid_opt_3 = opt_pgrid(tensor_3, split_opt)
          ENDIF
       ENDIF
 
-      CALL dbcsr_tas_release_info(split_opt)
+      IF(ASSOCIATED(split_opt)) THEN
+         CALL dbcsr_tas_release_info(split_opt)
+         DEALLOCATE(split_opt)
+      ENDIF
 
       IF (PRESENT(unit_nr)) THEN
          CALL dbcsr_t_write_tensor_info(tensor_contr_3, unit_nr, full_info=log_verbose)

--- a/src/tensors/dbcsr_tensor.F
+++ b/src/tensors/dbcsr_tensor.F
@@ -35,6 +35,7 @@ MODULE dbcsr_tensor
       dbcsr_iterator_next_block, dbcsr_iterator_start, dbcsr_iterator_stop, &
       dbcsr_transpose, dbcsr_no_transpose, dbcsr_scalar, dbcsr_put_block, &
       ${uselist(dtype_float_param)}$, dbcsr_clear
+   USE dbcsr_tas_types, ONLY: dbcsr_tas_split_info
    USE dbcsr_tas_base, ONLY: &
       dbcsr_tas_copy, dbcsr_tas_finalize, dbcsr_tas_get_data_type, dbcsr_tas_get_info, dbcsr_tas_info
    USE dbcsr_tas_mm, ONLY: dbcsr_tas_multiply
@@ -48,7 +49,7 @@ MODULE dbcsr_tensor
                                  ndims_iterator, &
                                  dbcsr_t_reserve_blocks, &
                                  block_nd
-   USE dbcsr_tensor_index, ONLY: get_mapping_info, &
+   USE dbcsr_tensor_index, ONLY: dbcsr_t_get_mapping_info, &
                                  nd_to_2d_mapping, &
                                  dbcsr_t_inverse_order, &
                                  permute_index
@@ -82,7 +83,8 @@ MODULE dbcsr_tensor
    USE dbcsr_toollib, ONLY: sort
    USE dbcsr_tensor_reshape, ONLY: dbcsr_t_reshape
    USE dbcsr_mpiwrap, ONLY: mp_comm_free
-   USE dbcsr_tas_split, ONLY: dbcsr_tas_mp_comm
+   USE dbcsr_tas_split, ONLY: &
+      dbcsr_tas_mp_comm, rowsplit, colsplit, dbcsr_tas_info_hold, dbcsr_tas_release_info
    USE dbcsr_data_types, ONLY: dbcsr_scalar_type
    USE dbcsr_tensor_split, ONLY: dbcsr_t_split_copyback, &
                                  dbcsr_t_make_compatible_blocks,&
@@ -198,8 +200,8 @@ CONTAINS
          out_tmp_1 => tensor_out
       ENDIF
 
-      CALL get_mapping_info(in_tmp_2%nd_index, map1_2d=map1_in_1, map2_2d=map1_in_2)
-      CALL get_mapping_info(out_tmp_1%nd_index, map1_2d=map2_in_1, map2_2d=map2_in_2)
+      CALL dbcsr_t_get_mapping_info(in_tmp_2%nd_index, map1_2d=map1_in_1, map2_2d=map1_in_2)
+      CALL dbcsr_t_get_mapping_info(out_tmp_1%nd_index, map1_2d=map2_in_1, map2_2d=map2_in_2)
 
       IF (.NOT. PRESENT(order)) THEN
          IF (array_eq_i(map1_in_1, map2_in_1) .AND. array_eq_i(map1_in_2, map2_in_2)) THEN
@@ -343,7 +345,13 @@ CONTAINS
 !> \param bounds_1 bounds corresponding to contract_1 AKA contract_2
 !> \param bounds_2 bounds corresponding to notcontract_1
 !> \param bounds_3 bounds corresponding to notcontract_2
-!> \param optimize_dist experimental: optimize distribution of tensors
+!> \param optimize_dist Whether distribution should be optimized internally. In the current implementation
+!>                      this guarantees optimal parameters only for dense matrices.
+!> \param pgrid_opt_1 Optionally return optimal process grid for tensor_1. This can be used to choose
+!>                    optimal process grids for subsequent tensor contractions with tensors of similar
+!>                    shape and sparsity.
+!> \param pgrid_opt_2 Optionally return optimal process grid for tensor_2.
+!> \param pgrid_opt_3 Optionally return optimal process grid for tensor_3.
 !> \param filter_eps As in DBCSR mm
 !> \param flop As in DBCSR mm
 !> \param move_data memory optimization: transfer data such that tensor_1 and tensor_2 may be empty
@@ -356,9 +364,10 @@ CONTAINS
                                contract_2, notcontract_2, &
                                map_1, map_2, &
                                bounds_1, bounds_2, bounds_3, &
-                               optimize_dist, filter_eps, flop, move_data, unit_nr, log_verbose)
-      TYPE(dbcsr_scalar_type), INTENT(IN) :: alpha
-      TYPE(dbcsr_t_type), INTENT(INOUT), TARGET  :: tensor_1, tensor_2
+                               optimize_dist, pgrid_opt_1, pgrid_opt_2, pgrid_opt_3, &
+                               filter_eps, flop, move_data, unit_nr, log_verbose)
+      TYPE(dbcsr_scalar_type), INTENT(IN)            :: alpha
+      TYPE(dbcsr_t_type), INTENT(INOUT), TARGET      :: tensor_1, tensor_2
       TYPE(dbcsr_scalar_type), INTENT(IN) :: beta
       INTEGER, DIMENSION(:), INTENT(IN)              :: contract_1, contract_2, map_1, map_2
       INTEGER, DIMENSION(:), INTENT(IN)              :: notcontract_1, notcontract_2
@@ -370,8 +379,10 @@ CONTAINS
       INTEGER, DIMENSION(2, SIZE(notcontract_2)), &
          INTENT(IN), OPTIONAL                        :: bounds_3
       LOGICAL, INTENT(IN), OPTIONAL                  :: optimize_dist
+      TYPE(dbcsr_t_pgrid_type), INTENT(OUT), &
+         OPTIONAL                                    :: pgrid_opt_1, pgrid_opt_2, pgrid_opt_3
       REAL(KIND=real_8), INTENT(IN), OPTIONAL        :: filter_eps
-      INTEGER(KIND=int_8), INTENT(OUT), OPTIONAL       :: flop
+      INTEGER(KIND=int_8), INTENT(OUT), OPTIONAL     :: flop
       LOGICAL, INTENT(IN), OPTIONAL                  :: move_data
       INTEGER, OPTIONAL, INTENT(IN)                  :: unit_nr
       LOGICAL, INTENT(IN), OPTIONAL                  :: log_verbose
@@ -388,7 +399,7 @@ CONTAINS
       INTEGER, DIMENSION(SIZE(map_1))                :: map_1_mod
       INTEGER, DIMENSION(SIZE(map_2))                :: map_2_mod
       CHARACTER(LEN=1)                               :: trans_1, trans_2, trans_3
-      LOGICAL                                        :: new_1, new_2, new_3
+      LOGICAL                                        :: new_1, new_2, new_3, move_data_1, move_data_2
       INTEGER                                        :: ndims1, ndims2, ndims3
       INTEGER                                        :: occ_1, occ_2
       INTEGER, DIMENSION(:), ALLOCATABLE             :: dims1, dims2, dims3
@@ -402,6 +413,7 @@ CONTAINS
       INTEGER, DIMENSION(2, dbcsr_t_ndims(tensor_1)) :: bounds_t1
       INTEGER, DIMENSION(2, dbcsr_t_ndims(tensor_2)) :: bounds_t2
       LOGICAL :: do_crop_1, do_crop_2
+      TYPE(dbcsr_tas_split_info) :: split_opt
 
       CALL timeset(routineN, handle)
 
@@ -430,6 +442,14 @@ CONTAINS
       assert_stmt = dbcsr_t_get_data_type(tensor_1) .EQ. dbcsr_t_get_data_type(tensor_2)
       DBCSR_ASSERT(assert_stmt)
 
+      IF(PRESENT(move_data)) THEN
+         move_data_1 = move_data
+         move_data_2 = move_data
+      ELSE
+         move_data_1 = .FALSE.
+         move_data_2 = .FALSE.
+      ENDIF
+
       CALL dbcsr_t_map_bounds_to_tensors(tensor_1, tensor_2, &
                                          contract_1, notcontract_1, &
                                          contract_2, notcontract_2, &
@@ -439,14 +459,16 @@ CONTAINS
 
       IF(do_crop_1) THEN
          ALLOCATE(tensor_crop_1)
-         CALL dbcsr_t_crop(tensor_1, tensor_crop_1, bounds_t1)
+         CALL dbcsr_t_crop(tensor_1, tensor_crop_1, bounds_t1, move_data=move_data_1)
+         move_data_1 = .TRUE.
       ELSE
          tensor_crop_1 => tensor_1
       ENDIF
 
       IF(do_crop_2) THEN
          ALLOCATE(tensor_crop_2)
-         CALL dbcsr_t_crop(tensor_2,tensor_crop_2,  bounds_t2)
+         CALL dbcsr_t_crop(tensor_2, tensor_crop_2,  bounds_t2, move_data=move_data_2)
+         move_data_2 = .TRUE.
       ELSE
          tensor_crop_2 => tensor_2
       ENDIF
@@ -462,6 +484,14 @@ CONTAINS
 
       IF (occ_1 == 0 .OR. occ_2 == 0) THEN
          CALL dbcsr_t_scale(tensor_3, beta)
+         IF(do_crop_1) THEN
+            CALL dbcsr_t_destroy(tensor_crop_1)
+            DEALLOCATE(tensor_crop_1)
+         ENDIF
+         IF(do_crop_2) THEN
+            CALL dbcsr_t_destroy(tensor_crop_2)
+            DEALLOCATE(tensor_crop_2)
+         ENDIF
          CALL timestop(handle)
          RETURN
       ENDIF
@@ -555,10 +585,10 @@ CONTAINS
          CALL reshape_mm_compatible(tensor_algn_1, tensor_algn_3, tensor_contr_1, tensor_contr_3, &
                                     contract_1_mod, notcontract_1_mod, map_2_mod, map_1_mod, &
                                     trans_1, trans_3, new_1, new_3, nodata2=.TRUE., optimize_dist=optimize_dist, &
-                                    move_data=move_data, unit_nr=unit_nr)
+                                    move_data_1=move_data_1, unit_nr=unit_nr)
 
          CALL reshape_mm_small(tensor_algn_2, contract_2_mod, notcontract_2_mod, tensor_contr_2, trans_2, &
-                               new_2, move_data=move_data, unit_nr=unit_nr)
+                               new_2, move_data=move_data_2, unit_nr=unit_nr)
 
       CASE (2)
          IF (PRESENT(unit_nr)) THEN
@@ -582,11 +612,11 @@ CONTAINS
          CALL reshape_mm_compatible(tensor_algn_1, tensor_algn_2, tensor_contr_1, tensor_contr_2, &
                                     notcontract_1_mod, contract_1_mod, notcontract_2_mod, contract_2_mod, &
                                     trans_1, trans_2, new_1, new_2, optimize_dist=optimize_dist, &
-                                    move_data=move_data, unit_nr=unit_nr)
+                                    move_data_1=move_data_1, move_data_2=move_data_2, unit_nr=unit_nr)
          CALL invert_transpose_flag(trans_1)
 
          CALL reshape_mm_small(tensor_algn_3, map_1_mod, map_2_mod, tensor_contr_3, trans_3, &
-                               new_3, nodata=.TRUE., move_data=move_data, unit_nr=unit_nr)
+                               new_3, nodata=.TRUE., unit_nr=unit_nr)
 
       CASE (3)
          IF (PRESENT(unit_nr)) THEN
@@ -609,13 +639,13 @@ CONTAINS
          CALL reshape_mm_compatible(tensor_algn_2, tensor_algn_3, tensor_contr_2, tensor_contr_3, &
                                     contract_2_mod, notcontract_2_mod, map_1_mod, map_2_mod, &
                                     trans_2, trans_3, new_2, new_3, nodata2=.TRUE., optimize_dist=optimize_dist, &
-                                    move_data=move_data, unit_nr=unit_nr)
+                                    move_data_1=move_data_2, unit_nr=unit_nr)
 
          CALL invert_transpose_flag(trans_2)
          CALL invert_transpose_flag(trans_3)
 
          CALL reshape_mm_small(tensor_algn_1, notcontract_1_mod, contract_1_mod, tensor_contr_1, &
-                               trans_1, new_1, move_data=move_data, unit_nr=unit_nr)
+                               trans_1, new_1, move_data=move_data_1, unit_nr=unit_nr)
 
       END SELECT
 
@@ -633,7 +663,38 @@ CONTAINS
                               tensor_contr_1%matrix_rep, tensor_contr_2%matrix_rep, &
                               beta, &
                               tensor_contr_3%matrix_rep, filter_eps=filter_eps, flop=flop, &
-                              io_unit=unit_nr, log_verbose=log_verbose)
+                              io_unit=unit_nr, log_verbose=log_verbose, &
+                              split_opt=split_opt, &
+                              move_data_a=move_data_1, move_data_b=move_data_2)
+
+      IF(PRESENT(pgrid_opt_1)) THEN
+         IF(new_1) THEN
+            CALL dbcsr_abort(__LOCATION__, &
+                             "pgrid_opt_1 can not be returned because tensor_1 not in matrix multiplication compatible layout")
+         ELSE
+            pgrid_opt_1 = opt_pgrid(tensor_1, split_opt)
+         ENDIF
+      ENDIF
+
+      IF(PRESENT(pgrid_opt_2)) THEN
+         IF(new_2) THEN
+            CALL dbcsr_abort(__LOCATION__, &
+                             "pgrid_opt_2 can not be returned because tensor_2 not in matrix multiplication compatible layout")
+         ELSE
+            pgrid_opt_2 = opt_pgrid(tensor_2, split_opt)
+         ENDIF
+      ENDIF
+
+      IF(PRESENT(pgrid_opt_3)) THEN
+         IF(new_3) THEN
+            CALL dbcsr_abort(__LOCATION__, &
+                             "pgrid_opt_3 can not be returned because tensor_3 not in matrix multiplication compatible layout")
+         ELSE
+            pgrid_opt_3 = opt_pgrid(tensor_3, split_opt)
+         ENDIF
+      ENDIF
+
+      CALL dbcsr_tas_release_info(split_opt)
 
       IF (PRESENT(unit_nr)) THEN
          CALL dbcsr_t_write_tensor_info(tensor_contr_3, unit_nr, full_info=log_verbose)
@@ -643,7 +704,7 @@ CONTAINS
       IF (new_3) THEN
          ! need redistribute if we created new tensor for tensor 3
          CALL dbcsr_t_scale(tensor_algn_3, beta)
-         CALL dbcsr_t_copy(tensor_contr_3, tensor_algn_3, summation=.TRUE., move_data=move_data)
+         CALL dbcsr_t_copy(tensor_contr_3, tensor_algn_3, summation=.TRUE., move_data=.TRUE.)
          IF (PRESENT(filter_eps)) CALL dbcsr_t_filter(tensor_algn_3, filter_eps)
          ! tensor_3 automatically has correct data because tensor_algn_3 contains a matrix
          ! pointer to data of tensor_3
@@ -691,7 +752,7 @@ CONTAINS
 
       CALL timestop(handle)
 
-   CONTAINS
+   END SUBROUTINE
 
 ! **************************************************************************************************
 !> \brief align tensor index with data
@@ -702,25 +763,25 @@ CONTAINS
 !> \param contract_out ...
 !> \param notcontract_out ...
 ! **************************************************************************************************
-      SUBROUTINE align_tensor(tensor_in, contract_in, notcontract_in, &
-                              tensor_out, contract_out, notcontract_out, indp_in, indp_out)
-         TYPE(dbcsr_t_type), INTENT(INOUT)               :: tensor_in
-         INTEGER, DIMENSION(:), INTENT(IN)            :: contract_in, notcontract_in
-         TYPE(dbcsr_t_type), INTENT(OUT)              :: tensor_out
-         INTEGER, DIMENSION(SIZE(contract_in)), &
-            INTENT(OUT)                               :: contract_out
-         INTEGER, DIMENSION(SIZE(notcontract_in)), &
-            INTENT(OUT)                               :: notcontract_out
-         CHARACTER(LEN=1), DIMENSION(dbcsr_t_ndims(tensor_in)), INTENT(IN) :: indp_in
-         CHARACTER(LEN=1), DIMENSION(dbcsr_t_ndims(tensor_in)), INTENT(OUT) :: indp_out
-         INTEGER, DIMENSION(dbcsr_t_ndims(tensor_in)) :: align
+   SUBROUTINE align_tensor(tensor_in, contract_in, notcontract_in, &
+                           tensor_out, contract_out, notcontract_out, indp_in, indp_out)
+      TYPE(dbcsr_t_type), INTENT(INOUT)               :: tensor_in
+      INTEGER, DIMENSION(:), INTENT(IN)            :: contract_in, notcontract_in
+      TYPE(dbcsr_t_type), INTENT(OUT)              :: tensor_out
+      INTEGER, DIMENSION(SIZE(contract_in)), &
+         INTENT(OUT)                               :: contract_out
+      INTEGER, DIMENSION(SIZE(notcontract_in)), &
+         INTENT(OUT)                               :: notcontract_out
+      CHARACTER(LEN=1), DIMENSION(dbcsr_t_ndims(tensor_in)), INTENT(IN) :: indp_in
+      CHARACTER(LEN=1), DIMENSION(dbcsr_t_ndims(tensor_in)), INTENT(OUT) :: indp_out
+      INTEGER, DIMENSION(dbcsr_t_ndims(tensor_in)) :: align
 
-         CALL dbcsr_t_align_index(tensor_in, tensor_out, order=align)
-         contract_out = align(contract_in)
-         notcontract_out = align(notcontract_in)
-         indp_out(align) = indp_in
+      CALL dbcsr_t_align_index(tensor_in, tensor_out, order=align)
+      contract_out = align(contract_in)
+      notcontract_out = align(notcontract_in)
+      indp_out(align) = indp_in
 
-      END SUBROUTINE
+   END SUBROUTINE
 
 ! **************************************************************************************************
 !> \brief Prepare tensor for contraction: redistribute to a 2d format which can be contracted by
@@ -740,57 +801,195 @@ CONTAINS
 !> \param new2 whether a new tensor 2 was created
 !> \param nodata1 don't copy data of tensor 1
 !> \param nodata2 don't copy data of tensor 2
-!> \param move_data memory optimization: transfer data s.t. tensor1 and tensor2 may be empty on return
+!> \param move_data_1 memory optimization: transfer data s.t. tensor1 may be empty on return
+!> \param move_data_2 memory optimization: transfer data s.t. tensor2 may be empty on return
 !> \param optimize_dist experimental: optimize distribution
 !> \param unit_nr output unit
 ! **************************************************************************************************
-      SUBROUTINE reshape_mm_compatible(tensor1, tensor2, tensor1_out, tensor2_out, ind1_free, ind1_linked, &
-                                       ind2_free, ind2_linked, trans1, trans2, new1, new2, nodata1, nodata2, move_data, &
-                                       optimize_dist, unit_nr)
-         TYPE(dbcsr_t_type), TARGET, INTENT(INOUT)   :: tensor1
-         TYPE(dbcsr_t_type), TARGET, INTENT(INOUT)   :: tensor2
-         TYPE(dbcsr_t_type), POINTER, INTENT(OUT)    :: tensor1_out, tensor2_out
-         INTEGER, DIMENSION(:), INTENT(IN)           :: ind1_free, ind2_free
-         INTEGER, DIMENSION(:), INTENT(IN)           :: ind1_linked, ind2_linked
-         CHARACTER(LEN=1), INTENT(OUT)               :: trans1, trans2
-         LOGICAL, INTENT(OUT)                        :: new1, new2
-         LOGICAL, INTENT(IN), OPTIONAL               :: nodata1, nodata2, move_data
-         LOGICAL, INTENT(IN), OPTIONAL               :: optimize_dist
-         INTEGER, INTENT(IN), OPTIONAL               :: unit_nr
-         INTEGER                                     :: ref_tensor, compat1, compat1_old, compat2, compat2_old, &
-                                                        comm_2d, io_unit
-         TYPE(array_list)                            :: dist_list
-         INTEGER, DIMENSION(:), ALLOCATABLE          :: mp_dims, dims
-         TYPE(dbcsr_t_distribution_type)             :: dist_in
-         INTEGER(KIND=int_8)                         :: nblkrows, nblkcols
-         LOGICAL                                     :: optimize_dist_prv
+   SUBROUTINE reshape_mm_compatible(tensor1, tensor2, tensor1_out, tensor2_out, ind1_free, ind1_linked, &
+                                    ind2_free, ind2_linked, trans1, trans2, new1, new2, nodata1, nodata2, move_data_1, &
+                                    move_data_2, optimize_dist, unit_nr)
+      TYPE(dbcsr_t_type), TARGET, INTENT(INOUT)   :: tensor1
+      TYPE(dbcsr_t_type), TARGET, INTENT(INOUT)   :: tensor2
+      TYPE(dbcsr_t_type), POINTER, INTENT(OUT)    :: tensor1_out, tensor2_out
+      INTEGER, DIMENSION(:), INTENT(IN)           :: ind1_free, ind2_free
+      INTEGER, DIMENSION(:), INTENT(IN)           :: ind1_linked, ind2_linked
+      CHARACTER(LEN=1), INTENT(OUT)               :: trans1, trans2
+      LOGICAL, INTENT(OUT)                        :: new1, new2
+      LOGICAL, INTENT(IN), OPTIONAL               :: nodata1, nodata2
+      LOGICAL, INTENT(INOUT), OPTIONAL            :: move_data_1, move_data_2
+      LOGICAL, INTENT(IN), OPTIONAL               :: optimize_dist
+      INTEGER, INTENT(IN), OPTIONAL               :: unit_nr
+      INTEGER                                     :: ref_tensor, compat1, compat1_old, compat2, compat2_old, &
+                                                     comm_2d, io_unit
+      TYPE(array_list)                            :: dist_list
+      INTEGER, DIMENSION(:), ALLOCATABLE          :: mp_dims, dims
+      TYPE(dbcsr_t_distribution_type)             :: dist_in
+      INTEGER(KIND=int_8)                         :: nblkrows, nblkcols
+      LOGICAL                                     :: optimize_dist_prv
 
-         NULLIFY(tensor1_out, tensor2_out)
-         IF (PRESENT(unit_nr)) THEN
-            io_unit = unit_nr
+      NULLIFY(tensor1_out, tensor2_out)
+      IF (PRESENT(unit_nr)) THEN
+         io_unit = unit_nr
+      ELSE
+         io_unit = 0
+      ENDIF
+
+      IF (SIZE(ind1_free) .GE. SIZE(ind2_free)) THEN
+         ref_tensor = 1
+      ELSE
+         ref_tensor = 2
+      ENDIF
+
+      IF (PRESENT(optimize_dist)) THEN
+         optimize_dist_prv = optimize_dist
+      ELSE
+         optimize_dist_prv = .FALSE.
+      ENDIF
+
+      compat1 = compat_map(tensor1%nd_index, ind1_linked)
+      compat2 = compat_map(tensor2%nd_index, ind2_linked)
+      compat1_old = compat1
+      compat2_old = compat2
+
+      IF (io_unit > 0) THEN
+         WRITE (io_unit, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor1%name), ":"
+         SELECT CASE (compat1)
+         CASE (0)
+            WRITE (io_unit, '(A)') "Not compatible"
+         CASE (1)
+            WRITE (io_unit, '(A)') "Normal"
+         CASE (2)
+            WRITE (io_unit, '(A)') "Transposed"
+         END SELECT
+         WRITE (io_unit, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor2%name), ":"
+         SELECT CASE (compat2)
+         CASE (0)
+            WRITE (io_unit, '(A)') "Not compatible"
+         CASE (1)
+            WRITE (io_unit, '(A)') "Normal"
+         CASE (2)
+            WRITE (io_unit, '(A)') "Transposed"
+         END SELECT
+      ENDIF
+
+      new1 = .FALSE.
+      new2 = .FALSE.
+
+      IF (compat1 == 0 .OR. optimize_dist_prv) THEN
+         new1 = .TRUE.
+      ENDIF
+
+      IF (compat2 == 0 .OR. optimize_dist_prv) THEN
+         new2 = .TRUE.
+      ENDIF
+
+      IF (ref_tensor == 1) THEN ! tensor 1 is reference and tensor 2 is reshaped compatible with tensor 1
+         IF (compat1 == 0 .OR. optimize_dist_prv) THEN ! tensor 1 is not contraction compatible --> reshape
+            IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "Redistribution of", TRIM(tensor1%name)
+            ALLOCATE (dims(dbcsr_t_ndims(tensor1)))
+            CALL blk_dims_tensor(tensor1, dims)
+            nblkrows = PRODUCT(INT(dims(ind1_linked), KIND=int_8))
+            nblkcols = PRODUCT(INT(dims(ind1_free), KIND=int_8))
+            comm_2d = dbcsr_tas_mp_comm(tensor1%pgrid%mp_comm_2d, nblkrows, nblkcols)
+            ALLOCATE (tensor1_out)
+            CALL dbcsr_t_remap(tensor1, ind1_linked, ind1_free, tensor1_out, comm_2d=comm_2d, &
+                               nodata=nodata1, move_data=move_data_1)
+            CALL mp_comm_free(comm_2d)
+            compat1 = 1
          ELSE
-            io_unit = 0
+            IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor1%name)
+            tensor1_out => tensor1
          ENDIF
-
-         IF (SIZE(ind1_free) .GE. SIZE(ind2_free)) THEN
-            ref_tensor = 1
+         IF (compat2 == 0 .OR. optimize_dist_prv) THEN ! tensor 2 is not contraction compatible --> reshape
+            IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A,1X,A,1X,A)') "Redistribution of", &
+               TRIM(tensor2%name), "compatible with", TRIM(tensor1%name)
+            dist_in = dbcsr_t_distribution(tensor1_out)
+            dist_list = array_sublist(dist_in%nd_dist, ind1_linked)
+            IF (compat1 == 1) THEN ! linked index is first 2d dimension
+               ! get distribution of linked index, tensor 2 must adopt this distribution
+               ! get grid dimensions of linked index
+               CALL dbcsr_t_get_mapping_info(dist_in%pgrid%nd_index_grid, dims1_2d=mp_dims)
+               ALLOCATE (tensor2_out)
+               CALL dbcsr_t_remap(tensor2, ind2_linked, ind2_free, tensor2_out, comm_2d=dist_in%pgrid%mp_comm_2d, &
+                                  dist1=dist_list, mp_dims_1=mp_dims, nodata=nodata2, move_data=move_data_2)
+            ELSEIF (compat1 == 2) THEN ! linked index is second 2d dimension
+               ! get distribution of linked index, tensor 2 must adopt this distribution
+               ! get grid dimensions of linked index
+               CALL dbcsr_t_get_mapping_info(dist_in%pgrid%nd_index_grid, dims2_2d=mp_dims)
+               ALLOCATE (tensor2_out)
+               CALL dbcsr_t_remap(tensor2, ind2_free, ind2_linked, tensor2_out, comm_2d=dist_in%pgrid%mp_comm_2d, &
+                                  dist2=dist_list, mp_dims_2=mp_dims, nodata=nodata2, move_data=move_data_2)
+            ELSE
+               DBCSR_ABORT("should not happen")
+            ENDIF
+            compat2 = compat1
          ELSE
-            ref_tensor = 2
+            IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor2%name)
+            tensor2_out => tensor2
          ENDIF
-
-         IF (PRESENT(optimize_dist)) THEN
-            optimize_dist_prv = optimize_dist
+      ELSE ! tensor 2 is reference and tensor 1 is reshaped compatible with tensor 2
+         IF (compat2 == 0 .OR. optimize_dist_prv) THEN ! tensor 2 is not contraction compatible --> reshape
+            IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "Redistribution of", TRIM(tensor2%name)
+            ALLOCATE (dims(dbcsr_t_ndims(tensor2)))
+            CALL blk_dims_tensor(tensor2, dims)
+            nblkrows = PRODUCT(INT(dims(ind2_linked), KIND=int_8))
+            nblkcols = PRODUCT(INT(dims(ind2_free), KIND=int_8))
+            comm_2d = dbcsr_tas_mp_comm(tensor2%pgrid%mp_comm_2d, nblkrows, nblkcols)
+            ALLOCATE (tensor2_out)
+            CALL dbcsr_t_remap(tensor2, ind2_linked, ind2_free, tensor2_out, nodata=nodata2, move_data=move_data_2)
+            CALL mp_comm_free(comm_2d)
+            compat2 = 1
          ELSE
-            optimize_dist_prv = .FALSE.
+            IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor2%name)
+            tensor2_out => tensor2
          ENDIF
+         IF (compat1 == 0 .OR. optimize_dist_prv) THEN ! tensor 1 is not contraction compatible --> reshape
+            IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A,1X,A,1X,A)') "Redistribution of", TRIM(tensor1%name), &
+               "compatible with", TRIM(tensor2%name)
+            dist_in = dbcsr_t_distribution(tensor2_out)
+            dist_list = array_sublist(dist_in%nd_dist, ind2_linked)
+            IF (compat2 == 1) THEN
+               CALL dbcsr_t_get_mapping_info(dist_in%pgrid%nd_index_grid, dims1_2d=mp_dims)
+               ALLOCATE (tensor1_out)
+               CALL dbcsr_t_remap(tensor1, ind1_linked, ind1_free, tensor1_out, comm_2d=dist_in%pgrid%mp_comm_2d, &
+                                  dist1=dist_list, mp_dims_1=mp_dims, nodata=nodata1, move_data=move_data_1)
+            ELSEIF (compat2 == 2) THEN
+               CALL dbcsr_t_get_mapping_info(dist_in%pgrid%nd_index_grid, dims2_2d=mp_dims)
+               ALLOCATE (tensor1_out)
+               CALL dbcsr_t_remap(tensor1, ind1_free, ind1_linked, tensor1_out, comm_2d=dist_in%pgrid%mp_comm_2d, &
+                                  dist2=dist_list, mp_dims_2=mp_dims, nodata=nodata1, move_data=move_data_1)
+            ELSE
+               DBCSR_ABORT("should not happen")
+            ENDIF
+            compat1 = compat2
+         ELSE
+            IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor1%name)
+            tensor1_out => tensor1
+         ENDIF
+      ENDIF
 
-         compat1 = compat_map(tensor1%nd_index, ind1_linked)
-         compat2 = compat_map(tensor2%nd_index, ind2_linked)
-         compat1_old = compat1
-         compat2_old = compat2
+      SELECT CASE (compat1)
+      CASE (1)
+         trans1 = dbcsr_no_transpose
+      CASE (2)
+         trans1 = dbcsr_transpose
+      CASE DEFAULT
+         DBCSR_ABORT("should not happen")
+      END SELECT
 
-         IF (io_unit > 0) THEN
-            WRITE (io_unit, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor1%name), ":"
+      SELECT CASE (compat2)
+      CASE (1)
+         trans2 = dbcsr_no_transpose
+      CASE (2)
+         trans2 = dbcsr_transpose
+      CASE DEFAULT
+         DBCSR_ABORT("should not happen")
+      END SELECT
+
+      IF (io_unit > 0) THEN
+         IF (compat1 .NE. compat1_old) THEN
+            WRITE (io_unit, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor1_out%name), ":"
             SELECT CASE (compat1)
             CASE (0)
                WRITE (io_unit, '(A)') "Not compatible"
@@ -799,7 +998,9 @@ CONTAINS
             CASE (2)
                WRITE (io_unit, '(A)') "Transposed"
             END SELECT
-            WRITE (io_unit, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor2%name), ":"
+         ENDIF
+         IF (compat2 .NE. compat2_old) THEN
+            WRITE (io_unit, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor2_out%name), ":"
             SELECT CASE (compat2)
             CASE (0)
                WRITE (io_unit, '(A)') "Not compatible"
@@ -809,147 +1010,12 @@ CONTAINS
                WRITE (io_unit, '(A)') "Transposed"
             END SELECT
          ENDIF
+      ENDIF
 
-         new1 = .FALSE.
-         new2 = .FALSE.
+      IF(new1 .AND. PRESENT(move_data_1)) move_data_1 = .TRUE.
+      IF(new2 .AND. PRESENT(move_data_2)) move_data_2 = .TRUE.
 
-         IF (compat1 == 0 .OR. optimize_dist_prv) THEN
-            new1 = .TRUE.
-         ENDIF
-
-         IF (compat2 == 0 .OR. optimize_dist_prv) THEN
-            new2 = .TRUE.
-         ENDIF
-
-         IF (ref_tensor == 1) THEN ! tensor 1 is reference and tensor 2 is reshaped compatible with tensor 1
-            IF (compat1 == 0 .OR. optimize_dist_prv) THEN ! tensor 1 is not contraction compatible --> reshape
-               IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "Redistribution of", TRIM(tensor1%name)
-               ALLOCATE (dims(dbcsr_t_ndims(tensor1)))
-               CALL blk_dims_tensor(tensor1, dims)
-               nblkrows = PRODUCT(INT(dims(ind1_linked), KIND=int_8))
-               nblkcols = PRODUCT(INT(dims(ind1_free), KIND=int_8))
-               comm_2d = dbcsr_tas_mp_comm(tensor1%pgrid%mp_comm_2d, nblkrows, nblkcols)
-               ALLOCATE (tensor1_out)
-               CALL dbcsr_t_remap(tensor1, ind1_linked, ind1_free, tensor1_out, comm_2d=comm_2d, &
-                                  nodata=nodata1, move_data=move_data)
-               CALL mp_comm_free(comm_2d)
-               compat1 = 1
-            ELSE
-               IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor1%name)
-               tensor1_out => tensor1
-            ENDIF
-            IF (compat2 == 0 .OR. optimize_dist_prv) THEN ! tensor 2 is not contraction compatible --> reshape
-               IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A,1X,A,1X,A)') "Redistribution of", &
-                  TRIM(tensor2%name), "compatible with", TRIM(tensor1%name)
-               dist_in = dbcsr_t_distribution(tensor1_out)
-               dist_list = array_sublist(dist_in%nd_dist, ind1_linked)
-               IF (compat1 == 1) THEN ! linked index is first 2d dimension
-                  ! get distribution of linked index, tensor 2 must adopt this distribution
-                  ! get grid dimensions of linked index
-                  CALL get_mapping_info(dist_in%pgrid%nd_index_grid, dims1_2d=mp_dims)
-                  ALLOCATE (tensor2_out)
-                  CALL dbcsr_t_remap(tensor2, ind2_linked, ind2_free, tensor2_out, comm_2d=dist_in%pgrid%mp_comm_2d, &
-                                     dist1=dist_list, mp_dims_1=mp_dims, nodata=nodata2, move_data=move_data)
-               ELSEIF (compat1 == 2) THEN ! linked index is second 2d dimension
-                  ! get distribution of linked index, tensor 2 must adopt this distribution
-                  ! get grid dimensions of linked index
-                  CALL get_mapping_info(dist_in%pgrid%nd_index_grid, dims2_2d=mp_dims)
-                  ALLOCATE (tensor2_out)
-                  CALL dbcsr_t_remap(tensor2, ind2_free, ind2_linked, tensor2_out, comm_2d=dist_in%pgrid%mp_comm_2d, &
-                                     dist2=dist_list, mp_dims_2=mp_dims, nodata=nodata2, move_data=move_data)
-               ELSE
-                  DBCSR_ABORT("should not happen")
-               ENDIF
-               compat2 = compat1
-            ELSE
-               IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor2%name)
-               tensor2_out => tensor2
-            ENDIF
-         ELSE ! tensor 2 is reference and tensor 1 is reshaped compatible with tensor 2
-            IF (compat2 == 0 .OR. optimize_dist_prv) THEN ! tensor 2 is not contraction compatible --> reshape
-               IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "Redistribution of", TRIM(tensor2%name)
-               ALLOCATE (dims(dbcsr_t_ndims(tensor2)))
-               CALL blk_dims_tensor(tensor2, dims)
-               nblkrows = PRODUCT(INT(dims(ind2_linked), KIND=int_8))
-               nblkcols = PRODUCT(INT(dims(ind2_free), KIND=int_8))
-               comm_2d = dbcsr_tas_mp_comm(tensor2%pgrid%mp_comm_2d, nblkrows, nblkcols)
-               ALLOCATE (tensor2_out)
-               CALL dbcsr_t_remap(tensor2, ind2_linked, ind2_free, tensor2_out, nodata=nodata2, move_data=move_data)
-               CALL mp_comm_free(comm_2d)
-               compat2 = 1
-            ELSE
-               IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor2%name)
-               tensor2_out => tensor2
-            ENDIF
-            IF (compat1 == 0 .OR. optimize_dist_prv) THEN ! tensor 1 is not contraction compatible --> reshape
-               IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A,1X,A,1X,A)') "Redistribution of", TRIM(tensor1%name), &
-                  "compatible with", TRIM(tensor2%name)
-               dist_in = dbcsr_t_distribution(tensor2_out)
-               dist_list = array_sublist(dist_in%nd_dist, ind2_linked)
-               IF (compat2 == 1) THEN
-                  CALL get_mapping_info(dist_in%pgrid%nd_index_grid, dims1_2d=mp_dims)
-                  ALLOCATE (tensor1_out)
-                  CALL dbcsr_t_remap(tensor1, ind1_linked, ind1_free, tensor1_out, comm_2d=dist_in%pgrid%mp_comm_2d, &
-                                     dist1=dist_list, mp_dims_1=mp_dims, nodata=nodata1, move_data=move_data)
-               ELSEIF (compat2 == 2) THEN
-                  CALL get_mapping_info(dist_in%pgrid%nd_index_grid, dims2_2d=mp_dims)
-                  ALLOCATE (tensor1_out)
-                  CALL dbcsr_t_remap(tensor1, ind1_free, ind1_linked, tensor1_out, comm_2d=dist_in%pgrid%mp_comm_2d, &
-                                     dist2=dist_list, mp_dims_2=mp_dims, nodata=nodata1, move_data=move_data)
-               ELSE
-                  DBCSR_ABORT("should not happen")
-               ENDIF
-               compat1 = compat2
-            ELSE
-               IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor1%name)
-               tensor1_out => tensor1
-            ENDIF
-         ENDIF
-
-         SELECT CASE (compat1)
-         CASE (1)
-            trans1 = dbcsr_no_transpose
-         CASE (2)
-            trans1 = dbcsr_transpose
-         CASE DEFAULT
-            DBCSR_ABORT("should not happen")
-         END SELECT
-
-         SELECT CASE (compat2)
-         CASE (1)
-            trans2 = dbcsr_no_transpose
-         CASE (2)
-            trans2 = dbcsr_transpose
-         CASE DEFAULT
-            DBCSR_ABORT("should not happen")
-         END SELECT
-
-         IF (io_unit > 0) THEN
-            IF (compat1 .NE. compat1_old) THEN
-               WRITE (io_unit, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor1_out%name), ":"
-               SELECT CASE (compat1)
-               CASE (0)
-                  WRITE (io_unit, '(A)') "Not compatible"
-               CASE (1)
-                  WRITE (io_unit, '(A)') "Normal"
-               CASE (2)
-                  WRITE (io_unit, '(A)') "Transposed"
-               END SELECT
-            ENDIF
-            IF (compat2 .NE. compat2_old) THEN
-               WRITE (io_unit, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor2_out%name), ":"
-               SELECT CASE (compat2)
-               CASE (0)
-                  WRITE (io_unit, '(A)') "Not compatible"
-               CASE (1)
-                  WRITE (io_unit, '(A)') "Normal"
-               CASE (2)
-                  WRITE (io_unit, '(A)') "Transposed"
-               END SELECT
-            ENDIF
-         ENDIF
-
-      END SUBROUTINE
+   END SUBROUTINE
 
 ! **************************************************************************************************
 !> \brief Prepare tensor for contraction: redistribute to a 2d format which can be contracted by
@@ -964,36 +1030,69 @@ CONTAINS
 !> \param move_data memory optimization: transfer data s.t. tensor_in may be empty on return
 !> \param unit_nr output unit
 ! **************************************************************************************************
-      SUBROUTINE reshape_mm_small(tensor_in, ind1, ind2, tensor_out, trans, new, nodata, move_data, unit_nr)
-         TYPE(dbcsr_t_type), TARGET, INTENT(INOUT)   :: tensor_in
-         INTEGER, DIMENSION(:), INTENT(IN)           :: ind1, ind2
-         TYPE(dbcsr_t_type), POINTER, INTENT(OUT)    :: tensor_out
-         CHARACTER(LEN=1), INTENT(OUT)               :: trans
-         LOGICAL, INTENT(OUT)                        :: new
-         LOGICAL, INTENT(IN), OPTIONAL               :: nodata, move_data
-         INTEGER, INTENT(IN), OPTIONAL               :: unit_nr
-         INTEGER                                     :: compat1, compat2, compat1_old, compat2_old, io_unit
-         LOGICAL                                     :: nodata_prv
+   SUBROUTINE reshape_mm_small(tensor_in, ind1, ind2, tensor_out, trans, new, nodata, move_data, unit_nr)
+      TYPE(dbcsr_t_type), TARGET, INTENT(INOUT)   :: tensor_in
+      INTEGER, DIMENSION(:), INTENT(IN)           :: ind1, ind2
+      TYPE(dbcsr_t_type), POINTER, INTENT(OUT)    :: tensor_out
+      CHARACTER(LEN=1), INTENT(OUT)               :: trans
+      LOGICAL, INTENT(OUT)                        :: new
+      LOGICAL, INTENT(IN), OPTIONAL               :: nodata, move_data
+      INTEGER, INTENT(IN), OPTIONAL               :: unit_nr
+      INTEGER                                     :: compat1, compat2, compat1_old, compat2_old, io_unit
+      LOGICAL                                     :: nodata_prv
 
-         NULLIFY(tensor_out)
-         IF (PRESENT(nodata)) THEN
-            nodata_prv = nodata
+      NULLIFY(tensor_out)
+      IF (PRESENT(nodata)) THEN
+         nodata_prv = nodata
+      ELSE
+         nodata_prv = .FALSE.
+      ENDIF
+
+      IF (PRESENT(unit_nr)) THEN
+         io_unit = unit_nr
+      ELSE
+         io_unit = 0
+      ENDIF
+
+      new = .FALSE.
+      compat1 = compat_map(tensor_in%nd_index, ind1)
+      compat2 = compat_map(tensor_in%nd_index, ind2)
+      compat1_old = compat1; compat2_old = compat2
+      IF (io_unit > 0) THEN
+         WRITE (io_unit, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor_in%name), ":"
+         IF (compat1 == 1 .AND. compat2 == 2) THEN
+            WRITE (io_unit, '(A)') "Normal"
+         ELSEIF (compat1 == 2 .AND. compat2 == 1) THEN
+            WRITE (io_unit, '(A)') "Transposed"
          ELSE
-            nodata_prv = .FALSE.
+            WRITE (io_unit, '(A)') "Not compatible"
          ENDIF
+      ENDIF
+      IF (compat1 == 0 .or. compat2 == 0) THEN ! index mapping not compatible with contract index
 
-         IF (PRESENT(unit_nr)) THEN
-            io_unit = unit_nr
-         ELSE
-            io_unit = 0
-         ENDIF
+         IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "Redistribution of", TRIM(tensor_in%name)
 
-         new = .FALSE.
-         compat1 = compat_map(tensor_in%nd_index, ind1)
-         compat2 = compat_map(tensor_in%nd_index, ind2)
-         compat1_old = compat1; compat2_old = compat2
-         IF (io_unit > 0) THEN
-            WRITE (io_unit, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor_in%name), ":"
+         ALLOCATE (tensor_out)
+         CALL dbcsr_t_remap(tensor_in, ind1, ind2, tensor_out, nodata=nodata, move_data=move_data)
+         compat1 = 1
+         compat2 = 2
+         new = .TRUE.
+      ELSE
+         IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor_in%name)
+         tensor_out => tensor_in
+      ENDIF
+
+      IF (compat1 == 1 .AND. compat2 == 2) THEN
+         trans = dbcsr_no_transpose
+      ELSEIF (compat1 == 2 .AND. compat2 == 1) THEN
+         trans = dbcsr_transpose
+      ELSE
+         DBCSR_ABORT("this should not happen")
+      ENDIF
+
+      IF (io_unit > 0) THEN
+         IF (compat1_old .NE. compat1 .OR. compat2_old .NE. compat2) THEN
+            WRITE (io_unit, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor_out%name), ":"
             IF (compat1 == 1 .AND. compat2 == 2) THEN
                WRITE (io_unit, '(A)') "Normal"
             ELSEIF (compat1 == 2 .AND. compat2 == 1) THEN
@@ -1002,85 +1101,63 @@ CONTAINS
                WRITE (io_unit, '(A)') "Not compatible"
             ENDIF
          ENDIF
-         IF (compat1 == 0 .or. compat2 == 0) THEN ! index mapping not compatible with contract index
+      ENDIF
 
-            IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "Redistribution of", TRIM(tensor_in%name)
-
-            ALLOCATE (tensor_out)
-            CALL dbcsr_t_remap(tensor_in, ind1, ind2, tensor_out, nodata=nodata, move_data=move_data)
-            compat1 = 1
-            compat2 = 2
-            new = .TRUE.
-         ELSE
-            IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor_in%name)
-            tensor_out => tensor_in
-         ENDIF
-
-         IF (compat1 == 1 .AND. compat2 == 2) THEN
-            trans = dbcsr_no_transpose
-         ELSEIF (compat1 == 2 .AND. compat2 == 1) THEN
-            trans = dbcsr_transpose
-         ELSE
-            DBCSR_ABORT("this should not happen")
-         ENDIF
-
-         IF (io_unit > 0) THEN
-            IF (compat1_old .NE. compat1 .OR. compat2_old .NE. compat2) THEN
-               WRITE (io_unit, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor_out%name), ":"
-               IF (compat1 == 1 .AND. compat2 == 2) THEN
-                  WRITE (io_unit, '(A)') "Normal"
-               ELSEIF (compat1 == 2 .AND. compat2 == 1) THEN
-                  WRITE (io_unit, '(A)') "Transposed"
-               ELSE
-                  WRITE (io_unit, '(A)') "Not compatible"
-               ENDIF
-            ENDIF
-         ENDIF
-
-      END SUBROUTINE
+   END SUBROUTINE
 
 ! **************************************************************************************************
 !> \brief Check if 2d index is compatible with tensor index
 !> \param nd_index ...
 !> \param compat_ind ...
 ! **************************************************************************************************
-      FUNCTION compat_map(nd_index, compat_ind)
-         TYPE(nd_to_2d_mapping), INTENT(IN) :: nd_index
-         INTEGER, DIMENSION(:), INTENT(IN)  :: compat_ind
-         INTEGER, DIMENSION(:), ALLOCATABLE :: map1, map2
-         INTEGER                            :: compat_map
+   FUNCTION compat_map(nd_index, compat_ind)
+      TYPE(nd_to_2d_mapping), INTENT(IN) :: nd_index
+      INTEGER, DIMENSION(:), INTENT(IN)  :: compat_ind
+      INTEGER, DIMENSION(:), ALLOCATABLE :: map1, map2
+      INTEGER                            :: compat_map
 
-         CALL get_mapping_info(nd_index, map1_2d=map1, map2_2d=map2)
+      CALL dbcsr_t_get_mapping_info(nd_index, map1_2d=map1, map2_2d=map2)
 
-         compat_map = 0
-         IF (array_eq_i(map1, compat_ind)) THEN
-            compat_map = 1
-         ELSEIF (array_eq_i(map2, compat_ind)) THEN
-            compat_map = 2
-         ENDIF
+      compat_map = 0
+      IF (array_eq_i(map1, compat_ind)) THEN
+         compat_map = 1
+      ELSEIF (array_eq_i(map2, compat_ind)) THEN
+         compat_map = 2
+      ENDIF
 
-      END FUNCTION
+   END FUNCTION
 
-      SUBROUTINE invert_transpose_flag(trans_flag)
-         CHARACTER(LEN=1), INTENT(INOUT)                    :: trans_flag
+   SUBROUTINE invert_transpose_flag(trans_flag)
+      CHARACTER(LEN=1), INTENT(INOUT)                    :: trans_flag
 
-         IF (trans_flag == dbcsr_transpose) THEN
-            trans_flag = dbcsr_no_transpose
-         ELSEIF (trans_flag == dbcsr_no_transpose) THEN
-            trans_flag = dbcsr_transpose
-         ENDIF
-      END SUBROUTINE
+      IF (trans_flag == dbcsr_transpose) THEN
+         trans_flag = dbcsr_no_transpose
+      ELSEIF (trans_flag == dbcsr_no_transpose) THEN
+         trans_flag = dbcsr_transpose
+      ENDIF
+   END SUBROUTINE
 
-      SUBROUTINE index_linked_sort(ind_ref, ind_dep)
-         INTEGER, DIMENSION(:), INTENT(INOUT) :: ind_ref, ind_dep
-         INTEGER, DIMENSION(SIZE(ind_ref))    :: sort_indices
+   SUBROUTINE index_linked_sort(ind_ref, ind_dep)
+      INTEGER, DIMENSION(:), INTENT(INOUT) :: ind_ref, ind_dep
+      INTEGER, DIMENSION(SIZE(ind_ref))    :: sort_indices
 
-         CALL sort(ind_ref, SIZE(ind_ref), sort_indices)
-         ind_dep(:) = ind_dep(sort_indices)
-
-      END SUBROUTINE
+      CALL sort(ind_ref, SIZE(ind_ref), sort_indices)
+      ind_dep(:) = ind_dep(sort_indices)
 
    END SUBROUTINE
+
+   FUNCTION opt_pgrid(tensor, tas_split_info)
+      TYPE(dbcsr_t_type), INTENT(IN) :: tensor
+      TYPE(dbcsr_tas_split_info), INTENT(IN) :: tas_split_info
+      INTEGER, DIMENSION(:), ALLOCATABLE :: map1, map2
+      TYPE(dbcsr_t_pgrid_type) :: opt_pgrid
+
+      CALL dbcsr_t_get_mapping_info(tensor%pgrid%nd_index_grid, map1_2d=map1, map2_2d=map2)
+      opt_pgrid = dbcsr_t_nd_mp_comm(tas_split_info%mp_comm, map1, map2)
+
+      ALLOCATE(opt_pgrid%tas_split_info, SOURCE=tas_split_info)
+      CALL dbcsr_tas_info_hold(opt_pgrid%tas_split_info)
+   END FUNCTION
 
 ! **************************************************************************************************
 !> \brief Default distribution that is more or less cyclic (round robin) and load balanced with different
@@ -1242,7 +1319,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      CALL get_mapping_info(tensor_in%nd_index_blk, map1_2d=map1_2d, map2_2d=map2_2d)
+      CALL dbcsr_t_get_mapping_info(tensor_in%nd_index_blk, map1_2d=map1_2d, map2_2d=map2_2d)
       order_prv = dbcsr_t_inverse_order([map1_2d, map2_2d])
       CALL dbcsr_t_permute_index(tensor_in, tensor_out, order=order_prv)
 
@@ -1283,6 +1360,9 @@ CONTAINS
       tensor_out%nd_index = nd_index_rs
       tensor_out%nd_index_blk = nd_index_blk_rs
       tensor_out%pgrid%mp_comm_2d = tensor_in%pgrid%mp_comm_2d
+      IF(ALLOCATED(tensor_in%pgrid%tas_split_info)) THEN
+         ALLOCATE(tensor_out%pgrid%tas_split_info, SOURCE=tensor_in%pgrid%tas_split_info)
+      ENDIF
       tensor_out%refcount => tensor_in%refcount
       CALL dbcsr_t_hold(tensor_out)
 
@@ -1490,9 +1570,9 @@ CONTAINS
       INTEGER, DIMENSION(:), ALLOCATABLE :: map11, map12, map21, map22, map31, map32
       INTEGER :: ichar1, ichar2, ichar3
 
-      CALL get_mapping_info(tensor_1%nd_index_blk, map1_2d=map11, map2_2d=map12)
-      CALL get_mapping_info(tensor_2%nd_index_blk, map1_2d=map21, map2_2d=map22)
-      CALL get_mapping_info(tensor_3%nd_index_blk, map1_2d=map31, map2_2d=map32)
+      CALL dbcsr_t_get_mapping_info(tensor_1%nd_index_blk, map1_2d=map11, map2_2d=map12)
+      CALL dbcsr_t_get_mapping_info(tensor_2%nd_index_blk, map1_2d=map21, map2_2d=map22)
+      CALL dbcsr_t_get_mapping_info(tensor_3%nd_index_blk, map1_2d=map31, map2_2d=map32)
 
       IF (unit_nr .GT. 0) THEN
          WRITE (unit_nr, '(T2,A)') "INDEX INFO"

--- a/src/tensors/dbcsr_tensor.F
+++ b/src/tensors/dbcsr_tensor.F
@@ -87,7 +87,7 @@ MODULE dbcsr_tensor
       dbcsr_tas_mp_comm, rowsplit, colsplit, dbcsr_tas_info_hold, dbcsr_tas_release_info
    USE dbcsr_data_types, ONLY: dbcsr_scalar_type
    USE dbcsr_tensor_split, ONLY: dbcsr_t_split_copyback, &
-                                 dbcsr_t_make_compatible_blocks,&
+                                 dbcsr_t_make_compatible_blocks, &
                                  dbcsr_t_crop
    USE dbcsr_tensor_io, ONLY: dbcsr_t_write_tensor_info, &
                               dbcsr_t_write_tensor_dist
@@ -418,7 +418,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      NULLIFY(tensor_contr_1, tensor_contr_2, tensor_contr_3, tensor_crop_1, tensor_crop_2, split_opt)
+      NULLIFY (tensor_contr_1, tensor_contr_2, tensor_contr_3, tensor_crop_1, tensor_crop_2, split_opt)
 
       DBCSR_ASSERT(tensor_1%valid)
       DBCSR_ASSERT(tensor_2%valid)
@@ -445,7 +445,7 @@ CONTAINS
       assert_stmt = dbcsr_t_get_data_type(tensor_1) .EQ. dbcsr_t_get_data_type(tensor_2)
       DBCSR_ASSERT(assert_stmt)
 
-      IF(PRESENT(move_data)) THEN
+      IF (PRESENT(move_data)) THEN
          move_data_1 = move_data
          move_data_2 = move_data
       ELSE
@@ -460,17 +460,17 @@ CONTAINS
                                          bounds_1=bounds_1, bounds_2=bounds_2, bounds_3=bounds_3, &
                                          do_crop_1=do_crop_1, do_crop_2=do_crop_2)
 
-      IF(do_crop_1) THEN
-         ALLOCATE(tensor_crop_1)
+      IF (do_crop_1) THEN
+         ALLOCATE (tensor_crop_1)
          CALL dbcsr_t_crop(tensor_1, tensor_crop_1, bounds_t1, move_data=move_data_1)
          move_data_1 = .TRUE.
       ELSE
          tensor_crop_1 => tensor_1
       ENDIF
 
-      IF(do_crop_2) THEN
-         ALLOCATE(tensor_crop_2)
-         CALL dbcsr_t_crop(tensor_2, tensor_crop_2,  bounds_t2, move_data=move_data_2)
+      IF (do_crop_2) THEN
+         ALLOCATE (tensor_crop_2)
+         CALL dbcsr_t_crop(tensor_2, tensor_crop_2, bounds_t2, move_data=move_data_2)
          move_data_2 = .TRUE.
       ELSE
          tensor_crop_2 => tensor_2
@@ -487,13 +487,13 @@ CONTAINS
 
       IF (occ_1 == 0 .OR. occ_2 == 0) THEN
          CALL dbcsr_t_scale(tensor_3, beta)
-         IF(do_crop_1) THEN
+         IF (do_crop_1) THEN
             CALL dbcsr_t_destroy(tensor_crop_1)
-            DEALLOCATE(tensor_crop_1)
+            DEALLOCATE (tensor_crop_1)
          ENDIF
-         IF(do_crop_2) THEN
+         IF (do_crop_2) THEN
             CALL dbcsr_t_destroy(tensor_crop_2)
-            DEALLOCATE(tensor_crop_2)
+            DEALLOCATE (tensor_crop_2)
          ENDIF
          CALL timestop(handle)
          RETURN
@@ -670,30 +670,30 @@ CONTAINS
                               split_opt=split_opt, &
                               move_data_a=move_data_1, move_data_b=move_data_2)
 
-      IF(PRESENT(pgrid_opt_1) .AND. ASSOCIATED(split_opt)) THEN
-         IF(.NOT. new_1) THEN
-            ALLOCATE(pgrid_opt_1)
+      IF (PRESENT(pgrid_opt_1) .AND. ASSOCIATED(split_opt)) THEN
+         IF (.NOT. new_1) THEN
+            ALLOCATE (pgrid_opt_1)
             pgrid_opt_1 = opt_pgrid(tensor_1, split_opt)
          ENDIF
       ENDIF
 
-      IF(PRESENT(pgrid_opt_2) .AND. ASSOCIATED(split_opt)) THEN
-         IF(.NOT. new_2) THEN
-            ALLOCATE(pgrid_opt_2)
+      IF (PRESENT(pgrid_opt_2) .AND. ASSOCIATED(split_opt)) THEN
+         IF (.NOT. new_2) THEN
+            ALLOCATE (pgrid_opt_2)
             pgrid_opt_2 = opt_pgrid(tensor_2, split_opt)
          ENDIF
       ENDIF
 
-      IF(PRESENT(pgrid_opt_3) .AND. ASSOCIATED(split_opt)) THEN
-         IF(.NOT. new_3) THEN
-            ALLOCATE(pgrid_opt_3)
+      IF (PRESENT(pgrid_opt_3) .AND. ASSOCIATED(split_opt)) THEN
+         IF (.NOT. new_3) THEN
+            ALLOCATE (pgrid_opt_3)
             pgrid_opt_3 = opt_pgrid(tensor_3, split_opt)
          ENDIF
       ENDIF
 
-      IF(ASSOCIATED(split_opt)) THEN
+      IF (ASSOCIATED(split_opt)) THEN
          CALL dbcsr_tas_release_info(split_opt)
-         DEALLOCATE(split_opt)
+         DEALLOCATE (split_opt)
       ENDIF
 
       IF (PRESENT(unit_nr)) THEN
@@ -719,14 +719,14 @@ CONTAINS
       CALL dbcsr_t_destroy(tensor_algn_2)
       CALL dbcsr_t_destroy(tensor_algn_3)
 
-      IF(do_crop_1) THEN
+      IF (do_crop_1) THEN
          CALL dbcsr_t_destroy(tensor_crop_1)
-         DEALLOCATE(tensor_crop_1)
+         DEALLOCATE (tensor_crop_1)
       ENDIF
 
-      IF(do_crop_2) THEN
+      IF (do_crop_2) THEN
          CALL dbcsr_t_destroy(tensor_crop_2)
-         DEALLOCATE(tensor_crop_2)
+         DEALLOCATE (tensor_crop_2)
       ENDIF
 
       IF (new_1) THEN
@@ -828,7 +828,7 @@ CONTAINS
       INTEGER(KIND=int_8)                         :: nblkrows, nblkcols
       LOGICAL                                     :: optimize_dist_prv
 
-      NULLIFY(tensor1_out, tensor2_out)
+      NULLIFY (tensor1_out, tensor2_out)
       IF (PRESENT(unit_nr)) THEN
          io_unit = unit_nr
       ELSE
@@ -1012,8 +1012,8 @@ CONTAINS
          ENDIF
       ENDIF
 
-      IF(new1 .AND. PRESENT(move_data_1)) move_data_1 = .TRUE.
-      IF(new2 .AND. PRESENT(move_data_2)) move_data_2 = .TRUE.
+      IF (new1 .AND. PRESENT(move_data_1)) move_data_1 = .TRUE.
+      IF (new2 .AND. PRESENT(move_data_2)) move_data_2 = .TRUE.
 
    END SUBROUTINE
 
@@ -1041,7 +1041,7 @@ CONTAINS
       INTEGER                                     :: compat1, compat2, compat1_old, compat2_old, io_unit
       LOGICAL                                     :: nodata_prv
 
-      NULLIFY(tensor_out)
+      NULLIFY (tensor_out)
       IF (PRESENT(nodata)) THEN
          nodata_prv = nodata
       ELSE
@@ -1155,7 +1155,7 @@ CONTAINS
       CALL dbcsr_t_get_mapping_info(tensor%pgrid%nd_index_grid, map1_2d=map1, map2_2d=map2)
       opt_pgrid = dbcsr_t_nd_mp_comm(tas_split_info%mp_comm, map1, map2)
 
-      ALLOCATE(opt_pgrid%tas_split_info, SOURCE=tas_split_info)
+      ALLOCATE (opt_pgrid%tas_split_info, SOURCE=tas_split_info)
       CALL dbcsr_tas_info_hold(opt_pgrid%tas_split_info)
    END FUNCTION
 
@@ -1360,8 +1360,8 @@ CONTAINS
       tensor_out%nd_index = nd_index_rs
       tensor_out%nd_index_blk = nd_index_blk_rs
       tensor_out%pgrid%mp_comm_2d = tensor_in%pgrid%mp_comm_2d
-      IF(ALLOCATED(tensor_in%pgrid%tas_split_info)) THEN
-         ALLOCATE(tensor_out%pgrid%tas_split_info, SOURCE=tensor_in%pgrid%tas_split_info)
+      IF (ALLOCATED(tensor_in%pgrid%tas_split_info)) THEN
+         ALLOCATE (tensor_out%pgrid%tas_split_info, SOURCE=tensor_in%pgrid%tas_split_info)
       ENDIF
       tensor_out%refcount => tensor_in%refcount
       CALL dbcsr_t_hold(tensor_out)
@@ -1433,7 +1433,7 @@ CONTAINS
                                   contract_2, notcontract_2, &
                                   bounds_1, bounds_2, bounds_3)
       TYPE(dbcsr_t_type), INTENT(INOUT)  :: tensor_1, tensor_2
-      INTEGER, DIMENSION(:), INTENT(IN)  :: contract_1, contract_2,&
+      INTEGER, DIMENSION(:), INTENT(IN)  :: contract_1, contract_2, &
                                             notcontract_1, notcontract_2
       INTEGER, DIMENSION(2, SIZE(contract_1)), &
          OPTIONAL                                    :: bounds_1

--- a/src/tensors/dbcsr_tensor_api.F
+++ b/src/tensors/dbcsr_tensor_api.F
@@ -57,6 +57,8 @@ MODULE dbcsr_tensor_api
    USE dbcsr_tensor_test, ONLY: dbcsr_t_contract_test, &
                                 dbcsr_t_checksum
    USE dbcsr_tensor_split, ONLY: dbcsr_t_split_blocks
+   USE dbcsr_tensor_index, ONLY: dbcsr_t_get_mapping_info
+   USE dbcsr_tensor_io, ONLY: dbcsr_t_write_split_info
 
    IMPLICIT NONE
 
@@ -101,5 +103,7 @@ MODULE dbcsr_tensor_api
    PUBLIC :: dbcsr_t_get_num_blocks, dbcsr_t_get_num_blocks_total
    PUBLIC :: dbcsr_t_get_nze, dbcsr_t_get_nze_total
    PUBLIC :: dbcsr_t_clear
+   PUBLIC :: dbcsr_t_get_mapping_info
+   PUBLIC :: dbcsr_t_write_split_info
 
 END MODULE dbcsr_tensor_api

--- a/src/tensors/dbcsr_tensor_block.F
+++ b/src/tensors/dbcsr_tensor_block.F
@@ -395,7 +395,7 @@ CONTAINS
       TYPE(dbcsr_t_type), INTENT(INOUT) :: tensor_out
       INTEGER                           :: handle
 
-      INTEGER, DIMENSION(:,:), ALLOCATABLE :: blk_ind
+      INTEGER, DIMENSION(:, :), ALLOCATABLE :: blk_ind
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_reserve_blocks_template', &
                                      routineP = moduleN//':'//routineN
 
@@ -488,7 +488,7 @@ CONTAINS
 
       nblk = dbcsr_t_get_num_blocks(tensor)
 
-      ALLOCATE(blk_ind(nblk, ndims_tensor(tensor)))
+      ALLOCATE (blk_ind(nblk, ndims_tensor(tensor)))
 
       CALL dbcsr_t_iterator_start(iterator, tensor)
       DO iblk = 1, nblk

--- a/src/tensors/dbcsr_tensor_block.F
+++ b/src/tensors/dbcsr_tensor_block.F
@@ -44,7 +44,7 @@ MODULE dbcsr_tensor_block
                                  get_nd_indices, &
                                  destroy_nd_to_2d_mapping, &
                                  get_2d_indices, &
-                                 get_mapping_info, &
+                                 dbcsr_t_get_mapping_info, &
                                  create_nd_to_2d_mapping
    USE dbcsr_array_list_methods, ONLY: array_list, &
                                        get_array_elements, &
@@ -702,9 +702,9 @@ CONTAINS
 
       CALL timeset(routineN, handle)
       ! reshape block
-      CALL get_mapping_info(tensor%nd_index_blk, map1_2d=map1_2d, map2_2d=map2_2d)
+      CALL dbcsr_t_get_mapping_info(tensor%nd_index_blk, map1_2d=map1_2d, map2_2d=map2_2d)
       CALL create_nd_to_2d_mapping(map_blk, sizes, map1_2d, map2_2d)
-      CALL get_mapping_info(map_blk, dims_2d=dims_2d)
+      CALL dbcsr_t_get_mapping_info(map_blk, dims_2d=dims_2d)
       CALL allocate_any(block_2d, shape_spec=dims_2d)
       CALL reshape_nd_to_2d_block(map_blk, block, block_2d)
 
@@ -785,7 +785,7 @@ CONTAINS
          ! convert pointer to allocatable
          CALL allocate_any(block_2d, source=block_2d_ptr)
 
-         CALL get_mapping_info(tensor%nd_index_blk, map1_2d=map1_2d, map2_2d=map2_2d)
+         CALL dbcsr_t_get_mapping_info(tensor%nd_index_blk, map1_2d=map1_2d, map2_2d=map2_2d)
          CALL create_nd_to_2d_mapping(map_blk, sizes, map1_2d, map2_2d)
          CALL reshape_2d_to_nd_block(map_blk, block_2d, block)
       ENDIF

--- a/src/tensors/dbcsr_tensor_index.F
+++ b/src/tensors/dbcsr_tensor_index.F
@@ -25,7 +25,7 @@ MODULE dbcsr_tensor_index
       create_nd_to_2d_mapping, &
       destroy_nd_to_2d_mapping, &
       get_2d_indices, &
-      get_mapping_info, &
+      dbcsr_t_get_mapping_info, &
       get_nd_indices, &
       nd_to_2d_mapping, &
       ndims_mapping, &
@@ -145,8 +145,8 @@ CONTAINS
 !> \param base base index
 !> \param col_major is index in column major order
 ! **************************************************************************************************
-   SUBROUTINE get_mapping_info(map, ndim_nd, ndim1_2d, ndim2_2d, dims_2d_i8, dims_2d, dims_nd, dims1_2d, dims2_2d, &
-                               map1_2d, map2_2d, map_nd, base, col_major)
+   SUBROUTINE dbcsr_t_get_mapping_info(map, ndim_nd, ndim1_2d, ndim2_2d, dims_2d_i8, dims_2d, dims_nd, dims1_2d, dims2_2d, &
+                                       map1_2d, map2_2d, map_nd, base, col_major)
       TYPE(nd_to_2d_mapping), INTENT(IN)                 :: map
       INTEGER, INTENT(OUT), OPTIONAL                     :: ndim_nd, ndim1_2d, ndim2_2d
       INTEGER(KIND=int_8), DIMENSION(2), INTENT(OUT), OPTIONAL       :: dims_2d_i8
@@ -190,7 +190,7 @@ CONTAINS
          col_major = map%col_major
       ENDIF
 
-   END SUBROUTINE get_mapping_info
+   END SUBROUTINE dbcsr_t_get_mapping_info
 
 ! **************************************************************************************************
 !> \brief transform nd index to flat index
@@ -362,7 +362,7 @@ CONTAINS
                                                             map2_2d_reorder
       INTEGER, DIMENSION(ndims_mapping(map_in))          :: dims_nd, dims_reorder
 
-      CALL get_mapping_info(map_in, ndim_nd, dims_nd=dims_nd, map1_2d=map1_2d, map2_2d=map2_2d)
+      CALL dbcsr_t_get_mapping_info(map_in, ndim_nd, dims_nd=dims_nd, map1_2d=map1_2d, map2_2d=map2_2d)
 
       dims_reorder(order) = dims_nd
 

--- a/src/tensors/dbcsr_tensor_io.F
+++ b/src/tensors/dbcsr_tensor_io.F
@@ -19,12 +19,14 @@ MODULE dbcsr_tensor_io
 
    USE dbcsr_tensor_types, ONLY: &
       dbcsr_t_get_info, dbcsr_t_type, ndims_tensor, dbcsr_t_get_num_blocks, dbcsr_t_get_num_blocks_total, &
-      blk_dims_tensor, dbcsr_t_get_stored_coordinates, dbcsr_t_get_nze, dbcsr_t_get_nze_total
+      blk_dims_tensor, dbcsr_t_get_stored_coordinates, dbcsr_t_get_nze, dbcsr_t_get_nze_total, &
+      dbcsr_t_pgrid_type
    USE dbcsr_kinds, ONLY: default_string_length, int_8, real_8
    USE dbcsr_mpiwrap, ONLY: mp_environ, mp_sum, mp_max
    USE dbcsr_tensor_block, ONLY: &
       dbcsr_t_iterator_type, dbcsr_t_iterator_next_block, dbcsr_t_iterator_start, &
       dbcsr_t_iterator_blocks_left, dbcsr_t_iterator_stop, dbcsr_t_get_block
+   USE dbcsr_tas_io, ONLY: dbcsr_tas_write_split_info
 
 #include "base/dbcsr_base_uses.f90"
 
@@ -37,7 +39,8 @@ MODULE dbcsr_tensor_io
       dbcsr_t_write_tensor_dist, &
       dbcsr_t_write_blocks, &
       dbcsr_t_write_block, &
-      dbcsr_t_write_block_indices
+      dbcsr_t_write_block_indices, &
+      dbcsr_t_write_split_info
 
 CONTAINS
 
@@ -285,5 +288,14 @@ CONTAINS
 #:endfor
       ENDDO
       CALL dbcsr_t_iterator_stop(iterator)
+   END SUBROUTINE
+
+   SUBROUTINE dbcsr_t_write_split_info(pgrid, unit_nr)
+      TYPE(dbcsr_t_pgrid_type), INTENT(IN) :: pgrid
+      INTEGER, INTENT(IN) :: unit_nr
+
+      IF(ALLOCATED(pgrid%tas_split_info)) THEN
+         CALL dbcsr_tas_write_split_info(pgrid%tas_split_info, unit_nr)
+      ENDIF
    END SUBROUTINE
 END MODULE

--- a/src/tensors/dbcsr_tensor_io.F
+++ b/src/tensors/dbcsr_tensor_io.F
@@ -294,7 +294,7 @@ CONTAINS
       TYPE(dbcsr_t_pgrid_type), INTENT(IN) :: pgrid
       INTEGER, INTENT(IN) :: unit_nr
 
-      IF(ALLOCATED(pgrid%tas_split_info)) THEN
+      IF (ALLOCATED(pgrid%tas_split_info)) THEN
          CALL dbcsr_tas_write_split_info(pgrid%tas_split_info, unit_nr)
       ENDIF
    END SUBROUTINE

--- a/src/tensors/dbcsr_tensor_reshape.F
+++ b/src/tensors/dbcsr_tensor_reshape.F
@@ -154,7 +154,7 @@ CONTAINS
 
       IF (move_prv) CALL dbcsr_t_clear(tensor_in)
 
-      CALL communicate_buffer(mp_comm, buffer_recv, buffer_send, req_array)
+      CALL dbcsr_t_communicate_buffer(mp_comm, buffer_recv, buffer_send, req_array)
       DO iproc = 0, numnodes - 1
          CALL block_buffer_destroy(buffer_send(iproc))
       ENDDO
@@ -334,7 +334,7 @@ CONTAINS
 !> \param buffer_send ...
 !> \param req_array ...
 ! **************************************************************************************************
-   SUBROUTINE communicate_buffer(mp_comm, buffer_recv, buffer_send, req_array)
+   SUBROUTINE dbcsr_t_communicate_buffer(mp_comm, buffer_recv, buffer_send, req_array)
       INTEGER, INTENT(IN)                    :: mp_comm
       TYPE(block_buffer_type), DIMENSION(0:), INTENT(INOUT) :: buffer_recv, buffer_send
       INTEGER, DIMENSION(:, :), INTENT(OUT)               :: req_array
@@ -342,7 +342,7 @@ CONTAINS
       INTEGER                                :: iproc, mynode, numnodes, rec_counter, &
                                                 send_counter
       INTEGER                                   :: handle
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'communicate_buffer', &
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_communicate_buffer', &
                                      routineP = moduleN//':'//routineN
 
       CALL timeset(routineN, handle)

--- a/src/tensors/dbcsr_tensor_split.F
+++ b/src/tensors/dbcsr_tensor_split.F
@@ -28,7 +28,7 @@ MODULE dbcsr_tensor_split
                                  dbcsr_t_iterator_next_block, &
                                  dbcsr_t_reserve_blocks, &
                                  dbcsr_t_reserved_block_indices
-   USE dbcsr_tensor_index, ONLY: get_mapping_info
+   USE dbcsr_tensor_index, ONLY: dbcsr_t_get_mapping_info
    USE dbcsr_tensor_types, ONLY: dbcsr_t_create, &
                                  dbcsr_t_get_data_type, &
                                  dbcsr_t_type, &
@@ -40,7 +40,6 @@ MODULE dbcsr_tensor_split
                                  dbcsr_t_clear, &
                                  dbcsr_t_finalize, &
                                  dbcsr_t_get_num_blocks,&
-                                 dbcsr_t_filter, &
                                  dbcsr_t_blk_offsets, &
                                  dbcsr_t_blk_sizes
    USE dbcsr_api, ONLY: ${uselist(dtype_float_param)}$
@@ -154,7 +153,7 @@ CONTAINS
 
       ENDDO
 
-      CALL get_mapping_info(tensor_in%nd_index_blk, map1_2d=map1_2d, map2_2d=map2_2d)
+      CALL dbcsr_t_get_mapping_info(tensor_in%nd_index_blk, map1_2d=map1_2d, map2_2d=map2_2d)
 
 #:for ndim in ndims
       IF (ndims_tensor(tensor_in) == ${ndim}$) THEN
@@ -594,14 +593,15 @@ CONTAINS
 
    END SUBROUTINE
 
-   SUBROUTINE dbcsr_t_crop(tensor_in, tensor_out, bounds)
+   SUBROUTINE dbcsr_t_crop(tensor_in, tensor_out, bounds, move_data)
       TYPE(dbcsr_t_type), INTENT(INOUT) :: tensor_in
       TYPE(dbcsr_t_type), INTENT(OUT) :: tensor_out
       INTEGER, DIMENSION(2, ndims_tensor(tensor_in)), INTENT(IN) :: bounds
+      LOGICAL, INTENT(IN), OPTIONAL :: move_data
       INTEGER, DIMENSION(2, ndims_tensor(tensor_in)) :: blk_bounds
       TYPE(dbcsr_t_iterator_type)                     :: iter
       INTEGER, DIMENSION(ndims_tensor(tensor_in)) :: blk_index, blk_size, blk_offset
-      LOGICAL :: found
+      LOGICAL :: found, move_data_prv
       INTEGER :: idim, blk, iblk, iblk_all, nblk
       INTEGER, DIMENSION(:, :), ALLOCATABLE :: blk_ind, blk_ind_tmp
 #:for dparam, dtype, dsuffix in dtype_float_list
@@ -609,6 +609,12 @@ CONTAINS
       ${dtype}$, DIMENSION(${shape_colon(n=ndim)}$), ALLOCATABLE :: block_${dsuffix}$_${ndim}$d, block_put_${dsuffix}$_${ndim}$d
 #:endfor
 #:endfor
+
+      IF(PRESENT(move_data)) THEN
+         move_data_prv = move_data
+      ELSE
+         move_data_prv = .FALSE.
+      ENDIF
 
       CALL dbcsr_t_create(tensor_in, tensor_out)
 
@@ -665,6 +671,8 @@ CONTAINS
       ENDDO iter_loop
       CALL dbcsr_t_iterator_stop(iter)
       CALL dbcsr_t_finalize(tensor_out)
+
+      IF(move_data_prv) CALL dbcsr_t_clear(tensor_in)
    END SUBROUTINE
 
 END MODULE

--- a/src/tensors/dbcsr_tensor_split.F
+++ b/src/tensors/dbcsr_tensor_split.F
@@ -39,7 +39,7 @@ MODULE dbcsr_tensor_split
                                  dbcsr_t_distribution_new, &
                                  dbcsr_t_clear, &
                                  dbcsr_t_finalize, &
-                                 dbcsr_t_get_num_blocks,&
+                                 dbcsr_t_get_num_blocks, &
                                  dbcsr_t_blk_offsets, &
                                  dbcsr_t_blk_sizes
    USE dbcsr_api, ONLY: ${uselist(dtype_float_param)}$
@@ -610,7 +610,7 @@ CONTAINS
 #:endfor
 #:endfor
 
-      IF(PRESENT(move_data)) THEN
+      IF (PRESENT(move_data)) THEN
          move_data_prv = move_data
       ELSE
          move_data_prv = .FALSE.
@@ -620,8 +620,8 @@ CONTAINS
 
       ! reserve blocks inside bounds
       CALL dbcsr_t_reserved_block_indices(tensor_in, blk_ind)
-      nblk=dbcsr_t_get_num_blocks(tensor_in)
-      ALLOCATE(blk_ind_tmp(nblk, ndims_tensor(tensor_in)))
+      nblk = dbcsr_t_get_num_blocks(tensor_in)
+      ALLOCATE (blk_ind_tmp(nblk, ndims_tensor(tensor_in)))
       blk_ind_tmp(:, :) = 0
       iblk = 0
       blk_loop: DO iblk_all = 1, nblk
@@ -635,8 +635,8 @@ CONTAINS
          blk_ind_tmp(iblk, :) = blk_ind(iblk_all, :)
       ENDDO blk_loop
 
-      DEALLOCATE(blk_ind)
-      ALLOCATE(blk_ind(iblk, ndims_tensor(tensor_in)))
+      DEALLOCATE (blk_ind)
+      ALLOCATE (blk_ind(iblk, ndims_tensor(tensor_in)))
       blk_ind(:, :) = blk_ind_tmp(:iblk, :)
 
       CALL dbcsr_t_reserve_blocks(tensor_out, blk_ind)
@@ -672,7 +672,7 @@ CONTAINS
       CALL dbcsr_t_iterator_stop(iter)
       CALL dbcsr_t_finalize(tensor_out)
 
-      IF(move_data_prv) CALL dbcsr_t_clear(tensor_in)
+      IF (move_data_prv) CALL dbcsr_t_clear(tensor_in)
    END SUBROUTINE
 
 END MODULE

--- a/src/tensors/dbcsr_tensor_test.F
+++ b/src/tensors/dbcsr_tensor_test.F
@@ -37,7 +37,7 @@ MODULE dbcsr_tensor_test
                                  mp_environ_pgrid, &
                                  dbcsr_t_pgrid_type, &
                                  dbcsr_t_pgrid_create, &
-                                 dbcsr_t_pgrid_destroy,&
+                                 dbcsr_t_pgrid_destroy, &
                                  dbcsr_t_get_info
    USE dbcsr_tensor_io, ONLY: &
       dbcsr_t_write_blocks, dbcsr_t_write_block_indices
@@ -385,7 +385,7 @@ CONTAINS
 
 #:for dim in range(1, maxdim+1)
             IF (${dim}$ <= ndims) THEN
-               DEALLOCATE(dist1_${dim}$, dist2_${dim}$)
+               DEALLOCATE (dist1_${dim}$, dist2_${dim}$)
             ENDIF
 #:endfor
 
@@ -752,26 +752,26 @@ CONTAINS
       do_crop_1 = .FALSE.; do_crop_2 = .FALSE.!; do_crop_3 = .FALSE.
 
       ! crop tensor as first step
-      bounds_t1(1,:) = 1
-      CALL dbcsr_t_get_info(tensor_1, nfull_total=bounds_t1(2,:))
+      bounds_t1(1, :) = 1
+      CALL dbcsr_t_get_info(tensor_1, nfull_total=bounds_t1(2, :))
 
-      bounds_t2(1,:) = 1
-      CALL dbcsr_t_get_info(tensor_2, nfull_total=bounds_t2(2,:))
+      bounds_t2(1, :) = 1
+      CALL dbcsr_t_get_info(tensor_2, nfull_total=bounds_t2(2, :))
 
-      IF(PRESENT(bounds_1)) THEN
-         bounds_t1(:,contract_1) = bounds_1
+      IF (PRESENT(bounds_1)) THEN
+         bounds_t1(:, contract_1) = bounds_1
          do_crop_1 = .TRUE.
-         bounds_t2(:,contract_2) = bounds_1
+         bounds_t2(:, contract_2) = bounds_1
          do_crop_2 = .TRUE.
       ENDIF
 
-      IF(PRESENT(bounds_2)) THEN
-         bounds_t1(:,notcontract_1) = bounds_2
+      IF (PRESENT(bounds_2)) THEN
+         bounds_t1(:, notcontract_1) = bounds_2
          do_crop_1 = .TRUE.
       ENDIF
 
-      IF(PRESENT(bounds_3)) THEN
-         bounds_t2(:,notcontract_2) = bounds_3
+      IF (PRESENT(bounds_3)) THEN
+         bounds_t2(:, notcontract_2) = bounds_3
          do_crop_2 = .TRUE.
       ENDIF
 

--- a/src/tensors/dbcsr_tensor_test.F
+++ b/src/tensors/dbcsr_tensor_test.F
@@ -52,7 +52,7 @@ MODULE dbcsr_tensor_test
                             mp_cart_create
    USE dbcsr_allocate_wrap, ONLY: allocate_any
    USE dbcsr_tensor_index, ONLY: combine_index, &
-                                 get_mapping_info
+                                 dbcsr_t_get_mapping_info
    USE dbcsr_tas_test, ONLY: dbcsr_tas_checksum
    USE dbcsr_data_types, ONLY: dbcsr_scalar_type
 #include "base/dbcsr_base_uses.f90"
@@ -383,6 +383,12 @@ CONTAINS
             CALL dbcsr_t_destroy(tensor2)
             CALL dbcsr_t_distribution_destroy(dist2)
 
+#:for dim in range(1, maxdim+1)
+            IF (${dim}$ <= ndims) THEN
+               DEALLOCATE(dist1_${dim}$, dist2_${dim}$)
+            ENDIF
+#:endfor
+
          ENDDO
       ENDDO
       CALL dbcsr_t_pgrid_destroy(comm_nd)
@@ -396,9 +402,10 @@ CONTAINS
 !> \param mp_comm
 ! **************************************************************************************************
    SUBROUTINE dbcsr_t_random_dist(dist_array, dist_size, nbins, mp_comm)
-      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(out) :: dist_array
+      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(OUT) :: dist_array
       INTEGER, INTENT(IN)                             :: dist_size, nbins, mp_comm
       REAL, DIMENSION(dist_size)                      :: rn
+      INTEGER, DIMENSION(dist_size)                   :: rn_int
       INTEGER                                         :: numnodes, mynode
 
       CALL mp_environ(numnodes, mynode, mp_comm)
@@ -408,7 +415,8 @@ CONTAINS
       ENDIF
       CALL mp_bcast(rn, 0, mp_comm)
 
-      CALL allocate_any(dist_array, source=FLOOR(rn*nbins))
+      rn_int = FLOOR(rn*nbins)
+      CALL allocate_any(dist_array, source=rn_int)
 
    END SUBROUTINE dbcsr_t_random_dist
 
@@ -558,7 +566,7 @@ CONTAINS
       LOGICAL                                                    :: found
 
       DBCSR_ASSERT(dbcsr_t_ndims(tensor) .EQ. ${ndim}$)
-      CALL get_mapping_info(tensor%nd_index, dims_nd=dims_nd)
+      CALL dbcsr_t_get_mapping_info(tensor%nd_index, dims_nd=dims_nd)
       CALL allocate_any(array, shape_spec=dims_nd)
       array(${shape_colon(ndim)}$) = 0.0_${dprec}$
 
@@ -602,7 +610,7 @@ CONTAINS
       INTEGER, DIMENSION(dbcsr_t_ndims(tensor))                  :: blk_start, blk_end
 
       DBCSR_ASSERT(dbcsr_t_ndims(tensor) .EQ. ${ndim}$)
-      CALL get_mapping_info(tensor%nd_index, dims_nd=dims_nd)
+      CALL dbcsr_t_get_mapping_info(tensor%nd_index, dims_nd=dims_nd)
 
       CALL dbcsr_t_iterator_start(iterator, tensor)
       DO WHILE (dbcsr_t_iterator_blocks_left(iterator))
@@ -730,6 +738,7 @@ CONTAINS
                             contract_2, notcontract_2, &
                             map_1, map_2, &
                             bounds_1=bounds_1, bounds_2=bounds_2, bounds_3=bounds_3, &
+                            filter_eps=1.0E-12_real_8, &
                             unit_nr=io_unit, log_verbose=log_verbose)
 
       cs_3 = dbcsr_t_checksum(tensor_3)
@@ -834,7 +843,7 @@ CONTAINS
       eql_diff = MAXVAL(ABS(array_3_test_mm(:, :) - array_3_mm(:, :)))
       notzero = MAXVAL(ABS(array_3_test_mm(:, :))) .GT. 1.0E-12_${dprec}$
 
-      eql = eql_diff .LT. 1.0E-12_${dprec}$
+      eql = eql_diff .LT. 1.0E-11_${dprec}$
 
       IF (.NOT. eql .OR. .NOT. notzero) THEN
          IF (io_unit > 0) WRITE (io_unit, *) 'Test failed!', eql_diff

--- a/src/tensors/dbcsr_tensor_types.F
+++ b/src/tensors/dbcsr_tensor_types.F
@@ -500,7 +500,7 @@ CONTAINS
          DBCSR_ABORT("inconsistent process grid dimensions")
       ENDIF
 
-      IF(ALLOCATED(pgrid_prv%tas_split_info)) THEN
+      IF (ALLOCATED(pgrid_prv%tas_split_info)) THEN
          CALL dbcsr_tas_distribution_new(dist%dist, comm_2d, row_dist_obj, col_dist_obj, split_info=pgrid_prv%tas_split_info)
       ELSE
          CALL dbcsr_tas_distribution_new(dist%dist, comm_2d, row_dist_obj, col_dist_obj)
@@ -1054,10 +1054,10 @@ CONTAINS
       CALL dbcsr_t_get_mapping_info(pgrid%nd_index_grid, dims_2d=pdims_2d)
       CALL mp_cart_create(mp_comm, 2, pdims_2d, pos, pgrid%mp_comm_2d)
 
-      IF(PRESENT(nsplit)) THEN
+      IF (PRESENT(nsplit)) THEN
          DBCSR_ASSERT(PRESENT(dimsplit))
          CALL dbcsr_tas_create_split(info, pgrid%mp_comm_2d, dimsplit, nsplit, opt_nsplit=.FALSE.)
-         ALLOCATE(pgrid%tas_split_info, SOURCE=info)
+         ALLOCATE (pgrid%tas_split_info, SOURCE=info)
       ENDIF
 
       CALL timestop(handle)
@@ -1079,9 +1079,9 @@ CONTAINS
       ENDIF
       IF (.NOT. keep_comm_prv) CALL mp_comm_free(pgrid%mp_comm_2d)
       CALL destroy_nd_to_2d_mapping(pgrid%nd_index_grid)
-      IF(ALLOCATED(pgrid%tas_split_info) .AND. .NOT. keep_comm_prv) THEN
+      IF (ALLOCATED(pgrid%tas_split_info) .AND. .NOT. keep_comm_prv) THEN
          CALL dbcsr_tas_release_info(pgrid%tas_split_info)
-         DEALLOCATE(pgrid%tas_split_info)
+         DEALLOCATE (pgrid%tas_split_info)
       ENDIF
    END SUBROUTINE
 
@@ -1102,7 +1102,7 @@ CONTAINS
       ALLOCATE (dims(SIZE(map1_2d) + SIZE(map2_2d)))
       CALL dbcsr_t_get_mapping_info(pgrid_in%nd_index_grid, dims_nd=dims, map1_2d=map1_2d_old, map2_2d=map2_2d_old)
       CALL dbcsr_t_pgrid_create(pgrid_in%mp_comm_2d, dims, pgrid_out, map1_2d, map2_2d)
-      IF(array_eq_i(map1_2d_old, map1_2d) .AND. array_eq_i(map2_2d_old, map2_2d)) THEN
+      IF (array_eq_i(map1_2d_old, map1_2d) .AND. array_eq_i(map2_2d_old, map2_2d)) THEN
          IF (ALLOCATED(pgrid_in%tas_split_info)) THEN
             ALLOCATE (pgrid_out%tas_split_info, SOURCE=pgrid_in%tas_split_info)
             CALL dbcsr_tas_info_hold(pgrid_out%tas_split_info)

--- a/src/tensors/dbcsr_tensor_types.F
+++ b/src/tensors/dbcsr_tensor_types.F
@@ -27,7 +27,8 @@ MODULE dbcsr_tensor_types
                                        sum_of_arrays, &
                                        array_sublist, &
                                        get_arrays, &
-                                       get_ith_array
+                                       get_ith_array, &
+                                       array_eq_i
    USE dbcsr_api, ONLY: &
       dbcsr_distribution_get, &
       dbcsr_distribution_type, &
@@ -42,18 +43,20 @@ MODULE dbcsr_tensor_types
       dbcsr_tas_destroy, dbcsr_tas_get_stored_coordinates, dbcsr_tas_set, dbcsr_tas_filter, &
       dbcsr_tas_get_num_blocks, dbcsr_tas_get_num_blocks_total, dbcsr_tas_get_data_size, dbcsr_tas_get_nze, &
       dbcsr_tas_get_nze_total, dbcsr_tas_clear
-   USE dbcsr_tas_types, ONLY: dbcsr_tas_type, dbcsr_tas_distribution_type, dbcsr_tas_create_split_info
+   USE dbcsr_tas_types, ONLY: &
+      dbcsr_tas_type, dbcsr_tas_distribution_type, dbcsr_tas_split_info
    USE dbcsr_tensor_index, ONLY: get_2d_indices, &
                                  get_nd_indices, &
                                  create_nd_to_2d_mapping, &
                                  destroy_nd_to_2d_mapping, &
-                                 get_mapping_info, &
+                                 dbcsr_t_get_mapping_info, &
                                  nd_to_2d_mapping, &
                                  split_index, &
                                  combine_index, &
                                  ndims_mapping
    USE dbcsr_tas_split, ONLY: dbcsr_tas_create_split_rows_or_cols, &
-                              dbcsr_tas_release_info
+                              dbcsr_tas_release_info, &
+                              dbcsr_tas_info_hold
    USE dbcsr_kinds, ONLY: default_string_length, int_8
    USE dbcsr_mpiwrap, ONLY: mp_cart_create, &
                             mp_cart_rank, &
@@ -108,10 +111,11 @@ MODULE dbcsr_tensor_types
    TYPE dbcsr_t_pgrid_type
       TYPE(nd_to_2d_mapping) :: nd_index_grid
       INTEGER                :: mp_comm_2d
+      TYPE(dbcsr_tas_split_info), ALLOCATABLE :: tas_split_info
    END TYPE
 
    TYPE dbcsr_t_type
-      TYPE(dbcsr_tas_type), POINTER          :: matrix_rep => NULL()
+      TYPE(dbcsr_tas_type), POINTER        :: matrix_rep => NULL()
       TYPE(nd_to_2d_mapping)               :: nd_index_blk
       TYPE(nd_to_2d_mapping)               :: nd_index
       TYPE(array_list)                     :: blk_sizes
@@ -208,21 +212,21 @@ CONTAINS
       INTEGER, DIMENSION(:), ALLOCATABLE :: index_map
 
       IF (which_dim == 1) THEN
-         CALL get_mapping_info(map_blks, &
-                               dims_2d_i8=matrix_dims, &
-                               map1_2d=index_map, &
-                               dims1_2d=new_dbcsr_tas_dist_t%dims)
-         CALL get_mapping_info(map_grid, &
-                               dims_2d=grid_dims, &
-                               dims1_2d=new_dbcsr_tas_dist_t%dims_grid)
+         CALL dbcsr_t_get_mapping_info(map_blks, &
+                                       dims_2d_i8=matrix_dims, &
+                                       map1_2d=index_map, &
+                                       dims1_2d=new_dbcsr_tas_dist_t%dims)
+         CALL dbcsr_t_get_mapping_info(map_grid, &
+                                       dims_2d=grid_dims, &
+                                       dims1_2d=new_dbcsr_tas_dist_t%dims_grid)
       ELSEIF (which_dim == 2) THEN
-         CALL get_mapping_info(map_blks, &
-                               dims_2d_i8=matrix_dims, &
-                               map2_2d=index_map, &
-                               dims2_2d=new_dbcsr_tas_dist_t%dims)
-         CALL get_mapping_info(map_grid, &
-                               dims_2d=grid_dims, &
-                               dims2_2d=new_dbcsr_tas_dist_t%dims_grid)
+         CALL dbcsr_t_get_mapping_info(map_blks, &
+                                       dims_2d_i8=matrix_dims, &
+                                       map2_2d=index_map, &
+                                       dims2_2d=new_dbcsr_tas_dist_t%dims)
+         CALL dbcsr_t_get_mapping_info(map_grid, &
+                                       dims_2d=grid_dims, &
+                                       dims2_2d=new_dbcsr_tas_dist_t%dims_grid)
       ELSE
          DBCSR_ABORT("Unknown value for which_dim")
       ENDIF
@@ -324,15 +328,15 @@ CONTAINS
       TYPE(dbcsr_tas_blk_size_t) :: new_dbcsr_tas_blk_size_t
 
       IF (which_dim == 1) THEN
-         CALL get_mapping_info(map_blks, &
-                               dims_2d_i8=matrix_dims, &
-                               map1_2d=index_map, &
-                               dims1_2d=new_dbcsr_tas_blk_size_t%dims)
+         CALL dbcsr_t_get_mapping_info(map_blks, &
+                                       dims_2d_i8=matrix_dims, &
+                                       map1_2d=index_map, &
+                                       dims1_2d=new_dbcsr_tas_blk_size_t%dims)
       ELSEIF (which_dim == 2) THEN
-         CALL get_mapping_info(map_blks, &
-                               dims_2d_i8=matrix_dims, &
-                               map2_2d=index_map, &
-                               dims2_2d=new_dbcsr_tas_blk_size_t%dims)
+         CALL dbcsr_t_get_mapping_info(map_blks, &
+                                       dims_2d_i8=matrix_dims, &
+                                       map2_2d=index_map, &
+                                       dims2_2d=new_dbcsr_tas_blk_size_t%dims)
       ELSE
          DBCSR_ABORT("Unknown value for which_dim")
       ENDIF
@@ -449,18 +453,14 @@ CONTAINS
 !> \param nd_dist_1 distribution vector for first dimension
 !> \param nd_dist_2 distribution vector for second dimension
 !> \param nd_dist_3 ...
-!> \param ngroup How many subgroups (splits) for longest matrix dimension
-!> \param dimsplit which dimension to split (1: row, 2: column)
 !> \param own_comm whether distribution should own communicator
 ! **************************************************************************************************
-   SUBROUTINE dbcsr_t_distribution_new(dist, pgrid, map1_2d, map2_2d, ${varlist("nd_dist")}$, ngroup, dimsplit, own_comm)
+   SUBROUTINE dbcsr_t_distribution_new(dist, pgrid, map1_2d, map2_2d, ${varlist("nd_dist")}$, own_comm)
 
       TYPE(dbcsr_t_distribution_type), INTENT(OUT)    :: dist
       TYPE(dbcsr_t_pgrid_type), INTENT(IN)            :: pgrid
       INTEGER, DIMENSION(:), INTENT(IN)               :: map1_2d, map2_2d
       INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL     :: ${varlist("nd_dist")}$
-      INTEGER, INTENT(IN), OPTIONAL                   :: ngroup
-      INTEGER, INTENT(IN), OPTIONAL                   :: dimsplit
       LOGICAL, INTENT(IN), OPTIONAL                   :: own_comm
       INTEGER                                         :: ndims, comm_2d
       INTEGER, DIMENSION(2)                           :: pdims_2d_check, &
@@ -470,12 +470,10 @@ CONTAINS
       TYPE(array_list)                                :: nd_dist
       TYPE(nd_to_2d_mapping)                          :: map_blks, map_grid
       INTEGER                                         :: handle
-      TYPE(dbcsr_tas_dist_t)                            :: row_dist_obj, col_dist_obj
+      TYPE(dbcsr_tas_dist_t)                          :: row_dist_obj, col_dist_obj
       TYPE(dbcsr_t_pgrid_type)                        :: pgrid_prv
       LOGICAL                                         :: need_pgrid_remap
-      INTEGER, DIMENSION(:), ALLOCATABLE               :: map1_2d_check, map2_2d_check
-      INTEGER                                         :: igroup, ngroup_prv
-      TYPE(dbcsr_tas_create_split_info)                        :: split_info
+      INTEGER, DIMENSION(:), ALLOCATABLE              :: map1_2d_check, map2_2d_check
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_distribution_new', &
                                      routineP = moduleN//':'//routineN
 
@@ -489,7 +487,7 @@ CONTAINS
 
       need_pgrid_remap = .TRUE.
       IF (PRESENT(own_comm)) THEN
-         CALL get_mapping_info(pgrid%nd_index_grid, map1_2d=map1_2d_check, map2_2d=map2_2d_check)
+         CALL dbcsr_t_get_mapping_info(pgrid%nd_index_grid, map1_2d=map1_2d_check, map2_2d=map2_2d_check)
          IF (own_comm) THEN
             IF (.NOT. array_eq_i(map1_2d_check, map1_2d) .OR. .NOT. array_eq_i(map2_2d_check, map2_2d)) THEN
                DBCSR_ABORT("map1_2d / map2_2d are not consistent with pgrid")
@@ -513,7 +511,7 @@ CONTAINS
       row_dist_obj = dbcsr_tas_dist_t(nd_dist, map_blks, map_grid, 1)
       col_dist_obj = dbcsr_tas_dist_t(nd_dist, map_blks, map_grid, 2)
 
-      CALL get_mapping_info(map_grid, dims_2d=pdims_2d)
+      CALL dbcsr_t_get_mapping_info(map_grid, dims_2d=pdims_2d)
 
       comm_2d = pgrid_prv%mp_comm_2d !dbcsr_t_2d_mp_comm(comm_nd, map1_2d, map2_2d)
 
@@ -522,22 +520,8 @@ CONTAINS
          DBCSR_ABORT("inconsistent process grid dimensions")
       ENDIF
 
-      IF (PRESENT(ngroup)) THEN
-         DBCSR_ASSERT(PRESENT(dimsplit))
-
-         IF (MOD(pdims_2d(dimsplit), ngroup) .NE. 0) THEN
-            DBCSR_ABORT("split factor must divide process grid dimension")
-         ENDIF
-
-         igroup = task_coor_2d(dimsplit)/(pdims_2d(dimsplit)/ngroup)
-
-         ngroup_prv = ngroup
-         CALL dbcsr_tas_create_split_rows_or_cols(split_info, comm_2d, ngroup_prv, igroup, dimsplit)
-
-         DBCSR_ASSERT(ngroup_prv == ngroup)
-
-         CALL dbcsr_tas_distribution_new(dist%dist, comm_2d, row_dist_obj, col_dist_obj, split_info=split_info)
-         CALL dbcsr_tas_release_info(split_info)
+      IF(ALLOCATED(pgrid_prv%tas_split_info)) THEN
+         CALL dbcsr_tas_distribution_new(dist%dist, comm_2d, row_dist_obj, col_dist_obj, split_info=pgrid_prv%tas_split_info)
       ELSE
          CALL dbcsr_tas_distribution_new(dist%dist, comm_2d, row_dist_obj, col_dist_obj)
       ENDIF
@@ -668,7 +652,7 @@ CONTAINS
       dims = sizes_of_arrays(blk_size)
 
       CALL create_nd_to_2d_mapping(map, dims, map1_2d, map2_2d)
-      CALL get_mapping_info(map, dims_2d_i8=dims_2d)
+      CALL dbcsr_t_get_mapping_info(map, dims_2d_i8=dims_2d)
 
       row_blk_size_obj = dbcsr_tas_blk_size_t(blk_size, map, 1)
       col_blk_size_obj = dbcsr_tas_blk_size_t(blk_size, map, 2)
@@ -1083,7 +1067,7 @@ CONTAINS
       CALL mp_environ(nproc, iproc, mp_comm)
       IF (ANY(dims == 0)) CALL mp_dims_create(nproc, dims)
       CALL create_nd_to_2d_mapping(pgrid%nd_index_grid, dims, map1_2d_prv, map2_2d_prv, base=0, col_major=.FALSE.)
-      CALL get_mapping_info(pgrid%nd_index_grid, dims_2d=pdims_2d)
+      CALL dbcsr_t_get_mapping_info(pgrid%nd_index_grid, dims_2d=pdims_2d)
       CALL mp_cart_create(mp_comm, 2, pdims_2d, pos, pgrid%mp_comm_2d)
 
       CALL timestop(handle)
@@ -1105,6 +1089,10 @@ CONTAINS
       ENDIF
       IF (.NOT. keep_comm_prv) CALL mp_comm_free(pgrid%mp_comm_2d)
       CALL destroy_nd_to_2d_mapping(pgrid%nd_index_grid)
+      IF(ALLOCATED(pgrid%tas_split_info) .AND. .NOT. keep_comm_prv) THEN
+         CALL dbcsr_tas_release_info(pgrid%tas_split_info)
+         DEALLOCATE(pgrid%tas_split_info)
+      ENDIF
    END SUBROUTINE
 
 ! **************************************************************************************************
@@ -1119,10 +1107,17 @@ CONTAINS
       INTEGER, DIMENSION(:), INTENT(IN) :: map1_2d, map2_2d
       TYPE(dbcsr_t_pgrid_type), INTENT(OUT) :: pgrid_out
       INTEGER, DIMENSION(:), ALLOCATABLE :: dims
+      INTEGER, ALLOCATABLE, DIMENSION(:) :: map1_2d_old, map2_2d_old
 
       ALLOCATE (dims(SIZE(map1_2d) + SIZE(map2_2d)))
-      CALL get_mapping_info(pgrid_in%nd_index_grid, dims_nd=dims)
+      CALL dbcsr_t_get_mapping_info(pgrid_in%nd_index_grid, dims_nd=dims, map1_2d=map1_2d_old, map2_2d=map2_2d_old)
       CALL dbcsr_t_pgrid_create(pgrid_in%mp_comm_2d, dims, pgrid_out, map1_2d, map2_2d)
+      IF(array_eq_i(map1_2d_old, map1_2d) .AND. array_eq_i(map2_2d_old, map2_2d)) THEN
+         IF (ALLOCATED(pgrid_in%tas_split_info)) THEN
+            ALLOCATE (pgrid_out%tas_split_info, SOURCE=pgrid_in%tas_split_info)
+            CALL dbcsr_tas_info_hold(pgrid_out%tas_split_info)
+         ENDIF
+      ENDIF
    END SUBROUTINE
 
 ! **************************************************************************************************
@@ -1139,7 +1134,8 @@ CONTAINS
       INTEGER :: nproc
 
       CALL mp_environ(nproc, dims_2d, task_coor_2d, pgrid%mp_comm_2d)
-      CALL get_mapping_info(pgrid%nd_index_grid, dims_nd=dims)
+      CALL mp_environ(nproc, dims_2d, task_coor_2d, pgrid%mp_comm_2d)
+      CALL dbcsr_t_get_mapping_info(pgrid%nd_index_grid, dims_nd=dims)
       task_coor = get_nd_indices(pgrid%nd_index_grid, INT(task_coor_2d, KIND=int_8))
    END SUBROUTINE
 
@@ -1226,8 +1222,8 @@ CONTAINS
       INTEGER, INTENT(OUT), OPTIONAL                            :: data_type
       INTEGER, DIMENSION(ndims_tensor(tensor))                  :: pdims_tmp, my_ploc_tmp
 
-      IF (PRESENT(nblks_total)) CALL get_mapping_info(tensor%nd_index_blk, dims_nd=nblks_total)
-      IF (PRESENT(nfull_total)) CALL get_mapping_info(tensor%nd_index, dims_nd=nfull_total)
+      IF (PRESENT(nblks_total)) CALL dbcsr_t_get_mapping_info(tensor%nd_index_blk, dims_nd=nblks_total)
+      IF (PRESENT(nfull_total)) CALL dbcsr_t_get_mapping_info(tensor%nd_index, dims_nd=nfull_total)
       IF (PRESENT(nblks_local)) nblks_local(:) = tensor%nblks_local
       IF (PRESENT(nfull_local)) nfull_local(:) = tensor%nfull_local
 

--- a/src/tensors/dbcsr_tensor_types.F
+++ b/src/tensors/dbcsr_tensor_types.F
@@ -18,21 +18,11 @@ MODULE dbcsr_tensor_types
 #:set maxdim = maxrank
 #:set ndims = range(2,maxdim+1)
 
-   USE dbcsr_array_list_methods, ONLY: array_list, &
-                                       array_offsets, &
-                                       create_array_list, &
-                                       destroy_array_list, &
-                                       get_array_elements, &
-                                       sizes_of_arrays, &
-                                       sum_of_arrays, &
-                                       array_sublist, &
-                                       get_arrays, &
-                                       get_ith_array, &
-                                       array_eq_i
+   USE dbcsr_array_list_methods, ONLY: &
+      array_list, array_offsets, create_array_list, destroy_array_list, get_array_elements, &
+      sizes_of_arrays, sum_of_arrays, array_sublist, get_arrays, get_ith_array, array_eq_i
    USE dbcsr_api, ONLY: &
-      dbcsr_distribution_get, &
-      dbcsr_distribution_type, &
-      dbcsr_get_info, dbcsr_type, &
+      dbcsr_distribution_get, dbcsr_distribution_type, dbcsr_get_info, dbcsr_type, &
       ${uselist(dtype_float_param)}$
    USE dbcsr_kinds, ONLY: &
       ${uselist(dtype_float_prec)}$, &
@@ -45,25 +35,15 @@ MODULE dbcsr_tensor_types
       dbcsr_tas_get_nze_total, dbcsr_tas_clear
    USE dbcsr_tas_types, ONLY: &
       dbcsr_tas_type, dbcsr_tas_distribution_type, dbcsr_tas_split_info
-   USE dbcsr_tensor_index, ONLY: get_2d_indices, &
-                                 get_nd_indices, &
-                                 create_nd_to_2d_mapping, &
-                                 destroy_nd_to_2d_mapping, &
-                                 dbcsr_t_get_mapping_info, &
-                                 nd_to_2d_mapping, &
-                                 split_index, &
-                                 combine_index, &
-                                 ndims_mapping
-   USE dbcsr_tas_split, ONLY: dbcsr_tas_create_split_rows_or_cols, &
-                              dbcsr_tas_release_info, &
-                              dbcsr_tas_info_hold
+   USE dbcsr_tensor_index, ONLY: &
+      get_2d_indices, get_nd_indices, create_nd_to_2d_mapping, destroy_nd_to_2d_mapping, &
+      dbcsr_t_get_mapping_info, nd_to_2d_mapping, split_index, combine_index, ndims_mapping
+   USE dbcsr_tas_split, ONLY: &
+      dbcsr_tas_create_split_rows_or_cols, dbcsr_tas_release_info, dbcsr_tas_info_hold, &
+      dbcsr_tas_create_split
    USE dbcsr_kinds, ONLY: default_string_length, int_8
-   USE dbcsr_mpiwrap, ONLY: mp_cart_create, &
-                            mp_cart_rank, &
-                            mp_environ, &
-                            mp_dims_create, &
-                            mp_comm_free, mp_comm_dup, &
-                            mp_sum, mp_max
+   USE dbcsr_mpiwrap, ONLY: &
+      mp_cart_create, mp_cart_rank, mp_environ, mp_dims_create, mp_comm_free, mp_comm_dup, mp_sum, mp_max
    USE dbcsr_tas_global, ONLY: dbcsr_tas_distribution, dbcsr_tas_rowcol_data
    USE dbcsr_allocate_wrap, ONLY: allocate_any
    USE dbcsr_data_types, ONLY: dbcsr_scalar_type
@@ -109,8 +89,8 @@ MODULE dbcsr_tensor_types
       ndims_tensor
 
    TYPE dbcsr_t_pgrid_type
-      TYPE(nd_to_2d_mapping) :: nd_index_grid
-      INTEGER                :: mp_comm_2d
+      TYPE(nd_to_2d_mapping)                  :: nd_index_grid
+      INTEGER                                 :: mp_comm_2d
       TYPE(dbcsr_tas_split_info), ALLOCATABLE :: tas_split_info
    END TYPE
 
@@ -1038,15 +1018,19 @@ CONTAINS
 !> \param pgrid n-dimensional grid object
 !> \param map1_2d which nd-indices map to first matrix index and in which order
 !> \param map2_2d which nd-indices map to first matrix index and in which order
+!> \param nsplit impose a constant split factor
+!> \param dimsplit which matrix dimension to split
 ! **************************************************************************************************
-   SUBROUTINE dbcsr_t_pgrid_create(mp_comm, dims, pgrid, map1_2d, map2_2d)
+   SUBROUTINE dbcsr_t_pgrid_create(mp_comm, dims, pgrid, map1_2d, map2_2d, nsplit, dimsplit)
       INTEGER, INTENT(IN) :: mp_comm
       INTEGER, DIMENSION(:), INTENT(INOUT) :: dims
       TYPE(dbcsr_t_pgrid_type), INTENT(OUT) :: pgrid
       INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL :: map1_2d, map2_2d
+      INTEGER, INTENT(IN), OPTIONAL :: nsplit, dimsplit
       INTEGER :: nproc, iproc, ndims, i, handle
       INTEGER, DIMENSION(2) :: pdims_2d, pos
       INTEGER, DIMENSION(:), ALLOCATABLE :: map1_2d_prv, map2_2d_prv
+      TYPE(dbcsr_tas_split_info) :: info
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_pgrid_create', &
                                      routineP = moduleN//':'//routineN
@@ -1069,6 +1053,12 @@ CONTAINS
       CALL create_nd_to_2d_mapping(pgrid%nd_index_grid, dims, map1_2d_prv, map2_2d_prv, base=0, col_major=.FALSE.)
       CALL dbcsr_t_get_mapping_info(pgrid%nd_index_grid, dims_2d=pdims_2d)
       CALL mp_cart_create(mp_comm, 2, pdims_2d, pos, pgrid%mp_comm_2d)
+
+      IF(PRESENT(nsplit)) THEN
+         DBCSR_ASSERT(PRESENT(dimsplit))
+         CALL dbcsr_tas_create_split(info, pgrid%mp_comm_2d, dimsplit, nsplit, opt_nsplit=.FALSE.)
+         ALLOCATE(pgrid%tas_split_info, SOURCE=info)
+      ENDIF
 
       CALL timestop(handle)
    END SUBROUTINE

--- a/tests/dbcsr_tas_unittest.F
+++ b/tests/dbcsr_tas_unittest.F
@@ -78,22 +78,22 @@ PROGRAM dbcsr_tas_unittest
    IF (mynode == 0) WRITE (io_unit, '(A)') "DBCSR TALL-AND-SKINNY MATRICES"
    IF (mynode == 0) WRITE (io_unit, '(1X, A, 1X, A, I10, 1X, A, 1X, I10)') "Split info for matrix", &
       TRIM(A%matrix%name), dbcsr_tas_nblkrows_total(A), 'X', dbcsr_tas_nblkcols_total(A)
-   CALL dbcsr_tas_write_split_info(dbcsr_tas_info(A), "A", io_unit)
+   CALL dbcsr_tas_write_split_info(dbcsr_tas_info(A), io_unit, name="A")
    IF (mynode == 0) WRITE (io_unit, '(1X, A, 1X, A, I10, 1X, A, 1X, I10)') "Split info for matrix", &
       TRIM(At%matrix%name), dbcsr_tas_nblkrows_total(At), 'X', dbcsr_tas_nblkcols_total(At)
-   CALL dbcsr_tas_write_split_info(dbcsr_tas_info(At), "At", io_unit)
+   CALL dbcsr_tas_write_split_info(dbcsr_tas_info(At), io_unit, name="At")
    IF (mynode == 0) WRITE (io_unit, '(1X, A, 1X, A, I10, 1X, A, 1X, I10)') "Split info for matrix", &
       TRIM(B%matrix%name), dbcsr_tas_nblkrows_total(B), 'X', dbcsr_tas_nblkcols_total(B)
-   CALL dbcsr_tas_write_split_info(dbcsr_tas_info(B), "B", io_unit)
+   CALL dbcsr_tas_write_split_info(dbcsr_tas_info(B), io_unit, name="B")
    IF (mynode == 0) WRITE (io_unit, '(1X, A, 1X, A, I10, 1X, A, 1X, I10)') "Split info for matrix", &
       TRIM(Bt%matrix%name), dbcsr_tas_nblkrows_total(Bt), 'X', dbcsr_tas_nblkcols_total(Bt)
-   CALL dbcsr_tas_write_split_info(dbcsr_tas_info(Bt), "Bt", io_unit)
+   CALL dbcsr_tas_write_split_info(dbcsr_tas_info(Bt), io_unit, name="Bt")
    IF (mynode == 0) WRITE (io_unit, '(1X, A, 1X, A, I10, 1X, A, 1X, I10)') "Split info for matrix", &
       TRIM(C%matrix%name), dbcsr_tas_nblkrows_total(C), 'X', dbcsr_tas_nblkcols_total(C)
-   CALL dbcsr_tas_write_split_info(dbcsr_tas_info(C), "C", io_unit)
+   CALL dbcsr_tas_write_split_info(dbcsr_tas_info(C), io_unit, name="C")
    IF (mynode == 0) WRITE (io_unit, '(1X, A, 1X, A, I10, 1X, A, 1X, I10)') "Split info for matrix", &
       TRIM(Ct%matrix%name), dbcsr_tas_nblkrows_total(Ct), 'X', dbcsr_tas_nblkcols_total(Ct)
-   CALL dbcsr_tas_write_split_info(dbcsr_tas_info(Ct), "Ct", io_unit)
+   CALL dbcsr_tas_write_split_info(dbcsr_tas_info(Ct), io_unit, name="Ct")
 
    CALL dbcsr_tas_test_mm('N', 'N', 'N', B, A, Ct_out, unit_nr=default_output_unit, filter_eps=filter_eps)
    CALL dbcsr_tas_test_mm('T', 'N', 'N', Bt, A, Ct_out, unit_nr=default_output_unit, filter_eps=filter_eps)

--- a/tests/dbcsr_tensor_unittest.F
+++ b/tests/dbcsr_tensor_unittest.F
@@ -781,10 +781,12 @@ PROGRAM dbcsr_tensor_unittest
 ! Cleanup for tensor contraction tests                                                             !
 !--------------------------------------------------------------------------------------------------!
 
-      DEALLOCATE (size_1, size_2, size_3, size_4)
+      DEALLOCATE (size_1, size_2, size_3, size_4, size_5)
       DEALLOCATE (blk_ind_1_1, blk_ind_2_1, blk_ind_3_1)
       DEALLOCATE (blk_ind_3_2, blk_ind_4_2)
       DEALLOCATE (blk_ind_1_3, blk_ind_2_3, blk_ind_4_3)
+      DEALLOCATE (blk_ind_1_4, blk_ind_2_4, blk_ind_4_4, blk_ind_5_4)
+      DEALLOCATE (blk_ind_3_5, blk_ind_4_5, blk_ind_5_5)
       DEALLOCATE (dist1_1, dist1_2, dist1_3, dist2_1, dist2_2, dist3_1, dist3_2, dist3_3)
       CALL dbcsr_t_pgrid_destroy(pgrid_3d)
       CALL dbcsr_t_pgrid_destroy(pgrid_2d)


### PR DESCRIPTION
With these changes, process grids and process sub-groups are optimized internally in tensor contraction based on estimated sparsity of result tensor. Subsequent tensor contractions with tensors of similar shape and sparsity can optionally reuse optimized grid.

Finally (with corresponding changes in CP2K, a pull request will follow), we can get rid of the performance-critical parameters [GROUP_SIZE_3C](https://manual.cp2k.org/trunk/CP2K_INPUT/FORCE_EVAL/DFT/XC/WF_CORRELATION/IM_TIME.html#GROUP_SIZE_3C) and [GROUP_SIZE_P](https://manual.cp2k.org/trunk/CP2K_INPUT/FORCE_EVAL/DFT/XC/WF_CORRELATION/IM_TIME.html#GROUP_SIZE_P) in CP2K.

This pr comes with some API changes, probably the last tensor API changes before v2.0.