### PR TITLE
CMake: use default '-ffree-line-length' of 132 for gfortran

### DIFF
--- a/cmake/CompilerConfiguration.cmake
+++ b/cmake/CompilerConfiguration.cmake
@@ -1,11 +1,11 @@
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-  set(CMAKE_Fortran_FLAGS          "-ffree-form -ffree-line-length-none -std=f2008ts")
+  set(CMAKE_Fortran_FLAGS          "-ffree-form -std=f2008ts")
   set(CMAKE_Fortran_FLAGS_RELEASE  "-O3 -funroll-loops")
   set(CMAKE_Fortran_FLAGS_COVERAGE "-O0 -g --coverage")
   set(CMAKE_Fortran_FLAGS_DEBUG    "-O0 -ggdb")
 elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
   set(CMAKE_Fortran_FLAGS          "-free -stand f08 -fpp")
-  set(CMAKE_Fortran_FLAGS_RELEASE  "-O3 -diag-disable=5268")  # Disable the line-length-extension warning #5268
+  set(CMAKE_Fortran_FLAGS_RELEASE  "-O3")
   set(CMAKE_Fortran_FLAGS_DEBUG    "-O0 -debug")
 elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "PGI")
   set(CMAKE_Fortran_FLAGS          "-Mfreeform -Mextend -Mallocatable=03")  # -Mallocatable=03: enable F2003+ assignment semantics

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -129,9 +129,8 @@ set(DBCSR_HIP_SRCS
 # set the __SHORT_FILE__ per file for dbcsr sources
 foreach (dbcsr_src ${DBCSR_SRCS})
   # add_fypp_sources returns a path in the current binary dir
-  get_filename_component(dbcsr_src "${dbcsr_src}" ABSOLUTE)
-  file(RELATIVE_PATH short_file "${CMAKE_CURRENT_BINARY_DIR}" "${dbcsr_src}")
-  set_source_files_properties(${dbcsr_src} PROPERTIES COMPILE_DEFINITIONS __SHORT_FILE__="dbcsr/${short_file}")
+  get_filename_component(short_file "${dbcsr_src}" NAME)
+  set_source_files_properties(${dbcsr_src} PROPERTIES COMPILE_DEFINITIONS __SHORT_FILE__="${short_file}")
 endforeach ()
 
 

--- a/src/core/dbcsr_lib.F
+++ b/src/core/dbcsr_lib.F
@@ -209,9 +209,11 @@ CONTAINS
       ! Check whether DBCSR and libsmm_acc (GPU backend) have the same level of threading
       IF (dbcsr_thread_safe /= libsmm_acc_thread_safe) then
          IF (dbcsr_thread_safe /= 0) then
-            DBCSR_ABORT("DBCSR compiled w/ threading support while libsmm_acc compiled w/o threading support.")
+            CALL dbcsr_abort(__LOCATION__, &
+                             "DBCSR compiled w/ threading support while libsmm_acc compiled w/o threading support.")
          ELSE
-            DBCSR_ABORT("DBCSR compiled w/o threading support while libsmm_acc is compiled w/ threading support.")
+            CALL dbcsr_abort(__LOCATION__, &
+                             "DBCSR compiled w/o threading support while libsmm_acc is compiled w/ threading support.")
          ENDIF
       ENDIF
 

--- a/tests/dbcsr_performance_driver.F
+++ b/tests/dbcsr_performance_driver.F
@@ -66,7 +66,8 @@ PROGRAM dbcsr_performance_driver
    ELSE
       npdims(2) = atoi(args(1))
       IF (MOD(numnodes, npdims(2)) .NE. 0) THEN
-         DBCSR_ABORT("numnodes is not multiple of npcols")
+         CALL dbcsr_abort(__LOCATION__, &
+                          "numnodes is not multiple of npcols")
       ENDIF
       npdims(1) = numnodes/npdims(2)
    ENDIF

--- a/tests/dbcsr_performance_multiply.F
+++ b/tests/dbcsr_performance_multiply.F
@@ -161,7 +161,9 @@ CONTAINS
 
       chksum_check = atol(args(i + 1))
       chksum_threshold = ator(args(i + 2))
-      IF (chksum_check .AND. chksum_threshold .LE. 0.0) DBCSR_ABORT("Checksum threshold must be positive!")
+      IF (chksum_check .AND. chksum_threshold .LE. 0.0) &
+         CALL dbcsr_abort(__LOCATION__, &
+                          "Checksum threshold must be positive!")
       chksum_ref = ator(args(i + 3))
       chksum_ref_pos = ator(args(i + 4))
 
@@ -674,7 +676,9 @@ CONTAINS
                   "  threshold = ", chksum_threshold
                chksum_err = .TRUE.
             ENDIF
-            IF (chksum_err) DBCSR_ABORT("Wrong Checksums. Test failed!")
+            IF (chksum_err) &
+               CALL dbcsr_abort(__LOCATION__, &
+                                "Wrong Checksums. Test failed!")
          ENDIF
          WRITE (io_unit, *)
          WRITE (io_unit, *)

--- a/tests/dbcsr_test_multiply.F
+++ b/tests/dbcsr_test_multiply.F
@@ -245,7 +245,8 @@ CONTAINS
                   my_sizes_n => sizes_n
                   my_sizes_k => sizes_k
                ELSE
-                  DBCSR_ABORT("something wrong here... ")
+                  CALL dbcsr_abort(__LOCATION__, &
+                                   "something wrong here... ")
                END IF
 
                IF (.FALSE.) THEN


### PR DESCRIPTION
DBCSR source code should respect the 132 character limit (as specified
in the Fortran standard).

Use only filename for __SHORT_FILE__ (as in CP2K) to avoid exceeding the
line length.