### PR TITLE
Separate implementations for ACC and ACC_LIBSMM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ endif ()
 set(CMAKE_CXX_STANDARD 11)
 
 # =================================================================================================
-# PACKAGE DISCOVERY
+# PACKAGE DISCOVERY (compiler configuration can impact package discovery)
 
 # =================================== BLAS, LAPACK, PkgConfig
 find_package(BLAS REQUIRED)
@@ -101,13 +101,10 @@ find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
 find_package(PkgConfig)
 
-# =================================== OpenMP, MPI
-if (USE_OPENMP)
-  find_package(OpenMP REQUIRED)
-endif ()
+# =================================== MPI
 if (USE_MPI)
   get_property(REQUIRED_MPI_COMPONENTS GLOBAL PROPERTY ENABLED_LANGUAGES)
-  list(REMOVE_ITEM REQUIRED_MPI_COMPONENTS CUDA)  # CUDA does not have a MPI component
+  list(REMOVE_ITEM REQUIRED_MPI_COMPONENTS CUDA)  # CUDA does not have an MPI component
   find_package(MPI COMPONENTS ${REQUIRED_MPI_COMPONENTS} REQUIRED)
 
   if (NOT MPI_Fortran_HAVE_F90_MODULE)
@@ -118,15 +115,20 @@ Intel MPI compiler wrappers. Check the INSTALL.md for more information.")
   endif ()
 endif ()
 
+# =================================== OpenMP and OpenMP/offload backend
+if (USE_OPENMP)
+  find_package(OpenMP REQUIRED)
+endif ()
+
 # =================================== SMM (Small Matrix-Matrix multiplication)
 if (USE_SMM MATCHES "blas")
   message("-- Using BLAS for Small Matrix Multiplication")
 elseif (USE_SMM MATCHES "libxsmm")
-  # rely on pkg-config since it's quiet hard to link against libxsmm properly
+  # rely on pkg-config in order to link against libxsmm
   pkg_check_modules(deps REQUIRED IMPORTED_TARGET GLOBAL libxsmmf)
   message("-- Using libxsmm for Small Matrix Multiplication")
 else()
-  message(FATAL_ERROR "Unknown SMM library specified" )
+  message(FATAL_ERROR "Unknown SMM library specified")
 endif ()
 
 # =================================== GPU backend
@@ -251,6 +253,7 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     "Debug" "Release" "Coverage")
 endif ()
 
+# compiler configuration could have impacted package discovery (above)
 include(CompilerConfiguration)
 include(CheckCompilerSupport)
 

--- a/Makefile
+++ b/Makefile
@@ -88,12 +88,12 @@ endif
 # Declare PHONY targets =====================================================
 .PHONY : $(BIN_NAMES) \
          dirs makedep \
-	 default_target $(LIBRARY) all \
+         default_target $(LIBRARY) all \
          toolversions \
          toolflags \
          pretty prettyclean \
          install clean realclean help \
-	 version test
+         version test
 
 # Discover files and directories ============================================
 ALL_SRC_DIRS := $(shell find $(SRCDIR) -type d | awk '{printf("%s:",$$1)}')
@@ -373,7 +373,7 @@ define pretty_func
 	@cmp -s $1 $2; \
 	RETVAL=$$?; \
 	if [ $$RETVAL -ne 0 ]; then \
-	    cp $2 $1; \
+		cp $2 $1; \
 	fi
 endef
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,10 +176,6 @@ target_include_directories(dbcsr PUBLIC
 target_compile_definitions(dbcsr PRIVATE __STATM_TOTAL)
 set_target_properties(dbcsr PROPERTIES LINKER_LANGUAGE Fortran)
 
-if (OpenMP_FOUND)
-  target_link_libraries(dbcsr PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
-
 if (MPI_FOUND)
   # once built, a user of the dbcsr library can not influence anything anymore by setting those flags:
   target_compile_definitions(dbcsr PRIVATE __parallel __MPI_VERSION=${MPI_Fortran_VERSION_MAJOR})
@@ -192,6 +188,13 @@ if (MPI_FOUND)
   # compiler flags at this point.
   # when built against MPI, a dbcsr consumer has to specify the MPI flags as well, therefore: PUBLIC
   target_link_libraries(dbcsr PUBLIC MPI::MPI_Fortran)
+endif ()
+
+# =================================================================================================
+# DBCSR's OpenMP/offload backend
+
+if (OpenMP_FOUND)
+  target_link_libraries(dbcsr PRIVATE OpenMP::OpenMP_Fortran)
 endif ()
 
 # =================================================================================================
@@ -218,7 +221,8 @@ function(CUDA_CONVERT_FLAGS EXISTING_TARGET)
 endfunction()
 
 if (USE_CUDA)
-  if (${CMAKE_VERSION} VERSION_LESS 3.13)
+  # issue seems to be present even with CMake 3.14.5 in some environments
+  #if (${CMAKE_VERSION} VERSION_LESS 3.13)
       # workaround for CUDA support with CMake <3.13, see also
       # see https://gitlab.kitware.com/cmake/cmake/issues/17929
       # and https://cliutils.gitlab.io/modern-cmake/chapters/packages/CUDA.html
@@ -228,7 +232,7 @@ if (USE_CUDA)
       if (MPI_FOUND)
         cuda_convert_flags(MPI::MPI)
       endif ()
-  endif ()
+  #endif ()
 
   target_link_libraries(dbcsr PUBLIC cuda)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -221,9 +221,8 @@ function(CUDA_CONVERT_FLAGS EXISTING_TARGET)
 endfunction()
 
 if (USE_CUDA)
-  # issue seems to be present even with CMake 3.14.5 in some environments
-  #if (${CMAKE_VERSION} VERSION_LESS 3.13)
-      # workaround for CUDA support with CMake <3.13, see also
+  if (${CMAKE_VERSION} VERSION_LESS 3.16)
+      # workaround for CUDA support with CMake <3.16, see also
       # see https://gitlab.kitware.com/cmake/cmake/issues/17929
       # and https://cliutils.gitlab.io/modern-cmake/chapters/packages/CUDA.html
       if (OpenMP_FOUND)
@@ -232,7 +231,7 @@ if (USE_CUDA)
       if (MPI_FOUND)
         cuda_convert_flags(MPI::MPI)
       endif ()
-  #endif ()
+  endif ()
 
   target_link_libraries(dbcsr PUBLIC cuda)
 

--- a/src/acc/PACKAGE
+++ b/src/acc/PACKAGE
@@ -1,5 +1,5 @@
 {
 "description": "Generic Accelerator API",
 "archive": "libdbcsr",
-"requires": ["../base", "include", "cuda", "hip", "libsmm_acc", "libsmm_acc/include"]
+"requires": ["../base", "include", "cuda", "hip", "libsmm_acc"]
 }

--- a/src/acc/acc_event.cpp
+++ b/src/acc/acc_event.cpp
@@ -38,6 +38,7 @@ extern "C" int acc_event_destroy(void* event){
     ACC(Event_t)* acc_event = (ACC(Event_t*)) event;
 
     if(verbose_print) printf("EventDestroy, called\n");
+    if (event == NULL) return 0; /* not an error */
     ACC(Error_t) cErr = ACC(EventDestroy)(*acc_event);
     free(acc_event);
     if (acc_error_check(cErr)) return -1;

--- a/src/acc/acc_init.cpp
+++ b/src/acc/acc_init.cpp
@@ -15,7 +15,7 @@
 
 #include <stdio.h>
 #include "include/acc.h"
-#include "libsmm_acc/include/libsmm_acc.h"
+#include "include/acc_libsmm.h"
 
 #ifdef __CUDA_PROFILING
 #include <nvToolsExtCudaRt.h>

--- a/src/acc/acc_stream.cpp
+++ b/src/acc/acc_stream.cpp
@@ -66,6 +66,7 @@ extern "C" int acc_stream_destroy(void* stream){
     ACC(Stream_t)* acc_stream = (ACC(Stream_t)*) stream;
 
     if(verbose_print) printf("StreamDestroy called\n");
+    if (stream == NULL) return 0; /* not an error */
     ACC(Error_t) cErr = ACC(StreamDestroy)(*acc_stream);
     free(acc_stream);
     if (acc_error_check (cErr)) return -1;

--- a/src/acc/cublaswrap/PACKAGE
+++ b/src/acc/cublaswrap/PACKAGE
@@ -1,5 +1,5 @@
 {
 "description": "Wrapper for CUBLAS functions",
 "archive": "libdbcsr",
-"requires": ["../../base", "../", "../cuda", "../hip"]
+"requires": ["../../base", "..", "../cuda", "../hip"]
 }

--- a/src/acc/hipblaswrap/PACKAGE
+++ b/src/acc/hipblaswrap/PACKAGE
@@ -1,5 +1,5 @@
 {
 "description": "Wrapper for HIPBLAS functions",
 "archive": "libdbcsr",
-"requires": ["../../base", "../", "../hip", "../cuda"]
+"requires": ["../../base", "..", "../hip", "../cuda"]
 }

--- a/src/acc/include/PACKAGE
+++ b/src/acc/include/PACKAGE
@@ -1,5 +1,5 @@
 {
-"description": "Backend API of accelerator support",
+"description": "Accelerator backend API and API for accelerated LIBSMM",
 "archive": "libdbcsr",
 "requires": []
 }

--- a/src/acc/include/acc.h
+++ b/src/acc/include/acc.h
@@ -16,8 +16,17 @@ extern "C" {
 #endif
 
 /** types */
-typedef void* acc_stream_t;
-typedef void* acc_event_t;
+typedef void acc_stream_t;
+typedef void acc_event_t;
+typedef int acc_bool_t;
+
+typedef enum acc_data_t {
+  ACC_DATA_F64 = 3,
+  ACC_DATA_F32 = 1,
+  ACC_DATA_C64 = 7,
+  ACC_DATA_C32 = 5,
+  ACC_DATA_UNKNOWN = -1
+} acc_data_t;
 
 /** accelerator driver initialization and finalization */
 int acc_init(void);
@@ -30,28 +39,28 @@ int acc_set_active_device(int device_id);
 
 /** streams */
 int acc_stream_priority_range(int* least, int* greatest);
-int acc_stream_create(acc_stream_t* stream_p, const char* name, int priority);
-int acc_stream_destroy(acc_stream_t stream);
-int acc_stream_sync(acc_stream_t stream);
-int acc_stream_wait_event(acc_stream_t stream, acc_event_t event);
+int acc_stream_create(acc_stream_t** stream_p, const char* name, int priority);
+int acc_stream_destroy(acc_stream_t* stream);
+int acc_stream_sync(acc_stream_t* stream);
+int acc_stream_wait_event(acc_stream_t* stream, acc_event_t* event);
 
 /** events */
-int acc_event_create(acc_event_t* event_p);
-int acc_event_destroy(acc_event_t event);
-int acc_event_record(acc_event_t event, acc_stream_t stream);
-int acc_event_query(acc_event_t event, int* has_occurred);
-int acc_event_synchronize(acc_event_t event);
+int acc_event_create(acc_event_t** event_p);
+int acc_event_destroy(acc_event_t* event);
+int acc_event_record(acc_event_t* event, acc_stream_t* stream);
+int acc_event_query(acc_event_t* event, acc_bool_t* has_occurred);
+int acc_event_synchronize(acc_event_t* event);
 
 /** memory */
 int acc_dev_mem_allocate(void** dev_mem, size_t n);
 int acc_dev_mem_deallocate(void* dev_mem);
 int acc_dev_mem_set_ptr(void** dev_mem, void* other, size_t lb);
-int acc_host_mem_allocate(void** host_mem, size_t n, acc_stream_t stream);
-int acc_host_mem_deallocate(void* host_mem, acc_stream_t stream);
-int acc_memcpy_h2d(const void* host_mem, void* dev_mem, size_t count, acc_stream_t stream);
-int acc_memcpy_d2h(const void* dev_mem, void* host_mem, size_t count, acc_stream_t stream);
-int acc_memcpy_d2d(const void* devmem_src, void* devmem_dst, size_t count, acc_stream_t stream);
-int acc_memset_zero(void* dev_mem, size_t offset, size_t length, acc_stream_t stream);
+int acc_host_mem_allocate(void** host_mem, size_t n, acc_stream_t* stream);
+int acc_host_mem_deallocate(void* host_mem, acc_stream_t* stream);
+int acc_memcpy_h2d(const void* host_mem, void* dev_mem, size_t count, acc_stream_t* stream);
+int acc_memcpy_d2h(const void* dev_mem, void* host_mem, size_t count, acc_stream_t* stream);
+int acc_memcpy_d2d(const void* devmem_src, void* devmem_dst, size_t count, acc_stream_t* stream);
+int acc_memset_zero(void* dev_mem, size_t offset, size_t length, acc_stream_t* stream);
 int acc_dev_mem_info(size_t* mem_free, size_t* mem_total);
 
 #ifdef __cplusplus

--- a/src/acc/include/acc_libsmm.h
+++ b/src/acc/include/acc_libsmm.h
@@ -9,27 +9,26 @@
 #ifndef DBCSR_ACC_LIBSMM_H
 #define DBCSR_ACC_LIBSMM_H
 
-#include "../../include/acc.h"
-
-#ifdef __CUDA
-#include "../../cuda/acc_cuda.h"
-#else
-#include "../../hip/acc_hip.h"
-#endif
+#include "acc.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int libsmm_acc_process(void* param_stack, int stack_size,
-    int nparams, int datatype, void* a_data, void* b_data, void* c_data,
-    int m_max, int n_max, int k_max, int def_mnk, acc_stream_t stream);
-
-int libsmm_acc_transpose(void* trs_stack, int offset, int nblks,
-    void* buffer, int datatype, int m, int n, acc_stream_t stream);
+typedef struct libsmm_acc_stack_descriptor_type {
+  int m, n, k, max_m, max_n, max_k;
+  acc_bool_t defined_mnk;
+} libsmm_acc_stack_descriptor_type;
 
 int libsmm_acc_init(void);
 int libsmm_acc_is_thread_safe(void);
+
+int libsmm_acc_transpose(const int* dev_trs_stack, int offset, int nblks,
+  void* dev_data, acc_data_t datatype, int m, int n, acc_stream_t* stream);
+
+int libsmm_acc_process(const libsmm_acc_stack_descriptor_type* dev_param_stack, int stack_size,
+  int nparams, acc_data_t datatype, const void* dev_a_data, const void* dev_b_data, void* dev_c_data,
+  int m_max, int n_max, int k_max, acc_bool_t def_mnk, acc_stream_t* stream);
 
 #ifdef __cplusplus
 }

--- a/src/acc/libsmm_acc/PACKAGE
+++ b/src/acc/libsmm_acc/PACKAGE
@@ -1,5 +1,5 @@
 {
 "description": "Generic GPU-accelerated library for small matrix multiplications",
 "archive": "libdbcsr",
-"requires": ["include", "../include", "../cuda/", "../hip/"]
+"requires": ["../include", "../cuda", "../hip"]
 }

--- a/src/acc/libsmm_acc/include/PACKAGE
+++ b/src/acc/libsmm_acc/include/PACKAGE
@@ -1,5 +1,0 @@
-{
-"description": "API definition of libsmm_acc",
-"archive": "libdbcsr",
-"requires": [],
-}

--- a/src/acc/libsmm_acc/libsmm_acc.h
+++ b/src/acc/libsmm_acc/libsmm_acc.h
@@ -10,7 +10,13 @@
 #ifndef LIBSMM_ACC_H
 #define LIBSMM_ACC_H
 
-#include "include/libsmm_acc.h"
+#ifdef __CUDA
+# include "../cuda/acc_cuda.h"
+#else
+# include "../hip/acc_hip.h"
+#endif
+
+#include "../include/acc_libsmm.h"
 #include "parameters_utils.h"
 
 #include <cstdio>
@@ -34,13 +40,13 @@ struct kernel_launcher {
 
 static std::unordered_map<Triplet, kernel_launcher> kernel_handles;
 
-int libsmm_acc_process_d(int *param_stack, int stack_size,
+int libsmm_acc_process_d(const int *param_stack, int stack_size,
                          ACC_DRV(stream) stream, int m, int n, int k,
-                         double * a_data, double * b_data, double * c_data);
+                         const double * a_data, const double * b_data, double * c_data);
 
 static std::unordered_map<Triplet, ACC_DRV(function)> transpose_handles;
 
-int libsmm_acc_transpose_d(int *trs_stack, int offset, int nblks, double *buffer,
+int libsmm_acc_transpose_d(const int *trs_stack, int offset, int nblks, double *buffer,
                            int m, int n, ACC_DRV(stream) stream);
 
 #endif // LIBSMM_ACC_H

--- a/src/acc/libsmm_acc/libsmm_acc_benchmark.h
+++ b/src/acc/libsmm_acc/libsmm_acc_benchmark.h
@@ -18,11 +18,11 @@
 
 #define MAX_BLOCK_DIM 80
 
-typedef int (*KernelLauncher)(int *param_stack, int stack_size, ACC_DRV(stream) stream,
+typedef int (*KernelLauncher)(const int *param_stack, int stack_size, ACC_DRV(stream) stream,
                               int m_max, int n_max, int k_max,
-                              double *a_data, double *b_data, double *c_data);
+                              const double *a_data, const double *b_data, double *c_data);
 
-typedef int (*TransposeLauncher)(int *param_stack, int offset, int nblks,
+typedef int (*TransposeLauncher)(const int *param_stack, int offset, int nblks,
                                  double *buffer, int m, int n, ACC_DRV(stream) stream);
 
 enum benchmark_mode {test, tune, timing};

--- a/src/acc/libsmm_acc/libsmm_acc_init.cpp
+++ b/src/acc/libsmm_acc/libsmm_acc_init.cpp
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: GPL-2.0+                                                              *
  *------------------------------------------------------------------------------------------------*/
 
-#include "include/libsmm_acc.h"
+#include "libsmm_acc.h"
 #include "libsmm_acc_init.h"
 #include "parameters.h"
 


### PR DESCRIPTION
Regain separate implementations for ACC ("cuda", "hip", later "openmp") and ACC_LIBSMM ("libsmm_acc", later "libsmm_omp"). This change also includes the updated interfaces (header files) for ACC and ACC_LIBSMM both implementing improved type-safety. Both, CUDA and HIP backends are updated accordingly.

In addition, the CUDA/HIP backend got some minor adjustment to pass with the new/upcoming ACC/interface test (`acc_stream_destroy`, `acc_event_destroy`). Also, some issue compiling with CUDA on POWER received an update (disabled "issue seems to be present even with CMake 3.14.5 in some environments" as it is present with newer CMake).