### PR TITLE
Tensors: new features for `dbcsr_t_contract`

### DIFF
--- a/src/tas/dbcsr_tas_mm.F
+++ b/src/tas/dbcsr_tas_mm.F
@@ -689,6 +689,13 @@ CONTAINS
          ENDIF
       ENDIF
 
+      IF (PRESENT(move_data_a)) THEN
+         IF(move_data_a) CALL dbcsr_tas_clear(matrix_a)
+      ENDIF
+      IF (PRESENT(move_data_b)) THEN
+         IF(move_data_b) CALL dbcsr_tas_clear(matrix_b)
+      ENDIF
+
       IF (PRESENT(flop)) THEN
          CALL mp_sum(flop, mp_comm)
          flop = (flop + numproc - 1)/numproc

--- a/src/tas/dbcsr_tas_mm.F
+++ b/src/tas/dbcsr_tas_mm.F
@@ -28,7 +28,7 @@ MODULE dbcsr_tas_mm
       dbcsr_tas_get_data_type, dbcsr_tas_info, dbcsr_tas_nblkcols_total, &
       dbcsr_tas_nblkrows_total, dbcsr_tas_filter, dbcsr_tas_get_info, dbcsr_tas_iterator_blocks_left, &
       dbcsr_tas_get_nze_total, dbcsr_tas_reserve_blocks, dbcsr_tas_iterator_start, dbcsr_tas_iterator_next_block, &
-      dbcsr_tas_iterator_stop, dbcsr_tas_copy, dbcsr_tas_get_block_p, dbcsr_tas_clear
+      dbcsr_tas_iterator_stop, dbcsr_tas_copy, dbcsr_tas_get_block_p, dbcsr_tas_clear, dbcsr_tas_get_num_blocks
    USE dbcsr_tas_types, ONLY: &
       dbcsr_tas_distribution_type, dbcsr_tas_split_info, dbcsr_tas_type, dbcsr_tas_iterator
    USE dbcsr_tas_global, ONLY: &
@@ -70,7 +70,7 @@ CONTAINS
 
    RECURSIVE SUBROUTINE dbcsr_tas_multiply(transa, transb, transc, alpha, matrix_a, matrix_b, beta, matrix_c, &
                                            optimize_dist, split_opt, filter_eps, flop, move_data_a, &
-                                           move_data_b, simple_split, io_unit, log_verbose)
+                                           move_data_b, retain_sparsity, simple_split, result_index, io_unit, log_verbose)
       !! tall-and-skinny matrix-matrix multiplication. Undocumented dummy arguments are identical to
       !! arguments of dbcsr_multiply (see dbcsr_mm, dbcsr_multiply_generic).
 
@@ -88,10 +88,11 @@ CONTAINS
          !! split_opt can not be returned, in this case the pointer is not associated
       REAL(KIND=real_8), INTENT(IN), OPTIONAL    :: filter_eps
       INTEGER(KIND=int_8), INTENT(OUT), OPTIONAL :: flop
-      LOGICAL, INTENT(IN), OPTIONAL              :: move_data_a, move_data_b, simple_split
+      LOGICAL, INTENT(IN), OPTIONAL              :: move_data_a, move_data_b, simple_split, retain_sparsity
          !! memory optimization: move data to matrix_c such that matrix_a is empty on return
          !! memory optimization: move data to matrix_c such that matrix_b is empty on return
          !! for internal use only
+      INTEGER(int_8), DIMENSION(:,:), ALLOCATABLE, INTENT(OUT), OPTIONAL :: result_index
       INTEGER, OPTIONAL, INTENT(IN)              :: io_unit
          !! unit number for logging output
       LOGICAL, OPTIONAL, INTENT(IN)              :: log_verbose
@@ -111,7 +112,8 @@ CONTAINS
       CHARACTER(LEN=1)                           :: tr_case, transa_prv, transb_prv, transc_prv
       TYPE(dbcsr_scalar_type)                    :: zero
       LOGICAL                                    :: new_a, new_b, new_c, simple_split_prv, opt_pgrid, &
-                                                    move_a, move_b, do_batched, simple_split_save
+                                                    move_a, move_b, do_batched, simple_split_save, &
+                                                    nodata_3
       TYPE(dbcsr_tas_split_info)                 :: info, info_a, info_b, info_c
       CHARACTER(LEN=*), PARAMETER                :: routineN = 'dbcsr_tas_multiply', &
                                                     routineP = moduleN//':'//routineN
@@ -135,6 +137,11 @@ CONTAINS
 
          info_a = dbcsr_tas_info(matrix_a); info_b = dbcsr_tas_info(matrix_b); info_c = dbcsr_tas_info(matrix_c)
          IF (info_a%strict_split .OR. info_b%strict_split .OR. info_c%strict_split) simple_split_prv = .TRUE.
+      ENDIF
+
+      nodata_3 = .TRUE.
+      IF(PRESENT(retain_sparsity)) THEN
+         IF(retain_sparsity) nodata_3 = .FALSE.
       ENDIF
 
       ! get prestored info for multiplication strategy in case of batched mm
@@ -250,7 +257,12 @@ CONTAINS
       IF (.NOT. simple_split_prv) THEN
          nze_a = dbcsr_tas_get_nze_total(matrix_a)
          nze_b = dbcsr_tas_get_nze_total(matrix_b)
-         nze_c = result_sparsity_estimate(transa, transb, transc, matrix_a, matrix_b, matrix_c, filter_eps)
+         CALL dbcsr_tas_result_index(transa, transb, transc, matrix_a, matrix_b, matrix_c, filter_eps, &
+                                     blk_ind=result_index, nze=nze_c, retain_sparsity=retain_sparsity)
+         IF(PRESENT(result_index)) THEN
+            CALL timestop(handle)
+            RETURN
+         ENDIF
 
          max_mm_dim = MAXLOC(dims, 1)
          nsplit = split_factor_estimate(max_mm_dim, nze_a, nze_b, nze_c, numproc)
@@ -292,7 +304,7 @@ CONTAINS
                                     nsplit=nsplit, &
                                     opt_nsplit=batched_repl == 0, &
                                     split_rc_1=split_a, split_rc_2=split_c, &
-                                    nodata2=.TRUE., comm_new=comm_tmp, &
+                                    nodata2=nodata_3, comm_new=comm_tmp, &
                                     move_data_1=move_a, unit_nr=io_unit)
 
          info = dbcsr_tas_info(matrix_a_rs)
@@ -331,7 +343,7 @@ CONTAINS
 
          IF (matrix_c%do_batched <= 1) THEN
             ALLOCATE (matrix_c_rs)
-            CALL reshape_mm_small(mp_comm, matrix_c, matrix_c_rs, transc_prv == dbcsr_transpose, transc_prv, nodata=.TRUE.)
+            CALL reshape_mm_small(mp_comm, matrix_c, matrix_c_rs, transc_prv == dbcsr_transpose, transc_prv, nodata=nodata_3)
             IF (matrix_c%do_batched == 1) THEN
                matrix_c%mm_storage%store_batched => matrix_c_rs
             ENDIF
@@ -358,7 +370,7 @@ CONTAINS
                                     nsplit=nsplit, &
                                     opt_nsplit=batched_repl == 0, &
                                     split_rc_1=split_b, split_rc_2=split_c, &
-                                    nodata2=.TRUE., comm_new=comm_tmp, &
+                                    nodata2=nodata_3, comm_new=comm_tmp, &
                                     move_data_1=move_b, unit_nr=io_unit)
          info = dbcsr_tas_info(matrix_b_rs)
          CALL dbcsr_tas_get_split_info(info, split_rowcol=split_rc, mp_comm=mp_comm)
@@ -458,7 +470,7 @@ CONTAINS
             DEALLOCATE (matrix_b_rep)
          ENDIF
 
-         CALL convert_to_new_pgrid(mp_comm_mm, matrix_c_rs%matrix, matrix_c_mm, nodata=.TRUE., optimize_pgrid=opt_pgrid)
+         CALL convert_to_new_pgrid(mp_comm_mm, matrix_c_rs%matrix, matrix_c_mm, nodata=nodata_3, optimize_pgrid=opt_pgrid)
 
          SELECT CASE (tr_case)
          CASE (dbcsr_no_transpose)
@@ -466,13 +478,13 @@ CONTAINS
 
             CALL dbcsr_multiply(transa=dbcsr_no_transpose, transb=dbcsr_no_transpose, alpha=alpha, &
                                 matrix_a=matrix_a_mm, matrix_b=matrix_b_mm, beta=beta, matrix_c=matrix_c_mm, &
-                                filter_eps=filter_eps_prv, flop=flop)
+                                filter_eps=filter_eps_prv, retain_sparsity=retain_sparsity, flop=flop)
             CALL timestop(handle2)
          CASE (dbcsr_transpose)
             CALL timeset(routineN//"_mm_1T", handle2)
             CALL dbcsr_multiply(transa=dbcsr_transpose, transb=dbcsr_no_transpose, alpha=alpha, &
                                 matrix_a=matrix_b_mm, matrix_b=matrix_a_mm, beta=beta, matrix_c=matrix_c_mm, &
-                                filter_eps=filter_eps_prv, flop=flop)
+                                filter_eps=filter_eps_prv, retain_sparsity=retain_sparsity, flop=flop)
 
             CALL timestop(handle2)
          END SELECT
@@ -507,7 +519,7 @@ CONTAINS
       CASE (2)
          IF (matrix_c%do_batched <= 1) THEN
             ALLOCATE (matrix_c_rep)
-            CALL dbcsr_tas_replicate(matrix_c_rs%matrix, dbcsr_tas_info(matrix_a_rs), matrix_c_rep, nodata=.TRUE.)
+            CALL dbcsr_tas_replicate(matrix_c_rs%matrix, dbcsr_tas_info(matrix_a_rs), matrix_c_rep, nodata=nodata_3)
             IF (matrix_c%do_batched == 1) THEN
                matrix_c%mm_storage%store_batched_repl => matrix_c_rep
                matrix_c%do_batched = 2
@@ -533,12 +545,12 @@ CONTAINS
             DEALLOCATE (matrix_b_rs)
          ENDIF
 
-         CALL convert_to_new_pgrid(mp_comm_mm, matrix_c_rep%matrix, matrix_c_mm, nodata=.TRUE., optimize_pgrid=opt_pgrid)
+         CALL convert_to_new_pgrid(mp_comm_mm, matrix_c_rep%matrix, matrix_c_mm, nodata=nodata_3, optimize_pgrid=opt_pgrid)
 
          CALL timeset(routineN//"_mm_2", handle2)
          CALL dbcsr_multiply(transa=transa_prv, transb=transb_prv, alpha=alpha, matrix_a=matrix_a_mm, &
                              matrix_b=matrix_b_mm, beta=beta, matrix_c=matrix_c_mm, &
-                             filter_eps=filter_eps_prv/REAL(nsplit, KIND=real_8), flop=flop)
+                             filter_eps=filter_eps_prv/REAL(nsplit, KIND=real_8), retain_sparsity=retain_sparsity, flop=flop)
          CALL timestop(handle2)
 
          IF (opt_pgrid) THEN
@@ -605,20 +617,20 @@ CONTAINS
             CALL dbcsr_tas_destroy(matrix_b_rs)
             DEALLOCATE (matrix_b_rs)
          ENDIF
-         CALL convert_to_new_pgrid(mp_comm_mm, matrix_c_rs%matrix, matrix_c_mm, nodata=.TRUE., optimize_pgrid=opt_pgrid)
+         CALL convert_to_new_pgrid(mp_comm_mm, matrix_c_rs%matrix, matrix_c_mm, nodata=nodata_3, optimize_pgrid=opt_pgrid)
 
          SELECT CASE (tr_case)
          CASE (dbcsr_no_transpose)
             CALL timeset(routineN//"_mm_3N", handle2)
             CALL dbcsr_multiply(transa=dbcsr_no_transpose, transb=dbcsr_no_transpose, alpha=alpha, &
                                 matrix_a=matrix_a_mm, matrix_b=matrix_b_mm, beta=beta, matrix_c=matrix_c_mm, &
-                                filter_eps=filter_eps_prv, flop=flop)
+                                filter_eps=filter_eps_prv, retain_sparsity=retain_sparsity, flop=flop)
             CALL timestop(handle2)
          CASE (dbcsr_transpose)
             CALL timeset(routineN//"_mm_3T", handle2)
             CALL dbcsr_multiply(transa=dbcsr_no_transpose, transb=dbcsr_transpose, alpha=alpha, &
                                 matrix_a=matrix_b_mm, matrix_b=matrix_a_mm, beta=beta, matrix_c=matrix_c_mm, &
-                                filter_eps=filter_eps_prv, flop=flop)
+                                filter_eps=filter_eps_prv, retain_sparsity=retain_sparsity, flop=flop)
             CALL timestop(handle2)
          END SELECT
 
@@ -1261,51 +1273,79 @@ CONTAINS
 
    END SUBROUTINE
 
-   FUNCTION result_sparsity_estimate(transa, transb, transc, matrix_a, matrix_b, matrix_c, filter_eps, io_unit) RESULT(nze)
+   SUBROUTINE dbcsr_tas_result_index(transa, transb, transc, matrix_a, matrix_b, matrix_c, filter_eps, &
+                                     io_unit, blk_ind, nze, retain_sparsity)
       !! Estimate sparsity pattern of C resulting from A x B = C by multiplying the block norms of A and B
       !! Same dummy arguments as dbcsr_tas_multiply
-
       CHARACTER(LEN=1), INTENT(IN)               :: transa, transb, transc
-      TYPE(dbcsr_tas_type), INTENT(INOUT)        :: matrix_a, matrix_b, matrix_c
-      TYPE(dbcsr_tas_type)                       :: matrix_a_bnorm, matrix_b_bnorm, matrix_c_bnorm
+      TYPE(dbcsr_tas_type), INTENT(INOUT), TARGET        :: matrix_a, matrix_b, matrix_c
+      TYPE(dbcsr_tas_type), POINTER                      :: matrix_a_bnorm, matrix_b_bnorm, matrix_c_bnorm
       REAL(KIND=real_8), INTENT(IN), OPTIONAL    :: filter_eps
       INTEGER, INTENT(IN), OPTIONAL              :: io_unit
-      INTEGER(KIND=int_8)                        :: row, col, nze
-      INTEGER                                    :: bn, row_size, col_size, mp_comm, handle
-      TYPE(dbcsr_tas_iterator)                   :: iter
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'result_sparsity_estimate', &
+      INTEGER(int_8), DIMENSION(:,:), ALLOCATABLE, INTENT(OUT), OPTIONAL :: blk_ind
+      LOGICAL, INTENT(IN), OPTIONAL :: retain_sparsity
+      INTEGER(int_8), INTENT(OUT), OPTIONAL :: nze
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_tas_result_index', &
                                      routineP = moduleN//':'//routineN
+      LOGICAL :: retain_sparsity_prv
+      INTEGER :: bn, row_size, col_size, handle, iblk, mp_comm, nblk
+      INTEGER(int_8) :: row, col
+      TYPE(dbcsr_tas_iterator) :: iter
 
       CALL timeset(routineN, handle)
 
-      CALL create_block_norms_matrix(matrix_a, matrix_a_bnorm)
-      CALL create_block_norms_matrix(matrix_b, matrix_b_bnorm)
-      CALL create_block_norms_matrix(matrix_c, matrix_c_bnorm, nodata=.TRUE.)
+      IF(PRESENT(retain_sparsity)) THEN
+         retain_sparsity_prv = retain_sparsity
+      ELSE
+         retain_sparsity_prv = .FALSE.
+      ENDIF
 
-      CALL dbcsr_tas_multiply(transa, transb, transc, dbcsr_scalar(1.0_real_8), matrix_a_bnorm, &
-                              matrix_b_bnorm, dbcsr_scalar(0.0_real_8), matrix_c_bnorm, &
-                              filter_eps=filter_eps, move_data_a=.TRUE., move_data_b=.TRUE., &
-                              simple_split=.TRUE., io_unit=io_unit)
+      IF (.NOT. retain_sparsity_prv) THEN
+         ALLOCATE(matrix_a_bnorm, matrix_b_bnorm, matrix_c_bnorm)
+         CALL create_block_norms_matrix(matrix_a, matrix_a_bnorm)
+         CALL create_block_norms_matrix(matrix_b, matrix_b_bnorm)
+         CALL create_block_norms_matrix(matrix_c, matrix_c_bnorm, nodata=.TRUE.)
+
+         CALL dbcsr_tas_multiply(transa, transb, transc, dbcsr_scalar(1.0_real_8), matrix_a_bnorm, &
+                                 matrix_b_bnorm, dbcsr_scalar(0.0_real_8), matrix_c_bnorm, &
+                                 filter_eps=filter_eps, move_data_a=.TRUE., move_data_b=.TRUE., &
+                                 simple_split=.TRUE., io_unit=io_unit)
+         CALL dbcsr_tas_destroy(matrix_a_bnorm)
+         CALL dbcsr_tas_destroy(matrix_b_bnorm)
+
+         DEALLOCATE(matrix_a_bnorm, matrix_b_bnorm)
+      ELSE
+         matrix_c_bnorm => matrix_c
+      ENDIF
+
+      nblk = dbcsr_tas_get_num_blocks(matrix_c_bnorm)
+      IF(PRESENT(blk_ind)) ALLOCATE(blk_ind(nblk, 2))
 
       CALL dbcsr_tas_iterator_start(iter, matrix_c_bnorm)
-      nze = 0
-      DO WHILE (dbcsr_tas_iterator_blocks_left(iter))
+      IF(PRESENT(nze)) nze = 0
+      DO iblk=1,nblk
          CALL dbcsr_tas_iterator_next_block(iter, row, col, bn)
          row_size = matrix_c%row_blk_size%data(row)
          col_size = matrix_c%col_blk_size%data(col)
-         nze = nze + row_size*col_size
+         IF(PRESENT(nze)) nze = nze + row_size*col_size
+         IF(PRESENT(blk_ind)) blk_ind(iblk, :) = [row, col]
       ENDDO
       CALL dbcsr_tas_iterator_stop(iter)
 
-      CALL dbcsr_tas_get_split_info(dbcsr_tas_info(matrix_a), mp_comm=mp_comm)
-      CALL mp_sum(nze, mp_comm)
+      IF(PRESENT(nze)) THEN
+         CALL dbcsr_tas_get_split_info(dbcsr_tas_info(matrix_a), mp_comm=mp_comm)
+         CALL mp_sum(nze, mp_comm)
+      ENDIF
 
-      CALL dbcsr_tas_destroy(matrix_a_bnorm)
-      CALL dbcsr_tas_destroy(matrix_b_bnorm)
-      CALL dbcsr_tas_destroy(matrix_c_bnorm)
+      IF (.NOT. retain_sparsity_prv) THEN
+         CALL dbcsr_tas_destroy(matrix_c_bnorm)
+         DEALLOCATE(matrix_c_bnorm)
+      ENDIF
+
       CALL timestop(handle)
 
-   END FUNCTION
+   END SUBROUTINE
 
    FUNCTION split_factor_estimate(max_mm_dim, nze_a, nze_b, nze_c, numnodes) RESULT(nsplit)
       !! Estimate optimal split factor for AxB=C from occupancies (number of non-zero elements)

--- a/src/tensors/dbcsr_tensor.F
+++ b/src/tensors/dbcsr_tensor.F
@@ -93,7 +93,8 @@ MODULE dbcsr_tensor
       dbcsr_t_reserve_blocks, &
       dbcsr_t_copy_matrix_to_tensor, &
       dbcsr_t_copy_tensor_to_matrix, &
-      dbcsr_t_need_contract,&
+      dbcsr_t_need_contract, &
+      dbcsr_t_contract_index, &
       dbcsr_t_batched_contract_init, &
       dbcsr_t_batched_contract_finalize
 
@@ -384,31 +385,35 @@ CONTAINS
 
    END SUBROUTINE
 
-   ! todo: write expert / driver routine and high-level wrapper
    SUBROUTINE dbcsr_t_contract(alpha, tensor_1, tensor_2, beta, tensor_3, &
                                contract_1, notcontract_1, &
                                contract_2, notcontract_2, &
                                map_1, map_2, &
                                bounds_1, bounds_2, bounds_3, &
                                optimize_dist, pgrid_opt_1, pgrid_opt_2, pgrid_opt_3, &
-                               filter_eps, flop, move_data, retain_sparsity, result_index, unit_nr, log_verbose)
+                               filter_eps, flop, move_data, retain_sparsity, unit_nr, log_verbose)
       !! Contract tensors by multiplying matrix representations.
       !! tensor_3(map_1, map_2) := alpha * tensor_1(notcontract_1, contract_1)
       !! * tensor_2(contract_2, notcontract_2)
       !! + beta * tensor_3(map_1, map_2)
 
       TYPE(dbcsr_scalar_type), INTENT(IN)            :: alpha
-      TYPE(dbcsr_t_type), INTENT(INOUT), TARGET      :: tensor_1, tensor_2
+      TYPE(dbcsr_t_type), INTENT(INOUT), TARGET      :: tensor_1
          !! first tensor (in)
+      TYPE(dbcsr_t_type), INTENT(INOUT), TARGET      :: tensor_2
          !! second tensor (in)
       TYPE(dbcsr_scalar_type), INTENT(IN)            :: beta
-      INTEGER, DIMENSION(:), INTENT(IN)              :: contract_1, contract_2, map_1, map_2
+      INTEGER, DIMENSION(:), INTENT(IN)              :: contract_1
          !! indices of tensor_1 to contract
+      INTEGER, DIMENSION(:), INTENT(IN)              :: contract_2
          !! indices of tensor_2 to contract (1:1 with contract_1)
+      INTEGER, DIMENSION(:), INTENT(IN)              :: map_1
          !! which indices of tensor_3 map to non-contracted indices of tensor_1 (1:1 with notcontract_1)
+      INTEGER, DIMENSION(:), INTENT(IN)              :: map_2
          !! which indices of tensor_3 map to non-contracted indices of tensor_2 (1:1 with notcontract_2)
-      INTEGER, DIMENSION(:), INTENT(IN)              :: notcontract_1, notcontract_2
+      INTEGER, DIMENSION(:), INTENT(IN)              :: notcontract_1
          !! indices of tensor_1 not to contract
+      INTEGER, DIMENSION(:), INTENT(IN)              :: notcontract_2
          !! indices of tensor_2 not to contract
       TYPE(dbcsr_t_type), INTENT(INOUT), TARGET      :: tensor_3
          !! contracted tensor (out)
@@ -425,11 +430,15 @@ CONTAINS
          !! Whether distribution should be optimized internally. In the current implementation this guarantees optimal parameters
          !! only for dense matrices.
       TYPE(dbcsr_t_pgrid_type), INTENT(OUT), &
-         POINTER, OPTIONAL                           :: pgrid_opt_1, pgrid_opt_2, pgrid_opt_3
+         POINTER, OPTIONAL                           :: pgrid_opt_1
          !! Optionally return optimal process grid for tensor_1. This can be used to choose optimal process grids for subsequent
          !! tensor contractions with tensors of similar shape and sparsity. Under some conditions, pgrid_opt_1 can not be returned,
          !! in this case the pointer is not associated.
+      TYPE(dbcsr_t_pgrid_type), INTENT(OUT), &
+         POINTER, OPTIONAL                           :: pgrid_opt_2
          !! Optionally return optimal process grid for tensor_2.
+      TYPE(dbcsr_t_pgrid_type), INTENT(OUT), &
+         POINTER, OPTIONAL                           :: pgrid_opt_3
          !! Optionally return optimal process grid for tensor_3.
       REAL(KIND=real_8), INTENT(IN), OPTIONAL        :: filter_eps
          !! As in DBCSR mm
@@ -438,11 +447,81 @@ CONTAINS
       LOGICAL, INTENT(IN), OPTIONAL                  :: move_data
          !! memory optimization: transfer data such that tensor_1 and tensor_2 may be empty on return
       LOGICAL, INTENT(IN), OPTIONAL                  :: retain_sparsity
-      INTEGER, DIMENSION(:, :), ALLOCATABLE, OPTIONAL, INTENT(OUT) :: result_index
+         !! enforce the sparsity pattern of the existing tensor_3; default is no
       INTEGER, OPTIONAL, INTENT(IN)                  :: unit_nr
          !! output unit for logging
       LOGICAL, INTENT(IN), OPTIONAL                  :: log_verbose
          !! verbose logging (for testing only)
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_contract', &
+                                     routineP = moduleN//':'//routineN
+
+      INTEGER                     :: handle
+
+      CALL timeset(routineN, handle)
+      CALL dbcsr_t_contract_expert(alpha, tensor_1, tensor_2, beta, tensor_3, &
+                                   contract_1, notcontract_1, &
+                                   contract_2, notcontract_2, &
+                                   map_1, map_2, &
+                                   bounds_1=bounds_1, &
+                                   bounds_2=bounds_2, &
+                                   bounds_3=bounds_3, &
+                                   optimize_dist=optimize_dist, &
+                                   pgrid_opt_1=pgrid_opt_1, &
+                                   pgrid_opt_2=pgrid_opt_2, &
+                                   pgrid_opt_3=pgrid_opt_3, &
+                                   filter_eps=filter_eps, &
+                                   flop=flop, &
+                                   move_data=move_data, &
+                                   retain_sparsity=retain_sparsity, &
+                                   unit_nr=unit_nr, &
+                                   log_verbose=log_verbose)
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+   SUBROUTINE dbcsr_t_contract_expert(alpha, tensor_1, tensor_2, beta, tensor_3, &
+                                      contract_1, notcontract_1, &
+                                      contract_2, notcontract_2, &
+                                      map_1, map_2, &
+                                      bounds_1, bounds_2, bounds_3, &
+                                      optimize_dist, pgrid_opt_1, pgrid_opt_2, pgrid_opt_3, &
+                                      filter_eps, flop, move_data, retain_sparsity, result_index, unit_nr, log_verbose)
+      !! expert routine for tensor contraction. For internal use only.
+      TYPE(dbcsr_scalar_type), INTENT(IN)            :: alpha
+      TYPE(dbcsr_t_type), INTENT(INOUT), TARGET      :: tensor_1
+      TYPE(dbcsr_t_type), INTENT(INOUT), TARGET      :: tensor_2
+      TYPE(dbcsr_scalar_type), INTENT(IN)            :: beta
+      INTEGER, DIMENSION(:), INTENT(IN)              :: contract_1
+      INTEGER, DIMENSION(:), INTENT(IN)              :: contract_2
+      INTEGER, DIMENSION(:), INTENT(IN)              :: map_1
+      INTEGER, DIMENSION(:), INTENT(IN)              :: map_2
+      INTEGER, DIMENSION(:), INTENT(IN)              :: notcontract_1
+      INTEGER, DIMENSION(:), INTENT(IN)              :: notcontract_2
+      TYPE(dbcsr_t_type), INTENT(INOUT), TARGET      :: tensor_3
+      INTEGER, DIMENSION(2, SIZE(contract_1)), &
+         INTENT(IN), OPTIONAL                        :: bounds_1
+      INTEGER, DIMENSION(2, SIZE(notcontract_1)), &
+         INTENT(IN), OPTIONAL                        :: bounds_2
+      INTEGER, DIMENSION(2, SIZE(notcontract_2)), &
+         INTENT(IN), OPTIONAL                        :: bounds_3
+      LOGICAL, INTENT(IN), OPTIONAL                  :: optimize_dist
+      TYPE(dbcsr_t_pgrid_type), INTENT(OUT), &
+         POINTER, OPTIONAL                           :: pgrid_opt_1
+      TYPE(dbcsr_t_pgrid_type), INTENT(OUT), &
+         POINTER, OPTIONAL                           :: pgrid_opt_2
+      TYPE(dbcsr_t_pgrid_type), INTENT(OUT), &
+         POINTER, OPTIONAL                           :: pgrid_opt_3
+      REAL(KIND=real_8), INTENT(IN), OPTIONAL        :: filter_eps
+      INTEGER(KIND=int_8), INTENT(OUT), OPTIONAL     :: flop
+      LOGICAL, INTENT(IN), OPTIONAL                  :: move_data
+      LOGICAL, INTENT(IN), OPTIONAL                  :: retain_sparsity
+      INTEGER, DIMENSION(:, :), ALLOCATABLE, &
+         OPTIONAL, INTENT(OUT)                       :: result_index
+         !! get indices of non-zero tensor blocks for tensor_3 without actually performing contraction
+         !! this is an estimate based on block norm multiplication
+      INTEGER, OPTIONAL, INTENT(IN)                  :: unit_nr
+      LOGICAL, INTENT(IN), OPTIONAL                  :: log_verbose
 
       TYPE(dbcsr_t_type), POINTER                    :: tensor_contr_1, tensor_contr_2, tensor_contr_3
       TYPE(dbcsr_t_type)                             :: tensor_algn_1, tensor_algn_2, tensor_algn_3
@@ -450,7 +529,7 @@ CONTAINS
 
       INTEGER(int_8), DIMENSION(:,:), ALLOCATABLE  :: result_index_2d
       LOGICAL                                        :: assert_stmt
-      INTEGER                                        :: data_type, handle, max_mm_dim, max_tensor, mp_comm, &
+      INTEGER                                        :: data_type, max_mm_dim, max_tensor, mp_comm, &
                                                         iblk, nblk
       INTEGER, DIMENSION(SIZE(contract_1))           :: contract_1_mod
       INTEGER, DIMENSION(SIZE(notcontract_1))        :: notcontract_1_mod
@@ -464,7 +543,7 @@ CONTAINS
       INTEGER                                        :: occ_1, occ_2
       INTEGER, DIMENSION(:), ALLOCATABLE             :: dims1, dims2, dims3
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_contract', &
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_contract_expert', &
                                      routineP = moduleN//':'//routineN
       CHARACTER(LEN=1), DIMENSION(:), ALLOCATABLE    :: indchar1, indchar2, indchar3, indchar1_mod, &
                                                         indchar2_mod, indchar3_mod
@@ -474,8 +553,6 @@ CONTAINS
       INTEGER, DIMENSION(2, dbcsr_t_ndims(tensor_2)) :: bounds_t2
       LOGICAL                                        :: do_crop_1, do_crop_2, do_write_3, nodata_3
       TYPE(dbcsr_tas_split_info), POINTER            :: split_opt
-
-      CALL timeset(routineN, handle)
 
       NULLIFY (tensor_contr_1, tensor_contr_2, tensor_contr_3, tensor_crop_1, tensor_crop_2, split_opt)
 
@@ -559,7 +636,6 @@ CONTAINS
             CALL dbcsr_t_destroy(tensor_crop_2)
             DEALLOCATE (tensor_crop_2)
          ENDIF
-         CALL timestop(handle)
          RETURN
       ENDIF
 
@@ -747,7 +823,7 @@ CONTAINS
             result_index(iblk,:) = get_nd_indices(tensor_contr_3%nd_index_blk, result_index_2d(iblk,:))
          ENDDO
 
-         IF (new_1) THEN ! todo: create cleanup routine
+         IF (new_1) THEN
             CALL dbcsr_t_destroy(tensor_contr_1)
             DEALLOCATE (tensor_contr_1)
          ENDIF
@@ -777,7 +853,6 @@ CONTAINS
          CALL dbcsr_t_destroy(tensor_algn_2)
          CALL dbcsr_t_destroy(tensor_algn_3)
 
-         CALL timestop(handle)
          RETURN
       ENDIF
 
@@ -878,8 +953,6 @@ CONTAINS
             WRITE (unit_nr, '(A)') repeat("-", 80)
          ENDIF
       ENDIF
-
-      CALL timestop(handle)
 
    END SUBROUTINE
 
@@ -1515,6 +1588,49 @@ CONTAINS
       ENDDO blk_loop
 
       CALL dbcsr_t_iterator_stop(iter)
+   END SUBROUTINE
+
+   SUBROUTINE dbcsr_t_contract_index(alpha, tensor_1, tensor_2, beta, tensor_3, &
+                                     contract_1, notcontract_1, &
+                                     contract_2, notcontract_2, &
+                                     map_1, map_2, &
+                                     bounds_1, bounds_2, bounds_3, &
+                                     filter_eps, result_index)
+      !! get indices of non-zero tensor blocks for contraction result without actually
+      !! performing contraction.
+      !! this is an estimate based on block norm multiplication.
+      !! See documentation of dbcsr_t_contract.
+      TYPE(dbcsr_scalar_type), INTENT(IN)            :: alpha
+      TYPE(dbcsr_t_type), INTENT(INOUT), TARGET      :: tensor_1
+      TYPE(dbcsr_t_type), INTENT(INOUT), TARGET      :: tensor_2
+      TYPE(dbcsr_scalar_type), INTENT(IN)            :: beta
+      INTEGER, DIMENSION(:), INTENT(IN)              :: contract_1
+      INTEGER, DIMENSION(:), INTENT(IN)              :: contract_2
+      INTEGER, DIMENSION(:), INTENT(IN)              :: map_1
+      INTEGER, DIMENSION(:), INTENT(IN)              :: map_2
+      INTEGER, DIMENSION(:), INTENT(IN)              :: notcontract_1
+      INTEGER, DIMENSION(:), INTENT(IN)              :: notcontract_2
+      TYPE(dbcsr_t_type), INTENT(INOUT), TARGET      :: tensor_3
+      INTEGER, DIMENSION(2, SIZE(contract_1)), &
+         INTENT(IN), OPTIONAL                        :: bounds_1
+      INTEGER, DIMENSION(2, SIZE(notcontract_1)), &
+         INTENT(IN), OPTIONAL                        :: bounds_2
+      INTEGER, DIMENSION(2, SIZE(notcontract_2)), &
+         INTENT(IN), OPTIONAL                        :: bounds_3
+      REAL(KIND=real_8), INTENT(IN), OPTIONAL        :: filter_eps
+      INTEGER, DIMENSION(:, :), ALLOCATABLE, &
+         INTENT(OUT)                                 :: result_index
+         !! indices of non-zero tensor blocks for tensor_3
+
+      CALL dbcsr_t_contract_expert(alpha, tensor_1, tensor_2, beta, tensor_3, &
+                                   contract_1, notcontract_1, &
+                                   contract_2, notcontract_2, &
+                                   map_1, map_2, &
+                                   bounds_1=bounds_1, &
+                                   bounds_2=bounds_2, &
+                                   bounds_3=bounds_3, &
+                                   filter_eps=filter_eps, &
+                                   result_index=result_index)
    END SUBROUTINE
 
    FUNCTION dbcsr_t_need_contract(tensor_1, tensor_2, contract_1, notcontract_1, &

--- a/src/tensors/dbcsr_tensor.F
+++ b/src/tensors/dbcsr_tensor.F
@@ -39,7 +39,7 @@ MODULE dbcsr_tensor
       dbcsr_t_iterator_blocks_left, dbcsr_t_iterator_stop, dbcsr_t_iterator_next_block, &
       ndims_iterator, dbcsr_t_reserve_blocks, block_nd, destroy_block
    USE dbcsr_tensor_index, ONLY: &
-      dbcsr_t_get_mapping_info, nd_to_2d_mapping, dbcsr_t_inverse_order, permute_index
+      dbcsr_t_get_mapping_info, nd_to_2d_mapping, dbcsr_t_inverse_order, permute_index, get_nd_indices
    USE dbcsr_tensor_types, ONLY: &
       dbcsr_t_create, dbcsr_t_get_data_type, dbcsr_t_type, ndims_tensor, dims_tensor, &
       dbcsr_t_distribution_type, dbcsr_t_distribution, dbcsr_t_nd_mp_comm, dbcsr_t_destroy, &
@@ -384,13 +384,14 @@ CONTAINS
 
    END SUBROUTINE
 
+   ! todo: write expert / driver routine and high-level wrapper
    SUBROUTINE dbcsr_t_contract(alpha, tensor_1, tensor_2, beta, tensor_3, &
                                contract_1, notcontract_1, &
                                contract_2, notcontract_2, &
                                map_1, map_2, &
                                bounds_1, bounds_2, bounds_3, &
                                optimize_dist, pgrid_opt_1, pgrid_opt_2, pgrid_opt_3, &
-                               filter_eps, flop, move_data, unit_nr, log_verbose)
+                               filter_eps, flop, move_data, retain_sparsity, result_index, unit_nr, log_verbose)
       !! Contract tensors by multiplying matrix representations.
       !! tensor_3(map_1, map_2) := alpha * tensor_1(notcontract_1, contract_1)
       !! * tensor_2(contract_2, notcontract_2)
@@ -436,6 +437,8 @@ CONTAINS
          !! As in DBCSR mm
       LOGICAL, INTENT(IN), OPTIONAL                  :: move_data
          !! memory optimization: transfer data such that tensor_1 and tensor_2 may be empty on return
+      LOGICAL, INTENT(IN), OPTIONAL                  :: retain_sparsity
+      INTEGER, DIMENSION(:, :), ALLOCATABLE, OPTIONAL, INTENT(OUT) :: result_index
       INTEGER, OPTIONAL, INTENT(IN)                  :: unit_nr
          !! output unit for logging
       LOGICAL, INTENT(IN), OPTIONAL                  :: log_verbose
@@ -444,8 +447,11 @@ CONTAINS
       TYPE(dbcsr_t_type), POINTER                    :: tensor_contr_1, tensor_contr_2, tensor_contr_3
       TYPE(dbcsr_t_type)                             :: tensor_algn_1, tensor_algn_2, tensor_algn_3
       TYPE(dbcsr_t_type), POINTER                    :: tensor_crop_1, tensor_crop_2
+
+      INTEGER(int_8), DIMENSION(:,:), ALLOCATABLE  :: result_index_2d
       LOGICAL                                        :: assert_stmt
-      INTEGER                                        :: data_type, handle, max_mm_dim, max_tensor, mp_comm
+      INTEGER                                        :: data_type, handle, max_mm_dim, max_tensor, mp_comm, &
+                                                        iblk, nblk
       INTEGER, DIMENSION(SIZE(contract_1))           :: contract_1_mod
       INTEGER, DIMENSION(SIZE(notcontract_1))        :: notcontract_1_mod
       INTEGER, DIMENSION(SIZE(contract_2))           :: contract_2_mod
@@ -466,7 +472,7 @@ CONTAINS
                                          ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o']
       INTEGER, DIMENSION(2, dbcsr_t_ndims(tensor_1)) :: bounds_t1
       INTEGER, DIMENSION(2, dbcsr_t_ndims(tensor_2)) :: bounds_t2
-      LOGICAL                                        :: do_crop_1, do_crop_2, do_write_3
+      LOGICAL                                        :: do_crop_1, do_crop_2, do_write_3, nodata_3
       TYPE(dbcsr_tas_split_info), POINTER            :: split_opt
 
       CALL timeset(routineN, handle)
@@ -504,6 +510,11 @@ CONTAINS
       ELSE
          move_data_1 = .FALSE.
          move_data_2 = .FALSE.
+      ENDIF
+
+      nodata_3 = .TRUE.
+      IF(PRESENT(retain_sparsity)) THEN
+         IF(retain_sparsity) nodata_3 = .FALSE.
       ENDIF
 
       CALL dbcsr_t_map_bounds_to_tensors(tensor_1, tensor_2, &
@@ -640,7 +651,7 @@ CONTAINS
 
          CALL reshape_mm_compatible(tensor_algn_1, tensor_algn_3, tensor_contr_1, tensor_contr_3, &
                                     contract_1_mod, notcontract_1_mod, map_2_mod, map_1_mod, &
-                                    trans_1, trans_3, new_1, new_3, nodata2=.TRUE., optimize_dist=optimize_dist, &
+                                    trans_1, trans_3, new_1, new_3, nodata2=nodata_3, optimize_dist=optimize_dist, &
                                     move_data_1=move_data_1, unit_nr=unit_nr)
 
          CALL reshape_mm_small(tensor_algn_2, contract_2_mod, notcontract_2_mod, tensor_contr_2, trans_2, &
@@ -672,7 +683,7 @@ CONTAINS
          CALL invert_transpose_flag(trans_1)
 
          CALL reshape_mm_small(tensor_algn_3, map_1_mod, map_2_mod, tensor_contr_3, trans_3, &
-                               new_3, nodata=.TRUE., unit_nr=unit_nr)
+                               new_3, nodata=nodata_3, unit_nr=unit_nr)
 
       CASE (3)
          IF (PRESENT(unit_nr)) THEN
@@ -694,7 +705,7 @@ CONTAINS
 
          CALL reshape_mm_compatible(tensor_algn_2, tensor_algn_3, tensor_contr_2, tensor_contr_3, &
                                     contract_2_mod, notcontract_2_mod, map_1_mod, map_2_mod, &
-                                    trans_2, trans_3, new_2, new_3, nodata2=.TRUE., optimize_dist=optimize_dist, &
+                                    trans_2, trans_3, new_2, new_3, nodata2=nodata_3, optimize_dist=optimize_dist, &
                                     move_data_1=move_data_2, unit_nr=unit_nr)
 
          CALL invert_transpose_flag(trans_2)
@@ -715,13 +726,60 @@ CONTAINS
          IF (new_2) CALL dbcsr_t_write_tensor_dist(tensor_contr_2, unit_nr)
       ENDIF
 
-      CALL dbcsr_tas_multiply(trans_1, trans_2, trans_3, alpha, &
-                              tensor_contr_1%matrix_rep, tensor_contr_2%matrix_rep, &
-                              beta, &
-                              tensor_contr_3%matrix_rep, filter_eps=filter_eps, flop=flop, &
-                              io_unit=unit_nr, log_verbose=log_verbose, &
-                              split_opt=split_opt, &
-                              move_data_a=move_data_1, move_data_b=move_data_2)
+      IF(.NOT. PRESENT(result_index)) THEN
+         CALL dbcsr_tas_multiply(trans_1, trans_2, trans_3, alpha, &
+                                 tensor_contr_1%matrix_rep, tensor_contr_2%matrix_rep, &
+                                 beta, &
+                                 tensor_contr_3%matrix_rep, filter_eps=filter_eps, flop=flop, &
+                                 io_unit=unit_nr, log_verbose=log_verbose, &
+                                 split_opt=split_opt, &
+                                 move_data_a=move_data_1, move_data_b=move_data_2, retain_sparsity=retain_sparsity)
+      ELSE
+         CALL dbcsr_tas_multiply(trans_1, trans_2, trans_3, alpha, &
+                                 tensor_contr_1%matrix_rep, tensor_contr_2%matrix_rep, &
+                                 beta, &
+                                 tensor_contr_3%matrix_rep, filter_eps=filter_eps, &
+                                 result_index=result_index_2d)
+
+         nblk = SIZE(result_index_2d,1)
+         ALLOCATE(result_index(nblk, dbcsr_t_ndims(tensor_contr_3)))
+         DO iblk = 1, nblk
+            result_index(iblk,:) = get_nd_indices(tensor_contr_3%nd_index_blk, result_index_2d(iblk,:))
+         ENDDO
+
+         IF (new_1) THEN ! todo: create cleanup routine
+            CALL dbcsr_t_destroy(tensor_contr_1)
+            DEALLOCATE (tensor_contr_1)
+         ENDIF
+         IF (new_2) THEN
+            CALL dbcsr_t_destroy(tensor_contr_2)
+            DEALLOCATE (tensor_contr_2)
+         ENDIF
+         IF (new_3) THEN
+            CALL dbcsr_t_destroy(tensor_contr_3)
+            DEALLOCATE (tensor_contr_3)
+         ENDIF
+         IF (do_crop_1) THEN
+            CALL dbcsr_t_destroy(tensor_crop_1)
+            DEALLOCATE (tensor_crop_1)
+         ENDIF
+         IF (do_crop_2) THEN
+            CALL dbcsr_t_destroy(tensor_crop_2)
+            DEALLOCATE (tensor_crop_2)
+         ENDIF
+
+         IF (ASSOCIATED(split_opt)) THEN
+            CALL dbcsr_tas_release_info(split_opt)
+            DEALLOCATE (split_opt)
+         ENDIF
+
+         CALL dbcsr_t_destroy(tensor_algn_1)
+         CALL dbcsr_t_destroy(tensor_algn_2)
+         CALL dbcsr_t_destroy(tensor_algn_3)
+
+         CALL timestop(handle)
+         RETURN
+      ENDIF
 
       IF (PRESENT(pgrid_opt_1) .AND. ASSOCIATED(split_opt)) THEN
          IF (.NOT. new_1) THEN

--- a/src/tensors/dbcsr_tensor.F
+++ b/src/tensors/dbcsr_tensor.F
@@ -445,7 +445,7 @@ CONTAINS
       INTEGER(KIND=int_8), INTENT(OUT), OPTIONAL     :: flop
          !! As in DBCSR mm
       LOGICAL, INTENT(IN), OPTIONAL                  :: move_data
-         !! memory optimization: transfer data such that tensor_1 and tensor_2 may be empty on return
+         !! memory optimization: transfer data such that tensor_1 and tensor_2 are empty on return
       LOGICAL, INTENT(IN), OPTIONAL                  :: retain_sparsity
          !! enforce the sparsity pattern of the existing tensor_3; default is no
       INTEGER, OPTIONAL, INTENT(IN)                  :: unit_nr
@@ -944,6 +944,13 @@ CONTAINS
       IF (new_3) THEN
          CALL dbcsr_t_destroy(tensor_contr_3)
          DEALLOCATE (tensor_contr_3)
+      ENDIF
+
+      IF(PRESENT(move_data)) THEN
+         IF(move_data) THEN
+            CALL dbcsr_t_clear(tensor_1)
+            CALL dbcsr_t_clear(tensor_2)
+         ENDIF
       ENDIF
 
       IF (PRESENT(unit_nr)) THEN

--- a/src/tensors/dbcsr_tensor_api.F
+++ b/src/tensors/dbcsr_tensor_api.F
@@ -19,7 +19,7 @@ MODULE dbcsr_tensor_api
       dbcsr_t_contract, dbcsr_t_get_block, dbcsr_t_get_stored_coordinates, dbcsr_t_put_block, &
       dbcsr_t_reserve_blocks, dbcsr_t_copy_matrix_to_tensor, dbcsr_t_copy, &
       dbcsr_t_copy_tensor_to_matrix, dbcsr_t_need_contract, dbcsr_t_batched_contract_init, &
-      dbcsr_t_batched_contract_finalize, dbcsr_t_ndims
+      dbcsr_t_batched_contract_finalize, dbcsr_t_ndims, dbcsr_t_contract_index
    USE dbcsr_tensor_block, ONLY: &
       dbcsr_t_iterator_blocks_left, dbcsr_t_iterator_next_block, dbcsr_t_iterator_start, &
       dbcsr_t_iterator_stop, dbcsr_t_iterator_type, dbcsr_t_reserved_block_indices
@@ -94,5 +94,6 @@ MODULE dbcsr_tensor_api
    PUBLIC :: dbcsr_t_ndims
    PUBLIC :: dbcsr_t_pgrid_change_dims
    PUBLIC :: dbcsr_t_reserved_block_indices
+   PUBLIC :: dbcsr_t_contract_index
 
 END MODULE dbcsr_tensor_api

--- a/src/tensors/dbcsr_tensor_api.F
+++ b/src/tensors/dbcsr_tensor_api.F
@@ -22,7 +22,7 @@ MODULE dbcsr_tensor_api
       dbcsr_t_batched_contract_finalize, dbcsr_t_ndims
    USE dbcsr_tensor_block, ONLY: &
       dbcsr_t_iterator_blocks_left, dbcsr_t_iterator_next_block, dbcsr_t_iterator_start, &
-      dbcsr_t_iterator_stop, dbcsr_t_iterator_type
+      dbcsr_t_iterator_stop, dbcsr_t_iterator_type, dbcsr_t_reserved_block_indices
    USE dbcsr_tensor_types, ONLY: &
       dbcsr_t_create, dbcsr_t_destroy, dbcsr_t_distribution_destroy, dbcsr_t_distribution_new, &
       dbcsr_t_distribution_type, dbcsr_t_nd_mp_comm, dbcsr_t_nd_mp_free, dbcsr_t_type, &
@@ -93,5 +93,6 @@ MODULE dbcsr_tensor_api
    PUBLIC :: dbcsr_t_batched_contract_finalize
    PUBLIC :: dbcsr_t_ndims
    PUBLIC :: dbcsr_t_pgrid_change_dims
+   PUBLIC :: dbcsr_t_reserved_block_indices
 
 END MODULE dbcsr_tensor_api


### PR DESCRIPTION
This generalizes `retain_sparsity` feature of DBCSR matmul to tensors. A new API routine is made available to predict sparsity pattern of contraction result.