### PR TITLE
make: add -D__CUDA if compiling with nvcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ endif
 ifneq ($(ARCH_NUMBER),)
 # If compiling with nvcc
 ifneq (,$(findstring nvcc,$(NVCC)))
+NVFLAGS += -D__CUDA # add the flag for compilation with CUDA
 #if "-arch" has not yet been set in NVFLAGS
 ifeq ($(findstring "-arch", $(NVFLAGS)), '')
 NVFLAGS += -arch sm_$(ARCH_NUMBER)


### PR DESCRIPTION
If compiling with nvcc, automatically add `-D__CUDA` to `NVFLAGS` in the `Makefile`.

This removes the need to add `-D__CUDA` to CP2K arch files when compiling CP2K with DBCSR > v2.0.1. 

Solves the issue in https://github.com/cp2k/cp2k/pull/744 .