### PR TITLE
Support GNU toolchain and Intel MPI

### DIFF
--- a/.ci/daint.cscs.ch/gnu.build.sh
+++ b/.ci/daint.cscs.ch/gnu.build.sh
@@ -27,6 +27,7 @@ cd "${SCRATCH}/${BUILD_TAG}.gnu"
 
 cmake \
     -DCMAKE_SYSTEM_NAME=CrayLinuxEnvironment \
+    -DCMAKE_CROSSCOMPILING_EMULATOR="" \
     -DUSE_CUDA=ON \
     -DUSE_CUBLAS=ON \
     -DWITH_GPU=P100 \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,13 @@ foreach(line ${VERSION_INFO})
   endif ()
 endforeach()
 
+# __HAS_NO_MPI_MOD controls if mpi.f is included which may not accept strict f2008 flag during compilation
+if (MPI_FOUND AND (MPI_Fortran_LIBRARY_VERSION_STRING MATCHES "Intel") AND (NOT ${CMAKE_Fortran_COMPILER_ID} MATCHES "Intel"))
+  # get_target_property for COMPILE_OPTIONS is apparently not working even with own/separate target (NOTFOUND)
+  # see also: https://stackoverflow.com/questions/28344564/cmake-remove-a-compile-flag-for-a-single-translation-unit
+  STRING(REGEX REPLACE "-std=.[^ ]*" "" CMAKE_Fortran_FLAGS ${CMAKE_Fortran_FLAGS})  # mpi.f is not strict f2008
+endif ()
+
 add_subdirectory(src)
 add_subdirectory(tests)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ find_package(PkgConfig)
 if (USE_MPI)
   get_property(REQUIRED_MPI_COMPONENTS GLOBAL PROPERTY ENABLED_LANGUAGES)
   list(REMOVE_ITEM REQUIRED_MPI_COMPONENTS CUDA)  # CUDA does not have a MPI component
+  set(MPI_DETERMINE_LIBRARY_VERSION true)  # prior to find_package
   find_package(MPI COMPONENTS ${REQUIRED_MPI_COMPONENTS} REQUIRED)
 endif ()
 
@@ -104,6 +105,12 @@ foreach(line ${VERSION_INFO})
     continue ()
   endif ()
 endforeach()
+
+# must be global since modified FLAGS apply to other subdirectories as well, e.g., examples
+# must be after include(CompilerConfiguration) due to modifying CMAKE_Fortran_FLAGS
+if (MPI_FOUND AND (MPI_Fortran_LIBRARY_VERSION_STRING MATCHES "Intel") AND (NOT ${CMAKE_Fortran_COMPILER_ID} MATCHES "Intel"))
+  STRING(REGEX REPLACE "-std=.[^ ]*" "-D__HAS_NO_MPI_MOD" CMAKE_Fortran_FLAGS ${CMAKE_Fortran_FLAGS})
+endif ()
 
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,12 +106,6 @@ foreach(line ${VERSION_INFO})
   endif ()
 endforeach()
 
-# must be global since modified FLAGS apply to other subdirectories as well, e.g., examples
-# must be after include(CompilerConfiguration) due to modifying CMAKE_Fortran_FLAGS
-if (MPI_FOUND AND (MPI_Fortran_LIBRARY_VERSION_STRING MATCHES "Intel") AND (NOT ${CMAKE_Fortran_COMPILER_ID} MATCHES "Intel"))
-  STRING(REGEX REPLACE "-std=.[^ ]*" "-D__HAS_NO_MPI_MOD" CMAKE_Fortran_FLAGS ${CMAKE_Fortran_FLAGS})
-endif ()
-
 add_subdirectory(src)
 add_subdirectory(tests)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,6 +16,12 @@ foreach (dbcsr_program_src ${DBCSR_PROGRAM_SRCS})
   set_target_properties(${dbcsr_program_name} PROPERTIES LINKER_LANGUAGE Fortran)
 endforeach ()
 
+# __HAS_NO_MPI_MOD controls whether mpi.mod is used or if mpi.f is included
+if (MPI_FOUND AND (MPI_Fortran_LIBRARY_VERSION_STRING MATCHES "Intel") AND (NOT ${CMAKE_Fortran_COMPILER_ID} MATCHES "Intel"))
+  STRING(REGEX REPLACE "-std=.[^ ]*" "" CMAKE_Fortran_FLAGS ${CMAKE_Fortran_FLAGS})  # mpi.f is not strict f2008
+  target_compile_definitions(${dbcsr_program_name} PRIVATE __HAS_NO_MPI_MOD)
+endif ()
+
 if (WITH_C_API)
   add_executable(dbcsr_example_3_cpp dbcsr_example_3.cpp)
   target_link_libraries(dbcsr_example_3_cpp dbcsr_c MPI::MPI_CXX)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,7 +15,7 @@ foreach (dbcsr_program_src ${DBCSR_PROGRAM_SRCS})
   # and needs to be told explicitly:
   set_target_properties(${dbcsr_program_name} PROPERTIES LINKER_LANGUAGE Fortran)
 
-  # __HAS_NO_MPI_MOD controls whether mpi.mod is used or if mpi.f is included
+  # __HAS_NO_MPI_MOD controls whether mpi.mod is used or if mpi.f is included; mpi.f may not accept flags about strict Fortran standard
   if (MPI_FOUND AND (MPI_Fortran_LIBRARY_VERSION_STRING MATCHES "Intel") AND (NOT ${CMAKE_Fortran_COMPILER_ID} MATCHES "Intel"))
     target_compile_definitions(${dbcsr_program_name} PRIVATE __HAS_NO_MPI_MOD)
   endif ()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -17,7 +17,7 @@ foreach (dbcsr_program_src ${DBCSR_PROGRAM_SRCS})
 
   # __HAS_NO_MPI_MOD controls whether mpi.mod is used or if mpi.f is included
   if (MPI_FOUND AND (MPI_Fortran_LIBRARY_VERSION_STRING MATCHES "Intel") AND (NOT ${CMAKE_Fortran_COMPILER_ID} MATCHES "Intel"))
-    target_compile_definitions(dbcsr PRIVATE __HAS_NO_MPI_MOD)
+    target_compile_definitions(${dbcsr_program_name} PRIVATE __HAS_NO_MPI_MOD)
   endif ()
 endforeach ()
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,13 +14,12 @@ foreach (dbcsr_program_src ${DBCSR_PROGRAM_SRCS})
   # with the Intel compiler CMake 3.12 seems to forget that the source is actually Fortran
   # and needs to be told explicitly:
   set_target_properties(${dbcsr_program_name} PROPERTIES LINKER_LANGUAGE Fortran)
-endforeach ()
 
-# __HAS_NO_MPI_MOD controls whether mpi.mod is used or if mpi.f is included
-if (MPI_FOUND AND (MPI_Fortran_LIBRARY_VERSION_STRING MATCHES "Intel") AND (NOT ${CMAKE_Fortran_COMPILER_ID} MATCHES "Intel"))
-  STRING(REGEX REPLACE "-std=.[^ ]*" "" CMAKE_Fortran_FLAGS ${CMAKE_Fortran_FLAGS})  # mpi.f is not strict f2008
-  target_compile_definitions(${dbcsr_program_name} PRIVATE __HAS_NO_MPI_MOD)
-endif ()
+  # __HAS_NO_MPI_MOD controls whether mpi.mod is used or if mpi.f is included
+  if (MPI_FOUND AND (MPI_Fortran_LIBRARY_VERSION_STRING MATCHES "Intel") AND (NOT ${CMAKE_Fortran_COMPILER_ID} MATCHES "Intel"))
+    target_compile_definitions(dbcsr PRIVATE __HAS_NO_MPI_MOD)
+  endif ()
+endforeach ()
 
 if (WITH_C_API)
   add_executable(dbcsr_example_3_cpp dbcsr_example_3.cpp)

--- a/examples/dbcsr_example_1.F
+++ b/examples/dbcsr_example_1.F
@@ -11,7 +11,9 @@ PROGRAM dbcsr_example_1
    !! DBCSR example 1
    !! This example shows how to create a dbcsr matrix
 
+#if !defined(__HAS_NO_MPI_MOD)
    USE mpi
+#endif
    USE dbcsr_api,                       ONLY: &
         dbcsr_create, dbcsr_distribution_new, dbcsr_distribution_release, dbcsr_distribution_type, &
         dbcsr_finalize, dbcsr_finalize_lib, dbcsr_init_lib, dbcsr_print, dbcsr_release, &
@@ -19,6 +21,9 @@ PROGRAM dbcsr_example_1
 
    IMPLICIT NONE
 
+#if defined(__HAS_NO_MPI_MOD)
+   INCLUDE "mpif.h"
+#endif
    TYPE(dbcsr_type)                         :: matrix_a
 
    INTEGER, DIMENSION(:), POINTER           :: col_blk_sizes, row_blk_sizes

--- a/examples/dbcsr_example_2.F
+++ b/examples/dbcsr_example_2.F
@@ -11,7 +11,9 @@ PROGRAM dbcsr_example_2
    !! DBCSR example 2
    !! This example shows how to set a dbcsr matrix
 
+#if !defined(__HAS_NO_MPI_MOD)
    USE mpi
+#endif
    USE dbcsr_api,                       ONLY: &
         dbcsr_create, dbcsr_distribution_get, dbcsr_distribution_new, dbcsr_distribution_release, &
         dbcsr_distribution_type, dbcsr_finalize, dbcsr_finalize_lib, dbcsr_get_stored_coordinates, &
@@ -20,6 +22,9 @@ PROGRAM dbcsr_example_2
 
    IMPLICIT NONE
 
+#if defined(__HAS_NO_MPI_MOD)
+   INCLUDE "mpif.h"
+#endif
    TYPE(dbcsr_type)                         :: matrix_a
 
    INTEGER, DIMENSION(:), POINTER           :: col_blk_sizes, row_blk_sizes

--- a/examples/dbcsr_example_3.F
+++ b/examples/dbcsr_example_3.F
@@ -11,7 +11,9 @@ PROGRAM dbcsr_example_3
    !! DBCSR example 3
    !! This example shows how to multiply two dbcsr matrices
 
+#if !defined(__HAS_NO_MPI_MOD)
    USE mpi
+#endif
    USE dbcsr_api,                       ONLY: &
         dbcsr_create, dbcsr_distribution_get, dbcsr_distribution_new, dbcsr_distribution_release, &
         dbcsr_distribution_type, dbcsr_finalize, dbcsr_finalize_lib, dbcsr_get_stored_coordinates, &
@@ -20,6 +22,9 @@ PROGRAM dbcsr_example_3
 
    IMPLICIT NONE
 
+#if defined(__HAS_NO_MPI_MOD)
+   INCLUDE "mpif.h"
+#endif
    TYPE(dbcsr_type)                         :: matrix_a, matrix_b, matrix_c
 
    INTEGER, DIMENSION(:), POINTER           :: col_blk_sizes, row_blk_sizes

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -230,6 +230,14 @@ if (MPI_FOUND)
   # compiler flags at this point.
   # when built against MPI, a dbcsr consumer has to specify the MPI flags as well, therefore: PUBLIC
   target_link_libraries(dbcsr PUBLIC MPI::MPI_Fortran)
+
+  if ((MPI_Fortran_LIBRARY_VERSION_STRING MATCHES "Intel") AND (NOT ${CMAKE_Fortran_COMPILER_ID} MATCHES "Intel"))
+    # get_property/set_property for COMPILE_OPTIONS does not work (NOTFOUND) may need separate library in mpi-directory
+    # see also: https://stackoverflow.com/questions/28344564/cmake-remove-a-compile-flag-for-a-single-translation-unit
+    STRING(REGEX REPLACE "-std=.[^ ]*" "" CMAKE_Fortran_FLAGS ${CMAKE_Fortran_FLAGS})  # mpi.f is not strict f2008
+    # __HAS_NO_MPI_MOD controls whether mpi.mod is used or if mpi.f is included
+    target_compile_definitions(dbcsr PRIVATE __HAS_NO_MPI_MOD)
+  endif ()
 endif ()
 
 # set the __SHORT_FILE__ per file for dbcsr sources

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -231,11 +231,8 @@ if (MPI_FOUND)
   # when built against MPI, a dbcsr consumer has to specify the MPI flags as well, therefore: PUBLIC
   target_link_libraries(dbcsr PUBLIC MPI::MPI_Fortran)
 
+  # __HAS_NO_MPI_MOD controls whether mpi.mod is used or if mpi.f is included
   if ((MPI_Fortran_LIBRARY_VERSION_STRING MATCHES "Intel") AND (NOT ${CMAKE_Fortran_COMPILER_ID} MATCHES "Intel"))
-    # get_property/set_property for COMPILE_OPTIONS does not work (NOTFOUND) may need separate library in mpi-directory
-    # see also: https://stackoverflow.com/questions/28344564/cmake-remove-a-compile-flag-for-a-single-translation-unit
-    STRING(REGEX REPLACE "-std=.[^ ]*" "" CMAKE_Fortran_FLAGS ${CMAKE_Fortran_FLAGS})  # mpi.f is not strict f2008
-    # __HAS_NO_MPI_MOD controls whether mpi.mod is used or if mpi.f is included
     target_compile_definitions(dbcsr PRIVATE __HAS_NO_MPI_MOD)
   endif ()
 endif ()


### PR DESCRIPTION
Ensure CMake attempts to determine the version/vendor string of the MPI component (MPI_DETERMINE_LIBRARY_VERSION=true). Define __HAS_NO_MPI_MOD preprocessor variable if non-Intel (Fortran-)compiler but Intel MPI is used. Apply -D__HAS_NO_MPI_MOD on a global basis. Support __HAS_NO_MPI_MOD (examples).

Note: attempts to apply settings more locally did not work out for various reasons (`get_source_file_property` and friends). In the end, the HAS_NO_MPI_MOD must be global and even apply to example code.