### PR TITLE
Tensors: use static array size for `dbcsr_t_contract_index`

### DIFF
--- a/src/tensors/dbcsr_tensor.F
+++ b/src/tensors/dbcsr_tensor.F
@@ -47,7 +47,8 @@ MODULE dbcsr_tensor
       dbcsr_t_distribution_destroy, dbcsr_t_distribution_new_expert, dbcsr_t_get_stored_coordinates, &
       blk_dims_tensor, dbcsr_t_hold, dbcsr_t_pgrid_type, mp_environ_pgrid, dbcsr_t_filter, &
       dbcsr_t_clear, dbcsr_t_finalize, dbcsr_t_get_num_blocks, dbcsr_t_scale, &
-      dbcsr_t_get_num_blocks_total, dbcsr_t_get_info, ndims_matrix_row, ndims_matrix_column
+      dbcsr_t_get_num_blocks_total, dbcsr_t_get_info, ndims_matrix_row, ndims_matrix_column, &
+      dbcsr_t_max_nblks_local
    USE dbcsr_kinds, ONLY: &
       ${uselist(dtype_float_prec)}$, default_string_length, int_8
    USE dbcsr_mpiwrap, ONLY: &
@@ -489,7 +490,8 @@ CONTAINS
                                       map_1, map_2, &
                                       bounds_1, bounds_2, bounds_3, &
                                       optimize_dist, pgrid_opt_1, pgrid_opt_2, pgrid_opt_3, &
-                                      filter_eps, flop, move_data, retain_sparsity, result_index, unit_nr, log_verbose)
+                                      filter_eps, flop, move_data, retain_sparsity, &
+                                      nblks_local, result_index, unit_nr, log_verbose)
       !! expert routine for tensor contraction. For internal use only.
       TYPE(dbcsr_scalar_type), INTENT(IN)            :: alpha
       TYPE(dbcsr_t_type), INTENT(INOUT), TARGET      :: tensor_1
@@ -519,7 +521,9 @@ CONTAINS
       INTEGER(KIND=int_8), INTENT(OUT), OPTIONAL     :: flop
       LOGICAL, INTENT(IN), OPTIONAL                  :: move_data
       LOGICAL, INTENT(IN), OPTIONAL                  :: retain_sparsity
-      INTEGER, DIMENSION(:, :), ALLOCATABLE, &
+      INTEGER, INTENT(OUT), OPTIONAL                 :: nblks_local
+         !! number of local blocks on this MPI rank
+      INTEGER, DIMENSION(dbcsr_t_max_nblks_local(tensor_3), ndims_tensor(tensor_3)), &
          OPTIONAL, INTENT(OUT)                       :: result_index
          !! get indices of non-zero tensor blocks for tensor_3 without actually performing contraction
          !! this is an estimate based on block norm multiplication
@@ -821,7 +825,14 @@ CONTAINS
                                  result_index=result_index_2d)
 
          nblk = SIZE(result_index_2d,1)
-         ALLOCATE(result_index(nblk, ndims_tensor(tensor_contr_3)))
+         IF(PRESENT(nblks_local)) nblks_local = nblk
+         IF (SIZE(result_index, 1) < nblk) THEN
+            CALL dbcsr_abort(__LOCATION__, &
+        "allocated size of `result_index` is too small. This error occurs due to a high load imbalance of distributed tensor data.")
+         ENDIF
+
+         result_index = 0
+
          DO iblk = 1, nblk
             result_index(iblk,:) = get_nd_indices_tensor(tensor_contr_3%nd_index_blk, result_index_2d(iblk,:))
          ENDDO
@@ -1612,7 +1623,8 @@ CONTAINS
                                      contract_2, notcontract_2, &
                                      map_1, map_2, &
                                      bounds_1, bounds_2, bounds_3, &
-                                     filter_eps, result_index)
+                                     filter_eps, &
+                                     nblks_local, result_index)
       !! get indices of non-zero tensor blocks for contraction result without actually
       !! performing contraction.
       !! this is an estimate based on block norm multiplication.
@@ -1635,9 +1647,12 @@ CONTAINS
       INTEGER, DIMENSION(2, SIZE(notcontract_2)), &
          INTENT(IN), OPTIONAL                        :: bounds_3
       REAL(KIND=real_8), INTENT(IN), OPTIONAL        :: filter_eps
-      INTEGER, DIMENSION(:, :), ALLOCATABLE, &
+      INTEGER, INTENT(OUT)                           :: nblks_local
+         !! number of local blocks on this MPI rank
+      INTEGER, DIMENSION(dbcsr_t_max_nblks_local(tensor_3), ndims_tensor(tensor_3)), &
          INTENT(OUT)                                 :: result_index
-         !! indices of non-zero tensor blocks for tensor_3
+         !! indices of local non-zero tensor blocks for tensor_3
+         !! only the elements result_index(:nblks_local, :) are relevant (all others are set to 0)
 
       CALL dbcsr_t_contract_expert(alpha, tensor_1, tensor_2, beta, tensor_3, &
                                    contract_1, notcontract_1, &
@@ -1647,6 +1662,7 @@ CONTAINS
                                    bounds_2=bounds_2, &
                                    bounds_3=bounds_3, &
                                    filter_eps=filter_eps, &
+                                   nblks_local=nblks_local, &
                                    result_index=result_index)
    END SUBROUTINE
 

--- a/src/tensors/dbcsr_tensor_api.F
+++ b/src/tensors/dbcsr_tensor_api.F
@@ -35,7 +35,7 @@ MODULE dbcsr_tensor_api
       dbcsr_t_mp_dims_create, dbcsr_t_pgrid_change_dims, dbcsr_t_ndims => ndims_tensor, &
       dbcsr_t_dims => dims_tensor, dbcsr_t_ndims_matrix_row => ndims_matrix_row, &
       dbcsr_t_ndims_matrix_column => ndims_matrix_column, dbcsr_t_blk_size, dbcsr_t_nblks_local, &
-      dbcsr_t_nblks_total
+      dbcsr_t_nblks_total, dbcsr_t_max_nblks_local
    USE dbcsr_tensor_test, ONLY: &
       dbcsr_t_contract_test, dbcsr_t_checksum
    USE dbcsr_tensor_split, ONLY: &
@@ -105,5 +105,6 @@ MODULE dbcsr_tensor_api
    PUBLIC :: dbcsr_t_nblks_local
    PUBLIC :: dbcsr_t_nblks_total
    PUBLIC :: dbcsr_t_blk_size
+   PUBLIC :: dbcsr_t_max_nblks_local
 
 END MODULE dbcsr_tensor_api

--- a/src/tensors/dbcsr_tensor_index.F
+++ b/src/tensors/dbcsr_tensor_index.F
@@ -135,7 +135,7 @@ CONTAINS
       ndims_mapping_column = map%ndim2_2d
    END FUNCTION
 
-   SUBROUTINE dbcsr_t_get_mapping_info(map, ndim_nd, ndim1_2d, ndim2_2d, dims_2d_i8, dims_2d, dims_nd, dims1_2d, dims2_2d, &
+   PURE SUBROUTINE dbcsr_t_get_mapping_info(map, ndim_nd, ndim1_2d, ndim2_2d, dims_2d_i8, dims_2d, dims_nd, dims1_2d, dims2_2d, &
                                        map1_2d, map2_2d, map_nd, base, col_major)
       !! get mapping info
 

--- a/src/tensors/dbcsr_tensor_types.F
+++ b/src/tensors/dbcsr_tensor_types.F
@@ -94,12 +94,14 @@ MODULE dbcsr_tensor_types
       ndims_matrix_column,&
       dbcsr_t_nblks_local,&
       dbcsr_t_nblks_total,&
-      dbcsr_t_blk_size
+      dbcsr_t_blk_size,&
+      dbcsr_t_max_nblks_local
 
    TYPE dbcsr_t_pgrid_type
       TYPE(nd_to_2d_mapping)                  :: nd_index_grid
       INTEGER                                 :: mp_comm_2d
       TYPE(dbcsr_tas_split_info), ALLOCATABLE :: tas_split_info
+      INTEGER                                 :: nproc
    END TYPE
 
    TYPE dbcsr_t_type
@@ -1206,6 +1208,9 @@ CONTAINS
          ALLOCATE (pgrid%tas_split_info, SOURCE=info)
       ENDIF
 
+      ! store number of MPI ranks because we need it for PURE function dbcsr_t_max_nblks_local
+      pgrid%nproc = nproc
+
       CALL timestop(handle)
    END SUBROUTINE
 
@@ -1524,6 +1529,29 @@ CONTAINS
       INTEGER(int_8) :: ndims_matrix_column
 
       ndims_matrix_column = ndims_mapping_column(tensor%nd_index_blk)
+   END FUNCTION
+
+   PURE FUNCTION dbcsr_t_max_nblks_local(tensor) RESULT(blk_count)
+      !! returns an estimate of maximum number of local blocks in tensor
+      !! (irrespective of the actual number of currently present blocks)
+      !! this estimate is based on the following assumption: tensor data is dense and
+      !! load balancing is within a factor of 2
+      TYPE(dbcsr_t_type), INTENT(IN) :: tensor
+      INTEGER :: blk_count, nproc
+      INTEGER, DIMENSION(ndims_tensor(tensor)) :: bdims
+      INTEGER(int_8) :: blk_count_total
+      INTEGER, PARAMETER :: max_load_imbalance = 2
+
+      CALL dbcsr_t_get_mapping_info(tensor%nd_index_blk, dims_nd=bdims)
+
+      blk_count_total = PRODUCT(INT(bdims, int_8))
+
+      ! can not call an MPI routine due to PURE
+      !CALL mp_environ(nproc, myproc, tensor%pgrid%mp_comm_2d)
+      nproc = tensor%pgrid%nproc
+
+      blk_count = INT(blk_count_total/nproc*max_load_imbalance)
+
    END FUNCTION
 
 END MODULE


### PR DESCRIPTION
This is a follow-up to #320 according to what was discussed in #274