### PR TITLE
Tensors: avoid use of intent(out) allocatables at the API level

### DIFF
--- a/src/tensors/dbcsr_array_list_methods.F
+++ b/src/tensors/dbcsr_array_list_methods.F
@@ -44,6 +44,11 @@ MODULE dbcsr_array_list_methods
       INTEGER, DIMENSION(:), ALLOCATABLE :: ptr
    END TYPE
 
+   INTERFACE get_ith_array
+      MODULE PROCEDURE allocate_and_get_ith_array
+      MODULE PROCEDURE get_ith_array
+   END INTERFACE
+
 CONTAINS
 
    PURE FUNCTION number_of_arrays(list)
@@ -55,7 +60,7 @@ CONTAINS
 
    END FUNCTION number_of_arrays
 
-   FUNCTION get_array_elements(list, indices)
+   PURE FUNCTION get_array_elements(list, indices)
       !! Get an element for each array.
 
       TYPE(array_list), INTENT(IN)                           :: list
@@ -167,7 +172,23 @@ CONTAINS
 
    END SUBROUTINE get_arrays
 
-   SUBROUTINE get_ith_array(list, i, array)
+   SUBROUTINE get_ith_array(list, i, array_size, array)
+      !! get ith array
+      TYPE(array_list), INTENT(IN)                    :: list
+      INTEGER, INTENT(IN)                             :: i
+      INTEGER, INTENT(IN)                             :: array_size
+      INTEGER, DIMENSION(array_size), INTENT(OUT)     :: array
+
+      ASSOCIATE (ptr=>list%ptr, col_data=>list%col_data)
+         DBCSR_ASSERT(i <= number_of_arrays(list))
+
+         array(:) = col_data(ptr(i):ptr(i + 1) - 1)
+
+      END ASSOCIATE
+
+   END SUBROUTINE
+
+   SUBROUTINE allocate_and_get_ith_array(list, i, array)
       !! get ith array
       TYPE(array_list), INTENT(IN)                    :: list
       INTEGER, INTENT(IN)                             :: i

--- a/src/tensors/dbcsr_tensor.F
+++ b/src/tensors/dbcsr_tensor.F
@@ -39,14 +39,15 @@ MODULE dbcsr_tensor
       dbcsr_t_iterator_blocks_left, dbcsr_t_iterator_stop, dbcsr_t_iterator_next_block, &
       ndims_iterator, dbcsr_t_reserve_blocks, block_nd, destroy_block
    USE dbcsr_tensor_index, ONLY: &
-      dbcsr_t_get_mapping_info, nd_to_2d_mapping, dbcsr_t_inverse_order, permute_index, get_nd_indices_tensor
+      dbcsr_t_get_mapping_info, nd_to_2d_mapping, dbcsr_t_inverse_order, permute_index, get_nd_indices_tensor, &
+      ndims_mapping_row, ndims_mapping_column
    USE dbcsr_tensor_types, ONLY: &
       dbcsr_t_create, dbcsr_t_get_data_type, dbcsr_t_type, ndims_tensor, dims_tensor, &
       dbcsr_t_distribution_type, dbcsr_t_distribution, dbcsr_t_nd_mp_comm, dbcsr_t_destroy, &
       dbcsr_t_distribution_destroy, dbcsr_t_distribution_new_expert, dbcsr_t_get_stored_coordinates, &
       blk_dims_tensor, dbcsr_t_hold, dbcsr_t_pgrid_type, mp_environ_pgrid, dbcsr_t_filter, &
       dbcsr_t_clear, dbcsr_t_finalize, dbcsr_t_get_num_blocks, dbcsr_t_scale, &
-      dbcsr_t_get_num_blocks_total, dbcsr_t_get_info
+      dbcsr_t_get_num_blocks_total, dbcsr_t_get_info, ndims_matrix_row, ndims_matrix_column
    USE dbcsr_kinds, ONLY: &
       ${uselist(dtype_float_prec)}$, default_string_length, int_8
    USE dbcsr_mpiwrap, ONLY: &
@@ -79,7 +80,6 @@ MODULE dbcsr_tensor
    PUBLIC :: &
       dbcsr_t_contract, &
       dbcsr_t_copy, &
-      dbcsr_t_dims, &
       dbcsr_t_get_block, &
       dbcsr_t_get_stored_coordinates, &
       dbcsr_t_inverse_order, &
@@ -88,7 +88,6 @@ MODULE dbcsr_tensor
       dbcsr_t_iterator_start, &
       dbcsr_t_iterator_stop, &
       dbcsr_t_iterator_type, &
-      dbcsr_t_ndims, &
       dbcsr_t_put_block, &
       dbcsr_t_reserve_blocks, &
       dbcsr_t_copy_matrix_to_tensor, &
@@ -97,14 +96,6 @@ MODULE dbcsr_tensor
       dbcsr_t_contract_index, &
       dbcsr_t_batched_contract_init, &
       dbcsr_t_batched_contract_finalize
-
-   INTERFACE dbcsr_t_ndims
-      MODULE PROCEDURE ndims_tensor
-   END INTERFACE
-
-   INTERFACE dbcsr_t_dims
-      MODULE PROCEDURE dims_tensor
-   END INTERFACE
 
 CONTAINS
 
@@ -202,7 +193,12 @@ CONTAINS
          in_tmp_3 => in_tmp_2
       ENDIF
 
+      ALLOCATE(map1_in_1(ndims_matrix_row(in_tmp_3)))
+      ALLOCATE(map1_in_2(ndims_matrix_column(in_tmp_3)))
       CALL dbcsr_t_get_mapping_info(in_tmp_3%nd_index, map1_2d=map1_in_1, map2_2d=map1_in_2)
+
+      ALLOCATE(map2_in_1(ndims_matrix_row(out_tmp_1)))
+      ALLOCATE(map2_in_2(ndims_matrix_column(out_tmp_1)))
       CALL dbcsr_t_get_mapping_info(out_tmp_1%nd_index, map1_2d=map2_in_1, map2_2d=map2_in_2)
 
       IF (.NOT. PRESENT(order)) THEN
@@ -350,7 +346,7 @@ CONTAINS
       !! copy tensor to matrix
 
       TYPE(dbcsr_t_type), INTENT(INOUT)      :: tensor_in
-      TYPE(dbcsr_type), INTENT(INOUT)           :: matrix_out
+      TYPE(dbcsr_type), INTENT(INOUT)        :: matrix_out
       LOGICAL, INTENT(IN), OPTIONAL          :: summation
          !! matrix_out = matrix_out + tensor_in
       TYPE(dbcsr_t_iterator_type)            :: iter
@@ -556,8 +552,8 @@ CONTAINS
                                                         indchar2_mod, indchar3_mod
       CHARACTER(LEN=1), DIMENSION(15) :: alph = &
                                          ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o']
-      INTEGER, DIMENSION(2, dbcsr_t_ndims(tensor_1)) :: bounds_t1
-      INTEGER, DIMENSION(2, dbcsr_t_ndims(tensor_2)) :: bounds_t2
+      INTEGER, DIMENSION(2, ndims_tensor(tensor_1)) :: bounds_t1
+      INTEGER, DIMENSION(2, ndims_tensor(tensor_2)) :: bounds_t2
       LOGICAL                                        :: do_crop_1, do_crop_2, do_write_3, nodata_3
       TYPE(dbcsr_tas_split_info), POINTER            :: split_opt
 
@@ -576,13 +572,13 @@ CONTAINS
       assert_stmt = SIZE(map_2) .EQ. SIZE(notcontract_2)
       DBCSR_ASSERT(assert_stmt)
 
-      assert_stmt = SIZE(notcontract_1) + SIZE(contract_1) .EQ. dbcsr_t_ndims(tensor_1)
+      assert_stmt = SIZE(notcontract_1) + SIZE(contract_1) .EQ. ndims_tensor(tensor_1)
       DBCSR_ASSERT(assert_stmt)
 
-      assert_stmt = SIZE(notcontract_2) + SIZE(contract_2) .EQ. dbcsr_t_ndims(tensor_2)
+      assert_stmt = SIZE(notcontract_2) + SIZE(contract_2) .EQ. ndims_tensor(tensor_2)
       DBCSR_ASSERT(assert_stmt)
 
-      assert_stmt = SIZE(map_1) + SIZE(map_2) .EQ. dbcsr_t_ndims(tensor_3)
+      assert_stmt = SIZE(map_1) + SIZE(map_2) .EQ. ndims_tensor(tensor_3)
       DBCSR_ASSERT(assert_stmt)
 
       assert_stmt = dbcsr_t_get_data_type(tensor_1) .EQ. dbcsr_t_get_data_type(tensor_2)
@@ -662,9 +658,9 @@ CONTAINS
       data_type = dbcsr_t_get_data_type(tensor_crop_1)
 
       ! align tensor index with data, tensor data is not modified
-      ndims1 = dbcsr_t_ndims(tensor_crop_1)
-      ndims2 = dbcsr_t_ndims(tensor_crop_2)
-      ndims3 = dbcsr_t_ndims(tensor_3)
+      ndims1 = ndims_tensor(tensor_crop_1)
+      ndims2 = ndims_tensor(tensor_crop_2)
+      ndims3 = ndims_tensor(tensor_3)
       ALLOCATE (indchar1(ndims1), indchar1_mod(ndims1))
       ALLOCATE (indchar2(ndims2), indchar2_mod(ndims2))
       ALLOCATE (indchar3(ndims3), indchar3_mod(ndims3))
@@ -825,7 +821,7 @@ CONTAINS
                                  result_index=result_index_2d)
 
          nblk = SIZE(result_index_2d,1)
-         ALLOCATE(result_index(nblk, dbcsr_t_ndims(tensor_contr_3)))
+         ALLOCATE(result_index(nblk, ndims_tensor(tensor_contr_3)))
          DO iblk = 1, nblk
             result_index(iblk,:) = get_nd_indices_tensor(tensor_contr_3%nd_index_blk, result_index_2d(iblk,:))
          ENDDO
@@ -980,9 +976,9 @@ CONTAINS
          INTENT(OUT)                               :: contract_out
       INTEGER, DIMENSION(SIZE(notcontract_in)), &
          INTENT(OUT)                               :: notcontract_out
-      CHARACTER(LEN=1), DIMENSION(dbcsr_t_ndims(tensor_in)), INTENT(IN) :: indp_in
-      CHARACTER(LEN=1), DIMENSION(dbcsr_t_ndims(tensor_in)), INTENT(OUT) :: indp_out
-      INTEGER, DIMENSION(dbcsr_t_ndims(tensor_in)) :: align
+      CHARACTER(LEN=1), DIMENSION(ndims_tensor(tensor_in)), INTENT(IN) :: indp_in
+      CHARACTER(LEN=1), DIMENSION(ndims_tensor(tensor_in)), INTENT(OUT) :: indp_out
+      INTEGER, DIMENSION(ndims_tensor(tensor_in)) :: align
 
       CALL dbcsr_t_align_index(tensor_in, tensor_out, order=align)
       contract_out = align(contract_in)
@@ -1093,7 +1089,7 @@ CONTAINS
       IF (ref_tensor == 1) THEN ! tensor 1 is reference and tensor 2 is reshaped compatible with tensor 1
          IF (compat1 == 0 .OR. optimize_dist_prv) THEN ! tensor 1 is not contraction compatible --> reshape
             IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "Redistribution of", TRIM(tensor1%name)
-            ALLOCATE (dims(dbcsr_t_ndims(tensor1)))
+            ALLOCATE (dims(ndims_tensor(tensor1)))
             CALL blk_dims_tensor(tensor1, dims)
             nblkrows = PRODUCT(INT(dims(ind1_linked), KIND=int_8))
             nblkcols = PRODUCT(INT(dims(ind1_free), KIND=int_8))
@@ -1115,6 +1111,7 @@ CONTAINS
             IF (compat1 == 1) THEN ! linked index is first 2d dimension
                ! get distribution of linked index, tensor 2 must adopt this distribution
                ! get grid dimensions of linked index
+               ALLOCATE(mp_dims(ndims_mapping_row(dist_in%pgrid%nd_index_grid)))
                CALL dbcsr_t_get_mapping_info(dist_in%pgrid%nd_index_grid, dims1_2d=mp_dims)
                ALLOCATE (tensor2_out)
                CALL dbcsr_t_remap(tensor2, ind2_linked, ind2_free, tensor2_out, comm_2d=dist_in%pgrid%mp_comm_2d, &
@@ -1122,6 +1119,7 @@ CONTAINS
             ELSEIF (compat1 == 2) THEN ! linked index is second 2d dimension
                ! get distribution of linked index, tensor 2 must adopt this distribution
                ! get grid dimensions of linked index
+               ALLOCATE(mp_dims(ndims_mapping_column(dist_in%pgrid%nd_index_grid)))
                CALL dbcsr_t_get_mapping_info(dist_in%pgrid%nd_index_grid, dims2_2d=mp_dims)
                ALLOCATE (tensor2_out)
                CALL dbcsr_t_remap(tensor2, ind2_free, ind2_linked, tensor2_out, comm_2d=dist_in%pgrid%mp_comm_2d, &
@@ -1137,7 +1135,7 @@ CONTAINS
       ELSE ! tensor 2 is reference and tensor 1 is reshaped compatible with tensor 2
          IF (compat2 == 0 .OR. optimize_dist_prv) THEN ! tensor 2 is not contraction compatible --> reshape
             IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "Redistribution of", TRIM(tensor2%name)
-            ALLOCATE (dims(dbcsr_t_ndims(tensor2)))
+            ALLOCATE (dims(ndims_tensor(tensor2)))
             CALL blk_dims_tensor(tensor2, dims)
             nblkrows = PRODUCT(INT(dims(ind2_linked), KIND=int_8))
             nblkcols = PRODUCT(INT(dims(ind2_free), KIND=int_8))
@@ -1156,11 +1154,13 @@ CONTAINS
             dist_in = dbcsr_t_distribution(tensor2_out)
             dist_list = array_sublist(dist_in%nd_dist, ind2_linked)
             IF (compat2 == 1) THEN
+               ALLOCATE(mp_dims(ndims_mapping_row(dist_in%pgrid%nd_index_grid)))
                CALL dbcsr_t_get_mapping_info(dist_in%pgrid%nd_index_grid, dims1_2d=mp_dims)
                ALLOCATE (tensor1_out)
                CALL dbcsr_t_remap(tensor1, ind1_linked, ind1_free, tensor1_out, comm_2d=dist_in%pgrid%mp_comm_2d, &
                                   dist1=dist_list, mp_dims_1=mp_dims, nodata=nodata1, move_data=move_data_1)
             ELSEIF (compat2 == 2) THEN
+               ALLOCATE(mp_dims(ndims_mapping_column(dist_in%pgrid%nd_index_grid)))
                CALL dbcsr_t_get_mapping_info(dist_in%pgrid%nd_index_grid, dims2_2d=mp_dims)
                ALLOCATE (tensor1_out)
                CALL dbcsr_t_remap(tensor1, ind1_free, ind1_linked, tensor1_out, comm_2d=dist_in%pgrid%mp_comm_2d, &
@@ -1318,7 +1318,8 @@ CONTAINS
       !! Check if 2d index is compatible with tensor index
       TYPE(nd_to_2d_mapping), INTENT(IN) :: nd_index
       INTEGER, DIMENSION(:), INTENT(IN)  :: compat_ind
-      INTEGER, DIMENSION(:), ALLOCATABLE :: map1, map2
+      INTEGER, DIMENSION(ndims_mapping_row(nd_index)) :: map1
+      INTEGER, DIMENSION(ndims_mapping_column(nd_index)) :: map2
       INTEGER                            :: compat_map
 
       CALL dbcsr_t_get_mapping_info(nd_index, map1_2d=map1, map2_2d=map2)
@@ -1354,9 +1355,10 @@ CONTAINS
    FUNCTION opt_pgrid(tensor, tas_split_info)
       TYPE(dbcsr_t_type), INTENT(IN) :: tensor
       TYPE(dbcsr_tas_split_info), INTENT(IN) :: tas_split_info
-      INTEGER, DIMENSION(:), ALLOCATABLE :: map1, map2
+      INTEGER, DIMENSION(ndims_matrix_row(tensor)) :: map1
+      INTEGER, DIMENSION(ndims_matrix_column(tensor)) :: map2
       TYPE(dbcsr_t_pgrid_type) :: opt_pgrid
-      INTEGER, DIMENSION(dbcsr_t_ndims(tensor)) :: dims
+      INTEGER, DIMENSION(ndims_tensor(tensor)) :: dims
 
       CALL dbcsr_t_get_mapping_info(tensor%pgrid%nd_index_grid, map1_2d=map1, map2_2d=map2)
       CALL blk_dims_tensor(tensor, dims)
@@ -1416,7 +1418,7 @@ CONTAINS
                                                 ${varlist("nd_dist")}$
       TYPE(dbcsr_t_distribution_type)        :: dist
       INTEGER                                :: comm_2d_prv, handle, i
-      INTEGER, DIMENSION(dbcsr_t_ndims(tensor_in)) :: pdims, myploc
+      INTEGER, DIMENSION(ndims_tensor(tensor_in)) :: pdims, myploc
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_remap', &
                                      routineP = moduleN//':'//routineN
       LOGICAL                               :: nodata_prv
@@ -1503,7 +1505,8 @@ CONTAINS
 
       TYPE(dbcsr_t_type), INTENT(INOUT)               :: tensor_in
       TYPE(dbcsr_t_type), INTENT(OUT)                 :: tensor_out
-      INTEGER, DIMENSION(:), ALLOCATABLE              :: map1_2d, map2_2d
+      INTEGER, DIMENSION(ndims_matrix_row(tensor_in)) :: map1_2d
+      INTEGER, DIMENSION(ndims_matrix_column(tensor_in)) :: map2_2d
       INTEGER, DIMENSION(ndims_tensor(tensor_in)), &
          INTENT(OUT), OPTIONAL                        :: order
          !! permutation resulting from alignment
@@ -1580,7 +1583,7 @@ CONTAINS
          !! bounds of (full) tensor index
       LOGICAL, ALLOCATABLE, DIMENSION(:), INTENT(OUT) :: ind
          !! indices with occupied blocks
-      INTEGER, DIMENSION(dbcsr_t_ndims(tensor)) :: bdims, blk_index, blk_size, blk_offset
+      INTEGER, DIMENSION(ndims_tensor(tensor)) :: bdims, blk_index, blk_size, blk_offset
       INTEGER :: bdim, blk, idim
       TYPE(dbcsr_t_iterator_type)                     :: iter
 
@@ -1664,8 +1667,8 @@ CONTAINS
          OPTIONAL                                    :: bounds_3
       INTEGER :: i
       LOGICAL, DIMENSION(:), ALLOCATABLE :: ind1, ind2
-      INTEGER, DIMENSION(2, dbcsr_t_ndims(tensor_1)) :: bounds_t1
-      INTEGER, DIMENSION(2, dbcsr_t_ndims(tensor_2)) :: bounds_t2
+      INTEGER, DIMENSION(2, ndims_tensor(tensor_1)) :: bounds_t1
+      INTEGER, DIMENSION(2, ndims_tensor(tensor_2)) :: bounds_t2
       LOGICAL :: dbcsr_t_need_contract
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_need_contract', &
                                      routineP = moduleN//':'//routineN
@@ -1714,10 +1717,10 @@ CONTAINS
       TYPE(dbcsr_t_type), INTENT(IN)      :: tensor_1, tensor_2
       INTEGER, DIMENSION(:), INTENT(IN)   :: contract_1, contract_2, &
                                              notcontract_1, notcontract_2
-      INTEGER, DIMENSION(2, dbcsr_t_ndims(tensor_1)), &
+      INTEGER, DIMENSION(2, ndims_tensor(tensor_1)), &
          INTENT(OUT)                                 :: bounds_t1
          !! bounds mapped to tensor_1
-      INTEGER, DIMENSION(2, dbcsr_t_ndims(tensor_2)), &
+      INTEGER, DIMENSION(2, ndims_tensor(tensor_2)), &
          INTENT(OUT)                                 :: bounds_t2
          !! bounds mapped to tensor_2
       INTEGER, DIMENSION(2, SIZE(contract_1)), &
@@ -1765,15 +1768,20 @@ CONTAINS
       !! print tensor contraction indices in a human readable way
 
       TYPE(dbcsr_t_type), INTENT(IN) :: tensor_1, tensor_2, tensor_3
-      CHARACTER(LEN=1), DIMENSION(dbcsr_t_ndims(tensor_1)), INTENT(IN) :: indchar1
+      CHARACTER(LEN=1), DIMENSION(ndims_tensor(tensor_1)), INTENT(IN) :: indchar1
          !! characters printed for index of tensor 1
-      CHARACTER(LEN=1), DIMENSION(dbcsr_t_ndims(tensor_2)), INTENT(IN) :: indchar2
+      CHARACTER(LEN=1), DIMENSION(ndims_tensor(tensor_2)), INTENT(IN) :: indchar2
          !! characters printed for index of tensor 2
-      CHARACTER(LEN=1), DIMENSION(dbcsr_t_ndims(tensor_3)), INTENT(IN) :: indchar3
+      CHARACTER(LEN=1), DIMENSION(ndims_tensor(tensor_3)), INTENT(IN) :: indchar3
          !! characters printed for index of tensor 3
       INTEGER, INTENT(IN) :: unit_nr
          !! output unit
-      INTEGER, DIMENSION(:), ALLOCATABLE :: map11, map12, map21, map22, map31, map32
+      INTEGER, DIMENSION(ndims_matrix_row(tensor_1)) :: map11
+      INTEGER, DIMENSION(ndims_matrix_column(tensor_1)) :: map12
+      INTEGER, DIMENSION(ndims_matrix_row(tensor_2)) :: map21
+      INTEGER, DIMENSION(ndims_matrix_column(tensor_2)) :: map22
+      INTEGER, DIMENSION(ndims_matrix_row(tensor_3)) :: map31
+      INTEGER, DIMENSION(ndims_matrix_column(tensor_3)) :: map32
       INTEGER :: ichar1, ichar2, ichar3
 
       CALL dbcsr_t_get_mapping_info(tensor_1%nd_index_blk, map1_2d=map11, map2_2d=map12)

--- a/src/tensors/dbcsr_tensor_api.F
+++ b/src/tensors/dbcsr_tensor_api.F
@@ -19,7 +19,8 @@ MODULE dbcsr_tensor_api
       dbcsr_t_contract, dbcsr_t_get_block, dbcsr_t_get_stored_coordinates, dbcsr_t_put_block, &
       dbcsr_t_reserve_blocks, dbcsr_t_copy_matrix_to_tensor, dbcsr_t_copy, &
       dbcsr_t_copy_tensor_to_matrix, dbcsr_t_need_contract, dbcsr_t_batched_contract_init, &
-      dbcsr_t_batched_contract_finalize, dbcsr_t_ndims, dbcsr_t_contract_index
+      dbcsr_t_batched_contract_finalize, &
+      dbcsr_t_contract_index
    USE dbcsr_tensor_block, ONLY: &
       dbcsr_t_iterator_blocks_left, dbcsr_t_iterator_next_block, dbcsr_t_iterator_start, &
       dbcsr_t_iterator_stop, dbcsr_t_iterator_type, dbcsr_t_reserved_block_indices
@@ -31,7 +32,10 @@ MODULE dbcsr_tensor_api
       dbcsr_t_mp_environ_pgrid => mp_environ_pgrid, dbcsr_t_blk_sizes, dbcsr_t_get_info, &
       dbcsr_t_finalize, dbcsr_t_scale, dbcsr_t_get_nze, dbcsr_t_get_nze_total, &
       dbcsr_t_get_num_blocks, dbcsr_t_get_num_blocks_total, dbcsr_t_clear, &
-      dbcsr_t_mp_dims_create, dbcsr_t_pgrid_change_dims
+      dbcsr_t_mp_dims_create, dbcsr_t_pgrid_change_dims, dbcsr_t_ndims => ndims_tensor, &
+      dbcsr_t_dims => dims_tensor, dbcsr_t_ndims_matrix_row => ndims_matrix_row, &
+      dbcsr_t_ndims_matrix_column => ndims_matrix_column, dbcsr_t_blk_size, dbcsr_t_nblks_local, &
+      dbcsr_t_nblks_total
    USE dbcsr_tensor_test, ONLY: &
       dbcsr_t_contract_test, dbcsr_t_checksum
    USE dbcsr_tensor_split, ONLY: &
@@ -92,8 +96,15 @@ MODULE dbcsr_tensor_api
    PUBLIC :: dbcsr_t_batched_contract_init
    PUBLIC :: dbcsr_t_batched_contract_finalize
    PUBLIC :: dbcsr_t_ndims
+   PUBLIC :: dbcsr_t_dims
    PUBLIC :: dbcsr_t_pgrid_change_dims
    PUBLIC :: dbcsr_t_reserved_block_indices
    PUBLIC :: dbcsr_t_contract_index
+   PUBLIC :: dbcsr_t_ndims_matrix_row
+   PUBLIC :: dbcsr_t_ndims_matrix_column
+   PUBLIC :: dbcsr_t_nblks_local
+   PUBLIC :: dbcsr_t_nblks_total
+   PUBLIC :: dbcsr_t_blk_size
+
 
 END MODULE dbcsr_tensor_api

--- a/src/tensors/dbcsr_tensor_block.F
+++ b/src/tensors/dbcsr_tensor_block.F
@@ -37,7 +37,7 @@ MODULE dbcsr_tensor_block
       get_arrays
    USE dbcsr_tensor_types, ONLY: &
       dbcsr_t_type, ndims_tensor, dbcsr_t_get_data_type, dbcsr_t_blk_sizes, dbcsr_t_get_num_blocks, &
-      dbcsr_t_finalize
+      dbcsr_t_finalize, ndims_matrix_row, ndims_matrix_column
    USE dbcsr_dist_operations, ONLY: &
       checker_tr
    USE dbcsr_toollib, ONLY: &
@@ -312,7 +312,7 @@ CONTAINS
       TYPE(dbcsr_t_type), INTENT(INOUT) :: tensor_out
       INTEGER                           :: handle
 
-      INTEGER, DIMENSION(:, :), ALLOCATABLE :: blk_ind
+      INTEGER, DIMENSION(dbcsr_t_get_num_blocks(tensor_in), ndims_tensor(tensor_in)) :: blk_ind
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_reserve_blocks_template', &
                                      routineP = moduleN//':'//routineN
 
@@ -410,13 +410,11 @@ CONTAINS
       INTEGER                                   :: blk, iblk, nblk
       TYPE(dbcsr_t_iterator_type)               :: iterator
       INTEGER, DIMENSION(ndims_tensor(tensor))  :: ind_nd
-      INTEGER, DIMENSION(:, :), ALLOCATABLE, INTENT(OUT) :: blk_ind
+      INTEGER, DIMENSION(dbcsr_t_get_num_blocks(tensor), ndims_tensor(tensor)), INTENT(OUT) :: blk_ind
 
       DBCSR_ASSERT(tensor%valid)
 
       nblk = dbcsr_t_get_num_blocks(tensor)
-
-      ALLOCATE (blk_ind(nblk, ndims_tensor(tensor)))
 
       CALL dbcsr_t_iterator_start(iterator, tensor)
       DO iblk = 1, nblk
@@ -580,7 +578,6 @@ CONTAINS
          !! whether block should be summed to existing block
       ${dtype}$, INTENT(IN), OPTIONAL                       :: scale
          !! scaling factor
-
       INTEGER(KIND=int_8), DIMENSION(2)                     :: ind_2d
       INTEGER, DIMENSION(2)                                 :: shape_2d
       ${dtype}$, POINTER, DIMENSION(:, :)                   :: block_2d

--- a/src/tensors/dbcsr_tensor_index.F
+++ b/src/tensors/dbcsr_tensor_index.F
@@ -32,6 +32,8 @@ MODULE dbcsr_tensor_index
       ndims_mapping, &
       split_tensor_index, &
       split_pgrid_index, &
+      ndims_mapping_row, &
+      ndims_mapping_column, &
       dbcsr_t_inverse_order, &
       permute_index
 
@@ -119,6 +121,20 @@ CONTAINS
       ndims_mapping = map%ndim_nd
    END FUNCTION
 
+   PURE FUNCTION ndims_mapping_row(map)
+      !! how many tensor dimensions are mapped to matrix row
+      TYPE(nd_to_2d_mapping), INTENT(IN) :: map
+      INTEGER :: ndims_mapping_row
+      ndims_mapping_row = map%ndim1_2d
+   END FUNCTION
+
+   PURE FUNCTION ndims_mapping_column(map)
+      !! how many tensor dimensions are mapped to matrix column
+      TYPE(nd_to_2d_mapping), INTENT(IN) :: map
+      INTEGER :: ndims_mapping_column
+      ndims_mapping_column = map%ndim2_2d
+   END FUNCTION
+
    SUBROUTINE dbcsr_t_get_mapping_info(map, ndim_nd, ndim1_2d, ndim2_2d, dims_2d_i8, dims_2d, dims_nd, dims1_2d, dims2_2d, &
                                        map1_2d, map2_2d, map_nd, base, col_major)
       !! get mapping info
@@ -135,11 +151,17 @@ CONTAINS
       INTEGER, DIMENSION(ndims_mapping(map)), &
          INTENT(OUT), OPTIONAL                           :: dims_nd
          !! nd dimensions
-      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(OUT), &
-         OPTIONAL                                        :: dims1_2d, dims2_2d, map1_2d, map2_2d
+      INTEGER, DIMENSION(ndims_mapping_row(map)), INTENT(OUT), &
+         OPTIONAL                                        :: dims1_2d
          !! dimensions that map to first 2d index
+      INTEGER, DIMENSION(ndims_mapping_column(map)), INTENT(OUT), &
+         OPTIONAL                                        :: dims2_2d
          !! dimensions that map to second 2d index
+      INTEGER, DIMENSION(ndims_mapping_row(map)), INTENT(OUT), &
+         OPTIONAL                                        :: map1_2d
          !! indices that map to first 2d index
+      INTEGER, DIMENSION(ndims_mapping_column(map)), INTENT(OUT), &
+         OPTIONAL                                        :: map2_2d
          !! indices that map to second 2d index
       INTEGER, DIMENSION(ndims_mapping(map)), &
          INTENT(OUT), OPTIONAL                           :: map_nd
@@ -158,16 +180,16 @@ CONTAINS
          dims_nd(:) = map%dims_nd(:)
       ENDIF
       IF (PRESENT(dims1_2d)) THEN
-         CALL allocate_any(dims1_2d, source=map%dims1_2d)
+         dims1_2d(:) = map%dims1_2d
       ENDIF
       IF (PRESENT(dims2_2d)) THEN
-         CALL allocate_any(dims2_2d, source=map%dims2_2d)
+         dims2_2d(:) = map%dims2_2d
       ENDIF
       IF (PRESENT(map1_2d)) THEN
-         CALL allocate_any(map1_2d, source=map%map1_2d)
+         map1_2d(:) = map%map1_2d
       ENDIF
       IF (PRESENT(map2_2d)) THEN
-         CALL allocate_any(map2_2d, source=map%map2_2d)
+         map2_2d(:) = map%map2_2d
       ENDIF
       IF (PRESENT(map_nd)) THEN
          map_nd(:) = map%map_nd(:)
@@ -360,16 +382,13 @@ CONTAINS
          INTENT(IN)                                      :: order
 
       INTEGER                                            :: ndim_nd
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: map1_2d, map1_2d_reorder, map2_2d, &
-                                                            map2_2d_reorder
+      INTEGER, DIMENSION(ndims_mapping_row(map_in))       :: map1_2d, map1_2d_reorder
+      INTEGER, DIMENSION(ndims_mapping_column(map_in))    :: map2_2d, map2_2d_reorder
       INTEGER, DIMENSION(ndims_mapping(map_in))          :: dims_nd, dims_reorder
 
       CALL dbcsr_t_get_mapping_info(map_in, ndim_nd, dims_nd=dims_nd, map1_2d=map1_2d, map2_2d=map2_2d)
 
       dims_reorder(order) = dims_nd
-
-      CALL allocate_any(map1_2d_reorder, shape_spec=SHAPE(map1_2d))
-      CALL allocate_any(map2_2d_reorder, shape_spec=SHAPE(map2_2d))
 
       map1_2d_reorder(:) = order(map1_2d)
       map2_2d_reorder(:) = order(map2_2d)

--- a/src/tensors/dbcsr_tensor_io.F
+++ b/src/tensors/dbcsr_tensor_io.F
@@ -17,7 +17,7 @@ MODULE dbcsr_tensor_io
    USE dbcsr_tensor_types, ONLY: &
       dbcsr_t_get_info, dbcsr_t_type, ndims_tensor, dbcsr_t_get_num_blocks, dbcsr_t_get_num_blocks_total, &
       blk_dims_tensor, dbcsr_t_get_stored_coordinates, dbcsr_t_get_nze, dbcsr_t_get_nze_total, &
-      dbcsr_t_pgrid_type
+      dbcsr_t_pgrid_type, dbcsr_t_nblks_total
    USE dbcsr_kinds, ONLY: default_string_length, int_8, real_8
    USE dbcsr_mpiwrap, ONLY: mp_environ, mp_sum, mp_max
    USE dbcsr_tensor_block, ONLY: &
@@ -49,17 +49,17 @@ CONTAINS
       LOGICAL, OPTIONAL, INTENT(IN)  :: full_info
          !! Whether to print distribution and block size vectors
       INTEGER, DIMENSION(ndims_tensor(tensor)) :: nblks_total, nfull_total, pdims, my_ploc, nblks_local, nfull_local
-      INTEGER, DIMENSION(:), ALLOCATABLE :: ${varlist("blks_local")}$
-      INTEGER, DIMENSION(:), ALLOCATABLE :: ${varlist("proc_dist")}$
-      INTEGER, DIMENSION(:), ALLOCATABLE :: ${varlist("blk_size")}$
-      INTEGER, DIMENSION(:), ALLOCATABLE :: ${varlist("blk_offset")}$
-      CHARACTER(len=default_string_length)                   :: name
-      INTEGER                            :: idim
-      INTEGER                            :: iblk
+
+#:for idim in range(1, maxdim+1)
+      INTEGER, DIMENSION(dbcsr_t_nblks_total(tensor,${idim}$)) :: proc_dist_${idim}$
+      INTEGER, DIMENSION(dbcsr_t_nblks_total(tensor,${idim}$)) :: blk_size_${idim}$
+#:endfor
+      CHARACTER(len=default_string_length)                     :: name
+      INTEGER                                                  :: idim
+      INTEGER                                                  :: iblk
 
       CALL dbcsr_t_get_info(tensor, nblks_total, nfull_total, nblks_local, nfull_local, pdims, my_ploc, &
-                            ${varlist("blks_local")}$, ${varlist("proc_dist")}$, ${varlist("blk_size")}$, &
-                            ${varlist("blk_offset")}$, &
+                            ${varlist("proc_dist")}$, ${varlist("blk_size")}$, &
                             name=name)
 
       IF (output_unit > 0) THEN

--- a/src/tensors/dbcsr_tensor_split.F
+++ b/src/tensors/dbcsr_tensor_split.F
@@ -39,7 +39,9 @@ MODULE dbcsr_tensor_split
                                  dbcsr_t_finalize, &
                                  dbcsr_t_get_num_blocks, &
                                  dbcsr_t_blk_offsets, &
-                                 dbcsr_t_blk_sizes
+                                 dbcsr_t_blk_sizes, &
+                                 ndims_matrix_row, &
+                                 ndims_matrix_column
    USE dbcsr_api, ONLY: ${uselist(dtype_float_param)}$
    USE dbcsr_kinds, ONLY: ${uselist(dtype_float_prec)}$
 
@@ -77,8 +79,9 @@ CONTAINS
       INTEGER                                         :: ${varlist("split_blk")}$
       INTEGER :: idim, i, isplit_sum, blk, nsplit, handle, splitsum, bcount
       INTEGER, DIMENSION(:, :), ALLOCATABLE           :: blks_to_allocate
-      INTEGER, DIMENSION(:), ALLOCATABLE :: dist_d, blk_size_d, blk_size_split_d, dist_split_d, &
-                                            map1_2d, map2_2d
+      INTEGER, DIMENSION(:), ALLOCATABLE :: dist_d, blk_size_d, blk_size_split_d, dist_split_d
+      INTEGER, DIMENSION(ndims_matrix_row(tensor_in)) :: map1_2d
+      INTEGER, DIMENSION(ndims_matrix_column(tensor_in)) :: map2_2d
       INTEGER, DIMENSION(ndims_tensor(tensor_in)) :: blk_index, blk_size, blk_offset, &
                                                      blk_shape
       INTEGER, DIMENSION(${maxdim}$) :: bi_split, inblock_offset
@@ -627,9 +630,10 @@ CONTAINS
       CALL dbcsr_t_create(tensor_in, tensor_out)
 
       ! reserve blocks inside bounds
+      ALLOCATE(blk_ind(dbcsr_t_get_num_blocks(tensor_in), ndims_tensor(tensor_in)))
       CALL dbcsr_t_reserved_block_indices(tensor_in, blk_ind)
       nblk = dbcsr_t_get_num_blocks(tensor_in)
-      ALLOCATE (blk_ind_tmp(nblk, ndims_tensor(tensor_in)))
+      ALLOCATE(blk_ind_tmp(dbcsr_t_get_num_blocks(tensor_in), ndims_tensor(tensor_in)))
       blk_ind_tmp(:, :) = 0
       iblk = 0
       blk_loop: DO iblk_all = 1, nblk

--- a/src/tensors/dbcsr_tensor_test.F
+++ b/src/tensors/dbcsr_tensor_test.F
@@ -18,9 +18,9 @@ MODULE dbcsr_tensor_test
    USE dbcsr_tas_base, ONLY: dbcsr_tas_info
    USE dbcsr_tensor, ONLY: &
       dbcsr_t_copy, dbcsr_t_get_block, dbcsr_t_iterator_type, dbcsr_t_iterator_blocks_left, &
-      dbcsr_t_iterator_next_block, dbcsr_t_iterator_start, dbcsr_t_iterator_stop, dbcsr_t_ndims, &
+      dbcsr_t_iterator_next_block, dbcsr_t_iterator_start, dbcsr_t_iterator_stop, &
       dbcsr_t_reserve_blocks, dbcsr_t_get_stored_coordinates, dbcsr_t_put_block, &
-      dbcsr_t_contract, dbcsr_t_inverse_order, dbcsr_t_dims
+      dbcsr_t_contract, dbcsr_t_inverse_order
    USE dbcsr_tensor_block, ONLY: block_nd
    USE dbcsr_tensor_types, ONLY: dbcsr_t_create, &
                                  dbcsr_t_destroy, &
@@ -28,6 +28,7 @@ MODULE dbcsr_tensor_test
                                  dbcsr_t_distribution_type, &
                                  dbcsr_t_distribution_destroy, &
                                  dims_tensor, &
+                                 ndims_tensor, &
                                  dbcsr_t_distribution_new, &
                                  dbcsr_t_nd_mp_comm, &
                                  dbcsr_t_get_data_type, &
@@ -48,8 +49,7 @@ MODULE dbcsr_tensor_test
                             mp_sum, &
                             mp_cart_create
    USE dbcsr_allocate_wrap, ONLY: allocate_any
-   USE dbcsr_tensor_index, ONLY: combine_tensor_index, &
-                                 dbcsr_t_get_mapping_info
+   USE dbcsr_tensor_index, ONLY: combine_tensor_index
    USE dbcsr_tas_test, ONLY: dbcsr_tas_checksum
    USE dbcsr_data_types, ONLY: dbcsr_scalar_type
 #include "base/dbcsr_base_uses.f90"
@@ -97,7 +97,7 @@ CONTAINS
       TYPE(dbcsr_t_type)                         :: tensor2_tmp
       TYPE(dbcsr_t_iterator_type)                :: iter
       TYPE(block_nd)                             :: blk_data1, blk_data2
-      INTEGER, DIMENSION(dbcsr_t_ndims(tensor1)) :: blk_size, ind_nd
+      INTEGER, DIMENSION(ndims_tensor(tensor1)) :: blk_size, ind_nd
       LOGICAL :: found
 
       ! create a copy of tensor2 that has exact same data format as tensor1
@@ -404,7 +404,7 @@ CONTAINS
 
       INTEGER                                            :: i, ib, my_nblks_alloc, nblks_alloc, proc
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ${varlist("my_blk_ind")}$
-      INTEGER, DIMENSION(dbcsr_t_ndims(tensor))          :: blk_index, blk_offset, blk_size, &
+      INTEGER, DIMENSION(ndims_tensor(tensor))          :: blk_index, blk_offset, blk_size, &
                                                             tensor_dims
       INTEGER, DIMENSION(:, :), ALLOCATABLE               :: ind_nd
 #:for ndim in ndims
@@ -416,11 +416,11 @@ CONTAINS
       nblks_alloc = SIZE(blk_ind_1)
       CALL mp_environ(numnodes, mynode, mp_comm)
 
-      ALLOCATE (ind_nd(nblks_alloc, dbcsr_t_ndims(tensor)))
+      ALLOCATE (ind_nd(nblks_alloc, ndims_tensor(tensor)))
       my_nblks_alloc = 0
       DO ib = 1, nblks_alloc
 #:for ndim in ndims
-         IF (dbcsr_t_ndims(tensor) == ${ndim}$) THEN
+         IF (ndims_tensor(tensor) == ${ndim}$) THEN
             ind_nd(ib, :) = [${varlist("blk_ind", nmax=ndim, suffix="(ib)")}$]
          ENDIF
 #:endfor
@@ -431,7 +431,7 @@ CONTAINS
       ENDDO
 
 #:for dim in range(1, maxdim+1)
-      IF (dbcsr_t_ndims(tensor) >= ${dim}$) THEN
+      IF (ndims_tensor(tensor) >= ${dim}$) THEN
          ALLOCATE (my_blk_ind_${dim}$ (my_nblks_alloc))
       ENDIF
 #:endfor
@@ -442,7 +442,7 @@ CONTAINS
          IF (proc == mynode) THEN
             i = i + 1
 #:for dim in range(1, maxdim+1)
-            IF (dbcsr_t_ndims(tensor) >= ${dim}$) THEN
+            IF (ndims_tensor(tensor) >= ${dim}$) THEN
                my_blk_ind_${dim}$ (i) = blk_ind_${dim}$ (ib)
             ENDIF
 #:endfor
@@ -450,7 +450,7 @@ CONTAINS
       ENDDO
 
 #:for ndim in ndims
-      IF (dbcsr_t_ndims(tensor) == ${ndim}$) THEN
+      IF (ndims_tensor(tensor) == ${ndim}$) THEN
          CALL dbcsr_t_reserve_blocks(tensor, ${varlist("my_blk_ind", nmax=ndim)}$)
       ENDIF
 #:endfor
@@ -460,7 +460,7 @@ CONTAINS
          CALL dbcsr_t_iterator_next_block(iterator, blk_index, blk, blk_size=blk_size, blk_offset=blk_offset)
 
 #:for ndim in ndims
-         IF (dbcsr_t_ndims(tensor) == ${ndim}$) THEN
+         IF (ndims_tensor(tensor) == ${ndim}$) THEN
             CALL allocate_any(blk_values_${ndim}$, shape_spec=blk_size)
             CALL dims_tensor(tensor, tensor_dims)
             IF (enumerate) THEN
@@ -522,14 +522,14 @@ CONTAINS
       ${dtype}$, ALLOCATABLE, DIMENSION(${shape_colon(ndim)}$), &
          INTENT(OUT)                                             :: array
       ${dtype}$, ALLOCATABLE, DIMENSION(${shape_colon(ndim)}$)   :: block
-      INTEGER, DIMENSION(dbcsr_t_ndims(tensor))                  :: dims_nd, ind_nd, blk_size, blk_offset
+      INTEGER, DIMENSION(ndims_tensor(tensor))                  :: dims_nd, ind_nd, blk_size, blk_offset
       TYPE(dbcsr_t_iterator_type)                                     :: iterator
       INTEGER                                                    :: blk, idim
-      INTEGER, DIMENSION(dbcsr_t_ndims(tensor))                  :: blk_start, blk_end
+      INTEGER, DIMENSION(ndims_tensor(tensor))                  :: blk_start, blk_end
       LOGICAL                                                    :: found
 
-      DBCSR_ASSERT(dbcsr_t_ndims(tensor) .EQ. ${ndim}$)
-      CALL dbcsr_t_get_mapping_info(tensor%nd_index, dims_nd=dims_nd)
+      DBCSR_ASSERT(ndims_tensor(tensor) .EQ. ${ndim}$)
+      CALL dbcsr_t_get_info(tensor, nfull_total=dims_nd)
       CALL allocate_any(array, shape_spec=dims_nd)
       array(${shape_colon(ndim)}$) = 0.0_${dprec}$
 
@@ -539,7 +539,7 @@ CONTAINS
          CALL dbcsr_t_get_block(tensor, ind_nd, block, found)
          DBCSR_ASSERT(found)
 
-         DO idim = 1, dbcsr_t_ndims(tensor)
+         DO idim = 1, ndims_tensor(tensor)
             blk_start(idim) = blk_offset(idim)
             blk_end(idim) = blk_offset(idim) + blk_size(idim) - 1
          ENDDO
@@ -562,19 +562,19 @@ CONTAINS
       ${dtype}$, ALLOCATABLE, DIMENSION(${shape_colon(ndim)}$), &
          INTENT(INOUT)                                           :: array
       ${dtype}$, ALLOCATABLE, DIMENSION(${shape_colon(ndim)}$)   :: block
-      INTEGER, DIMENSION(dbcsr_t_ndims(tensor))                  :: dims_nd, ind_nd, blk_size, blk_offset
+      INTEGER, DIMENSION(ndims_tensor(tensor))                  :: dims_nd, ind_nd, blk_size, blk_offset
       TYPE(dbcsr_t_iterator_type)                                     :: iterator
       INTEGER                                                    :: blk, idim
-      INTEGER, DIMENSION(dbcsr_t_ndims(tensor))                  :: blk_start, blk_end
+      INTEGER, DIMENSION(ndims_tensor(tensor))                  :: blk_start, blk_end
 
-      DBCSR_ASSERT(dbcsr_t_ndims(tensor) .EQ. ${ndim}$)
-      CALL dbcsr_t_get_mapping_info(tensor%nd_index, dims_nd=dims_nd)
+      DBCSR_ASSERT(ndims_tensor(tensor) .EQ. ${ndim}$)
+      CALL dbcsr_t_get_info(tensor, nfull_total=dims_nd)
 
       CALL dbcsr_t_iterator_start(iterator, tensor)
       DO WHILE (dbcsr_t_iterator_blocks_left(iterator))
          CALL dbcsr_t_iterator_next_block(iterator, ind_nd, blk, blk_size=blk_size, blk_offset=blk_offset)
          CALL allocate_any(block, shape_spec=blk_size)
-         DO idim = 1, dbcsr_t_ndims(tensor)
+         DO idim = 1, ndims_tensor(tensor)
             blk_start(idim) = blk_offset(idim)
             blk_end(idim) = blk_offset(idim) + blk_size(idim) - 1
          ENDDO
@@ -617,8 +617,8 @@ CONTAINS
       INTEGER                              :: io_unit, mynode, numnodes, mp_comm
       INTEGER, DIMENSION(:), ALLOCATABLE   :: size_1, size_2, size_3, &
                                               order_t1, order_t2, order_t3
-      INTEGER, DIMENSION(2, dbcsr_t_ndims(tensor_1)) :: bounds_t1
-      INTEGER, DIMENSION(2, dbcsr_t_ndims(tensor_2)) :: bounds_t2
+      INTEGER, DIMENSION(2, ndims_tensor(tensor_1)) :: bounds_t1
+      INTEGER, DIMENSION(2, ndims_tensor(tensor_2)) :: bounds_t2
 
 #:for ndim in ndims
       REAL(KIND=real_8), ALLOCATABLE, &
@@ -673,7 +673,7 @@ CONTAINS
          CALL dbcsr_t_write_blocks(tensor_1, io_unit, unit_nr, write_int)
       ENDIF
 
-      SELECT CASE (dbcsr_t_ndims(tensor_3))
+      SELECT CASE (ndims_tensor(tensor_3))
 #:for ndim in ndims
       CASE (${ndim}$)
          CALL dist_sparse_tensor_to_repl_dense_array(tensor_3, array_3_0_${ndim}$d)
@@ -724,7 +724,7 @@ CONTAINS
 
       ! Convert tensors to simple multidimensional arrays
 #:for i in range(1,4)
-      SELECT CASE (dbcsr_t_ndims(tensor_${i}$))
+      SELECT CASE (ndims_tensor(tensor_${i}$))
 #:for ndim in ndims
       CASE (${ndim}$)
 #:if i < 3
@@ -744,7 +744,7 @@ CONTAINS
       ! Get array sizes
 
 #:for i in range(1,4)
-      SELECT CASE (dbcsr_t_ndims(tensor_${i}$))
+      SELECT CASE (ndims_tensor(tensor_${i}$))
 #:for ndim in ndims
       CASE (${ndim}$)
          CALL allocate_any(size_${i}$, source=SHAPE(array_${i}$_${ndim}$d))
@@ -754,7 +754,7 @@ CONTAINS
 #:endfor
 
 #:for i in range(1,4)
-      ALLOCATE (order_t${i}$ (dbcsr_t_ndims(tensor_${i}$)))
+      ALLOCATE (order_t${i}$ (ndims_tensor(tensor_${i}$)))
 #:endfor
 
       ASSOCIATE (map_t1_1=>notcontract_1, map_t1_2=>contract_1, &
@@ -764,7 +764,7 @@ CONTAINS
 #:for i in range(1,4)
          order_t${i}$ (:) = dbcsr_t_inverse_order([map_t${i}$_1, map_t${i}$_2])
 
-         SELECT CASE (dbcsr_t_ndims(tensor_${i}$))
+         SELECT CASE (ndims_tensor(tensor_${i}$))
 #:for ndim in ndims
          CASE (${ndim}$)
             CALL allocate_any(array_${i}$_rs${ndim}$d, source=array_${i}$_${ndim}$d, order=order_t${i}$)
@@ -774,7 +774,7 @@ CONTAINS
          END SELECT
 #:endfor
 
-         SELECT CASE (dbcsr_t_ndims(tensor_3))
+         SELECT CASE (ndims_tensor(tensor_3))
 #:for ndim in ndims
          CASE (${ndim}$)
             CALL allocate_any(array_3_0_rs${ndim}$d, source=array_3_0_${ndim}$d, order=order_t3)

--- a/src/tensors/dbcsr_tensor_types.F
+++ b/src/tensors/dbcsr_tensor_types.F
@@ -35,7 +35,7 @@ MODULE dbcsr_tensor_types
    USE dbcsr_tensor_index, ONLY: &
       get_2d_indices_tensor, get_nd_indices_pgrid, create_nd_to_2d_mapping, destroy_nd_to_2d_mapping, &
       dbcsr_t_get_mapping_info, nd_to_2d_mapping, split_tensor_index, combine_tensor_index, combine_pgrid_index, &
-      split_pgrid_index, ndims_mapping
+      split_pgrid_index, ndims_mapping, ndims_mapping_row, ndims_mapping_column
    USE dbcsr_tas_split, ONLY: &
       dbcsr_tas_create_split_rows_or_cols, dbcsr_tas_release_info, dbcsr_tas_info_hold, &
       dbcsr_tas_create_split, dbcsr_tas_get_split_info
@@ -89,7 +89,12 @@ MODULE dbcsr_tensor_types
       dbcsr_t_type, &
       dims_tensor, &
       mp_environ_pgrid, &
-      ndims_tensor
+      ndims_tensor,&
+      ndims_matrix_row,&
+      ndims_matrix_column,&
+      dbcsr_t_nblks_local,&
+      dbcsr_t_nblks_total,&
+      dbcsr_t_blk_size
 
    TYPE dbcsr_t_pgrid_type
       TYPE(nd_to_2d_mapping)                  :: nd_index_grid
@@ -194,18 +199,24 @@ CONTAINS
       INTEGER, DIMENSION(:), ALLOCATABLE :: index_map
 
       IF (which_dim == 1) THEN
+         ALLOCATE (new_dbcsr_tas_dist_t%dims(ndims_mapping_row(map_blks)))
+         ALLOCATE (index_map(ndims_mapping_row(map_blks)))
          CALL dbcsr_t_get_mapping_info(map_blks, &
                                        dims_2d_i8=matrix_dims, &
                                        map1_2d=index_map, &
                                        dims1_2d=new_dbcsr_tas_dist_t%dims)
+         ALLOCATE (new_dbcsr_tas_dist_t%dims_grid(ndims_mapping_row(map_grid)))
          CALL dbcsr_t_get_mapping_info(map_grid, &
                                        dims_2d=grid_dims, &
                                        dims1_2d=new_dbcsr_tas_dist_t%dims_grid)
       ELSEIF (which_dim == 2) THEN
+         ALLOCATE (new_dbcsr_tas_dist_t%dims(ndims_mapping_column(map_blks)))
+         ALLOCATE (index_map(ndims_mapping_column(map_blks)))
          CALL dbcsr_t_get_mapping_info(map_blks, &
                                        dims_2d_i8=matrix_dims, &
                                        map2_2d=index_map, &
                                        dims2_2d=new_dbcsr_tas_dist_t%dims)
+         ALLOCATE (new_dbcsr_tas_dist_t%dims_grid(ndims_mapping_column(map_grid)))
          CALL dbcsr_t_get_mapping_info(map_grid, &
                                        dims_2d=grid_dims, &
                                        dims2_2d=new_dbcsr_tas_dist_t%dims_grid)
@@ -308,11 +319,15 @@ CONTAINS
       TYPE(dbcsr_tas_blk_size_t) :: new_dbcsr_tas_blk_size_t
 
       IF (which_dim == 1) THEN
+         ALLOCATE (index_map(ndims_mapping_row(map_blks)))
+         ALLOCATE (new_dbcsr_tas_blk_size_t%dims(ndims_mapping_row(map_blks)))
          CALL dbcsr_t_get_mapping_info(map_blks, &
                                        dims_2d_i8=matrix_dims, &
                                        map1_2d=index_map, &
                                        dims1_2d=new_dbcsr_tas_blk_size_t%dims)
       ELSEIF (which_dim == 2) THEN
+         ALLOCATE (index_map(ndims_mapping_column(map_blks)))
+         ALLOCATE (new_dbcsr_tas_blk_size_t%dims(ndims_mapping_column(map_blks)))
          CALL dbcsr_t_get_mapping_info(map_blks, &
                                        dims_2d_i8=matrix_dims, &
                                        map2_2d=index_map, &
@@ -537,7 +552,8 @@ CONTAINS
       TYPE(dbcsr_t_distribution_type), INTENT(OUT)    :: dist
       TYPE(dbcsr_t_pgrid_type), INTENT(IN)            :: pgrid
       INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL     :: ${varlist("nd_dist")}$
-      INTEGER, DIMENSION(:), ALLOCATABLE :: map1_2d, map2_2d
+      INTEGER, DIMENSION(ndims_mapping_row(pgrid%nd_index_grid)) :: map1_2d
+      INTEGER, DIMENSION(ndims_mapping_column(pgrid%nd_index_grid)) :: map2_2d
       INTEGER :: ndims
 
       CALL dbcsr_t_get_mapping_info(pgrid%nd_index_grid, map1_2d=map1_2d, map2_2d=map2_2d, ndim_nd=ndims)
@@ -570,7 +586,8 @@ CONTAINS
       TYPE(dbcsr_tas_dist_t)                          :: row_dist_obj, col_dist_obj
       TYPE(dbcsr_t_pgrid_type)                        :: pgrid_prv
       LOGICAL                                         :: need_pgrid_remap
-      INTEGER, DIMENSION(:), ALLOCATABLE              :: map1_2d_check, map2_2d_check
+      INTEGER, DIMENSION(ndims_mapping_row(pgrid%nd_index_grid)) :: map1_2d_check
+      INTEGER, DIMENSION(ndims_mapping_column(pgrid%nd_index_grid)) :: map2_2d_check
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_distribution_new', &
                                      routineP = moduleN//':'//routineN
 
@@ -866,6 +883,8 @@ CONTAINS
             CALL allocate_any(map1_2d_prv, source=map1_2d)
             CALL allocate_any(map2_2d_prv, source=map2_2d)
          ELSE
+            ALLOCATE(map1_2d_prv(ndims_matrix_row(tensor_in)))
+            ALLOCATE(map2_2d_prv(ndims_matrix_column(tensor_in)))
             CALL dbcsr_t_get_mapping_info(tensor_in%nd_index_blk, map1_2d=map1_2d_prv, map2_2d=map2_2d_prv)
          ENDIF
          IF (PRESENT(name)) THEN
@@ -1219,7 +1238,8 @@ CONTAINS
          !! new mapping
       TYPE(dbcsr_t_pgrid_type), INTENT(OUT) :: pgrid_out
       INTEGER, DIMENSION(:), ALLOCATABLE :: dims
-      INTEGER, ALLOCATABLE, DIMENSION(:) :: map1_2d_old, map2_2d_old
+      INTEGER, DIMENSION(ndims_mapping_row(pgrid_in%nd_index_grid)) :: map1_2d_old
+      INTEGER, DIMENSION(ndims_mapping_column(pgrid_in%nd_index_grid)) :: map2_2d_old
 
       ALLOCATE (dims(SIZE(map1_2d) + SIZE(map2_2d)))
       CALL dbcsr_t_get_mapping_info(pgrid_in%nd_index_grid, dims_nd=dims, map1_2d=map1_2d_old, map2_2d=map2_2d_old)
@@ -1241,7 +1261,8 @@ CONTAINS
          !! new process grid dimensions, should all be set > 0
       TYPE(dbcsr_t_pgrid_type)                :: pgrid_tmp
       INTEGER                                 :: nsplit, dimsplit
-      INTEGER, DIMENSION(:), ALLOCATABLE      :: map1_2d, map2_2d
+      INTEGER, DIMENSION(ndims_mapping_row(pgrid%nd_index_grid)) :: map1_2d
+      INTEGER, DIMENSION(ndims_mapping_column(pgrid%nd_index_grid)) :: map2_2d
       TYPe(nd_to_2d_mapping)                  :: nd_index_grid
       INTEGER, DIMENSION(2)                   :: pdims_2d
 
@@ -1339,14 +1360,16 @@ CONTAINS
          !! process coordinates in process grid
       INTEGER, INTENT(OUT), OPTIONAL, DIMENSION(ndims_tensor(tensor)) :: pdims
          !! process grid dimensions
-      INTEGER, DIMENSION(:), ALLOCATABLE, INTENT(OUT), OPTIONAL :: ${varlist("blks_local")}$
-         !! local blocks along dimension 1 and 2
-      INTEGER, DIMENSION(:), ALLOCATABLE, INTENT(OUT), OPTIONAL :: ${varlist("proc_dist")}$
-         !! distribution vector along dimension 1 and 2
-      INTEGER, DIMENSION(:), ALLOCATABLE, INTENT(OUT), OPTIONAL :: ${varlist("blk_size")}$
-         !! block sizes along dimension 1 and 2
-      INTEGER, DIMENSION(:), ALLOCATABLE, INTENT(OUT), OPTIONAL :: ${varlist("blk_offset")}$
-         !! block offsets along dimension 1 and 2
+#:for idim in range(1, maxdim+1)
+      INTEGER, DIMENSION(dbcsr_t_nblks_local(tensor,${idim}$)), INTENT(OUT), OPTIONAL :: blks_local_${idim}$
+         !! local blocks along dimension ${idim}$
+      INTEGER, DIMENSION(dbcsr_t_nblks_total(tensor,${idim}$)), INTENT(OUT), OPTIONAL :: proc_dist_${idim}$
+         !! distribution along dimension ${idim}$
+      INTEGER, DIMENSION(dbcsr_t_nblks_total(tensor,${idim}$)), INTENT(OUT), OPTIONAL :: blk_size_${idim}$
+         !! block sizes along dimension ${idim}$
+      INTEGER, DIMENSION(dbcsr_t_nblks_total(tensor,${idim}$)), INTENT(OUT), OPTIONAL :: blk_offset_${idim}$
+         !! block offsets along dimension ${idim}$
+#:endfor
       TYPE(dbcsr_t_distribution_type), INTENT(OUT), OPTIONAL    :: distribution
          !! distribution object
       CHARACTER(len=*), INTENT(OUT), OPTIONAL                   :: name
@@ -1366,10 +1389,18 @@ CONTAINS
 
 #:for idim in range(1, maxdim+1)
       IF (${idim}$ <= ndims_tensor(tensor)) THEN
-         IF (PRESENT(blks_local_${idim}$)) CALL get_ith_array(tensor%blks_local, ${idim}$, blks_local_${idim}$)
-         IF (PRESENT(proc_dist_${idim}$)) CALL get_ith_array(tensor%nd_dist, ${idim}$, proc_dist_${idim}$)
-         IF (PRESENT(blk_size_${idim}$)) CALL get_ith_array(tensor%blk_sizes, ${idim}$, blk_size_${idim}$)
-         IF (PRESENT(blk_offset_${idim}$)) CALL get_ith_array(tensor%blk_offsets, ${idim}$, blk_offset_${idim}$)
+         IF (PRESENT(blks_local_${idim}$)) CALL get_ith_array(tensor%blks_local, ${idim}$, &
+                                                              dbcsr_t_nblks_local(tensor, ${idim}$), &
+                                                              blks_local_${idim}$)
+         IF (PRESENT(proc_dist_${idim}$)) CALL get_ith_array(tensor%nd_dist, ${idim}$, &
+                                                             dbcsr_t_nblks_total(tensor, ${idim}$), &
+                                                             proc_dist_${idim}$)
+         IF (PRESENT(blk_size_${idim}$)) CALL get_ith_array(tensor%blk_sizes, ${idim}$, &
+                                                            dbcsr_t_nblks_total(tensor, ${idim}$), &
+                                                            blk_size_${idim}$)
+         IF (PRESENT(blk_offset_${idim}$)) CALL get_ith_array(tensor%blk_offsets, ${idim}$, &
+                                                              dbcsr_t_nblks_total(tensor, ${idim}$), &
+                                                              blk_offset_${idim}$)
       ENDIF
 #:endfor
 
@@ -1432,6 +1463,67 @@ CONTAINS
       TYPE(dbcsr_t_type), INTENT(IN) :: tensor
       INTEGER(KIND=int_8)            :: dbcsr_t_get_nze_total
       dbcsr_t_get_nze_total = dbcsr_tas_get_nze_total(tensor%matrix_rep)
+   END FUNCTION
+
+   PURE FUNCTION dbcsr_t_nblks_local(tensor, idim)
+      !! local number of blocks along dimension idim
+      TYPE(dbcsr_t_type), INTENT(IN) :: tensor
+      INTEGER, INTENT(IN) :: idim
+      INTEGER :: dbcsr_t_nblks_local
+
+      IF (idim > ndims_tensor(tensor)) THEN
+         dbcsr_t_nblks_local = 0
+      ELSE
+         dbcsr_t_nblks_local = tensor%nblks_local(idim)
+      ENDIF
+
+   END FUNCTION
+
+   PURE FUNCTION dbcsr_t_nblks_total(tensor, idim)
+      !! total numbers of blocks along dimension idim
+      TYPE(dbcsr_t_type), INTENT(IN) :: tensor
+      INTEGER, INTENT(IN) :: idim
+      INTEGER :: dbcsr_t_nblks_total
+
+      IF (idim > ndims_tensor(tensor)) THEN
+         dbcsr_t_nblks_total = 0
+      ELSE
+         dbcsr_t_nblks_total = tensor%nd_index_blk%dims_nd(idim)
+      ENDIF
+   END FUNCTION
+
+   PURE FUNCTION dbcsr_t_blk_size(tensor, ind, idim)
+      !! block size of block with index ind along dimension idim
+      TYPE(dbcsr_t_type), INTENT(IN) :: tensor
+      INTEGER, DIMENSION(ndims_tensor(tensor)), &
+         INTENT(IN) :: ind
+      INTEGER, INTENT(IN) :: idim
+      INTEGER, DIMENSION(ndims_tensor(tensor)) :: blk_size
+      INTEGER :: dbcsr_t_blk_size
+
+      IF (idim > ndims_tensor(tensor)) THEN
+         dbcsr_t_blk_size = 0
+      ELSE
+         blk_size(:) = get_array_elements(tensor%blk_sizes, ind)
+         dbcsr_t_blk_size = blk_size(idim)
+      ENDIF
+   END FUNCTION
+
+   PURE FUNCTION ndims_matrix_row(tensor)
+      !! how many tensor dimensions are mapped to matrix row
+      TYPE(dbcsr_t_type), INTENT(IN) :: tensor
+      INTEGER(int_8) :: ndims_matrix_row
+
+      ndims_matrix_row = ndims_mapping_row(tensor%nd_index_blk)
+
+   END FUNCTION
+
+   PURE FUNCTION ndims_matrix_column(tensor)
+      !! how many tensor dimensions are mapped to matrix column
+      TYPE(dbcsr_t_type), INTENT(IN) :: tensor
+      INTEGER(int_8) :: ndims_matrix_column
+
+      ndims_matrix_column = ndims_mapping_column(tensor%nd_index_blk)
    END FUNCTION
 
 END MODULE

--- a/tests/dbcsr_tensor_unittest.F
+++ b/tests/dbcsr_tensor_unittest.F
@@ -33,9 +33,9 @@ PROGRAM dbcsr_tensor_unittest
                                  dbcsr_t_pgrid_type, &
                                  dbcsr_t_pgrid_create, &
                                  dbcsr_t_get_info, &
-                                 dbcsr_t_pgrid_destroy
+                                 dbcsr_t_pgrid_destroy, &
+                                 ndims_tensor
    USE dbcsr_data_methods, ONLY: dbcsr_scalar
-   USE dbcsr_tensor,       ONLY: dbcsr_t_ndims
    USE dbcsr_kinds,        ONLY: real_8
 #include "base/dbcsr_base_uses.f90"
 
@@ -410,7 +410,7 @@ PROGRAM dbcsr_tensor_unittest
       CALL dbcsr_t_setup_test_tensor(tensor_B, mp_comm, .FALSE., blk_ind_3_2, blk_ind_4_2)
       CALL dbcsr_t_setup_test_tensor(tensor_C, mp_comm, .FALSE., blk_ind_1_3, blk_ind_2_3, blk_ind_4_3)
 
-      ALLOCATE(bounds_t(dbcsr_t_ndims(tensor_B)))
+      ALLOCATE(bounds_t(ndims_tensor(tensor_B)))
       CALL dbcsr_t_get_info(tensor_B, nfull_total=bounds_t)
 
       ALLOCATE(bounds(2,1))
@@ -462,7 +462,7 @@ PROGRAM dbcsr_tensor_unittest
       CALL dbcsr_t_setup_test_tensor(tensor_B, mp_comm, .FALSE., blk_ind_3_2, blk_ind_4_2)
       CALL dbcsr_t_setup_test_tensor(tensor_C, mp_comm, .FALSE., blk_ind_1_3, blk_ind_2_3, blk_ind_4_3)
 
-      ALLOCATE(bounds_t(dbcsr_t_ndims(tensor_C)))
+      ALLOCATE(bounds_t(ndims_tensor(tensor_C)))
       CALL dbcsr_t_get_info(tensor_C, nfull_total=bounds_t)
 
       ALLOCATE(bounds(2,2))
@@ -517,7 +517,7 @@ PROGRAM dbcsr_tensor_unittest
       CALL dbcsr_t_setup_test_tensor(tensor_B, mp_comm, .FALSE., blk_ind_1_4, blk_ind_2_4, blk_ind_4_4, blk_ind_5_4)
       CALL dbcsr_t_setup_test_tensor(tensor_C, mp_comm, .FALSE., blk_ind_3_5, blk_ind_4_5, blk_ind_5_5)
 
-      ALLOCATE(bounds_t(dbcsr_t_ndims(tensor_A)))
+      ALLOCATE(bounds_t(ndims_tensor(tensor_A)))
       CALL dbcsr_t_get_info(tensor_A, nfull_total=bounds_t)
       ALLOCATE(bounds_1(2, 2))
       bounds_1(1, 1) = 7
@@ -526,7 +526,7 @@ PROGRAM dbcsr_tensor_unittest
       bounds_1(2, 2) = bounds_t(1)
       DEALLOCATE(bounds_t)
 
-      ALLOCATE(bounds_t(dbcsr_t_ndims(tensor_B)))
+      ALLOCATE(bounds_t(ndims_tensor(tensor_B)))
       CALL dbcsr_t_get_info(tensor_B, nfull_total=bounds_t)
       ALLOCATE(bounds_2(2, 2))
       bounds_2(1, 1) = 1


### PR DESCRIPTION
intent(out) allocatables cause problems with C interoperability.
- allocations of arrays with known sizes should be controlled by the caller
- helper functions to get array sizes
- `dbcsr_t_contract_index` is the only exception, array size is not known
prior to calling this function

This helps with finalizing #274