### PR TITLE
TAS/tensor unit tests: consistent behaviour for different compilers and parallelization parameters

### DIFF
--- a/src/tas/dbcsr_tas_test.F
+++ b/src/tas/dbcsr_tas_test.F
@@ -44,6 +44,8 @@ MODULE dbcsr_tas_test
    USE dbcsr_operations, ONLY: dbcsr_maxabs, &
                                dbcsr_add
    USE dbcsr_transformations, ONLY: dbcsr_complete_redistribute
+   USE dbcsr_blas_operations, ONLY: &
+      dbcsr_lapack_larnv, set_larnv_seed
 #include "base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -55,6 +57,8 @@ MODULE dbcsr_tas_test
       dbcsr_tas_random_bsizes, &
       dbcsr_tas_setup_test_matrix, &
       dbcsr_tas_test_mm
+
+   INTEGER, SAVE :: randmat_counter = 0
 
 CONTAINS
    SUBROUTINE dbcsr_tas_setup_test_matrix(matrix, mp_comm_out, mp_comm, nrows, ncols, rbsizes, cbsizes, &
@@ -75,7 +79,7 @@ CONTAINS
       INTEGER                                            :: col_size, max_col_size, max_nze, &
                                                             max_row_size, mynode, node_holds_blk, &
                                                             numnodes, nze, row_size
-      INTEGER(KIND=int_8)                                :: col, col_s, row, row_s
+      INTEGER(KIND=int_8)                                :: col, col_s, row, row_s, nrow, ncol
       INTEGER, DIMENSION(2)                              :: pcoord, pdims
       LOGICAL                                            :: reuse_comm_prv, tr
       REAL(KIND=real_8)                                  :: rn
@@ -85,10 +89,16 @@ CONTAINS
       TYPE(dbcsr_tas_distribution_type)                    :: dist
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_tas_setup_test_matrix'
       INTEGER :: handle
+      INTEGER, DIMENSION(4)                              :: iseed, jseed
 
       ! we don't reserve blocks prior to putting them, so this time is meaningless and should not
       ! be considered in benchmark!
       CALL timeset(routineN, handle)
+
+      ! Check that the counter was initialised (or has not overflowed)
+      DBCSR_ASSERT(randmat_counter .NE. 0)
+      ! the counter goes into the seed. Every new call gives a new random matrix
+      randmat_counter = randmat_counter + 1
 
       IF (PRESENT(reuse_comm)) THEN
          reuse_comm_prv = reuse_comm
@@ -119,11 +129,16 @@ CONTAINS
       max_col_size = MAXVAL(cbsizes)
       max_nze = max_row_size*max_col_size
 
+      nrow = dbcsr_tas_nblkrows_total(matrix)
+      ncol = dbcsr_tas_nblkcols_total(matrix)
+
       ALLOCATE (values(max_row_size, max_col_size))
+
+      CALL set_larnv_seed(7, 42, 3, 42, randmat_counter, jseed)
 
       DO row = 1, dbcsr_tas_nblkrows_total(matrix)
          DO col = 1, dbcsr_tas_nblkcols_total(matrix)
-            CALL RANDOM_NUMBER(rn)
+            CALL dlarnv(1, jseed, 1, rn)
             IF (rn .LT. sparsity) THEN
                tr = .FALSE.
                row_s = row; col_s = col
@@ -133,7 +148,8 @@ CONTAINS
                   row_size = rbsize_obj%data(row_s)
                   col_size = cbsize_obj%data(col_s)
                   nze = row_size*col_size
-                  CALL RANDOM_NUMBER(values(1:row_size, 1:col_size))
+                  CALL set_larnv_seed(INT(row_s), INT(nrow), INT(col_s), INT(ncol), randmat_counter, iseed)
+                  CALL dlarnv(1, iseed, max_nze, values)
                   CALL dbcsr_tas_put_block(matrix, row_s, col_s, values(1:row_size, 1:col_size))
                ENDIF
             ENDIF

--- a/src/tas/dbcsr_tas_test.F
+++ b/src/tas/dbcsr_tas_test.F
@@ -169,7 +169,7 @@ CONTAINS
 
       IF (PRESENT(io_unit)) THEN
       IF (io_unit > 0) THEN
-         WRITE (io_unit, *) "starting tall-and-skinny benchmark"
+         WRITE (io_unit, "(A)") "starting tall-and-skinny benchmark"
       ENDIF
       ENDIF
       CALL timeset("benchmark_tas_mm", handle1)
@@ -179,7 +179,7 @@ CONTAINS
       CALL timestop(handle1)
       IF (PRESENT(io_unit)) THEN
       IF (io_unit > 0) THEN
-         WRITE (io_unit, *) "tall-and-skinny benchmark completed"
+         WRITE (io_unit, "(A)") "tall-and-skinny benchmark completed"
       ENDIF
       ENDIF
 
@@ -223,7 +223,7 @@ CONTAINS
          CALL dbcsr_complete_redistribute(dbcsr_b, dbcsr_b_mm)
          IF (PRESENT(io_unit)) THEN
          IF (io_unit > 0) THEN
-            WRITE (io_unit, *) "starting dbcsr benchmark"
+            WRITE (io_unit, "(A)") "starting dbcsr benchmark"
          ENDIF
          ENDIF
          CALL timeset("benchmark_dbcsr_mm", handle2)
@@ -232,7 +232,7 @@ CONTAINS
          CALL timestop(handle2)
          IF (PRESENT(io_unit)) THEN
          IF (io_unit > 0) THEN
-            WRITE (io_unit, *) "dbcsr benchmark completed"
+            WRITE (io_unit, "(A)") "dbcsr benchmark completed"
          ENDIF
          ENDIF
 
@@ -348,14 +348,14 @@ CONTAINS
       IF (ABS(norm) .GT. test_tol) THEN
          WRITE (io_unit, '(A, A, A, A, A, 1X, A)') TRIM(matrix_a%matrix%name), transa, ' X ', TRIM(matrix_b%matrix%name), &
             transb, 'failed!'
-         WRITE (io_unit, *) "checksums", sq_cs, rc_cs
-         WRITE (io_unit, *) "difference norm", norm
+         WRITE (io_unit, "(A,1X,E9.2,1X,E9.2)") "checksums", sq_cs, rc_cs
+         WRITE (io_unit, "(A,1X,E9.2)") "difference norm", norm
          DBCSR_ABORT("")
       ELSE
          WRITE (io_unit, '(A, A, A, A, A, 1X, A)') TRIM(matrix_a%matrix%name), transa, ' X ', TRIM(matrix_b%matrix%name), &
             transb, 'passed!'
-         WRITE (io_unit, *) "checksums", sq_cs, rc_cs
-         WRITE (io_unit, *) "difference norm", norm
+         WRITE (io_unit, "(A,1X,E9.2,1X,E9.2)") "checksums", sq_cs, rc_cs
+         WRITE (io_unit, "(A,1X,E9.2)") "difference norm", norm
       ENDIF
       ENDIF
 

--- a/src/tensors/dbcsr_tensor_test.F
+++ b/src/tensors/dbcsr_tensor_test.F
@@ -662,9 +662,9 @@ CONTAINS
 
       IF (debug) THEN
          IF (io_unit > 0) THEN
-            WRITE (io_unit, *) "checksum ", TRIM(tensor_1%name), cs_1
-            WRITE (io_unit, *) "checksum ", TRIM(tensor_2%name), cs_2
-            WRITE (io_unit, *) "checksum ", TRIM(tensor_3%name), cs_3
+            WRITE (io_unit, "(A, E9.2)") "checksum ", TRIM(tensor_1%name), cs_1
+            WRITE (io_unit, "(A, E9.2)") "checksum ", TRIM(tensor_2%name), cs_2
+            WRITE (io_unit, "(A, E9.2)") "checksum ", TRIM(tensor_3%name), cs_3
          ENDIF
       ENDIF
 
@@ -692,7 +692,7 @@ CONTAINS
 
       IF (debug) THEN
          IF (io_unit > 0) THEN
-            WRITE (io_unit, *) "checksum ", TRIM(tensor_3%name), cs_3
+            WRITE (io_unit, "(A, E9.2)") "checksum ", TRIM(tensor_3%name), cs_3
          ENDIF
       ENDIF
 

--- a/src/tensors/dbcsr_tensor_test.F
+++ b/src/tensors/dbcsr_tensor_test.F
@@ -49,9 +49,12 @@ MODULE dbcsr_tensor_test
                             mp_sum, &
                             mp_cart_create
    USE dbcsr_allocate_wrap, ONLY: allocate_any
-   USE dbcsr_tensor_index, ONLY: combine_tensor_index
+   USE dbcsr_tensor_index, ONLY: &
+      combine_tensor_index, get_2d_indices_tensor, dbcsr_t_get_mapping_info
    USE dbcsr_tas_test, ONLY: dbcsr_tas_checksum
    USE dbcsr_data_types, ONLY: dbcsr_scalar_type
+   USE dbcsr_blas_operations, ONLY: &
+      dbcsr_lapack_larnv, set_larnv_seed
 #include "base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -86,6 +89,10 @@ MODULE dbcsr_tensor_test
 #:endfor
 #:endfor
    END INTERFACE
+
+
+   INTEGER, SAVE :: randmat_counter = 0
+
 CONTAINS
 
    FUNCTION dbcsr_t_equal(tensor1, tensor2)
@@ -278,8 +285,8 @@ CONTAINS
 #:for dim in range(1, maxdim+1)
             IF (${dim}$ <= ndims) THEN
                nblks = SIZE(blk_size_${dim}$)
-               CALL dbcsr_t_random_dist(dist1_${dim}$, nblks, pdims(${dim}$), mp_comm)
-               CALL dbcsr_t_random_dist(dist2_${dim}$, nblks, pdims(${dim}$), mp_comm)
+               CALL dbcsr_t_random_dist(dist1_${dim}$, nblks, pdims(${dim}$))
+               CALL dbcsr_t_random_dist(dist2_${dim}$, nblks, pdims(${dim}$))
             ENDIF
 #:endfor
 
@@ -370,26 +377,20 @@ CONTAINS
       CALL dbcsr_t_pgrid_destroy(comm_nd)
    END SUBROUTINE
 
-   SUBROUTINE dbcsr_t_random_dist(dist_array, dist_size, nbins, mp_comm)
-      !! Create test distribution
+   SUBROUTINE dbcsr_t_random_dist(dist_array, dist_size, nbins)
+      INTEGER, DIMENSION(:), INTENT(OUT), ALLOCATABLE    :: dist_array
+      INTEGER, INTENT(IN)                                :: dist_size, nbins
 
-      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(OUT) :: dist_array
-      INTEGER, INTENT(IN)                             :: dist_size, nbins, mp_comm
-      REAL, DIMENSION(dist_size)                      :: rn
-      INTEGER, DIMENSION(dist_size)                   :: rn_int
-      INTEGER                                         :: numnodes, mynode
+      INTEGER                                            :: i
 
-      CALL mp_environ(numnodes, mynode, mp_comm)
+      ALLOCATE (dist_array(dist_size))
+      !CALL RANDOM_NUMBER (dist_array)
+      DO i = 1, dist_size
+         dist_array(i) = MODULO(nbins - i, nbins)
+      END DO
 
-      IF (mynode .EQ. 0) THEN
-         CALL RANDOM_NUMBER(rn)
-      ENDIF
-      CALL mp_bcast(rn, 0, mp_comm)
+   END SUBROUTINE
 
-      rn_int = FLOOR(rn*nbins)
-      CALL allocate_any(dist_array, source=rn_int)
-
-   END SUBROUTINE dbcsr_t_random_dist
 
    SUBROUTINE dbcsr_t_setup_test_tensor(tensor, mp_comm, enumerate, ${varlist("blk_ind")}$)
       !! Allocate and fill test tensor - entries are enumerated by their index s.t. they only depend
@@ -402,7 +403,7 @@ CONTAINS
          !! index along respective dimension of non-zero blocks
       INTEGER                                            :: blk, numnodes, mynode
 
-      INTEGER                                            :: i, ib, my_nblks_alloc, nblks_alloc, proc
+      INTEGER                                            :: i, ib, my_nblks_alloc, nblks_alloc, proc, nze
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ${varlist("my_blk_ind")}$
       INTEGER, DIMENSION(ndims_tensor(tensor))          :: blk_index, blk_offset, blk_size, &
                                                             tensor_dims
@@ -412,9 +413,17 @@ CONTAINS
          DIMENSION(${shape_colon(ndim)}$)                :: blk_values_${ndim}$
 #:endfor
       TYPE(dbcsr_t_iterator_type)                        :: iterator
+      INTEGER, DIMENSION(4)                              :: iseed
+      INTEGER, DIMENSION(2)                              :: blk_index_2d, nblks_2d
 
       nblks_alloc = SIZE(blk_ind_1)
       CALL mp_environ(numnodes, mynode, mp_comm)
+
+      IF(.NOT. enumerate) THEN
+         DBCSR_ASSERT(randmat_counter .NE. 0)
+
+         randmat_counter = randmat_counter + 1
+      ENDIF
 
       ALLOCATE (ind_nd(nblks_alloc, ndims_tensor(tensor)))
       my_nblks_alloc = 0
@@ -459,6 +468,13 @@ CONTAINS
       DO WHILE (dbcsr_t_iterator_blocks_left(iterator))
          CALL dbcsr_t_iterator_next_block(iterator, blk_index, blk, blk_size=blk_size, blk_offset=blk_offset)
 
+         IF(.NOT. enumerate) THEN
+            blk_index_2d = INT(get_2d_indices_tensor(tensor%nd_index_blk, blk_index))
+            CALL dbcsr_t_get_mapping_info(tensor%nd_index_blk, dims_2d=nblks_2d)
+            CALL set_larnv_seed(blk_index_2d(1), nblks_2d(1), blk_index_2d(2), nblks_2d(2), randmat_counter, iseed)
+            nze = PRODUCT(blk_size)
+         ENDIF
+
 #:for ndim in ndims
          IF (ndims_tensor(tensor) == ${ndim}$) THEN
             CALL allocate_any(blk_values_${ndim}$, shape_spec=blk_size)
@@ -466,7 +482,7 @@ CONTAINS
             IF (enumerate) THEN
                CALL enumerate_block_elements(blk_size, blk_offset, tensor_dims, blk_${ndim}$=blk_values_${ndim}$)
             ELSE
-               CALL random_number(blk_values_${ndim}$)
+               CALL dlarnv(1, iseed, nze, blk_values_${ndim}$)
             ENDIF
             CALL dbcsr_t_put_block(tensor, blk_index, blk_size, blk_values_${ndim}$)
             DEALLOCATE (blk_values_${ndim}$)

--- a/tests/dbcsr_tensor_unittest.F
+++ b/tests/dbcsr_tensor_unittest.F
@@ -275,25 +275,25 @@ PROGRAM dbcsr_tensor_unittest
       CALL dbcsr_t_pgrid_create(mp_comm, pdims_3d, pgrid_3d)
       CALL dbcsr_t_pgrid_create(mp_comm, pdims_2d, pgrid_2d)
 
-      CALL dbcsr_t_random_dist(dist1_1, nblks_1, pdims_3d(1), mp_comm)
-      CALL dbcsr_t_random_dist(dist1_2, nblks_2, pdims_3d(2), mp_comm)
-      CALL dbcsr_t_random_dist(dist1_3, nblks_3, pdims_3d(3), mp_comm)
+      CALL dbcsr_t_random_dist(dist1_1, nblks_1, pdims_3d(1))
+      CALL dbcsr_t_random_dist(dist1_2, nblks_2, pdims_3d(2))
+      CALL dbcsr_t_random_dist(dist1_3, nblks_3, pdims_3d(3))
 
-      CALL dbcsr_t_random_dist(dist2_1, nblks_3, pdims_2d(1), mp_comm)
-      CALL dbcsr_t_random_dist(dist2_2, nblks_4, pdims_2d(2), mp_comm)
+      CALL dbcsr_t_random_dist(dist2_1, nblks_3, pdims_2d(1))
+      CALL dbcsr_t_random_dist(dist2_2, nblks_4, pdims_2d(2))
 
-      CALL dbcsr_t_random_dist(dist3_1, nblks_1, pdims_3d(1), mp_comm)
-      CALL dbcsr_t_random_dist(dist3_2, nblks_2, pdims_3d(2), mp_comm)
-      CALL dbcsr_t_random_dist(dist3_3, nblks_4, pdims_3d(3), mp_comm)
+      CALL dbcsr_t_random_dist(dist3_1, nblks_1, pdims_3d(1))
+      CALL dbcsr_t_random_dist(dist3_2, nblks_2, pdims_3d(2))
+      CALL dbcsr_t_random_dist(dist3_3, nblks_4, pdims_3d(3))
 
-      CALL dbcsr_t_random_dist(dist4_1, nblks_1, pdims_4d(1), mp_comm)
-      CALL dbcsr_t_random_dist(dist4_2, nblks_2, pdims_4d(2), mp_comm)
-      CALL dbcsr_t_random_dist(dist4_3, nblks_4, pdims_4d(3), mp_comm)
-      CALL dbcsr_t_random_dist(dist4_4, nblks_5, pdims_4d(4), mp_comm)
+      CALL dbcsr_t_random_dist(dist4_1, nblks_1, pdims_4d(1))
+      CALL dbcsr_t_random_dist(dist4_2, nblks_2, pdims_4d(2))
+      CALL dbcsr_t_random_dist(dist4_3, nblks_4, pdims_4d(3))
+      CALL dbcsr_t_random_dist(dist4_4, nblks_5, pdims_4d(4))
 
-      CALL dbcsr_t_random_dist(dist5_1, nblks_3, pdims_3d(1), mp_comm)
-      CALL dbcsr_t_random_dist(dist5_2, nblks_4, pdims_3d(2), mp_comm)
-      CALL dbcsr_t_random_dist(dist5_3, nblks_5, pdims_3d(3), mp_comm)
+      CALL dbcsr_t_random_dist(dist5_1, nblks_3, pdims_3d(1))
+      CALL dbcsr_t_random_dist(dist5_2, nblks_4, pdims_3d(2))
+      CALL dbcsr_t_random_dist(dist5_3, nblks_5, pdims_3d(3))
 
 !--------------------------------------------------------------------------------------------------!
 ! Test 4: Testing tensor contraction (12|3)x(3|4)=(12|4)                                           !


### PR DESCRIPTION
Behaviour of these unit tests was inconsistent with different compilers and with different parallelization parameters due to use of `random_number` and list-directed IO.

This may also fix the failures of TAS unit test with Cray CCE compiler.