### PR TITLE
revised calc_norms

### DIFF
--- a/src/mm/dbcsr_mm_cannon.F
+++ b/src/mm/dbcsr_mm_cannon.F
@@ -1586,7 +1586,7 @@ CONTAINS
             CALL dbcsr_print(right_buffer_calc%mats(v_ki_right, 1), nodata=.TRUE.)
          ENDIF
          !
-         ! form here the code for dbcsr_mm_driver_inner_init was taken
+         ! from here the code for dbcsr_mm_driver_inner_init was taken
          !
          IF (.FALSE.) WRITE (*, *) routineN//" TICK", metronome
          ! Since the right matrix is shifted vertically, the

--- a/src/mm/dbcsr_mm_common.f90
+++ b/src/mm/dbcsr_mm_common.f90
@@ -8,7 +8,7 @@
 !--------------------------------------------------------------------------------------------------!
 
 #:include '../data/dbcsr.fypp'
-#:for n, nametype1, base1, prec1, kind1, type1, dkind1 in inst_params_float
+#:for n, nametype1, base1, prec1, kind1, type1, typesize1, dkind1 in inst_params_float
   SUBROUTINE calc_norms_${nametype1}$ (norms, nblks, &
                                        blki, rbs, cbs, DATA)
      !! Calculates norms of the entire matrix with minimal overhead.
@@ -19,7 +19,7 @@
      ${type1}$, DIMENSION(:), &
         INTENT(IN)                            :: DATA
 
-     INTEGER, PARAMETER                       :: simd = 64 / ${typesize1}$
+     INTEGER, PARAMETER                       :: simd = 64/${typesize1}$
      INTEGER                                  :: i, n, blk, bp, bpe, row, col
      REAL(kind=sp)                            :: val
 
@@ -27,9 +27,7 @@
 
 !$OMP     parallel default(none) &
 !$OMP              private (i, n, row, col, blk, bp, bpe, val) &
-!$OMP              shared (nblks, simd) &
-!$OMP              shared (rbs, cbs, blki, &
-!$OMP                      data, norms)
+!$OMP              shared (nblks, rbs, cbs, blki, data, norms)
 !$OMP     do
      DO i = 1, nblks, simd
         n = MIN(i + simd, nblks)
@@ -38,7 +36,7 @@
            IF (bp .NE. 0) THEN
               row = blki(1, blk)
               col = blki(2, blk)
-              bpe = bp + rbs(row) * cbs(col) - 1
+              bpe = bp + rbs(row)*cbs(col) - 1
               val = SQRT(REAL(SUM(DATA(bp:bpe)**2), KIND=sp))
            ELSE
               val = 0.0_sp

--- a/src/mm/dbcsr_mm_common.f90
+++ b/src/mm/dbcsr_mm_common.f90
@@ -19,7 +19,7 @@
      ${type1}$, DIMENSION(:), &
         INTENT(IN)                            :: DATA
 
-     INTEGER, PARAMETER                       :: nsimd = (1*64)/${typesize1}$
+     INTEGER, PARAMETER                       :: nsimd = (4*64)/${typesize1}$
      INTEGER                                  :: i, n, blk, bp, bpe, row, col
      REAL(kind=sp)                            :: vals(nsimd)
 

--- a/src/mm/dbcsr_mm_common.f90
+++ b/src/mm/dbcsr_mm_common.f90
@@ -32,7 +32,8 @@
         DO blk = 1, n
            bp = blki(3, blk + i)
            IF (bp .NE. 0) THEN
-!$OMP     task firstprivate(i, blk, row, col, bp, bpe)
+!$OMP     task default(none) shared(DATA, vals, blki, rbs, cbs) &
+!$OMP          firstprivate(i, blk, row, col, bp, bpe)
               row = blki(1, blk + i)
               col = blki(2, blk + i)
               bpe = bp + rbs(row)*cbs(col) - 1
@@ -44,7 +45,8 @@
         ENDDO
         ! SIMD: SQRT is intentionally not in above IF-condition
 !$OMP     taskwait
-!$OMP     task firstprivate(i, blk, n, vals)
+!$OMP     task default(none) shared (norms) &
+!$OMP          firstprivate(i, blk, n, vals)
         IF (n .EQ. nsimd) THEN
 !$OMP     simd
            DO blk = 1, nsimd


### PR DESCRIPTION
In calc_norms, ABS was removed and a simd-loop was introduced. In addition, the `schedule(dynamic)` was specified (which is default with GNU Compiler), however the loop in particular is potentially unbalanced due to data-dependent `DATA(bp:bpe)`.