### PR TITLE
removed OpenMP critical section around mp_allocate

### DIFF
--- a/src/data/dbcsr_ptr_util.f90
+++ b/src/data/dbcsr_ptr_util.f90
@@ -207,9 +207,7 @@
      IF (mem_type%acc_hostalloc .AND. n > 1) THEN
         CALL acc_hostmem_allocate(mem, n, mem_type%acc_stream)
      ELSE IF (mem_type%mpi .AND. dbcsr_data_allocation%use_mpi_allocator) THEN
-!$OMP critical(allocate)
         CALL mp_allocate(mem, n)
-!$OMP end critical(allocate)
      ELSE
         ALLOCATE (mem(n))
      ENDIF


### PR DESCRIPTION
Removed OpenMP critical section around mp_allocate since it calls MPI_TYPE_SIZE() and MPI_Mem_alloc() both of which are thread-safe (contribution suggested by Dmitri M.).