### PR TITLE
Various (smaller) fixes

### DIFF
--- a/src/acc/dbcsr_acc_devmem.F
+++ b/src/acc/dbcsr_acc_devmem.F
@@ -316,9 +316,9 @@ CONTAINS
       INTEGER                                  :: istat
 
       IF (this%size_in_bytes >= 0) &
-         DBCSR_ABORT("acc_devmem_sep_cptr: already allocated")
+         DBCSR_ABORT("acc_devmem_set_cptr: already allocated")
       IF (pointee%size_in_bytes < 0 .AND. size_in_bytes > 0) &
-         DBCSR_ABORT("acc_devmem_sep_cptr: out-of-bounds")
+         DBCSR_ABORT("acc_devmem_set_cptr: out-of-bounds")
       IF (size_in_bytes > 0) THEN
          IF ((lb_in_bytes + size_in_bytes) .GT. pointee%size_in_bytes) &
             DBCSR_ABORT("acc_devmem_set_cptr: out-of-bounds")

--- a/src/acc/include/acc.h
+++ b/src/acc/include/acc.h
@@ -6,6 +6,9 @@
  * For further information please visit https://dbcsr.cp2k.org                                    *
  * SPDX-License-Identifier: GPL-2.0+                                                              *
  *------------------------------------------------------------------------------------------------*/
+#ifndef DBCSR_ACC_H
+#define DBCSR_ACC_H
+
 #include <stddef.h>
 
 #ifdef __cplusplus
@@ -49,8 +52,10 @@ int acc_memcpy_h2d(const void* host_mem, void* dev_mem, size_t count, acc_stream
 int acc_memcpy_d2h(const void* dev_mem, void* host_mem, size_t count, acc_stream_t stream);
 int acc_memcpy_d2d(const void* devmem_src, void* devmem_dst, size_t count, acc_stream_t stream);
 int acc_memset_zero(void* dev_mem, size_t offset, size_t length, acc_stream_t stream);
-int acc_dev_mem_info(size_t* mem_free, size_t* mem_avail);
+int acc_dev_mem_info(size_t* mem_free, size_t* mem_total);
 
 #ifdef __cplusplus
 }
 #endif
+
+#endif /*DBCSR_ACC_H*/

--- a/src/acc/libsmm_acc/include/libsmm_acc.h
+++ b/src/acc/libsmm_acc/include/libsmm_acc.h
@@ -6,20 +6,26 @@
  * For further information please visit https://dbcsr.cp2k.org                                    *
  * SPDX-License-Identifier: GPL-2.0+                                                              *
  *------------------------------------------------------------------------------------------------*/
+#ifndef DBCSR_ACC_LIBSMM_H
+#define DBCSR_ACC_LIBSMM_H
+
+#include "../../include/acc.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
-int libsmm_acc_process (void *param_stack, int stack_size,
-    int nparams, int datatype, void *a_data, void *b_data, void *c_data,
-    int m_max, int n_max, int k_max, int def_mnk, void* stream);
+int libsmm_acc_process(void* param_stack, int stack_size,
+    int nparams, int datatype, void* a_data, void* b_data, void* c_data,
+    int m_max, int n_max, int k_max, int def_mnk, acc_stream_t stream);
 
-int libsmm_acc_transpose (void *trs_stack, int offset, int nblks,
-    void *buffer, int datatype, int m, int n, void* stream);
+int libsmm_acc_transpose(void* trs_stack, int offset, int nblks,
+    void* buffer, int datatype, int m, int n, acc_stream_t stream);
 
-int libsmm_acc_libcusmm_is_thread_safe (void);
+int libsmm_acc_libcusmm_is_thread_safe(void);
 
 #ifdef __cplusplus
- }
+}
 #endif
+
+#endif /*DBCSR_ACC_LIBSMM_H*/

--- a/src/tensors/dbcsr_tensor_block.F
+++ b/src/tensors/dbcsr_tensor_block.F
@@ -176,6 +176,7 @@ CONTAINS
       TYPE(block_nd), INTENT(IN)         :: block
       INTEGER, ALLOCATABLE, DIMENSION(:) :: block_size
 
+      block_size = 0 ! invalid
       SELECT CASE (block%data_type)
 #:for dparam, dtype, dsuffix in dtype_float_list
       CASE (${dparam}$)


### PR DESCRIPTION
Fixed compilation with xlf (dbcsr_tensor_block.F). Fixed typos (dbcsr_acc_devmem.F). ACC/SMM/interface: include guards, rely on acc_stream_t (rather than void*), and code cleanup.