### PR TITLE
libsmm_acc: bugfix

### DIFF
--- a/src/acc/libsmm_acc/libsmm_acc.cpp
+++ b/src/acc/libsmm_acc/libsmm_acc.cpp
@@ -186,7 +186,9 @@ inline void jit_kernel(ACC_DRV(function)& kern_func, libsmm_acc_algo algo, int t
 }
 
 
-void add_kernel_handle_to_jitted_kernels(ACC_DRV(function) kern_func, ACC_DRV(stream) stream, Triplet h_mnk, int& threads, int& grouping, bool& cpu_fallback){
+kernel_map_iterator add_kernel_handle_to_jitted_kernels(ACC_DRV(function) kern_func, ACC_DRV(stream) stream, Triplet h_mnk, int& threads, int& grouping){
+
+    kernel_map_iterator kernel_it = kernel_handles.end();
 
     // Check whether autotuned parameters are given for this kernel, and if so, retrieve them
     if (ht.find(h_mnk) != ht.end()){
@@ -207,13 +209,12 @@ void add_kernel_handle_to_jitted_kernels(ACC_DRV(function) kern_func, ACC_DRV(st
         validate_kernel(kern_func, stream, threads, grouping, h_mnk[0], h_mnk[1], h_mnk[2]);
 
         // Store the handle to the JIT-ed kernel
-        kernel_handles.emplace(h_mnk, kernel_launcher(kern_func, threads, grouping));
-
-    } else { // there exist no autotuned parameters for this (m, n, k)-triplet, fall back to CPU
-
-        cpu_fallback = true;
+        auto kernel_it_emplaced = kernel_handles.emplace(h_mnk, kernel_launcher(kern_func, threads, grouping));
+        kernel_it = kernel_it_emplaced.first;
 
     }
+
+    return kernel_it;
 
 }
 
@@ -224,8 +225,7 @@ int libsmm_acc_process_d(const int *param_stack, int stack_size, ACC_DRV(stream)
     ACC_DRV(function) kern_func = NULL;
     int threads, grouping;
     Triplet h_mnk = { m, n, k };
-    static bool cpu_fallback = false;
-    std::unordered_map<std::array<int, 3>, kernel_launcher>::iterator kernel_it;
+    kernel_map_iterator kernel_it;
 
 #if defined _OPENMP
 #pragma omp critical (jit_multiplication)
@@ -236,16 +236,16 @@ int libsmm_acc_process_d(const int *param_stack, int stack_size, ACC_DRV(stream)
     kernel_it = kernel_handles.find(h_mnk);
     if (kernel_it == kernel_handles.end()){  // the kernel has not been JIT-ed yet
 
-        add_kernel_handle_to_jitted_kernels(kern_func, stream, h_mnk, threads, grouping, cpu_fallback);
-        kernel_it = kernel_handles.find(h_mnk);
+        kernel_it = add_kernel_handle_to_jitted_kernels(kern_func, stream, h_mnk, threads, grouping);
 
-    }  // now the kernel has been jitted
+    }  // if the kernel could be jited successfully, the kernel_it iterator now points to the kernel_launcher.
+       // if this wasn't possible, is set to kernel_handles.end()
 
 #if defined _OPENMP
 }
 #endif
 
-    if(cpu_fallback){
+    if (kernel_it == kernel_handles.end()){  // the kernel could not be JIT-ed, so we should fall back to CPU
 
         return -2; // fall back to CPU
 

--- a/src/acc/libsmm_acc/libsmm_acc.cpp
+++ b/src/acc/libsmm_acc/libsmm_acc.cpp
@@ -227,10 +227,8 @@ int libsmm_acc_process_d(const int *param_stack, int stack_size, ACC_DRV(stream)
     Triplet h_mnk = { m, n, k };
     kernel_map_iterator kernel_it;
 
-#if defined _OPENMP
 #pragma omp critical (jit_multiplication)
 {
-#endif
 
     // Look up the kernel in the table of already JITed kernels
     kernel_it = kernel_handles.find(h_mnk);
@@ -241,9 +239,7 @@ int libsmm_acc_process_d(const int *param_stack, int stack_size, ACC_DRV(stream)
     }  // if the kernel could be jited successfully, the kernel_it iterator now points to the kernel_launcher.
        // if this wasn't possible, is set to kernel_handles.end()
 
-#if defined _OPENMP
 }
-#endif
 
     if (kernel_it == kernel_handles.end()){  // the kernel could not be JIT-ed, so we should fall back to CPU
 
@@ -337,10 +333,8 @@ int libsmm_acc_transpose_d(const int *trs_stack, int offset, int nblks,
     Triplet h_mnk = { m, n, 0 };
     std::unordered_map<std::array<int, 3>, ACC_DRV(function)>::iterator kernel_it;
 
-#if defined _OPENMP
 #pragma omp critical (jit_transpose)
 {
-#endif
 
     kernel_it = transpose_handles.find(h_mnk);
     if(kernel_it == transpose_handles.end()){  // the kernel has not been JIT-ed yet
@@ -352,9 +346,7 @@ int libsmm_acc_transpose_d(const int *trs_stack, int offset, int nblks,
 
     }
 
-#if defined _OPENMP
 }
-#endif
 
     // Construct argument pointer list and launch function
     kern_func = kernel_it->second; // retrieve handle

--- a/src/acc/libsmm_acc/libsmm_acc.h
+++ b/src/acc/libsmm_acc/libsmm_acc.h
@@ -38,6 +38,8 @@ struct kernel_launcher {
     kernel_launcher(ACC_DRV(function) const& kf, int th, int gp): kernel_function(kf), threads(th), grouping (gp) {}
 };
 
+typedef std::unordered_map<Triplet, kernel_launcher>::iterator kernel_map_iterator;
+
 static std::unordered_map<Triplet, kernel_launcher> kernel_handles;
 
 int libsmm_acc_process_d(const int *param_stack, int stack_size,

--- a/tests/dbcsr_unittest3.F
+++ b/tests/dbcsr_unittest3.F
@@ -76,6 +76,12 @@ PROGRAM dbcsr_unittest
    ! multiply ------------------------------------------------------------------
 
    ! ...
+   CALL dbcsr_test_multiplies("blocks_1_3_4", &
+                              group, mp_env, npdims, io_unit, matrix_sizes=(/496, 48, 48/), &
+                              sparsities=(/0.5_dp, 0.5_dp, 0.5_dp/), retain_sparsity=.FALSE., &
+                              alpha=CMPLX(1.0_dp, 0.0_dp, dp), beta=CMPLX(0.0_dp, 0.0_dp, dp), &
+                              bs_m=(/1, 1, 1, 3, 1, 4/), bs_n=(/1, 1, 1, 3, 1, 4/), bs_k=(/1, 1, 1, 3, 1, 4/), &
+                              limits=(/1, 496, 1, 48, 1, 48/))
    CALL dbcsr_test_multiplies("blocks_4_5_7", &
                               group, mp_env, npdims, io_unit, matrix_sizes=(/496, 48, 48/), &
                               sparsities=(/0.5_dp, 0.5_dp, 0.5_dp/), retain_sparsity=.FALSE., &
@@ -106,6 +112,12 @@ PROGRAM dbcsr_unittest
                               alpha=CMPLX(1.0_dp, 0.0_dp, dp), beta=CMPLX(0.0_dp, 0.0_dp, dp), &
                               bs_m=(/1, 23/), bs_n=(/1, 23/), bs_k=(/1, 23/), &
                               limits=(/1, 552, 1, 46, 1, 46/))
+   CALL dbcsr_test_multiplies("blocks_45_67_78", &
+                              group, mp_env, npdims, io_unit, matrix_sizes=(/570, 190, 190/), &
+                              sparsities=(/0.5_dp, 0.5_dp, 0.5_dp/), retain_sparsity=.FALSE., &
+                              alpha=CMPLX(1.0_dp, 0.0_dp, dp), beta=CMPLX(0.0_dp, 0.0_dp, dp), &
+                              bs_m=(/1, 45, 1, 67, 1, 78/), bs_n=(/1, 45, 1, 67, 1, 78/), bs_k=(/1, 45, 1, 67, 1, 78/), &
+                              limits=(/1, 570, 1, 190, 1, 190/))
 
    ! end of test cases ---------------------------------------------------------
 


### PR DESCRIPTION
- **libsmm_acc**: fix a concurrency bug

    The static variable `cpu_fallback`, once set to `false` by one
    thread, was causing other threads to fall back to the CPU although
    they could launch a kernel on the GPU.
    Solve this issue by determining whether to fall back to the CPU
    using the state of the "kernel handle", and getting rid of the static
    variable `cpu_fallback`.
    Also introduce a typedef and some simplifications for readability.

- **libsmm_acc**: remove superfluous ifdefs around openmp pragmas
- **tests**: add very small and very large block sizes