### PR TITLE
workaround for CCE compiler

### DIFF
--- a/.ci/daint.cscs.ch/Jenkinsfile
+++ b/.ci/daint.cscs.ch/Jenkinsfile
@@ -38,12 +38,11 @@ pipeline {
                                 run_batch("0:30:00", "cray", "build")
                             }
                         }
-                        // TODO: dbcsr_tensor_unittest is broken
-                        // stage('test') {
-                        //     steps {
-                        //         run_batch("1:00:00", "cray", "test")
-                        //     }
-                        // }
+                        stage('test') {
+                            steps {
+                                run_batch("1:00:00", "cray", "test")
+                            }
+                        }
                     }
                 }
                 stage("GNU") {

--- a/src/tas/dbcsr_tas_base.F
+++ b/src/tas/dbcsr_tas_base.F
@@ -442,12 +442,17 @@ CONTAINS
    SUBROUTINE dbcsr_tas_distribution_destroy(dist)
       TYPE(dbcsr_tas_distribution_type), INTENT(INOUT)     :: dist
 
-      IF (ALLOCATED(dist%row_dist)) THEN
-         DEALLOCATE (dist%row_dist)
-      ENDIF
-      IF (ALLOCATED(dist%col_dist)) THEN
-         DEALLOCATE (dist%col_dist)
-      ENDIF
+      ! Note: Issue with Cray CCE compiler
+      ! commented out the following deallocate statements on polymorphic variables,
+      ! these cause segfaults with CCE compiler at a later point
+
+      !IF (ALLOCATED(dist%row_dist)) THEN
+      !   DEALLOCATE (dist%row_dist)
+      !ENDIF
+      !IF (ALLOCATED(dist%col_dist)) THEN
+      !   DEALLOCATE (dist%col_dist)
+      !ENDIF
+
       IF (ALLOCATED(dist%local_rowcols)) THEN
          DEALLOCATE (dist%local_rowcols)
       ENDIF

--- a/src/tensors/dbcsr_tensor_types.F
+++ b/src/tensors/dbcsr_tensor_types.F
@@ -669,6 +669,8 @@ CONTAINS
       IF (dist%refcount == 0) THEN
          CALL dbcsr_t_pgrid_destroy(dist%pgrid)
          DEALLOCATE (dist%refcount)
+      ELSE
+         CALL dbcsr_t_pgrid_destroy(dist%pgrid, keep_comm=.TRUE.)
       ENDIF
 
       CALL timestop(handle)


### PR DESCRIPTION
With this workaround, `dbcsr_tensor_unittest` should run with Cray CCE compiler. Unfortunately I'm still not sure whether this is a bug on our side or a bug in the compiler.

For documentation, some details on the issue:

Output and gdb backtrace (commit 9139540254f55a37022f0c0d08bfc563bb4b71e8, compiler flags `-G0 -O0 -g -Rb`):
```
lib-4961 : WARNING 
  Subscript 69360416 is out of range for dimension 1 for array
  'list' at line 68 in file 'dbcsr_array_list_methods.F' with bounds 1:14.

Program received signal SIGSEGV, Segmentation fault.
0x00000000007c897b in get_array_elements (get_array_elements=..., list=..., 
    indices=...) at tensors/dbcsr_array_list_methods.F:68
68               get_array_elements(i) = list%col_data(ind)
(gdb) bt
#0  0x00000000007c897b in get_array_elements (get_array_elements=..., 
    list=..., indices=...) at tensors/dbcsr_array_list_methods.F:68
#1  0x00000000008ccce3 in r_dist_t (t=<optimized out>, rowcol=<optimized out>)
    at tensors/dbcsr_tensor_types.F:227
#2  0x0000000000ba4ddd in dbcsr_tas_get_stored_coordinates (matrix=..., 
    row=<optimized out>, column=<optimized out>, processor=<optimized out>)
    at tas/dbcsr_tas_base.F:475
#3  0x00000000008e643d in dbcsr_t_get_stored_coordinates (tensor=..., 
    ind_nd=..., processor=<optimized out>) at tensors/dbcsr_tensor_types.F:1257
#4  0x0000000000887dd1 in dbcsr_t_setup_test_tensor (tensor=..., 
    mp_comm=<optimized out>, enumerate=<optimized out>, blk_ind_1=..., 
    blk_ind_2=..., blk_ind_3=..., blk_ind_4=...)
    at tensors/dbcsr_tensor_test.F:552
#5  0x00000000008832c2 in dbcsr_t_test_formats (ndims=<optimized out>, 
    mp_comm=<optimized out>, unit_nr=<optimized out>, verbose=<optimized out>, 
    blk_size_1=..., blk_size_2=..., blk_size_3=..., blk_size_4=..., 
    blk_ind_1=..., blk_ind_2=..., blk_ind_3=..., blk_ind_4=...)
    at tensors/dbcsr_tensor_test.F:420
#6  0x000000000046137f in dbcsr_tensor_unittest ()
    at /scratch/snx3000/pseewald/dbcsr/tests/dbcsr_tensor_unittest.F:106
#7  0x00002aaab3da6f8a in __libc_start_main () from /lib64/libc.so.6
#8  0x000000000046044a in _start () at ../sysdeps/x86_64/start.S:120
```

Further inspection reveals that this is caused in `dbcsr_t_create_new(tensor, ...)`, in [this line](https://github.com/cp2k/dbcsr/blob/develop/src/tensors/dbcsr_tensor_types.F#L810) which among other things deallocates `dist_new%dist%row_dist`.

For some strange reason, this invalidates `tensor%matrix_rep%dist%row_dist%nd_dist`, causing the out of range warning. `tensor%matrix_rep%dist%row_dist` is a copy of `dist_new%dist%row_dist` but no data is shared (no pointers). The issue may have to do with `row_dist` being a polymorphic variable:
```
CLASS(dbcsr_tas_distribution), ALLOCATABLE :: row_dist
```

I did not manage to reproduce this issue with a standalone example.