### PR TITLE
Disable mempools on CPUs by default

### DIFF
--- a/src/core/dbcsr_config.F
+++ b/src/core/dbcsr_config.F
@@ -305,6 +305,7 @@ CONTAINS
 !> \param accdrv_do_inhomogenous ...
 !> \param accdrv_binning_nbins ...
 !> \param accdrv_binning_binsize ...
+!> \param use_mempools_cpu ...
 ! **************************************************************************************************
    SUBROUTINE dbcsr_get_default_config( &
       use_mpi_allocator, &
@@ -328,7 +329,8 @@ CONTAINS
       accdrv_min_flop_sort, &
       accdrv_do_inhomogenous, &
       accdrv_binning_nbins, &
-      accdrv_binning_binsize)
+      accdrv_binning_binsize, &
+      use_mempools_cpu)
 !
       LOGICAL, INTENT(OUT), OPTIONAL                     :: use_mpi_allocator
       INTEGER, INTENT(OUT), OPTIONAL                     :: mm_stack_size, avg_elements_images, &
@@ -347,6 +349,7 @@ CONTAINS
       LOGICAL, INTENT(OUT), OPTIONAL                     :: accdrv_do_inhomogenous
       INTEGER, INTENT(OUT), OPTIONAL                     :: accdrv_binning_nbins, &
                                                             accdrv_binning_binsize
+      LOGICAL, INTENT(OUT), OPTIONAL                     :: use_mempools_cpu
 
       TYPE(dbcsr_config_type)                            :: default_cfg
       TYPE(dbcsr_data_allocation_type)                   :: default_data_allocation
@@ -372,6 +375,7 @@ CONTAINS
       IF (PRESENT(accdrv_do_inhomogenous)) accdrv_do_inhomogenous = default_cfg%accdrv_do_inhomogenous
       IF (PRESENT(accdrv_binning_nbins)) accdrv_binning_nbins = default_cfg%accdrv_binning_nbins
       IF (PRESENT(accdrv_binning_binsize)) accdrv_binning_binsize = default_cfg%accdrv_binning_binsize
+      IF (PRESENT(use_mempools_cpu)) use_mempools_cpu = default_cfg%use_mempools_cpu
 
       DBCSR_ASSERT(default_cfg%nm_stacks == default_cfg%nn_stacks)
       DBCSR_ASSERT(default_cfg%nm_stacks == default_cfg%nk_stacks)

--- a/src/core/dbcsr_config.F
+++ b/src/core/dbcsr_config.F
@@ -121,6 +121,7 @@ MODULE dbcsr_config
       LOGICAL  :: accdrv_do_inhomogenous = .TRUE.
       INTEGER  :: accdrv_binning_nbins = 4096
       INTEGER  :: accdrv_binning_binsize = 16
+      LOGICAL  :: use_mempools_cpu = .FALSE.
    END TYPE dbcsr_config_type
 
    TYPE(dbcsr_config_type), PROTECTED, SAVE :: dbcsr_cfg = dbcsr_config_type() ! defaults
@@ -164,6 +165,7 @@ CONTAINS
 !> \param accdrv_do_inhomogenous ...
 !> \param accdrv_binning_nbins ...
 !> \param accdrv_binning_binsize ...
+!> \param use_mempools_cpu ...
 ! **************************************************************************************************
    SUBROUTINE dbcsr_set_config( &
       mm_driver, &
@@ -188,7 +190,8 @@ CONTAINS
       accdrv_min_flop_sort, &
       accdrv_do_inhomogenous, &
       accdrv_binning_nbins, &
-      accdrv_binning_binsize)
+      accdrv_binning_binsize, &
+      use_mempools_cpu)
 !
       CHARACTER(len=*), INTENT(IN), OPTIONAL             :: mm_driver
       LOGICAL, INTENT(IN), OPTIONAL                      :: use_mpi_allocator
@@ -208,6 +211,7 @@ CONTAINS
       LOGICAL, INTENT(IN), OPTIONAL                      :: accdrv_do_inhomogenous
       INTEGER, INTENT(IN), OPTIONAL                      :: accdrv_binning_nbins, &
                                                             accdrv_binning_binsize
+      LOGICAL, INTENT(IN), OPTIONAL                      :: use_mempools_cpu
 
       INTEGER                                            :: nthreads
 
@@ -230,6 +234,7 @@ CONTAINS
       IF (PRESENT(accdrv_do_inhomogenous)) dbcsr_cfg%accdrv_do_inhomogenous = accdrv_do_inhomogenous
       IF (PRESENT(accdrv_binning_nbins)) dbcsr_cfg%accdrv_binning_nbins = accdrv_binning_nbins
       IF (PRESENT(accdrv_binning_binsize)) dbcsr_cfg%accdrv_binning_binsize = accdrv_binning_binsize
+      IF (PRESENT(use_mempools_cpu)) dbcsr_cfg%use_mempools_cpu = use_mempools_cpu
 
       IF (PRESENT(comm_thread_load)) THEN
          dbcsr_cfg%comm_thread_load = comm_thread_load

--- a/src/data/dbcsr_mem_methods.F
+++ b/src/data/dbcsr_mem_methods.F
@@ -74,7 +74,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_mempool_limit_capacity', &
                                      routineP = moduleN//':'//routineN
 
-      IF (.NOT. ASSOCIATED(pool)) DBCSR_ABORT("pool not allocated")
+      IF (.NOT. ASSOCIATED(pool)) RETURN
 !$    CALL OMP_SET_LOCK(pool%lock)
       pool%capacity = MAX(pool%capacity, capacity)
 !$    CALL OMP_UNSET_LOCK(pool%lock)

--- a/src/mm/dbcsr_mm.F
+++ b/src/mm/dbcsr_mm.F
@@ -164,7 +164,7 @@ CONTAINS
 
       ! Each thread has its own working-matrix and its own mempool
       ALLOCATE (memtype_product_wm(ithread)%p)
-      CALL dbcsr_memtype_setup(memtype_product_wm(ithread)%p, has_pool=.TRUE.)
+      CALL dbcsr_memtype_setup(memtype_product_wm(ithread)%p, has_pool=dbcsr_cfg%use_mempools_cpu .OR. has_acc)
       CALL dbcsr_mempool_limit_capacity(memtype_product_wm(ithread)%p%pool, capacity=MAX(1, dbcsr_cfg%num_layers_3D))
    END SUBROUTINE dbcsr_multiply_lib_init
 
@@ -420,7 +420,7 @@ CONTAINS
                  output_unit
       INTEGER(KIND=int_8)                                :: my_flop
       LOGICAL :: ab_dense, keep_product_data, keep_sparsity, product_reindex, release_tdist, &
-                 transpose_left, transpose_right, use_dense_mult
+                 transpose_left, transpose_right, use_dense_mult, use_mempools
       REAL(KIND=dp)                                      :: cs
       TYPE(array_i1d_obj) :: dense_col_sizes, dense_k_sizes, dense_row_sizes, k_vmap, m_map, &
                              n_map, old_product_col_blk_offsets, old_product_col_blk_sizes, &
@@ -459,6 +459,8 @@ CONTAINS
       ithread = 0
 !$    ithread = OMP_GET_THREAD_NUM()
 
+      use_mempools = dbcsr_cfg%use_mempools_cpu .OR. has_acc
+
       ! setup driver-dependent memory-types and their memory-pools ---------------
 
       ! the ab_buffers are shared by all threads
@@ -486,7 +488,7 @@ CONTAINS
       ENDIF
 
       CALL dbcsr_memtype_setup(memtype_mpi_buffer, mpi=.TRUE.)
-      CALL dbcsr_memtype_setup(memtype_mpi_product, mpi=.TRUE., has_pool=.TRUE.)
+      CALL dbcsr_memtype_setup(memtype_mpi_product, mpi=.TRUE., has_pool=use_mempools)
 
       ! check parameters ---------------------------------------------------------
       transa_l = transa
@@ -616,8 +618,8 @@ CONTAINS
       ab_dense = use_dense_mult
       ! Use memory pools when no dense
       IF (.NOT. has_acc) THEN
-         CALL dbcsr_memtype_setup(memtype_abpanel_1, has_pool=.NOT. ab_dense, mpi=.TRUE.)
-         CALL dbcsr_memtype_setup(memtype_abpanel_2, has_pool=.NOT. ab_dense, mpi=.TRUE.)
+         CALL dbcsr_memtype_setup(memtype_abpanel_1, has_pool=.NOT. ab_dense .AND. use_mempools, mpi=.TRUE.)
+         CALL dbcsr_memtype_setup(memtype_abpanel_2, has_pool=.NOT. ab_dense .AND. use_mempools, mpi=.TRUE.)
       ENDIF
       !
       ! Submatrix selection


### PR DESCRIPTION
This circumvents the following issues #242:
1) memory may be needed otherwise
2) large memory pools cause inefficiencies for small matrix
multiplications

Issue 2) should be properly fixed but the presence of this configuration
option will still be justified by 1).