### PR TITLE
Tensors: improved load balancing

### DIFF
--- a/.ci/daint.cscs.ch/cray.test.sh
+++ b/.ci/daint.cscs.ch/cray.test.sh
@@ -31,4 +31,4 @@ export OMP_PROC_BIND=TRUE # set thread affinity
 # document the current environment
 env |& tee -a "${STAGE_NAME}.out"
 
-env CTEST_OUTPUT_ON_FAILURE=1 make test |& tee -a "${STAGE_NAME}.out"
+env CTEST_OUTPUT_ON_FAILURE=1 make test ARGS="--timeout 900" |& tee -a "${STAGE_NAME}.out"

--- a/.ci/daint.cscs.ch/gnu.test.sh
+++ b/.ci/daint.cscs.ch/gnu.test.sh
@@ -32,4 +32,4 @@ export OMP_PROC_BIND=TRUE # set thread affinity
 # document the current environment
 env |& tee -a "${STAGE_NAME}.out"
 
-env CTEST_OUTPUT_ON_FAILURE=1 make test |& tee -a "${STAGE_NAME}.out"
+env CTEST_OUTPUT_ON_FAILURE=1 make test ARGS="--timeout 900" |& tee -a "${STAGE_NAME}.out"

--- a/.ci/daint.cscs.ch/intel.test.sh
+++ b/.ci/daint.cscs.ch/intel.test.sh
@@ -32,4 +32,4 @@ export OMP_PROC_BIND=TRUE # set thread affinity
 # document the current environment
 env |& tee -a "${STAGE_NAME}.out"
 
-env CTEST_OUTPUT_ON_FAILURE=1 make test |& tee -a "${STAGE_NAME}.out"
+env CTEST_OUTPUT_ON_FAILURE=1 make test ARGS="--timeout 900" |& tee -a "${STAGE_NAME}.out"

--- a/src/tas/dbcsr_tas_global.F
+++ b/src/tas/dbcsr_tas_global.F
@@ -14,7 +14,8 @@ MODULE dbcsr_tas_global
    !! given row or column. Hence global array data such as distribution and block sizes are specified as
    !! function objects, leaving up to the caller how to efficiently store global data.
 
-   USE dbcsr_kinds, ONLY: int_8
+   USE dbcsr_kinds, ONLY: int_8, dp
+   USE dbcsr_toollib, ONLY: sort
 #include "base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -32,7 +33,7 @@ MODULE dbcsr_tas_global
       dbcsr_tas_dist_repl, &
       dbcsr_tas_distribution, &
       dbcsr_tas_rowcol_data, &
-      cyclic_weighted_dist
+      dbcsr_tas_default_distvec
 
    ! abstract type for distribution vectors along one dimension
    TYPE, ABSTRACT :: dbcsr_tas_distribution
@@ -341,32 +342,76 @@ CONTAINS
          bsize_vec(ind) = block_sizes%data(ind)
       ENDDO
 
-      CALL cyclic_weighted_dist(INT(nmrowcol), nprowcol, bsize_vec, dist_vec)
+      CALL dbcsr_tas_default_distvec(INT(nmrowcol), nprowcol, bsize_vec, dist_vec)
       dbcsr_tas_dist_arb_default = dbcsr_tas_dist_arb(dist_vec, nprowcol, nmrowcol)
 
    END FUNCTION
 
-   SUBROUTINE cyclic_weighted_dist(nel, nbin, weights, dist)
-      INTEGER, INTENT(IN) :: nel
-      INTEGER, INTENT(IN) :: nbin
-      INTEGER, DIMENSION(nel), INTENT(IN)            :: weights
-      INTEGER, DIMENSION(nel), INTENT(OUT)            :: dist
-      INTEGER, DIMENSION(nbin)                        :: occup
-      INTEGER                :: iel, ibin
-      INTEGER                :: niter
+   SUBROUTINE dbcsr_tas_default_distvec(nblk, nproc, blk_size, dist)
+      !! get a load-balanced and randomized distribution along one tensor dimension
+      INTEGER, INTENT(IN)                                :: nblk
+         !! number of blocks (along one tensor dimension)
+      INTEGER, INTENT(IN)                                :: nproc
+         !! number of processes (along one process grid dimension)
+      INTEGER, DIMENSION(nblk), INTENT(IN)                :: blk_size
+         !! block sizes
+      INTEGER, DIMENSION(nblk), INTENT(OUT)               :: dist
+         !! distribution
+
+      CALL distribute_lpt_random(nblk, nproc, blk_size, dist)
+
+   END SUBROUTINE
+
+   SUBROUTINE distribute_lpt_random(nel, nbin, weights, dist)
+      !! distribute `nel` elements with weights `weights` over `nbin` bins.
+      !! load balanced distribution is obtained by using LPT algorithm together with randomization over equivalent bins
+      !! (i.e. randomization over all bins with the smallest accumulated weight)
+      INTEGER, INTENT(IN)                                :: nel, nbin
+      INTEGER, DIMENSION(nel), INTENT(IN)                :: weights
+      INTEGER, DIMENSION(nel), INTENT(OUT)               :: dist
+
+      INTEGER                                            :: i, i_select, ibin, iel, min_occup, &
+                                                            n_avail
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: bins_avail
+      INTEGER, DIMENSION(4)                              :: iseed
+      INTEGER, DIMENSION(nel)                            :: sort_index, weights_s
+      INTEGER, DIMENSION(nbin)                           :: occup
+      LOGICAL, DIMENSION(nbin)                           :: bin_mask
+      REAL(dp)                                           :: rand
+      INTEGER, PARAMETER                                 :: n_idle = 1000
+
+      ! initialize seed based on input arguments such that random numbers are deterministic across all processes
+      iseed(1) = nel; iseed(2) = nbin; iseed(3) = MAXVAL(weights); iseed(4) = MINVAL(weights)
+
+      iseed(4) = iseed(4)*2 + 1 ! odd
+
+      iseed(:) = MODULO(iseed(:), 2**12)
+
+      DO i = 1, n_idle
+         CALL dlarnv(1, iseed, 1, rand)
+      ENDDO
 
       occup(:) = 0
-      ibin = 0
-      DO iel = 1, nel
-         niter = 0
-         ibin = MOD(ibin + 1, nbin)
-         DO WHILE (occup(ibin + 1) + weights(iel) .GE. MAXVAL(occup))
-            IF (MINLOC(occup, DIM=1) == ibin + 1) EXIT
-            ibin = MOD(ibin + 1, nbin)
-            niter = niter + 1
-         ENDDO
-         dist(iel) = ibin
-         occup(ibin + 1) = occup(ibin + 1) + weights(iel)
+      weights_s = weights
+      CALL sort(weights_s, nel, sort_index)
+
+      occup(:) = 0
+      DO iel = nel, 1, -1
+         min_occup = MINVAL(occup, 1)
+
+         ! available bins with min. occupancy
+         bin_mask = occup == min_occup
+         n_avail = COUNT(bin_mask)
+         ALLOCATE (bins_avail(n_avail))
+         bins_avail(:) = PACK((/(i, i=1, nbin)/), MASK=bin_mask)
+
+         CALL dlarnv(1, iseed, 1, rand)
+         i_select = FLOOR(rand*n_avail) + 1
+         ibin = bins_avail(i_select)
+         DEALLOCATE (bins_avail)
+
+         dist(sort_index(iel)) = ibin - 1
+         occup(ibin) = occup(ibin) + weights_s(iel)
       ENDDO
 
    END SUBROUTINE

--- a/src/tas/dbcsr_tas_io.F
+++ b/src/tas/dbcsr_tas_io.F
@@ -18,7 +18,7 @@ MODULE dbcsr_tas_io
       int_8, real_8, default_string_length
    USE dbcsr_tas_base, ONLY: &
       dbcsr_tas_get_info, dbcsr_tas_get_num_blocks, dbcsr_tas_get_num_blocks_total, dbcsr_tas_get_nze_total, &
-      dbcsr_tas_get_nze, dbcsr_tas_nblkrows_total, dbcsr_tas_nblkcols_total
+      dbcsr_tas_get_nze, dbcsr_tas_nblkrows_total, dbcsr_tas_nblkcols_total, dbcsr_tas_info
    USE dbcsr_tas_split, ONLY: &
       dbcsr_tas_get_split_info, rowsplit, colsplit
    USE dbcsr_mpiwrap, ONLY: &
@@ -34,73 +34,77 @@ MODULE dbcsr_tas_io
    PUBLIC :: &
       dbcsr_tas_write_dist, &
       dbcsr_tas_write_matrix_info, &
-      dbcsr_tas_write_split_info
+      dbcsr_tas_write_split_info, &
+      prep_output_unit
 
 CONTAINS
 
-   SUBROUTINE dbcsr_tas_write_matrix_info(matrix, output_unit, full_info)
+   SUBROUTINE dbcsr_tas_write_matrix_info(matrix, unit_nr, full_info)
       !! Write basic infos of tall-and-skinny matrix: block dimensions, full dimensions, process grid dimensions
 
       TYPE(dbcsr_tas_type), INTENT(IN) :: matrix
-      INTEGER, INTENT(IN)            :: output_unit
+      INTEGER, INTENT(IN)            :: unit_nr
       LOGICAL, OPTIONAL, INTENT(IN)  :: full_info
          !! Whether to print distribution and block size vectors
 
       INTEGER(KIND=int_8)                      :: nblkrows_total, nblkcols_total, nfullrows_total, &
                                                   nfullcols_total
-      INTEGER                                  :: nprow, npcol
+      INTEGER                                  :: nprow, npcol, unit_nr_prv
       CLASS(dbcsr_tas_distribution), ALLOCATABLE :: proc_row_dist, proc_col_dist
       CLASS(dbcsr_tas_rowcol_data), ALLOCATABLE  :: row_blk_size, col_blk_size
       INTEGER(KIND=int_8)                      :: iblk
       CHARACTER(default_string_length)         :: name
+
+      unit_nr_prv = prep_output_unit(unit_nr)
+      IF (unit_nr_prv == 0) RETURN
 
       CALL dbcsr_tas_get_info(matrix, nblkrows_total=nblkrows_total, nblkcols_total=nblkcols_total, &
                               nfullrows_total=nfullrows_total, nfullcols_total=nfullcols_total, &
                               nprow=nprow, npcol=npcol, proc_row_dist=proc_row_dist, proc_col_dist=proc_col_dist, &
                               row_blk_size=row_blk_size, col_blk_size=col_blk_size, name=name)
 
-      IF (output_unit > 0) THEN
-         WRITE (output_unit, "(T2,A)") &
+      IF (unit_nr_prv > 0) THEN
+         WRITE (unit_nr_prv, "(T2,A)") &
             "GLOBAL INFO OF "//TRIM(name)
-         WRITE (output_unit, "(T4,A,1X)", advance="no") "block dimensions:"
-         WRITE (output_unit, "(I12,I12)", advance="no") nblkrows_total, nblkcols_total
-         WRITE (output_unit, "(/T4,A,1X)", advance="no") "full dimensions:"
-         WRITE (output_unit, "(I14,I14)", advance="no") nfullrows_total, nfullcols_total
-         WRITE (output_unit, "(/T4,A,1X)", advance="no") "process grid dimensions:"
-         WRITE (output_unit, "(I10,I10)", advance="no") nprow, npcol
+         WRITE (unit_nr_prv, "(T4,A,1X)", advance="no") "block dimensions:"
+         WRITE (unit_nr_prv, "(I12,I12)", advance="no") nblkrows_total, nblkcols_total
+         WRITE (unit_nr_prv, "(/T4,A,1X)", advance="no") "full dimensions:"
+         WRITE (unit_nr_prv, "(I14,I14)", advance="no") nfullrows_total, nfullcols_total
+         WRITE (unit_nr_prv, "(/T4,A,1X)", advance="no") "process grid dimensions:"
+         WRITE (unit_nr_prv, "(I10,I10)", advance="no") nprow, npcol
          IF (PRESENT(full_info)) THEN
             IF (full_info) THEN
-               WRITE (output_unit, '(/T4,A)', advance='no') "Block sizes:"
-               WRITE (output_unit, '(/T8,A)', advance='no') 'Row:'
+               WRITE (unit_nr_prv, '(/T4,A)', advance='no') "Block sizes:"
+               WRITE (unit_nr_prv, '(/T8,A)', advance='no') 'Row:'
                DO iblk = 1, row_blk_size%nmrowcol
-                  WRITE (output_unit, '(I4,1X)', advance='no') row_blk_size%data(iblk)
+                  WRITE (unit_nr_prv, '(I4,1X)', advance='no') row_blk_size%data(iblk)
                ENDDO
-               WRITE (output_unit, '(/T8,A)', advance='no') 'Column:'
+               WRITE (unit_nr_prv, '(/T8,A)', advance='no') 'Column:'
                DO iblk = 1, col_blk_size%nmrowcol
-                  WRITE (output_unit, '(I4,1X)', advance='no') col_blk_size%data(iblk)
+                  WRITE (unit_nr_prv, '(I4,1X)', advance='no') col_blk_size%data(iblk)
                ENDDO
-               WRITE (output_unit, '(/T4,A)', advance='no') "Block distribution:"
-               WRITE (output_unit, '(/T8,A)', advance='no') 'Row:'
+               WRITE (unit_nr_prv, '(/T4,A)', advance='no') "Block distribution:"
+               WRITE (unit_nr_prv, '(/T8,A)', advance='no') 'Row:'
                DO iblk = 1, proc_row_dist%nmrowcol
-                  WRITE (output_unit, '(I4,1X)', advance='no') proc_row_dist%dist(iblk)
+                  WRITE (unit_nr_prv, '(I4,1X)', advance='no') proc_row_dist%dist(iblk)
                ENDDO
-               WRITE (output_unit, '(/T8,A)', advance='no') 'Column:'
+               WRITE (unit_nr_prv, '(/T8,A)', advance='no') 'Column:'
                DO iblk = 1, proc_col_dist%nmrowcol
-                  WRITE (output_unit, '(I4,1X)', advance='no') proc_col_dist%dist(iblk)
+                  WRITE (unit_nr_prv, '(I4,1X)', advance='no') proc_col_dist%dist(iblk)
                ENDDO
 
             ENDIF
          ENDIF
-         WRITE (output_unit, *)
+         WRITE (unit_nr_prv, *)
       ENDIF
 
    END SUBROUTINE
 
-   SUBROUTINE dbcsr_tas_write_dist(matrix, output_unit, full_info)
+   SUBROUTINE dbcsr_tas_write_dist(matrix, unit_nr, full_info)
       !! Write info on tall-and-skinny matrix distribution & load balance
 
       TYPE(dbcsr_tas_type), INTENT(IN) :: matrix
-      INTEGER, INTENT(IN)              :: output_unit
+      INTEGER, INTENT(IN)              :: unit_nr
       LOGICAL, INTENT(IN), OPTIONAL    :: full_info
          !! Whether to print subgroup DBCSR distribution
 
@@ -114,10 +118,13 @@ CONTAINS
                                           nblock_s, nelement_s, nblock_s_max
       REAL(KIND=real_8)                :: occupation
       INTEGER, DIMENSION(:), POINTER   :: rowdist => NULL(), coldist => NULL()
-      INTEGER                          :: split_rowcol, icol, irow
+      INTEGER                          :: split_rowcol, icol, irow, unit_nr_prv
 
-      CALL dbcsr_tas_get_info(matrix, name=name)
+      unit_nr_prv = prep_output_unit(unit_nr)
+      IF (unit_nr_prv == 0) RETURN
+
       CALL dbcsr_tas_get_split_info(matrix%dist%info, mp_comm, ngroup, igroup, mp_comm_group, split_rowcol)
+      CALL dbcsr_tas_get_info(matrix, name=name)
       CALL mp_environ(nproc, iproc, mp_comm)
 
       nblock = dbcsr_tas_get_num_blocks(matrix)
@@ -147,48 +154,51 @@ CONTAINS
       rowdist => dbcsr_distribution_row_dist(matrix%matrix%dist)
       coldist => dbcsr_distribution_col_dist(matrix%matrix%dist)
 
-      IF (output_unit > 0) THEN
-         WRITE (output_unit, "(T2,A)") &
+      IF (unit_nr_prv > 0) THEN
+         WRITE (unit_nr_prv, "(T2,A)") &
             "DISTRIBUTION OF "//TRIM(name)
-         WRITE (output_unit, "(T15,A,T68,I13)") "Number of non-zero blocks:", nblock_p_sum
-         WRITE (output_unit, "(T15,A,T75,F6.2)") "Percentage of non-zero blocks:", occupation
-         WRITE (output_unit, "(T15,A,T68,I13)") "Average number of blocks per group:", (nblock_p_sum + ngroup - 1)/ngroup
-         WRITE (output_unit, "(T15,A,T68,I13)") "Maximum number of blocks per group:", nblock_s_max
-         WRITE (output_unit, "(T15,A,T68,I13)") "Average number of matrix elements per group:", (nelement_p_sum + ngroup - 1)/ngroup
-         WRITE (output_unit, "(T15,A,T68,I13)") "Maximum number of matrix elements per group:", nelement_s_max
-         WRITE (output_unit, "(T15,A,T68,I13)") "Average number of blocks per CPU:", (nblock_p_sum + nproc - 1)/nproc
-         WRITE (output_unit, "(T15,A,T68,I13)") "Maximum number of blocks per CPU:", nblock_p_max
-         WRITE (output_unit, "(T15,A,T68,I13)") "Average number of matrix elements per CPU:", (nelement_p_sum + nproc - 1)/nproc
-         WRITE (output_unit, "(T15,A,T68,I13)") "Maximum number of matrix elements per CPU:", nelement_p_max
+         WRITE (unit_nr_prv, "(T15,A,T68,I13)") "Number of non-zero blocks:", nblock_p_sum
+         WRITE (unit_nr_prv, "(T15,A,T75,F6.2)") "Percentage of non-zero blocks:", occupation
+         WRITE (unit_nr_prv, "(T15,A,T68,I13)") "Average number of blocks per group:", (nblock_p_sum + ngroup - 1)/ngroup
+         WRITE (unit_nr_prv, "(T15,A,T68,I13)") "Maximum number of blocks per group:", nblock_s_max
+         WRITE (unit_nr_prv, "(T15,A,T68,I13)") "Average number of matrix elements per group:", (nelement_p_sum + ngroup - 1)/ngroup
+         WRITE (unit_nr_prv, "(T15,A,T68,I13)") "Maximum number of matrix elements per group:", nelement_s_max
+         WRITE (unit_nr_prv, "(T15,A,T68,I13)") "Average number of blocks per CPU:", (nblock_p_sum + nproc - 1)/nproc
+         WRITE (unit_nr_prv, "(T15,A,T68,I13)") "Maximum number of blocks per CPU:", nblock_p_max
+         WRITE (unit_nr_prv, "(T15,A,T68,I13)") "Average number of matrix elements per CPU:", (nelement_p_sum + nproc - 1)/nproc
+         WRITE (unit_nr_prv, "(T15,A,T68,I13)") "Maximum number of matrix elements per CPU:", nelement_p_max
          IF (PRESENT(full_info)) THEN
             IF (full_info) THEN
-               WRITE (output_unit, "(T15,A)") "Row distribution on subgroup:"
-               WRITE (output_unit, '(T15)', advance='no')
+               WRITE (unit_nr_prv, "(T15,A)") "Row distribution on subgroup:"
+               WRITE (unit_nr_prv, '(T15)', advance='no')
                DO irow = 1, SIZE(rowdist)
-                  WRITE (output_unit, '(I3, 1X)', advance='no') rowdist(irow)
+                  WRITE (unit_nr_prv, '(I3, 1X)', advance='no') rowdist(irow)
                ENDDO
-               WRITE (output_unit, "(/T15,A)") "Column distribution on subgroup:"
-               WRITE (output_unit, '(T15)', advance='no')
+               WRITE (unit_nr_prv, "(/T15,A)") "Column distribution on subgroup:"
+               WRITE (unit_nr_prv, '(T15)', advance='no')
                DO icol = 1, SIZE(coldist)
-                  WRITE (output_unit, '(I3, 1X)', advance='no') coldist(icol)
+                  WRITE (unit_nr_prv, '(I3, 1X)', advance='no') coldist(icol)
                ENDDO
-               WRITE (output_unit, *)
+               WRITE (unit_nr_prv, *)
             ENDIF
          ENDIF
       ENDIF
    END SUBROUTINE
 
-   SUBROUTINE dbcsr_tas_write_split_info(info, io_unit, name)
+   SUBROUTINE dbcsr_tas_write_split_info(info, unit_nr, name)
       !! Print info on how matrix is split
       TYPE(dbcsr_tas_split_info), INTENT(IN)             :: info
-      INTEGER, INTENT(IN) :: io_unit
+      INTEGER, INTENT(IN) :: unit_nr
       CHARACTER(len=*), INTENT(IN), OPTIONAL             :: name
       INTEGER                                            :: groupsize, igroup, mp_comm, &
                                                             mp_comm_group, mynode, nsplit, &
-                                                            numnodes, split_rowcol
+                                                            numnodes, split_rowcol, unit_nr_prv
       INTEGER, DIMENSION(2)                              :: coord, dims, groupcoord, groupdims, &
                                                             pgrid_offset
       CHARACTER(len=:), ALLOCATABLE                      :: name_prv
+
+      unit_nr_prv = prep_output_unit(unit_nr)
+      IF (unit_nr_prv == 0) RETURN
 
       IF (PRESENT(name)) THEN
          ALLOCATE (name_prv, SOURCE=TRIM(name))
@@ -197,27 +207,40 @@ CONTAINS
       ENDIF
 
       CALL dbcsr_tas_get_split_info(info, mp_comm, nsplit, igroup, mp_comm_group, split_rowcol, pgrid_offset)
+
       CALL mp_environ(numnodes, mynode, mp_comm)
       CALL mp_environ(numnodes, dims, coord, mp_comm)
       CALL mp_environ(groupsize, groupdims, groupcoord, mp_comm_group)
 
-      IF (io_unit > 0) THEN
+      IF (unit_nr_prv > 0) THEN
          SELECT CASE (split_rowcol)
          CASE (rowsplit)
-            WRITE (io_unit, "(T4,A,I4,1X,A,I4)") name_prv//"splitting rows by factor", nsplit
+            WRITE (unit_nr_prv, "(T4,A,I4,1X,A,I4)") name_prv//"splitting rows by factor", nsplit
          CASE (colsplit)
-            WRITE (io_unit, "(T4,A,I4,1X,A,I4)") name_prv//"splitting columns by factor", nsplit
+            WRITE (unit_nr_prv, "(T4,A,I4,1X,A,I4)") name_prv//"splitting columns by factor", nsplit
          END SELECT
-         WRITE (io_unit, "(T4,A,I4,A1,I4)") name_prv//"global grid sizes:", dims(1), "x", dims(2)
+         WRITE (unit_nr_prv, "(T4,A,I4,A1,I4)") name_prv//"global grid sizes:", dims(1), "x", dims(2)
       ENDIF
 
-      IF (io_unit > 0) THEN
-         WRITE (io_unit, "(T4,A,I4,A1,I4)") &
+      IF (unit_nr_prv > 0) THEN
+         WRITE (unit_nr_prv, "(T4,A,I4,A1,I4)") &
             name_prv//"grid sizes on subgroups:", &
             groupdims(1), "x", groupdims(2)
       ENDIF
 
    END SUBROUTINE
+
+   FUNCTION prep_output_unit(unit_nr) RESULT(unit_nr_out)
+      INTEGER, INTENT(IN), OPTIONAL :: unit_nr
+      INTEGER                       :: unit_nr_out
+
+      IF (PRESENT(unit_nr)) THEN
+         unit_nr_out = unit_nr
+      ELSE
+         unit_nr_out = 0
+      ENDIF
+
+   END FUNCTION
 
 END MODULE
 

--- a/src/tas/dbcsr_tas_mm.F
+++ b/src/tas/dbcsr_tas_mm.F
@@ -51,7 +51,7 @@ MODULE dbcsr_tas_mm
    USE dbcsr_operations, ONLY: &
       dbcsr_scale, dbcsr_get_info, dbcsr_copy, dbcsr_clear, dbcsr_add
    USE dbcsr_tas_io, ONLY: &
-      dbcsr_tas_write_dist, dbcsr_tas_write_matrix_info, dbcsr_tas_write_split_info
+      dbcsr_tas_write_dist, dbcsr_tas_write_matrix_info, dbcsr_tas_write_split_info, prep_output_unit
    USE dbcsr_work_operations, ONLY: dbcsr_create, dbcsr_finalize
    USE dbcsr_transformations, ONLY: dbcsr_redistribute
    USE dbcsr_dist_methods, ONLY: dbcsr_distribution_new
@@ -70,7 +70,7 @@ CONTAINS
 
    RECURSIVE SUBROUTINE dbcsr_tas_multiply(transa, transb, transc, alpha, matrix_a, matrix_b, beta, matrix_c, &
                                            optimize_dist, split_opt, filter_eps, flop, move_data_a, &
-                                           move_data_b, retain_sparsity, simple_split, result_index, io_unit, log_verbose)
+                                           move_data_b, retain_sparsity, simple_split, result_index, unit_nr, log_verbose)
       !! tall-and-skinny matrix-matrix multiplication. Undocumented dummy arguments are identical to
       !! arguments of dbcsr_multiply (see dbcsr_mm, dbcsr_multiply_generic).
 
@@ -93,7 +93,7 @@ CONTAINS
          !! memory optimization: move data to matrix_c such that matrix_b is empty on return
          !! for internal use only
       INTEGER(int_8), DIMENSION(:, :), ALLOCATABLE, INTENT(OUT), OPTIONAL :: result_index
-      INTEGER, OPTIONAL, INTENT(IN)              :: io_unit
+      INTEGER, OPTIONAL, INTENT(IN)              :: unit_nr
          !! unit number for logging output
       LOGICAL, OPTIONAL, INTENT(IN)              :: log_verbose
          !! only for testing: verbose output
@@ -106,7 +106,7 @@ CONTAINS
       INTEGER, DIMENSION(2)                      :: pdims, pcoord, pcoord_sub, pdims_sub
       INTEGER(KIND=int_8), DIMENSION(3)          :: dims
       INTEGER                                    :: max_mm_dim, data_type, mp_comm, comm_tmp, &
-                                                    handle, handle2, io_unit_prv, nsplit, nsplit_opt, numproc, numproc_sub, iproc, &
+                                                    handle, handle2, unit_nr_prv, nsplit, nsplit_opt, numproc, numproc_sub, iproc, &
                                                     mp_comm_group, mp_comm_mm, split_rc, split_a, split_b, split_c, &
                                                     mp_comm_opt, batched_repl, max_mm_dim_batched, nsplit_batched
       CHARACTER(LEN=1)                           :: tr_case, transa_prv, transb_prv, transc_prv
@@ -124,11 +124,7 @@ CONTAINS
 
       NULLIFY (matrix_b_rs, matrix_a_rs, matrix_c_rs, matrix_a_mm, matrix_b_mm, matrix_c_mm)
 
-      IF (PRESENT(io_unit)) THEN
-         io_unit_prv = io_unit
-      ELSE
-         io_unit_prv = 0
-      ENDIF
+      unit_nr_prv = prep_output_unit(unit_nr)
 
       IF (PRESENT(simple_split)) THEN
          simple_split_prv = simple_split
@@ -209,23 +205,20 @@ CONTAINS
       dims_b = [dbcsr_tas_nblkrows_total(matrix_b), dbcsr_tas_nblkcols_total(matrix_b)]
       dims_c = [dbcsr_tas_nblkrows_total(matrix_c), dbcsr_tas_nblkcols_total(matrix_c)]
 
-      IF (PRESENT(io_unit)) THEN
-         IF (io_unit_prv .GT. 0) THEN
-            WRITE (io_unit_prv, '(A)') repeat("-", 80)
-            WRITE (io_unit_prv, '(A,1X,A,1X,A,1X,A,1X,A,1X,A)') "DBCSR TAS MATRIX MULTIPLICATION:", &
-               TRIM(matrix_a%matrix%name), 'x', TRIM(matrix_b%matrix%name), '=', TRIM(matrix_c%matrix%name)
-            WRITE (io_unit_prv, '(A)') repeat("-", 80)
-         ENDIF
-         IF (do_batched) THEN
-            IF (io_unit_prv > 0) THEN
-               WRITE (io_unit_prv, "(T2,A)") &
-                  "BATCHED PROCESSING OF MATMUL"
-               IF (batched_repl > 0) THEN
-                  WRITE (io_unit_prv, "(T4,A,T80,I1)") "reusing replicated matrix:", batched_repl
-               ENDIF
+      IF (unit_nr_prv .GT. 0) THEN
+         WRITE (unit_nr_prv, '(A)') repeat("-", 80)
+         WRITE (unit_nr_prv, '(A,1X,A,1X,A,1X,A,1X,A,1X,A)') "DBCSR TAS MATRIX MULTIPLICATION:", &
+            TRIM(matrix_a%matrix%name), 'x', TRIM(matrix_b%matrix%name), '=', TRIM(matrix_c%matrix%name)
+         WRITE (unit_nr_prv, '(A)') repeat("-", 80)
+      ENDIF
+      IF (do_batched) THEN
+         IF (unit_nr_prv > 0) THEN
+            WRITE (unit_nr_prv, "(T2,A)") &
+               "BATCHED PROCESSING OF MATMUL"
+            IF (batched_repl > 0) THEN
+               WRITE (unit_nr_prv, "(T4,A,T80,I1)") "reusing replicated matrix:", batched_repl
             ENDIF
          ENDIF
-
       ENDIF
 
       IF (transa_prv .EQ. dbcsr_transpose) THEN
@@ -246,8 +239,8 @@ CONTAINS
 
       tr_case = ''
 
-      IF (io_unit_prv > 0) THEN
-         WRITE (io_unit_prv, "(T2,A, 1X, I12, 1X, I12, 1X, I12)") "mm dims:", dims(1), dims(2), dims(3)
+      IF (unit_nr_prv > 0) THEN
+         WRITE (unit_nr_prv, "(T2,A, 1X, I12, 1X, I12, 1X, I12)") "mm dims:", dims(1), dims(2), dims(3)
       ENDIF
 
       CALL dbcsr_tas_get_split_info(dbcsr_tas_info(matrix_a), mp_comm=mp_comm)
@@ -268,13 +261,13 @@ CONTAINS
          nsplit = split_factor_estimate(max_mm_dim, nze_a, nze_b, nze_c, numproc)
          nsplit_opt = nsplit
 
-         IF (io_unit_prv > 0) THEN
-            WRITE (io_unit_prv, "(T2,A)") &
+         IF (unit_nr_prv > 0) THEN
+            WRITE (unit_nr_prv, "(T2,A)") &
                "MM PARAMETERS"
-            WRITE (io_unit_prv, "(T4,A,T68,I13)") "Est. number of matrix elements per CPU of result matrix:", &
+            WRITE (unit_nr_prv, "(T4,A,T68,I13)") "Est. number of matrix elements per CPU of result matrix:", &
                (nze_c + numproc - 1)/numproc
 
-            WRITE (io_unit_prv, "(T4,A,T68,I13)") "Est. optimal split factor:", nsplit
+            WRITE (unit_nr_prv, "(T4,A,T68,I13)") "Est. optimal split factor:", nsplit
          ENDIF
 
       ELSEIF (batched_repl > 0) THEN
@@ -282,10 +275,10 @@ CONTAINS
          nsplit_opt = nsplit
          max_mm_dim = max_mm_dim_batched
          simple_split_prv = simple_split_save
-         IF (io_unit_prv > 0) THEN
-            WRITE (io_unit_prv, "(T2,A)") &
+         IF (unit_nr_prv > 0) THEN
+            WRITE (unit_nr_prv, "(T2,A)") &
                "MM PARAMETERS"
-            WRITE (io_unit_prv, "(T4,A,T68,I13)") "Est. optimal split factor:", nsplit
+            WRITE (unit_nr_prv, "(T4,A,T68,I13)") "Est. optimal split factor:", nsplit
          ENDIF
 
       ELSE
@@ -305,7 +298,7 @@ CONTAINS
                                     opt_nsplit=batched_repl == 0, &
                                     split_rc_1=split_a, split_rc_2=split_c, &
                                     nodata2=nodata_3, comm_new=comm_tmp, &
-                                    move_data_1=move_a, unit_nr=io_unit)
+                                    move_data_1=move_a, unit_nr=unit_nr_prv)
 
          info = dbcsr_tas_info(matrix_a_rs)
          CALL dbcsr_tas_get_split_info(info, split_rowcol=split_rc, mp_comm=mp_comm)
@@ -319,11 +312,11 @@ CONTAINS
 
          tr_case = transa_prv
 
-         IF (io_unit_prv > 0) THEN
+         IF (unit_nr_prv > 0) THEN
             IF (tr_case == 'N') THEN
-               WRITE (io_unit_prv, "(T2,A, 1X, A)") "mm case:", "| x + = |"
+               WRITE (unit_nr_prv, "(T2,A, 1X, A)") "mm case:", "| x + = |"
             ELSE
-               WRITE (io_unit_prv, "(T2,A, 1X, A)") "mm case:", "--T x + = --T"
+               WRITE (unit_nr_prv, "(T2,A, 1X, A)") "mm case:", "--T x + = --T"
             ENDIF
          ENDIF
 
@@ -336,7 +329,7 @@ CONTAINS
                                     opt_nsplit=batched_repl == 0, &
                                     split_rc_1=split_a, split_rc_2=split_b, &
                                     comm_new=comm_tmp, &
-                                    move_data_1=move_a, move_data_2=move_b, unit_nr=io_unit)
+                                    move_data_1=move_a, move_data_2=move_b, unit_nr=unit_nr_prv)
 
          info = dbcsr_tas_info(matrix_a_rs)
          CALL dbcsr_tas_get_split_info(info, split_rowcol=split_rc, mp_comm=mp_comm)
@@ -354,11 +347,11 @@ CONTAINS
          new_c = matrix_c%do_batched == 0
          tr_case = transa_prv
 
-         IF (io_unit_prv > 0) THEN
+         IF (unit_nr_prv > 0) THEN
             IF (tr_case == 'N') THEN
-               WRITE (io_unit_prv, "(T2,A, 1X, A)") "mm case:", "-- x --T = +"
+               WRITE (unit_nr_prv, "(T2,A, 1X, A)") "mm case:", "-- x --T = +"
             ELSE
-               WRITE (io_unit_prv, "(T2,A, 1X, A)") "mm case:", "|T x | = +"
+               WRITE (unit_nr_prv, "(T2,A, 1X, A)") "mm case:", "|T x | = +"
             ENDIF
          ENDIF
 
@@ -371,7 +364,7 @@ CONTAINS
                                     opt_nsplit=batched_repl == 0, &
                                     split_rc_1=split_b, split_rc_2=split_c, &
                                     nodata2=nodata_3, comm_new=comm_tmp, &
-                                    move_data_1=move_b, unit_nr=io_unit)
+                                    move_data_1=move_b, unit_nr=unit_nr_prv)
          info = dbcsr_tas_info(matrix_b_rs)
          CALL dbcsr_tas_get_split_info(info, split_rowcol=split_rc, mp_comm=mp_comm)
 
@@ -384,11 +377,11 @@ CONTAINS
 
          tr_case = transb_prv
 
-         IF (io_unit_prv > 0) THEN
+         IF (unit_nr_prv > 0) THEN
             IF (tr_case == 'N') THEN
-               WRITE (io_unit_prv, "(T2,A, 1X, A)") "mm case:", "+ x -- = --"
+               WRITE (unit_nr_prv, "(T2,A, 1X, A)") "mm case:", "+ x -- = --"
             ELSE
-               WRITE (io_unit_prv, "(T2,A, 1X, A)") "mm case:", "+ x |T = |T"
+               WRITE (unit_nr_prv, "(T2,A, 1X, A)") "mm case:", "+ x |T = |T"
             ENDIF
          ENDIF
 
@@ -411,19 +404,19 @@ CONTAINS
          filter_eps_prv = 0.0_real_8
       ENDIF
 
-      IF (PRESENT(io_unit)) THEN
-         IF (io_unit_prv > 0) THEN
-            WRITE (io_unit_prv, "(T2, A)") "SPLIT / PARALLELIZATION INFO"
+      IF (unit_nr_prv /= 0) THEN
+         IF (unit_nr_prv > 0) THEN
+            WRITE (unit_nr_prv, "(T2, A)") "SPLIT / PARALLELIZATION INFO"
          ENDIF
-         CALL dbcsr_tas_write_split_info(info, io_unit_prv)
-         IF (ASSOCIATED(matrix_a_rs)) CALL dbcsr_tas_write_matrix_info(matrix_a_rs, io_unit_prv, full_info=log_verbose)
-         IF (ASSOCIATED(matrix_b_rs)) CALL dbcsr_tas_write_matrix_info(matrix_b_rs, io_unit_prv, full_info=log_verbose)
-         IF (ASSOCIATED(matrix_c_rs)) CALL dbcsr_tas_write_matrix_info(matrix_c_rs, io_unit_prv, full_info=log_verbose)
-         IF (io_unit_prv > 0) THEN
+         CALL dbcsr_tas_write_split_info(info, unit_nr_prv)
+         IF (ASSOCIATED(matrix_a_rs)) CALL dbcsr_tas_write_matrix_info(matrix_a_rs, unit_nr_prv, full_info=log_verbose)
+         IF (ASSOCIATED(matrix_b_rs)) CALL dbcsr_tas_write_matrix_info(matrix_b_rs, unit_nr_prv, full_info=log_verbose)
+         IF (ASSOCIATED(matrix_c_rs)) CALL dbcsr_tas_write_matrix_info(matrix_c_rs, unit_nr_prv, full_info=log_verbose)
+         IF (unit_nr_prv > 0) THEN
             IF (opt_pgrid) THEN
-               WRITE (io_unit_prv, "(T4, A, 1X, A)") "Change process grid:", "Yes"
+               WRITE (unit_nr_prv, "(T4, A, 1X, A)") "Change process grid:", "Yes"
             ELSE
-               WRITE (io_unit_prv, "(T4, A, 1X, A)") "Change process grid:", "No"
+               WRITE (unit_nr_prv, "(T4, A, 1X, A)") "Change process grid:", "No"
             ENDIF
          ENDIF
       ENDIF
@@ -451,9 +444,9 @@ CONTAINS
             CALL dbcsr_tas_destroy(matrix_b_rs)
             DEALLOCATE (matrix_b_rs)
          ENDIF
-         IF (PRESENT(io_unit)) THEN
-            CALL dbcsr_tas_write_dist(matrix_a_rs, io_unit)
-            CALL dbcsr_tas_write_dist(matrix_b_rep, io_unit, full_info=log_verbose)
+         IF (unit_nr_prv /= 0) THEN
+            CALL dbcsr_tas_write_dist(matrix_a_rs, unit_nr_prv)
+            CALL dbcsr_tas_write_dist(matrix_b_rep, unit_nr_prv, full_info=log_verbose)
          ENDIF
 
          CALL convert_to_new_pgrid(mp_comm_mm, matrix_a_rs%matrix, matrix_a_mm, optimize_pgrid=opt_pgrid, move_data=move_a)
@@ -512,8 +505,8 @@ CONTAINS
 
          IF (PRESENT(filter_eps)) CALL dbcsr_tas_filter(matrix_c_rs, filter_eps)
 
-         IF (PRESENT(io_unit)) THEN
-            CALL dbcsr_tas_write_dist(matrix_c_rs, io_unit)
+         IF (unit_nr_prv /= 0) THEN
+            CALL dbcsr_tas_write_dist(matrix_c_rs, unit_nr_prv)
          ENDIF
 
       CASE (2)
@@ -528,9 +521,9 @@ CONTAINS
             matrix_c_rep => matrix_c%mm_storage%store_batched_repl
          ENDIF
 
-         IF (PRESENT(io_unit)) THEN
-            CALL dbcsr_tas_write_dist(matrix_a_rs, io_unit)
-            CALL dbcsr_tas_write_dist(matrix_b_rs, io_unit)
+         IF (unit_nr_prv /= 0) THEN
+            CALL dbcsr_tas_write_dist(matrix_a_rs, unit_nr_prv)
+            CALL dbcsr_tas_write_dist(matrix_b_rs, unit_nr_prv)
          ENDIF
 
          CALL convert_to_new_pgrid(mp_comm_mm, matrix_a_rs%matrix, matrix_a_mm, optimize_pgrid=opt_pgrid, move_data=move_a)
@@ -567,8 +560,8 @@ CONTAINS
             IF (new_b) DEALLOCATE (matrix_b_rs)
          ENDIF
 
-         IF (PRESENT(io_unit)) THEN
-            CALL dbcsr_tas_write_dist(matrix_c_rep, io_unit, full_info=log_verbose)
+         IF (unit_nr_prv /= 0) THEN
+            CALL dbcsr_tas_write_dist(matrix_c_rep, unit_nr_prv, full_info=log_verbose)
          ENDIF
 
          IF (matrix_c%do_batched == 0) THEN
@@ -598,9 +591,9 @@ CONTAINS
             CALL dbcsr_tas_destroy(matrix_a_rs)
             DEALLOCATE (matrix_a_rs)
          ENDIF
-         IF (PRESENT(io_unit)) THEN
-            CALL dbcsr_tas_write_dist(matrix_a_rep, io_unit, full_info=log_verbose)
-            CALL dbcsr_tas_write_dist(matrix_b_rs, io_unit)
+         IF (unit_nr_prv /= 0) THEN
+            CALL dbcsr_tas_write_dist(matrix_a_rep, unit_nr_prv, full_info=log_verbose)
+            CALL dbcsr_tas_write_dist(matrix_b_rs, unit_nr_prv)
          ENDIF
 
          CALL convert_to_new_pgrid(mp_comm_mm, matrix_a_rep%matrix, matrix_a_mm, optimize_pgrid=opt_pgrid, &
@@ -658,8 +651,8 @@ CONTAINS
 
          IF (PRESENT(filter_eps)) CALL dbcsr_tas_filter(matrix_c_rs, filter_eps)
 
-         IF (PRESENT(io_unit)) THEN
-            CALL dbcsr_tas_write_dist(matrix_c_rs, io_unit)
+         IF (unit_nr_prv /= 0) THEN
+            CALL dbcsr_tas_write_dist(matrix_c_rs, unit_nr_prv)
          ENDIF
       END SELECT
 
@@ -704,10 +697,10 @@ CONTAINS
       IF (PRESENT(optimize_dist)) THEN
          IF (optimize_dist) CALL mp_comm_free(comm_tmp)
       ENDIF
-      IF (io_unit_prv > 0) THEN
-         WRITE (io_unit_prv, '(A)') repeat("-", 80)
-         WRITE (io_unit_prv, '(A,1X,A,1X,A,1X,A,1X,A,1X,A)') "TAS MATRIX MULTIPLICATION DONE"
-         WRITE (io_unit_prv, '(A)') repeat("-", 80)
+      IF (unit_nr_prv > 0) THEN
+         WRITE (unit_nr_prv, '(A)') repeat("-", 80)
+         WRITE (unit_nr_prv, '(A,1X,A,1X,A,1X,A,1X,A,1X,A)') "TAS MATRIX MULTIPLICATION DONE"
+         WRITE (unit_nr_prv, '(A)') repeat("-", 80)
       ENDIF
 
       CALL timestop(handle)
@@ -834,7 +827,7 @@ CONTAINS
       INTEGER(KIND=int_8)                        :: d1, d2
       CHARACTER(LEN=*), PARAMETER                :: routineN = 'reshape_mm_compatible', &
                                                     routineP = moduleN//':'//routineN
-      INTEGER                                    :: handle, mp_comm, numnodes, io_unit, &
+      INTEGER                                    :: handle, mp_comm, numnodes, unit_nr_prv, &
                                                     nsplit_prv, ref, split_rc_ref
       INTEGER, DIMENSION(2)                      :: pcoord, pdims
       LOGICAL                                    :: optimize_dist_prv, trans1_newdist, trans2_newdist
@@ -859,12 +852,9 @@ CONTAINS
          nodata2_prv = .FALSE.
       ENDIF
 
+      unit_nr_prv = prep_output_unit(unit_nr)
+
       NULLIFY (matrix1_out, matrix2_out)
-      IF (PRESENT(unit_nr)) THEN
-         io_unit = unit_nr
-      ELSE
-         io_unit = 0
-      ENDIF
 
       IF (PRESENT(optimize_dist)) THEN
          optimize_dist_prv = optimize_dist
@@ -906,25 +896,25 @@ CONTAINS
                            move_data=move_data_1, nodata=nodata1, opt_nsplit=opt_nsplit)
          CALL change_split(matrix2_in, matrix2_out, nsplit_prv, split_rc_2, new2, &
                            move_data=move_data_2, nodata=nodata2, opt_nsplit=opt_nsplit)
-         IF (io_unit > 0) THEN
-            WRITE (io_unit, "(T2,A,1X,A,1X,A,1X,A)") "No redistribution of", TRIM(matrix1_in%matrix%name), &
+         IF (unit_nr_prv > 0) THEN
+            WRITE (unit_nr_prv, "(T2,A,1X,A,1X,A,1X,A)") "No redistribution of", TRIM(matrix1_in%matrix%name), &
                "and", TRIM(matrix2_in%matrix%name)
             IF (new1) THEN
-               WRITE (io_unit, "(T2,A,1X,A,1X,A)") "Change split factor of", TRIM(matrix1_in%matrix%name), ": Yes"
+               WRITE (unit_nr_prv, "(T2,A,1X,A,1X,A)") "Change split factor of", TRIM(matrix1_in%matrix%name), ": Yes"
             ELSE
-               WRITE (io_unit, "(T2,A,1X,A,1X,A)") "Change split factor of", TRIM(matrix1_in%matrix%name), ": No"
+               WRITE (unit_nr_prv, "(T2,A,1X,A,1X,A)") "Change split factor of", TRIM(matrix1_in%matrix%name), ": No"
             ENDIF
             IF (new2) THEN
-               WRITE (io_unit, "(T2,A,1X,A,1X,A)") "Change split factor of", TRIM(matrix2_in%matrix%name), ": Yes"
+               WRITE (unit_nr_prv, "(T2,A,1X,A,1X,A)") "Change split factor of", TRIM(matrix2_in%matrix%name), ": Yes"
             ELSE
-               WRITE (io_unit, "(T2,A,1X,A,1X,A)") "Change split factor of", TRIM(matrix2_in%matrix%name), ": No"
+               WRITE (unit_nr_prv, "(T2,A,1X,A,1X,A)") "Change split factor of", TRIM(matrix2_in%matrix%name), ": No"
             ENDIF
          ENDIF
       ELSE
 
          IF (optimize_dist_prv) THEN
-            IF (io_unit > 0) THEN
-               WRITE (io_unit, "(T2,A,1X,A,1X,A,1X,A)") "Optimizing distribution of", TRIM(matrix1_in%matrix%name), &
+            IF (unit_nr_prv > 0) THEN
+               WRITE (unit_nr_prv, "(T2,A,1X,A,1X,A,1X,A)") "Optimizing distribution of", TRIM(matrix1_in%matrix%name), &
                   "and", TRIM(matrix2_in%matrix%name)
             ENDIF
 
@@ -1002,8 +992,8 @@ CONTAINS
          ELSE
             SELECT CASE (ref)
             CASE (1)
-               IF (io_unit > 0) THEN
-                  WRITE (io_unit, "(T2,A,1X,A)") "Redistribution of", TRIM(matrix2_in%matrix%name)
+               IF (unit_nr_prv > 0) THEN
+                  WRITE (unit_nr_prv, "(T2,A,1X,A)") "Redistribution of", TRIM(matrix2_in%matrix%name)
                ENDIF
 
                CALL change_split(matrix1_in, matrix1_out, nsplit_prv, split_rc_1, new1, &
@@ -1014,8 +1004,8 @@ CONTAINS
                                         nodata=nodata2, move_data=move_data_2)
                new2 = .TRUE.
             CASE (2)
-               IF (io_unit > 0) THEN
-                  WRITE (io_unit, "(T2,A,1X,A)") "Redistribution of", TRIM(matrix1_in%matrix%name)
+               IF (unit_nr_prv > 0) THEN
+                  WRITE (unit_nr_prv, "(T2,A,1X,A)") "Redistribution of", TRIM(matrix1_in%matrix%name)
                ENDIF
 
                CALL change_split(matrix2_in, matrix2_out, nsplit_prv, split_rc_2, new2, &
@@ -1127,23 +1117,19 @@ CONTAINS
       CALL timestop(handle)
    END SUBROUTINE
 
-   FUNCTION dist_compatible(mat_a, mat_b, split_rc_a, split_rc_b, io_unit)
+   FUNCTION dist_compatible(mat_a, mat_b, split_rc_a, split_rc_b, unit_nr)
       !! Check whether matrices have same distribution and same split.
       TYPE(dbcsr_tas_type), INTENT(IN)           :: mat_a, mat_b
       INTEGER, INTENT(IN)                        :: split_rc_a, split_rc_b
-      INTEGER, INTENT(IN), OPTIONAL              :: io_unit
+      INTEGER, INTENT(IN), OPTIONAL              :: unit_nr
       LOGICAL                                    :: dist_compatible
 
       INTEGER                                    :: res, same_local_rowcols, split_check
       TYPE(dbcsr_tas_split_info)                 :: info_a, info_b
-      INTEGER                                    :: io_unit_prv, numproc
+      INTEGER                                    :: unit_nr_prv, numproc
       INTEGER, DIMENSION(2)                      :: pdims_a, pdims_b, pcoord_a, pcoord_b
 
-      IF (PRESENT(io_unit)) THEN
-         io_unit_prv = io_unit
-      ELSE
-         io_unit_prv = 0
-      ENDIF
+      unit_nr_prv = prep_output_unit(unit_nr)
 
       dist_compatible = .FALSE.
 
@@ -1168,34 +1154,34 @@ CONTAINS
          RETURN
       ENDIF
 
-      IF (io_unit_prv > 0) THEN
-         WRITE (io_unit_prv, *) "mp comm compatible"
+      IF (unit_nr_prv > 0) THEN
+         WRITE (unit_nr_prv, *) "mp comm compatible"
       ENDIF
 
       IF (mat_a%dist%info%split_rowcol == mat_b%dist%info%split_rowcol) THEN
 
-         IF (io_unit_prv > 0) THEN
-            WRITE (io_unit_prv, *) "split compatible"
+         IF (unit_nr_prv > 0) THEN
+            WRITE (unit_nr_prv, *) "split compatible"
          ENDIF
 
          same_local_rowcols = MERGE(1, 0, array_eq(mat_a%dist%local_rowcols, mat_b%dist%local_rowcols))
          CALL mp_sum(same_local_rowcols, info_a%mp_comm)
 
          IF (same_local_rowcols == numproc) THEN
-            IF (io_unit_prv > 0) THEN
-               WRITE (io_unit_prv, *) "local rowcols compatible"
+            IF (unit_nr_prv > 0) THEN
+               WRITE (unit_nr_prv, *) "local rowcols compatible"
             ENDIF
             dist_compatible = .TRUE.
          ELSE
-            IF (io_unit_prv > 0) THEN
-               WRITE (io_unit_prv, *) "local rowcols A", mat_a%dist%local_rowcols
-               WRITE (io_unit_prv, *) "local rowcols B", mat_b%dist%local_rowcols
+            IF (unit_nr_prv > 0) THEN
+               WRITE (unit_nr_prv, *) "local rowcols A", mat_a%dist%local_rowcols
+               WRITE (unit_nr_prv, *) "local rowcols B", mat_b%dist%local_rowcols
             ENDIF
          ENDIF
       ENDIF
 
-      IF (io_unit_prv > 0) THEN
-         WRITE (io_unit_prv, *) "is compatible?", dist_compatible
+      IF (unit_nr_prv > 0) THEN
+         WRITE (unit_nr_prv, *) "is compatible?", dist_compatible
       ENDIF
 
    END FUNCTION
@@ -1281,14 +1267,14 @@ CONTAINS
    END SUBROUTINE
 
    SUBROUTINE dbcsr_tas_result_index(transa, transb, transc, matrix_a, matrix_b, matrix_c, filter_eps, &
-                                     io_unit, blk_ind, nze, retain_sparsity)
+                                     unit_nr, blk_ind, nze, retain_sparsity)
       !! Estimate sparsity pattern of C resulting from A x B = C by multiplying the block norms of A and B
       !! Same dummy arguments as dbcsr_tas_multiply
       CHARACTER(LEN=1), INTENT(IN)               :: transa, transb, transc
       TYPE(dbcsr_tas_type), INTENT(INOUT), TARGET        :: matrix_a, matrix_b, matrix_c
       TYPE(dbcsr_tas_type), POINTER                      :: matrix_a_bnorm, matrix_b_bnorm, matrix_c_bnorm
       REAL(KIND=real_8), INTENT(IN), OPTIONAL    :: filter_eps
-      INTEGER, INTENT(IN), OPTIONAL              :: io_unit
+      INTEGER, INTENT(IN), OPTIONAL              :: unit_nr
       INTEGER(int_8), DIMENSION(:, :), ALLOCATABLE, INTENT(OUT), OPTIONAL :: blk_ind
       LOGICAL, INTENT(IN), OPTIONAL :: retain_sparsity
       INTEGER(int_8), INTENT(OUT), OPTIONAL :: nze
@@ -1317,7 +1303,7 @@ CONTAINS
          CALL dbcsr_tas_multiply(transa, transb, transc, dbcsr_scalar(1.0_real_8), matrix_a_bnorm, &
                                  matrix_b_bnorm, dbcsr_scalar(0.0_real_8), matrix_c_bnorm, &
                                  filter_eps=filter_eps, move_data_a=.TRUE., move_data_b=.TRUE., &
-                                 simple_split=.TRUE., io_unit=io_unit)
+                                 simple_split=.TRUE., unit_nr=unit_nr)
          CALL dbcsr_tas_destroy(matrix_a_bnorm)
          CALL dbcsr_tas_destroy(matrix_b_bnorm)
 

--- a/src/tas/dbcsr_tas_mm.F
+++ b/src/tas/dbcsr_tas_mm.F
@@ -33,7 +33,7 @@ MODULE dbcsr_tas_mm
       dbcsr_tas_distribution_type, dbcsr_tas_split_info, dbcsr_tas_type, dbcsr_tas_iterator
    USE dbcsr_tas_global, ONLY: &
       dbcsr_tas_dist_cyclic, dbcsr_tas_dist_arb, dbcsr_tas_distribution, dbcsr_tas_dist_arb_default, &
-      dbcsr_tas_rowcol_data, dbcsr_tas_blk_size_one, cyclic_weighted_dist
+      dbcsr_tas_rowcol_data, dbcsr_tas_blk_size_one, dbcsr_tas_default_distvec
    USE dbcsr_tas_reshape_ops, ONLY: &
       dbcsr_tas_merge, dbcsr_tas_replicate, dbcsr_tas_reshape
    USE dbcsr_tas_split, ONLY: &
@@ -1493,8 +1493,8 @@ CONTAINS
       CALL mp_environ(nproc, pdims, pcoord, mp_comm_cart)
 
       ALLOCATE (row_dist(nbrows), col_dist(nbcols))
-      CALL cyclic_weighted_dist(nbrows, pdims(1), rbsize, row_dist)
-      CALL cyclic_weighted_dist(nbcols, pdims(2), rcsize, col_dist)
+      CALL dbcsr_tas_default_distvec(nbrows, pdims(1), rbsize, row_dist)
+      CALL dbcsr_tas_default_distvec(nbcols, pdims(2), rcsize, col_dist)
 
       mp_obj = dbcsr_mp_environ(mp_comm_cart)
       CALL dbcsr_distribution_new(dist, mp_obj, row_dist, col_dist, reuse_arrays=.TRUE.)

--- a/src/tas/dbcsr_tas_test.F
+++ b/src/tas/dbcsr_tas_test.F
@@ -23,7 +23,8 @@ MODULE dbcsr_tas_test
    USE dbcsr_tas_types, ONLY: dbcsr_tas_distribution_type, &
                               dbcsr_tas_type
    USE dbcsr_tas_global, ONLY: dbcsr_tas_blk_size_arb, &
-                               dbcsr_tas_dist_cyclic
+                               dbcsr_tas_dist_cyclic, &
+                               dbcsr_tas_default_distvec
    USE dbcsr_tas_mm, ONLY: dbcsr_tas_multiply
    USE dbcsr_tas_split, ONLY: dbcsr_tas_mp_comm, &
                               dbcsr_tas_get_split_info
@@ -208,12 +209,15 @@ CONTAINS
          npdims(:) = 0
          CALL mp_cart_create(mp_comm, 2, npdims, myploc, comm_dbcsr)
 
-         CALL random_dist(rd_a, dbcsr_nblkrows_total(dbcsr_a), npdims(1))
-         CALL random_dist(cd_a, dbcsr_nblkcols_total(dbcsr_a), npdims(2))
-         CALL random_dist(rd_b, dbcsr_nblkrows_total(dbcsr_b), npdims(1))
-         CALL random_dist(cd_b, dbcsr_nblkcols_total(dbcsr_b), npdims(2))
-         CALL random_dist(rd_c, dbcsr_nblkrows_total(dbcsr_c), npdims(1))
-         CALL random_dist(cd_c, dbcsr_nblkcols_total(dbcsr_c), npdims(2))
+         ALLOCATE (rd_a(dbcsr_nblkrows_total(dbcsr_a))); ALLOCATE (cd_a(dbcsr_nblkcols_total(dbcsr_a)))
+         ALLOCATE (rd_b(dbcsr_nblkrows_total(dbcsr_b))); ALLOCATE (cd_b(dbcsr_nblkcols_total(dbcsr_b)))
+         ALLOCATE (rd_c(dbcsr_nblkrows_total(dbcsr_c))); ALLOCATE (cd_c(dbcsr_nblkcols_total(dbcsr_c)))
+         CALL dbcsr_tas_default_distvec(INT(dbcsr_nblkrows_total(dbcsr_a)), npdims(1), dbcsr_row_block_sizes(dbcsr_a), rd_a)
+         CALL dbcsr_tas_default_distvec(INT(dbcsr_nblkcols_total(dbcsr_a)), npdims(2), dbcsr_col_block_sizes(dbcsr_a), cd_a)
+         CALL dbcsr_tas_default_distvec(INT(dbcsr_nblkrows_total(dbcsr_b)), npdims(1), dbcsr_row_block_sizes(dbcsr_b), rd_b)
+         CALL dbcsr_tas_default_distvec(INT(dbcsr_nblkcols_total(dbcsr_b)), npdims(2), dbcsr_col_block_sizes(dbcsr_b), cd_b)
+         CALL dbcsr_tas_default_distvec(INT(dbcsr_nblkrows_total(dbcsr_c)), npdims(1), dbcsr_row_block_sizes(dbcsr_c), rd_c)
+         CALL dbcsr_tas_default_distvec(INT(dbcsr_nblkcols_total(dbcsr_c)), npdims(2), dbcsr_col_block_sizes(dbcsr_c), cd_c)
 
          mp_environ_tmp = dbcsr_mp_environ(comm_dbcsr)
          CALL dbcsr_distribution_new(dist_a, mp_environ_tmp, rd_a, cd_a, reuse_arrays=.TRUE.)
@@ -291,7 +295,7 @@ CONTAINS
 
       CALL dbcsr_tas_get_split_info(dbcsr_tas_info(matrix_a), mp_comm=mp_comm)
       CALL mp_environ(numnodes, mynode, mp_comm)
-      io_unit = 0
+      io_unit = -1
       IF (mynode .EQ. 0) io_unit = unit_nr
 
       CALL dbcsr_tas_multiply(transa, transb, transc, dbcsr_scalar(1.0_real_8), matrix_a, matrix_b, &
@@ -305,12 +309,15 @@ CONTAINS
       npdims(:) = 0
       CALL mp_cart_create(mp_comm, 2, npdims, myploc, comm_dbcsr)
 
-      CALL random_dist(rd_a, dbcsr_nblkrows_total(dbcsr_a), npdims(1))
-      CALL random_dist(cd_a, dbcsr_nblkcols_total(dbcsr_a), npdims(2))
-      CALL random_dist(rd_b, dbcsr_nblkrows_total(dbcsr_b), npdims(1))
-      CALL random_dist(cd_b, dbcsr_nblkcols_total(dbcsr_b), npdims(2))
-      CALL random_dist(rd_c, dbcsr_nblkrows_total(dbcsr_c), npdims(1))
-      CALL random_dist(cd_c, dbcsr_nblkcols_total(dbcsr_c), npdims(2))
+      ALLOCATE (rd_a(dbcsr_nblkrows_total(dbcsr_a))); ALLOCATE (cd_a(dbcsr_nblkcols_total(dbcsr_a)))
+      ALLOCATE (rd_b(dbcsr_nblkrows_total(dbcsr_b))); ALLOCATE (cd_b(dbcsr_nblkcols_total(dbcsr_b)))
+      ALLOCATE (rd_c(dbcsr_nblkrows_total(dbcsr_c))); ALLOCATE (cd_c(dbcsr_nblkcols_total(dbcsr_c)))
+      CALL dbcsr_tas_default_distvec(INT(dbcsr_nblkrows_total(dbcsr_a)), npdims(1), dbcsr_row_block_sizes(dbcsr_a), rd_a)
+      CALL dbcsr_tas_default_distvec(INT(dbcsr_nblkcols_total(dbcsr_a)), npdims(2), dbcsr_col_block_sizes(dbcsr_a), cd_a)
+      CALL dbcsr_tas_default_distvec(INT(dbcsr_nblkrows_total(dbcsr_b)), npdims(1), dbcsr_row_block_sizes(dbcsr_b), rd_b)
+      CALL dbcsr_tas_default_distvec(INT(dbcsr_nblkcols_total(dbcsr_b)), npdims(2), dbcsr_col_block_sizes(dbcsr_b), cd_b)
+      CALL dbcsr_tas_default_distvec(INT(dbcsr_nblkrows_total(dbcsr_c)), npdims(1), dbcsr_row_block_sizes(dbcsr_c), rd_c)
+      CALL dbcsr_tas_default_distvec(INT(dbcsr_nblkcols_total(dbcsr_c)), npdims(2), dbcsr_col_block_sizes(dbcsr_c), cd_c)
 
       mp_environ_tmp = dbcsr_mp_environ(comm_dbcsr)
       CALL dbcsr_distribution_new(dist_a, mp_environ_tmp, rd_a, cd_a, reuse_arrays=.TRUE.)
@@ -416,19 +423,5 @@ CONTAINS
          block_sizes(d) = sizes(size_i)
       ENDDO
    END SUBROUTINE
-
-   SUBROUTINE random_dist(dist_array, dist_size, nbins)
-      !! Create random distribution
-      INTEGER, DIMENSION(:), INTENT(out), POINTER        :: dist_array
-      INTEGER, INTENT(in)                                :: dist_size, nbins
-
-      INTEGER                                            :: i
-
-      ALLOCATE (dist_array(dist_size))
-      DO i = 1, dist_size
-         dist_array(i) = MODULO(nbins - i, nbins)
-      END DO
-
-   END SUBROUTINE random_dist
 
 END MODULE

--- a/src/tas/dbcsr_tas_test.F
+++ b/src/tas/dbcsr_tas_test.F
@@ -191,7 +191,7 @@ CONTAINS
       CALL timeset("benchmark_tas_mm", handle1)
       CALL dbcsr_tas_multiply(transa, transb, transc, dbcsr_scalar(1.0_real_8), matrix_a, matrix_b, &
                               dbcsr_scalar(0.0_real_8), matrix_c, &
-                              filter_eps=filter_eps, io_unit=io_unit)
+                              filter_eps=filter_eps, unit_nr=io_unit)
       CALL timestop(handle1)
       IF (PRESENT(io_unit)) THEN
       IF (io_unit > 0) THEN
@@ -296,7 +296,7 @@ CONTAINS
 
       CALL dbcsr_tas_multiply(transa, transb, transc, dbcsr_scalar(1.0_real_8), matrix_a, matrix_b, &
                               dbcsr_scalar(0.0_real_8), matrix_c, &
-                              filter_eps=filter_eps, io_unit=io_unit, log_verbose=log_verbose, optimize_dist=.TRUE.)
+                              filter_eps=filter_eps, unit_nr=io_unit, log_verbose=log_verbose, optimize_dist=.TRUE.)
 
       CALL dbcsr_tas_convert_to_dbcsr(matrix_a, dbcsr_a)
       CALL dbcsr_tas_convert_to_dbcsr(matrix_b, dbcsr_b)

--- a/src/tensors/dbcsr_tensor.F
+++ b/src/tensors/dbcsr_tensor.F
@@ -48,9 +48,9 @@ MODULE dbcsr_tensor
       blk_dims_tensor, dbcsr_t_hold, dbcsr_t_pgrid_type, mp_environ_pgrid, dbcsr_t_filter, &
       dbcsr_t_clear, dbcsr_t_finalize, dbcsr_t_get_num_blocks, dbcsr_t_scale, &
       dbcsr_t_get_num_blocks_total, dbcsr_t_get_info, ndims_matrix_row, ndims_matrix_column, &
-      dbcsr_t_max_nblks_local
+      dbcsr_t_max_nblks_local, dbcsr_t_default_distvec
    USE dbcsr_kinds, ONLY: &
-      ${uselist(dtype_float_prec)}$, default_string_length, int_8
+      ${uselist(dtype_float_prec)}$, default_string_length, int_8, dp
    USE dbcsr_mpiwrap, ONLY: &
       mp_environ, mp_max, mp_sum
    USE dbcsr_toollib, ONLY: &
@@ -456,6 +456,8 @@ CONTAINS
          !! enforce the sparsity pattern of the existing tensor_3; default is no
       INTEGER, OPTIONAL, INTENT(IN)                  :: unit_nr
          !! output unit for logging
+         !! set it to -1 on ranks that should not write (and any valid unit number on ranks that should write output)
+         !! if 0 on ALL ranks, no output is written
       LOGICAL, INTENT(IN), OPTIONAL                  :: log_verbose
          !! verbose logging (for testing only)
 
@@ -549,7 +551,7 @@ CONTAINS
       CHARACTER(LEN=1)                               :: trans_1, trans_2, trans_3
       LOGICAL                                        :: new_1, new_2, new_3, move_data_1, move_data_2
       INTEGER                                        :: ndims1, ndims2, ndims3
-      INTEGER                                        :: occ_1, occ_2, write_log
+      INTEGER                                        :: occ_1, occ_2
       INTEGER, DIMENSION(:), ALLOCATABLE             :: dims1, dims2, dims3
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_contract_expert', &
@@ -1366,36 +1368,6 @@ CONTAINS
       CALL dbcsr_tas_info_hold(opt_pgrid%tas_split_info)
    END FUNCTION
 
-   SUBROUTINE new_default_dist(nel, nbin, weights, dist)
-      !! Default distribution that is more or less cyclic (round robin) and load balanced with different
-      !! weights for each element.
-      !! This is used for creating adhoc distributions whenever tensors are mapped to new grids.
-
-      INTEGER, INTENT(IN) :: nel
-      INTEGER, INTENT(IN) :: nbin
-      INTEGER, DIMENSION(nel), INTENT(IN)            :: weights
-      INTEGER, DIMENSION(:), ALLOCATABLE, INTENT(OUT)            :: dist
-      INTEGER, DIMENSION(nbin)                        :: occup
-      INTEGER                :: iel, ibin
-      INTEGER                :: niter
-
-      ALLOCATE (dist(nel))
-      occup(:) = 0
-      ibin = 0
-      DO iel = 1, nel
-         niter = 0
-         ibin = MOD(ibin + 1, nbin)
-         DO WHILE (occup(ibin + 1) + weights(iel) .GE. MAXVAL(occup))
-            IF (MINLOC(occup, DIM=1) == ibin + 1) EXIT
-            ibin = MOD(ibin + 1, nbin)
-            niter = niter + 1
-         ENDDO
-         dist(iel) = ibin
-         occup(ibin + 1) = occup(ibin + 1) + weights(iel)
-      ENDDO
-
-   END SUBROUTINE
-
    SUBROUTINE dbcsr_t_remap(tensor_in, map1_2d, map2_2d, tensor_out, comm_2d, dist1, dist2, &
                             mp_dims_1, mp_dims_2, name, nodata, move_data)
       !! Copy tensor to tensor with modified index mapping
@@ -1470,7 +1442,8 @@ CONTAINS
          ENDIF
 
          IF (.NOT. ALLOCATED(nd_dist_${idim}$)) THEN
-            CALL new_default_dist(SIZE(blk_sizes_${idim}$), pdims(${idim}$), blk_sizes_${idim}$, nd_dist_${idim}$)
+            ALLOCATE (nd_dist_${idim}$ (SIZE(blk_sizes_${idim}$)))
+            CALL dbcsr_t_default_distvec(SIZE(blk_sizes_${idim}$), pdims(${idim}$), blk_sizes_${idim}$, nd_dist_${idim}$)
          ENDIF
 #:endfor
          CALL dbcsr_t_distribution_new_expert(dist, comm_nd, map1_2d, map2_2d, &

--- a/src/tensors/dbcsr_tensor.F
+++ b/src/tensors/dbcsr_tensor.F
@@ -66,7 +66,7 @@ MODULE dbcsr_tensor
    USE dbcsr_tensor_split, ONLY: &
       dbcsr_t_split_copyback, dbcsr_t_make_compatible_blocks, dbcsr_t_crop
    USE dbcsr_tensor_io, ONLY: &
-      dbcsr_t_write_tensor_info, dbcsr_t_write_tensor_dist
+      dbcsr_t_write_tensor_info, dbcsr_t_write_tensor_dist, prep_output_unit
    USE dbcsr_dist_operations, ONLY: &
       checker_tr
    USE dbcsr_toollib, ONLY: &
@@ -124,7 +124,7 @@ CONTAINS
 
       TYPE(dbcsr_t_type), POINTER                    :: in_tmp_1 => NULL(), in_tmp_2 => NULL(), &
                                                         in_tmp_3 => NULL(), out_tmp_1 => NULL()
-      INTEGER                                        :: handle
+      INTEGER                                        :: handle, unit_nr_prv
       INTEGER, DIMENSION(:), ALLOCATABLE             :: map1_in_1, map1_in_2, map2_in_1, map2_in_2
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_copy', &
@@ -138,6 +138,8 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       DBCSR_ASSERT(tensor_out%valid)
+
+      unit_nr_prv = prep_output_unit(unit_nr)
 
       IF (PRESENT(move_data)) THEN
          move_prv = move_data
@@ -236,7 +238,7 @@ CONTAINS
       ENDIF
 
       IF (new_out_1) THEN
-         IF (PRESENT(unit_nr)) THEN
+         IF (unit_nr_prv /= 0) THEN
             CALL dbcsr_t_write_tensor_dist(out_tmp_1, unit_nr)
          ENDIF
          CALL dbcsr_t_split_copyback(out_tmp_1, tensor_out, summation)
@@ -537,7 +539,7 @@ CONTAINS
       INTEGER(int_8), DIMENSION(:, :), ALLOCATABLE  :: result_index_2d
       LOGICAL                                        :: assert_stmt
       INTEGER                                        :: data_type, max_mm_dim, max_tensor, mp_comm, &
-                                                        iblk, nblk
+                                                        iblk, nblk, unit_nr_prv
       INTEGER, DIMENSION(SIZE(contract_1))           :: contract_1_mod
       INTEGER, DIMENSION(SIZE(notcontract_1))        :: notcontract_1_mod
       INTEGER, DIMENSION(SIZE(contract_2))           :: contract_2_mod
@@ -547,7 +549,7 @@ CONTAINS
       CHARACTER(LEN=1)                               :: trans_1, trans_2, trans_3
       LOGICAL                                        :: new_1, new_2, new_3, move_data_1, move_data_2
       INTEGER                                        :: ndims1, ndims2, ndims3
-      INTEGER                                        :: occ_1, occ_2
+      INTEGER                                        :: occ_1, occ_2, write_log
       INTEGER, DIMENSION(:), ALLOCATABLE             :: dims1, dims2, dims3
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_contract_expert', &
@@ -587,6 +589,8 @@ CONTAINS
 
       assert_stmt = dbcsr_t_get_data_type(tensor_1) .EQ. dbcsr_t_get_data_type(tensor_2)
       DBCSR_ASSERT(assert_stmt)
+
+      unit_nr_prv = prep_output_unit(unit_nr)
 
       IF (PRESENT(move_data)) THEN
          move_data_1 = move_data
@@ -646,17 +650,17 @@ CONTAINS
          RETURN
       ENDIF
 
-      IF (PRESENT(unit_nr)) THEN
-         IF (unit_nr > 0) THEN
-            WRITE (unit_nr, '(A)') repeat("-", 80)
-            WRITE (unit_nr, '(A,1X,A,1X,A,1X,A,1X,A,1X,A)') "DBCSR TENSOR CONTRACTION:", &
+      IF (unit_nr_prv /= 0) THEN
+         IF (unit_nr_prv > 0) THEN
+            WRITE (unit_nr_prv, '(A)') repeat("-", 80)
+            WRITE (unit_nr_prv, '(A,1X,A,1X,A,1X,A,1X,A,1X,A)') "DBCSR TENSOR CONTRACTION:", &
                TRIM(tensor_crop_1%name), 'x', TRIM(tensor_crop_2%name), '=', TRIM(tensor_3%name)
-            WRITE (unit_nr, '(A)') repeat("-", 80)
+            WRITE (unit_nr_prv, '(A)') repeat("-", 80)
          ENDIF
-         CALL dbcsr_t_write_tensor_info(tensor_crop_1, unit_nr, full_info=log_verbose)
-         CALL dbcsr_t_write_tensor_dist(tensor_crop_1, unit_nr)
-         CALL dbcsr_t_write_tensor_info(tensor_crop_2, unit_nr, full_info=log_verbose)
-         CALL dbcsr_t_write_tensor_dist(tensor_crop_2, unit_nr)
+         CALL dbcsr_t_write_tensor_info(tensor_crop_1, unit_nr_prv, full_info=log_verbose)
+         CALL dbcsr_t_write_tensor_dist(tensor_crop_1, unit_nr_prv)
+         CALL dbcsr_t_write_tensor_info(tensor_crop_2, unit_nr_prv, full_info=log_verbose)
+         CALL dbcsr_t_write_tensor_dist(tensor_crop_2, unit_nr_prv)
       ENDIF
 
       data_type = dbcsr_t_get_data_type(tensor_crop_1)
@@ -677,13 +681,11 @@ CONTAINS
       indchar3(map_1) = indchar1(notcontract_1)
       indchar3(map_2) = indchar2(notcontract_2)
 
-      IF (PRESENT(unit_nr)) CALL dbcsr_t_print_contraction_index(tensor_crop_1, indchar1, &
+      IF (unit_nr_prv /= 0) CALL dbcsr_t_print_contraction_index(tensor_crop_1, indchar1, &
                                                                  tensor_crop_2, indchar2, &
-                                                                 tensor_3, indchar3, unit_nr)
-      IF (PRESENT(unit_nr)) THEN
-         IF (unit_nr > 0) THEN
-            WRITE (unit_nr, '(T2,A)') "aligning tensor index with data"
-         ENDIF
+                                                                 tensor_3, indchar3, unit_nr_prv)
+      IF (unit_nr_prv > 0) THEN
+         WRITE (unit_nr_prv, '(T2,A)') "aligning tensor index with data"
       ENDIF
 
       CALL align_tensor(tensor_crop_1, contract_1, notcontract_1, &
@@ -695,9 +697,9 @@ CONTAINS
       CALL align_tensor(tensor_3, map_1, map_2, &
                         tensor_algn_3, map_1_mod, map_2_mod, indchar3, indchar3_mod)
 
-      IF (PRESENT(unit_nr)) CALL dbcsr_t_print_contraction_index(tensor_algn_1, indchar1_mod, &
+      IF (unit_nr_prv /= 0) CALL dbcsr_t_print_contraction_index(tensor_algn_1, indchar1_mod, &
                                                                  tensor_algn_2, indchar2_mod, &
-                                                                 tensor_algn_3, indchar3_mod, unit_nr)
+                                                                 tensor_algn_3, indchar3_mod, unit_nr_prv)
 
       ALLOCATE (dims1(ndims1))
       ALLOCATE (dims2(ndims2))
@@ -715,11 +717,9 @@ CONTAINS
       max_tensor = MAXLOC([PRODUCT(INT(dims1, int_8)), PRODUCT(INT(dims2, int_8)), PRODUCT(INT(dims3, int_8))], DIM=1)
       SELECT CASE (max_mm_dim)
       CASE (1)
-         IF (PRESENT(unit_nr)) THEN
-            IF (unit_nr > 0) THEN
-               WRITE (unit_nr, '(T2,A)') "large tensors: 1, 3; small tensor: 2"
-               WRITE (unit_nr, '(T2,A)') "sorting contraction indices"
-            ENDIF
+         IF (unit_nr_prv > 0) THEN
+            WRITE (unit_nr_prv, '(T2,A)') "large tensors: 1, 3; small tensor: 2"
+            WRITE (unit_nr_prv, '(T2,A)') "sorting contraction indices"
          ENDIF
          CALL index_linked_sort(contract_1_mod, contract_2_mod)
          CALL index_linked_sort(map_2_mod, notcontract_2_mod)
@@ -735,17 +735,15 @@ CONTAINS
          CALL reshape_mm_compatible(tensor_algn_1, tensor_algn_3, tensor_contr_1, tensor_contr_3, &
                                     contract_1_mod, notcontract_1_mod, map_2_mod, map_1_mod, &
                                     trans_1, trans_3, new_1, new_3, nodata2=nodata_3, optimize_dist=optimize_dist, &
-                                    move_data_1=move_data_1, unit_nr=unit_nr)
+                                    move_data_1=move_data_1, unit_nr=unit_nr_prv)
 
          CALL reshape_mm_small(tensor_algn_2, contract_2_mod, notcontract_2_mod, tensor_contr_2, trans_2, &
-                               new_2, move_data=move_data_2, unit_nr=unit_nr)
+                               new_2, move_data=move_data_2, unit_nr=unit_nr_prv)
 
       CASE (2)
-         IF (PRESENT(unit_nr)) THEN
-            IF (unit_nr > 0) THEN
-               WRITE (unit_nr, '(T2,A)') "large tensors: 1, 2; small tensor: 3"
-               WRITE (unit_nr, '(T2,A)') "sorting contraction indices"
-            ENDIF
+         IF (unit_nr_prv > 0) THEN
+            WRITE (unit_nr_prv, '(T2,A)') "large tensors: 1, 2; small tensor: 3"
+            WRITE (unit_nr_prv, '(T2,A)') "sorting contraction indices"
          ENDIF
 
          CALL index_linked_sort(notcontract_1_mod, map_1_mod)
@@ -762,18 +760,16 @@ CONTAINS
          CALL reshape_mm_compatible(tensor_algn_1, tensor_algn_2, tensor_contr_1, tensor_contr_2, &
                                     notcontract_1_mod, contract_1_mod, notcontract_2_mod, contract_2_mod, &
                                     trans_1, trans_2, new_1, new_2, optimize_dist=optimize_dist, &
-                                    move_data_1=move_data_1, move_data_2=move_data_2, unit_nr=unit_nr)
+                                    move_data_1=move_data_1, move_data_2=move_data_2, unit_nr=unit_nr_prv)
          CALL invert_transpose_flag(trans_1)
 
          CALL reshape_mm_small(tensor_algn_3, map_1_mod, map_2_mod, tensor_contr_3, trans_3, &
-                               new_3, nodata=nodata_3, unit_nr=unit_nr)
+                               new_3, nodata=nodata_3, unit_nr=unit_nr_prv)
 
       CASE (3)
-         IF (PRESENT(unit_nr)) THEN
-            IF (unit_nr > 0) THEN
-               WRITE (unit_nr, '(T2,A)') "large tensors: 2, 3; small tensor: 1"
-               WRITE (unit_nr, '(T2,A)') "sorting contraction indices"
-            ENDIF
+         IF (unit_nr_prv > 0) THEN
+            WRITE (unit_nr_prv, '(T2,A)') "large tensors: 2, 3; small tensor: 1"
+            WRITE (unit_nr_prv, '(T2,A)') "sorting contraction indices"
          ENDIF
          CALL index_linked_sort(map_1_mod, notcontract_1_mod)
          CALL index_linked_sort(contract_2_mod, contract_1_mod)
@@ -789,24 +785,24 @@ CONTAINS
          CALL reshape_mm_compatible(tensor_algn_2, tensor_algn_3, tensor_contr_2, tensor_contr_3, &
                                     contract_2_mod, notcontract_2_mod, map_1_mod, map_2_mod, &
                                     trans_2, trans_3, new_2, new_3, nodata2=nodata_3, optimize_dist=optimize_dist, &
-                                    move_data_1=move_data_2, unit_nr=unit_nr)
+                                    move_data_1=move_data_2, unit_nr=unit_nr_prv)
 
          CALL invert_transpose_flag(trans_2)
          CALL invert_transpose_flag(trans_3)
 
          CALL reshape_mm_small(tensor_algn_1, notcontract_1_mod, contract_1_mod, tensor_contr_1, &
-                               trans_1, new_1, move_data=move_data_1, unit_nr=unit_nr)
+                               trans_1, new_1, move_data=move_data_1, unit_nr=unit_nr_prv)
 
       END SELECT
 
-      IF (PRESENT(unit_nr)) CALL dbcsr_t_print_contraction_index(tensor_contr_1, indchar1_mod, &
+      IF (unit_nr_prv /= 0) CALL dbcsr_t_print_contraction_index(tensor_contr_1, indchar1_mod, &
                                                                  tensor_contr_2, indchar2_mod, &
-                                                                 tensor_contr_3, indchar3_mod, unit_nr)
-      IF (PRESENT(unit_nr)) THEN
-         IF (new_1) CALL dbcsr_t_write_tensor_info(tensor_contr_1, unit_nr, full_info=log_verbose)
-         IF (new_1) CALL dbcsr_t_write_tensor_dist(tensor_contr_1, unit_nr)
-         IF (new_2) CALL dbcsr_t_write_tensor_info(tensor_contr_2, unit_nr, full_info=log_verbose)
-         IF (new_2) CALL dbcsr_t_write_tensor_dist(tensor_contr_2, unit_nr)
+                                                                 tensor_contr_3, indchar3_mod, unit_nr_prv)
+      IF (unit_nr_prv /= 0) THEN
+         IF (new_1) CALL dbcsr_t_write_tensor_info(tensor_contr_1, unit_nr_prv, full_info=log_verbose)
+         IF (new_1) CALL dbcsr_t_write_tensor_dist(tensor_contr_1, unit_nr_prv)
+         IF (new_2) CALL dbcsr_t_write_tensor_info(tensor_contr_2, unit_nr_prv, full_info=log_verbose)
+         IF (new_2) CALL dbcsr_t_write_tensor_dist(tensor_contr_2, unit_nr_prv)
       ENDIF
 
       IF (.NOT. PRESENT(result_index)) THEN
@@ -814,7 +810,7 @@ CONTAINS
                                  tensor_contr_1%matrix_rep, tensor_contr_2%matrix_rep, &
                                  beta, &
                                  tensor_contr_3%matrix_rep, filter_eps=filter_eps, flop=flop, &
-                                 io_unit=unit_nr, log_verbose=log_verbose, &
+                                 unit_nr=unit_nr_prv, log_verbose=log_verbose, &
                                  split_opt=split_opt, &
                                  move_data_a=move_data_1, move_data_b=move_data_2, retain_sparsity=retain_sparsity)
       ELSE
@@ -896,14 +892,14 @@ CONTAINS
          DEALLOCATE (split_opt)
       ENDIF
 
-      IF (PRESENT(unit_nr)) THEN
+      IF (unit_nr_prv /= 0) THEN
          do_write_3 = .TRUE.
          IF (tensor_contr_3%matrix_rep%do_batched > 0) THEN
             IF (tensor_contr_3%matrix_rep%mm_storage%batched_out) do_write_3 = .FALSE.
          ENDIF
          IF (do_write_3) THEN
-            CALL dbcsr_t_write_tensor_info(tensor_contr_3, unit_nr, full_info=log_verbose)
-            CALL dbcsr_t_write_tensor_dist(tensor_contr_3, unit_nr)
+            CALL dbcsr_t_write_tensor_info(tensor_contr_3, unit_nr_prv, full_info=log_verbose)
+            CALL dbcsr_t_write_tensor_dist(tensor_contr_3, unit_nr_prv)
          ENDIF
       ENDIF
 
@@ -916,9 +912,9 @@ CONTAINS
          ! pointer to data of tensor_3
       ENDIF
 
-      IF (PRESENT(unit_nr)) THEN
-         IF (new_3 .AND. do_write_3) CALL dbcsr_t_write_tensor_info(tensor_3, unit_nr, full_info=log_verbose)
-         IF (new_3 .AND. do_write_3) CALL dbcsr_t_write_tensor_dist(tensor_3, unit_nr)
+      IF (unit_nr_prv /= 0) THEN
+         IF (new_3 .AND. do_write_3) CALL dbcsr_t_write_tensor_info(tensor_3, unit_nr_prv, full_info=log_verbose)
+         IF (new_3 .AND. do_write_3) CALL dbcsr_t_write_tensor_dist(tensor_3, unit_nr_prv)
       ENDIF
 
       CALL dbcsr_t_destroy(tensor_algn_1)
@@ -967,12 +963,10 @@ CONTAINS
          ENDIF
       ENDIF
 
-      IF (PRESENT(unit_nr)) THEN
-         IF (unit_nr > 0) THEN
-            WRITE (unit_nr, '(A)') repeat("-", 80)
-            WRITE (unit_nr, '(A)') "TENSOR CONTRACTION DONE"
-            WRITE (unit_nr, '(A)') repeat("-", 80)
-         ENDIF
+      IF (unit_nr_prv > 0) THEN
+         WRITE (unit_nr_prv, '(A)') repeat("-", 80)
+         WRITE (unit_nr_prv, '(A)') "TENSOR CONTRACTION DONE"
+         WRITE (unit_nr_prv, '(A)') repeat("-", 80)
       ENDIF
 
    END SUBROUTINE
@@ -1034,7 +1028,7 @@ CONTAINS
       INTEGER, INTENT(IN), OPTIONAL               :: unit_nr
          !! output unit
       INTEGER                                     :: ref_tensor, compat1, compat1_old, compat2, compat2_old, &
-                                                     comm_2d, io_unit
+                                                     comm_2d, unit_nr_prv
       TYPE(array_list)                            :: dist_list
       INTEGER, DIMENSION(:), ALLOCATABLE          :: mp_dims, dims
       TYPE(dbcsr_t_distribution_type)             :: dist_in
@@ -1042,11 +1036,8 @@ CONTAINS
       LOGICAL                                     :: optimize_dist_prv
 
       NULLIFY (tensor1_out, tensor2_out)
-      IF (PRESENT(unit_nr)) THEN
-         io_unit = unit_nr
-      ELSE
-         io_unit = 0
-      ENDIF
+
+      unit_nr_prv = prep_output_unit(unit_nr)
 
       IF (SIZE(ind1_free) .GE. SIZE(ind2_free)) THEN
          ref_tensor = 1
@@ -1065,24 +1056,24 @@ CONTAINS
       compat1_old = compat1
       compat2_old = compat2
 
-      IF (io_unit > 0) THEN
-         WRITE (io_unit, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor1%name), ":"
+      IF (unit_nr_prv > 0) THEN
+         WRITE (unit_nr_prv, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor1%name), ":"
          SELECT CASE (compat1)
          CASE (0)
-            WRITE (io_unit, '(A)') "Not compatible"
+            WRITE (unit_nr_prv, '(A)') "Not compatible"
          CASE (1)
-            WRITE (io_unit, '(A)') "Normal"
+            WRITE (unit_nr_prv, '(A)') "Normal"
          CASE (2)
-            WRITE (io_unit, '(A)') "Transposed"
+            WRITE (unit_nr_prv, '(A)') "Transposed"
          END SELECT
-         WRITE (io_unit, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor2%name), ":"
+         WRITE (unit_nr_prv, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor2%name), ":"
          SELECT CASE (compat2)
          CASE (0)
-            WRITE (io_unit, '(A)') "Not compatible"
+            WRITE (unit_nr_prv, '(A)') "Not compatible"
          CASE (1)
-            WRITE (io_unit, '(A)') "Normal"
+            WRITE (unit_nr_prv, '(A)') "Normal"
          CASE (2)
-            WRITE (io_unit, '(A)') "Transposed"
+            WRITE (unit_nr_prv, '(A)') "Transposed"
          END SELECT
       ENDIF
 
@@ -1099,7 +1090,7 @@ CONTAINS
 
       IF (ref_tensor == 1) THEN ! tensor 1 is reference and tensor 2 is reshaped compatible with tensor 1
          IF (compat1 == 0 .OR. optimize_dist_prv) THEN ! tensor 1 is not contraction compatible --> reshape
-            IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "Redistribution of", TRIM(tensor1%name)
+            IF (unit_nr_prv > 0) WRITE (unit_nr_prv, '(T2,A,1X,A)') "Redistribution of", TRIM(tensor1%name)
             ALLOCATE (dims(ndims_tensor(tensor1)))
             CALL blk_dims_tensor(tensor1, dims)
             nblkrows = PRODUCT(INT(dims(ind1_linked), KIND=int_8))
@@ -1111,11 +1102,11 @@ CONTAINS
             CALL mp_comm_free(comm_2d)
             compat1 = 1
          ELSE
-            IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor1%name)
+            IF (unit_nr_prv > 0) WRITE (unit_nr_prv, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor1%name)
             tensor1_out => tensor1
          ENDIF
          IF (compat2 == 0 .OR. optimize_dist_prv) THEN ! tensor 2 is not contraction compatible --> reshape
-            IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A,1X,A,1X,A)') "Redistribution of", &
+            IF (unit_nr_prv > 0) WRITE (unit_nr_prv, '(T2,A,1X,A,1X,A,1X,A)') "Redistribution of", &
                TRIM(tensor2%name), "compatible with", TRIM(tensor1%name)
             dist_in = dbcsr_t_distribution(tensor1_out)
             dist_list = array_sublist(dist_in%nd_dist, ind1_linked)
@@ -1140,12 +1131,12 @@ CONTAINS
             ENDIF
             compat2 = compat1
          ELSE
-            IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor2%name)
+            IF (unit_nr_prv > 0) WRITE (unit_nr_prv, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor2%name)
             tensor2_out => tensor2
          ENDIF
       ELSE ! tensor 2 is reference and tensor 1 is reshaped compatible with tensor 2
          IF (compat2 == 0 .OR. optimize_dist_prv) THEN ! tensor 2 is not contraction compatible --> reshape
-            IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "Redistribution of", TRIM(tensor2%name)
+            IF (unit_nr_prv > 0) WRITE (unit_nr_prv, '(T2,A,1X,A)') "Redistribution of", TRIM(tensor2%name)
             ALLOCATE (dims(ndims_tensor(tensor2)))
             CALL blk_dims_tensor(tensor2, dims)
             nblkrows = PRODUCT(INT(dims(ind2_linked), KIND=int_8))
@@ -1156,11 +1147,11 @@ CONTAINS
             CALL mp_comm_free(comm_2d)
             compat2 = 1
          ELSE
-            IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor2%name)
+            IF (unit_nr_prv > 0) WRITE (unit_nr_prv, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor2%name)
             tensor2_out => tensor2
          ENDIF
          IF (compat1 == 0 .OR. optimize_dist_prv) THEN ! tensor 1 is not contraction compatible --> reshape
-            IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A,1X,A,1X,A)') "Redistribution of", TRIM(tensor1%name), &
+            IF (unit_nr_prv > 0) WRITE (unit_nr_prv, '(T2,A,1X,A,1X,A,1X,A)') "Redistribution of", TRIM(tensor1%name), &
                "compatible with", TRIM(tensor2%name)
             dist_in = dbcsr_t_distribution(tensor2_out)
             dist_list = array_sublist(dist_in%nd_dist, ind2_linked)
@@ -1181,7 +1172,7 @@ CONTAINS
             ENDIF
             compat1 = compat2
          ELSE
-            IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor1%name)
+            IF (unit_nr_prv > 0) WRITE (unit_nr_prv, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor1%name)
             tensor1_out => tensor1
          ENDIF
       ENDIF
@@ -1204,27 +1195,27 @@ CONTAINS
          DBCSR_ABORT("should not happen")
       END SELECT
 
-      IF (io_unit > 0) THEN
+      IF (unit_nr_prv > 0) THEN
          IF (compat1 .NE. compat1_old) THEN
-            WRITE (io_unit, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor1_out%name), ":"
+            WRITE (unit_nr_prv, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor1_out%name), ":"
             SELECT CASE (compat1)
             CASE (0)
-               WRITE (io_unit, '(A)') "Not compatible"
+               WRITE (unit_nr_prv, '(A)') "Not compatible"
             CASE (1)
-               WRITE (io_unit, '(A)') "Normal"
+               WRITE (unit_nr_prv, '(A)') "Normal"
             CASE (2)
-               WRITE (io_unit, '(A)') "Transposed"
+               WRITE (unit_nr_prv, '(A)') "Transposed"
             END SELECT
          ENDIF
          IF (compat2 .NE. compat2_old) THEN
-            WRITE (io_unit, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor2_out%name), ":"
+            WRITE (unit_nr_prv, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor2_out%name), ":"
             SELECT CASE (compat2)
             CASE (0)
-               WRITE (io_unit, '(A)') "Not compatible"
+               WRITE (unit_nr_prv, '(A)') "Not compatible"
             CASE (1)
-               WRITE (io_unit, '(A)') "Normal"
+               WRITE (unit_nr_prv, '(A)') "Normal"
             CASE (2)
-               WRITE (io_unit, '(A)') "Transposed"
+               WRITE (unit_nr_prv, '(A)') "Transposed"
             END SELECT
          ENDIF
       ENDIF
@@ -1254,7 +1245,7 @@ CONTAINS
          !! memory optimization: transfer data s.t. tensor_in may be empty on return
       INTEGER, INTENT(IN), OPTIONAL               :: unit_nr
          !! output unit
-      INTEGER                                     :: compat1, compat2, compat1_old, compat2_old, io_unit
+      INTEGER                                     :: compat1, compat2, compat1_old, compat2_old, unit_nr_prv
       LOGICAL                                     :: nodata_prv
 
       NULLIFY (tensor_out)
@@ -1264,29 +1255,25 @@ CONTAINS
          nodata_prv = .FALSE.
       ENDIF
 
-      IF (PRESENT(unit_nr)) THEN
-         io_unit = unit_nr
-      ELSE
-         io_unit = 0
-      ENDIF
+      unit_nr_prv = prep_output_unit(unit_nr)
 
       new = .FALSE.
       compat1 = compat_map(tensor_in%nd_index, ind1)
       compat2 = compat_map(tensor_in%nd_index, ind2)
       compat1_old = compat1; compat2_old = compat2
-      IF (io_unit > 0) THEN
-         WRITE (io_unit, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor_in%name), ":"
+      IF (unit_nr_prv > 0) THEN
+         WRITE (unit_nr_prv, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor_in%name), ":"
          IF (compat1 == 1 .AND. compat2 == 2) THEN
-            WRITE (io_unit, '(A)') "Normal"
+            WRITE (unit_nr_prv, '(A)') "Normal"
          ELSEIF (compat1 == 2 .AND. compat2 == 1) THEN
-            WRITE (io_unit, '(A)') "Transposed"
+            WRITE (unit_nr_prv, '(A)') "Transposed"
          ELSE
-            WRITE (io_unit, '(A)') "Not compatible"
+            WRITE (unit_nr_prv, '(A)') "Not compatible"
          ENDIF
       ENDIF
       IF (compat1 == 0 .or. compat2 == 0) THEN ! index mapping not compatible with contract index
 
-         IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "Redistribution of", TRIM(tensor_in%name)
+         IF (unit_nr_prv > 0) WRITE (unit_nr_prv, '(T2,A,1X,A)') "Redistribution of", TRIM(tensor_in%name)
 
          ALLOCATE (tensor_out)
          CALL dbcsr_t_remap(tensor_in, ind1, ind2, tensor_out, nodata=nodata, move_data=move_data)
@@ -1298,7 +1285,7 @@ CONTAINS
          compat2 = 2
          new = .TRUE.
       ELSE
-         IF (io_unit > 0) WRITE (unit_nr, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor_in%name)
+         IF (unit_nr_prv > 0) WRITE (unit_nr_prv, '(T2,A,1X,A)') "No redistribution of", TRIM(tensor_in%name)
          tensor_out => tensor_in
       ENDIF
 
@@ -1310,15 +1297,15 @@ CONTAINS
          DBCSR_ABORT("this should not happen")
       ENDIF
 
-      IF (io_unit > 0) THEN
+      IF (unit_nr_prv > 0) THEN
          IF (compat1_old .NE. compat1 .OR. compat2_old .NE. compat2) THEN
-            WRITE (io_unit, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor_out%name), ":"
+            WRITE (unit_nr_prv, '(T2,A,1X,A,A,1X)', advance='no') "compatibility of", TRIM(tensor_out%name), ":"
             IF (compat1 == 1 .AND. compat2 == 2) THEN
-               WRITE (io_unit, '(A)') "Normal"
+               WRITE (unit_nr_prv, '(A)') "Normal"
             ELSEIF (compat1 == 2 .AND. compat2 == 1) THEN
-               WRITE (io_unit, '(A)') "Transposed"
+               WRITE (unit_nr_prv, '(A)') "Transposed"
             ELSE
-               WRITE (io_unit, '(A)') "Not compatible"
+               WRITE (unit_nr_prv, '(A)') "Not compatible"
             ENDIF
          ENDIF
       ENDIF
@@ -1798,53 +1785,57 @@ CONTAINS
       INTEGER, DIMENSION(ndims_matrix_column(tensor_2)) :: map22
       INTEGER, DIMENSION(ndims_matrix_row(tensor_3)) :: map31
       INTEGER, DIMENSION(ndims_matrix_column(tensor_3)) :: map32
-      INTEGER :: ichar1, ichar2, ichar3
+      INTEGER :: ichar1, ichar2, ichar3, unit_nr_prv
 
-      CALL dbcsr_t_get_mapping_info(tensor_1%nd_index_blk, map1_2d=map11, map2_2d=map12)
-      CALL dbcsr_t_get_mapping_info(tensor_2%nd_index_blk, map1_2d=map21, map2_2d=map22)
-      CALL dbcsr_t_get_mapping_info(tensor_3%nd_index_blk, map1_2d=map31, map2_2d=map32)
+      unit_nr_prv = prep_output_unit(unit_nr)
 
-      IF (unit_nr .GT. 0) THEN
-         WRITE (unit_nr, '(T2,A)') "INDEX INFO"
-         WRITE (unit_nr, '(T15,A)', advance='no') "tensor index: ("
+      IF (unit_nr_prv /= 0) THEN
+         CALL dbcsr_t_get_mapping_info(tensor_1%nd_index_blk, map1_2d=map11, map2_2d=map12)
+         CALL dbcsr_t_get_mapping_info(tensor_2%nd_index_blk, map1_2d=map21, map2_2d=map22)
+         CALL dbcsr_t_get_mapping_info(tensor_3%nd_index_blk, map1_2d=map31, map2_2d=map32)
+      ENDIF
+
+      IF (unit_nr_prv > 0) THEN
+         WRITE (unit_nr_prv, '(T2,A)') "INDEX INFO"
+         WRITE (unit_nr_prv, '(T15,A)', advance='no') "tensor index: ("
          DO ichar1 = 1, SIZE(indchar1)
-            WRITE (unit_nr, '(A1)', advance='no') indchar1(ichar1)
+            WRITE (unit_nr_prv, '(A1)', advance='no') indchar1(ichar1)
          ENDDO
-         WRITE (unit_nr, '(A)', advance='no') ") x ("
+         WRITE (unit_nr_prv, '(A)', advance='no') ") x ("
          DO ichar2 = 1, SIZE(indchar2)
-            WRITE (unit_nr, '(A1)', advance='no') indchar2(ichar2)
+            WRITE (unit_nr_prv, '(A1)', advance='no') indchar2(ichar2)
          ENDDO
-         WRITE (unit_nr, '(A)', advance='no') ") = ("
+         WRITE (unit_nr_prv, '(A)', advance='no') ") = ("
          DO ichar3 = 1, SIZE(indchar3)
-            WRITE (unit_nr, '(A1)', advance='no') indchar3(ichar3)
+            WRITE (unit_nr_prv, '(A1)', advance='no') indchar3(ichar3)
          ENDDO
-         WRITE (unit_nr, '(A)') ")"
+         WRITE (unit_nr_prv, '(A)') ")"
 
-         WRITE (unit_nr, '(T15,A)', advance='no') "matrix index: ("
+         WRITE (unit_nr_prv, '(T15,A)', advance='no') "matrix index: ("
          DO ichar1 = 1, SIZE(map11)
-            WRITE (unit_nr, '(A1)', advance='no') indchar1(map11(ichar1))
+            WRITE (unit_nr_prv, '(A1)', advance='no') indchar1(map11(ichar1))
          ENDDO
-         WRITE (unit_nr, '(A1)', advance='no') "|"
+         WRITE (unit_nr_prv, '(A1)', advance='no') "|"
          DO ichar1 = 1, SIZE(map12)
-            WRITE (unit_nr, '(A1)', advance='no') indchar1(map12(ichar1))
+            WRITE (unit_nr_prv, '(A1)', advance='no') indchar1(map12(ichar1))
          ENDDO
-         WRITE (unit_nr, '(A)', advance='no') ") x ("
+         WRITE (unit_nr_prv, '(A)', advance='no') ") x ("
          DO ichar2 = 1, SIZE(map21)
-            WRITE (unit_nr, '(A1)', advance='no') indchar2(map21(ichar2))
+            WRITE (unit_nr_prv, '(A1)', advance='no') indchar2(map21(ichar2))
          ENDDO
-         WRITE (unit_nr, '(A1)', advance='no') "|"
+         WRITE (unit_nr_prv, '(A1)', advance='no') "|"
          DO ichar2 = 1, SIZE(map22)
-            WRITE (unit_nr, '(A1)', advance='no') indchar2(map22(ichar2))
+            WRITE (unit_nr_prv, '(A1)', advance='no') indchar2(map22(ichar2))
          ENDDO
-         WRITE (unit_nr, '(A)', advance='no') ") = ("
+         WRITE (unit_nr_prv, '(A)', advance='no') ") = ("
          DO ichar3 = 1, SIZE(map31)
-            WRITE (unit_nr, '(A1)', advance='no') indchar3(map31(ichar3))
+            WRITE (unit_nr_prv, '(A1)', advance='no') indchar3(map31(ichar3))
          ENDDO
-         WRITE (unit_nr, '(A1)', advance='no') "|"
+         WRITE (unit_nr_prv, '(A1)', advance='no') "|"
          DO ichar3 = 1, SIZE(map32)
-            WRITE (unit_nr, '(A1)', advance='no') indchar3(map32(ichar3))
+            WRITE (unit_nr_prv, '(A1)', advance='no') indchar3(map32(ichar3))
          ENDDO
-         WRITE (unit_nr, '(A)') ")"
+         WRITE (unit_nr_prv, '(A)') ")"
       ENDIF
 
    END SUBROUTINE
@@ -1868,23 +1859,24 @@ CONTAINS
       TYPE(dbcsr_t_type), INTENT(INOUT) :: tensor
       INTEGER, INTENT(IN), OPTIONAL :: unit_nr
       LOGICAL :: do_write
+      INTEGER :: unit_nr_prv
+
+      unit_nr_prv = prep_output_unit(unit_nr)
 
       do_write = .FALSE.
-      IF (PRESENT(unit_nr)) THEN
-         IF (tensor%matrix_rep%do_batched > 0) THEN
-            IF (tensor%matrix_rep%mm_storage%batched_out) do_write = .TRUE.
-         ENDIF
+      IF (tensor%matrix_rep%do_batched > 0) THEN
+         IF (tensor%matrix_rep%mm_storage%batched_out) do_write = .TRUE.
       ENDIF
 
       CALL dbcsr_tas_batched_mm_finalize(tensor%matrix_rep)
 
-      IF (do_write .AND. PRESENT(unit_nr)) THEN
-         IF (unit_nr > 0) THEN
-            WRITE (unit_nr, "(T2,A)") &
+      IF (do_write .AND. unit_nr_prv /= 0) THEN
+         IF (unit_nr_prv > 0) THEN
+            WRITE (unit_nr_prv, "(T2,A)") &
                "FINALIZING BATCHED PROCESSING OF MATMUL"
          ENDIF
-         CALL dbcsr_t_write_tensor_info(tensor, unit_nr)
-         CALL dbcsr_t_write_tensor_dist(tensor, unit_nr)
+         CALL dbcsr_t_write_tensor_info(tensor, unit_nr_prv)
+         CALL dbcsr_t_write_tensor_dist(tensor, unit_nr_prv)
       ENDIF
 
    END SUBROUTINE

--- a/src/tensors/dbcsr_tensor_api.F
+++ b/src/tensors/dbcsr_tensor_api.F
@@ -35,7 +35,7 @@ MODULE dbcsr_tensor_api
       dbcsr_t_mp_dims_create, dbcsr_t_pgrid_change_dims, dbcsr_t_ndims => ndims_tensor, &
       dbcsr_t_dims => dims_tensor, dbcsr_t_ndims_matrix_row => ndims_matrix_row, &
       dbcsr_t_ndims_matrix_column => ndims_matrix_column, dbcsr_t_blk_size, dbcsr_t_nblks_local, &
-      dbcsr_t_nblks_total, dbcsr_t_max_nblks_local
+      dbcsr_t_nblks_total, dbcsr_t_max_nblks_local, dbcsr_t_default_distvec
    USE dbcsr_tensor_test, ONLY: &
       dbcsr_t_contract_test, dbcsr_t_checksum
    USE dbcsr_tensor_split, ONLY: &
@@ -106,5 +106,6 @@ MODULE dbcsr_tensor_api
    PUBLIC :: dbcsr_t_nblks_total
    PUBLIC :: dbcsr_t_blk_size
    PUBLIC :: dbcsr_t_max_nblks_local
+   PUBLIC :: dbcsr_t_default_distvec
 
 END MODULE dbcsr_tensor_api

--- a/src/tensors/dbcsr_tensor_io.F
+++ b/src/tensors/dbcsr_tensor_io.F
@@ -37,15 +37,16 @@ MODULE dbcsr_tensor_io
       dbcsr_t_write_blocks, &
       dbcsr_t_write_block, &
       dbcsr_t_write_block_indices, &
-      dbcsr_t_write_split_info
+      dbcsr_t_write_split_info, &
+      prep_output_unit
 
 CONTAINS
 
-   SUBROUTINE dbcsr_t_write_tensor_info(tensor, output_unit, full_info)
+   SUBROUTINE dbcsr_t_write_tensor_info(tensor, unit_nr, full_info)
       !! Write tensor global info: block dimensions, full dimensions and process grid dimensions
 
       TYPE(dbcsr_t_type), INTENT(IN) :: tensor
-      INTEGER, INTENT(IN)            :: output_unit
+      INTEGER, INTENT(IN)            :: unit_nr
       LOGICAL, OPTIONAL, INTENT(IN)  :: full_info
          !! Whether to print distribution and block size vectors
       INTEGER, DIMENSION(ndims_tensor(tensor)) :: nblks_total, nfull_total, pdims, my_ploc, nblks_local, nfull_local
@@ -53,72 +54,80 @@ CONTAINS
 #:for idim in range(1, maxdim+1)
       INTEGER, DIMENSION(dbcsr_t_nblks_total(tensor, ${idim}$)) :: proc_dist_${idim}$
       INTEGER, DIMENSION(dbcsr_t_nblks_total(tensor, ${idim}$)) :: blk_size_${idim}$
+      INTEGER, DIMENSION(dbcsr_t_nblks_total(tensor, ${idim}$)) :: blks_local_${idim}$
 #:endfor
       CHARACTER(len=default_string_length)                     :: name
       INTEGER                                                  :: idim
       INTEGER                                                  :: iblk
+      INTEGER                                                  :: unit_nr_prv
+
+      unit_nr_prv = prep_output_unit(unit_nr)
+      IF (unit_nr_prv == 0) RETURN
 
       CALL dbcsr_t_get_info(tensor, nblks_total, nfull_total, nblks_local, nfull_local, pdims, my_ploc, &
-                            ${varlist("proc_dist")}$, ${varlist("blk_size")}$, &
+                            ${varlist("blks_local")}$, ${varlist("proc_dist")}$, ${varlist("blk_size")}$, &
                             name=name)
 
-      IF (output_unit > 0) THEN
-         WRITE (output_unit, "(T2,A)") &
+      IF (unit_nr_prv > 0) THEN
+         WRITE (unit_nr_prv, "(T2,A)") &
             "GLOBAL INFO OF "//TRIM(name)
-         WRITE (output_unit, "(T4,A,1X)", advance="no") "block dimensions:"
+         WRITE (unit_nr_prv, "(T4,A,1X)", advance="no") "block dimensions:"
          DO idim = 1, ndims_tensor(tensor)
-            WRITE (output_unit, "(I6)", advance="no") nblks_total(idim)
+            WRITE (unit_nr_prv, "(I6)", advance="no") nblks_total(idim)
          ENDDO
-         WRITE (output_unit, "(/T4,A,1X)", advance="no") "full dimensions:"
+         WRITE (unit_nr_prv, "(/T4,A,1X)", advance="no") "full dimensions:"
          DO idim = 1, ndims_tensor(tensor)
-            WRITE (output_unit, "(I8)", advance="no") nfull_total(idim)
+            WRITE (unit_nr_prv, "(I8)", advance="no") nfull_total(idim)
          ENDDO
-         WRITE (output_unit, "(/T4,A,1X)", advance="no") "process grid dimensions:"
+         WRITE (unit_nr_prv, "(/T4,A,1X)", advance="no") "process grid dimensions:"
          DO idim = 1, ndims_tensor(tensor)
-            WRITE (output_unit, "(I6)", advance="no") pdims(idim)
+            WRITE (unit_nr_prv, "(I6)", advance="no") pdims(idim)
          ENDDO
-         WRITE (output_unit, *)
+         WRITE (unit_nr_prv, *)
 
          IF (PRESENT(full_info)) THEN
             IF (full_info) THEN
-               WRITE (output_unit, '(T4,A)', advance='no') "Block sizes:"
+               WRITE (unit_nr_prv, '(T4,A)', advance='no') "Block sizes:"
 #:for dim in range(1, maxdim+1)
                IF (ndims_tensor(tensor) >= ${dim}$) THEN
-                  WRITE (output_unit, '(/T8,A,1X,I1,A,1X)', advance='no') 'Dim', ${dim}$, ':'
+                  WRITE (unit_nr_prv, '(/T8,A,1X,I1,A,1X)', advance='no') 'Dim', ${dim}$, ':'
                   DO iblk = 1, SIZE(blk_size_${dim}$)
-                     WRITE (output_unit, '(I2,1X)', advance='no') blk_size_${dim}$ (iblk)
+                     WRITE (unit_nr_prv, '(I2,1X)', advance='no') blk_size_${dim}$ (iblk)
                   ENDDO
                ENDIF
 #:endfor
-               WRITE (output_unit, '(/T4,A)', advance='no') "Block distribution:"
+               WRITE (unit_nr_prv, '(/T4,A)', advance='no') "Block distribution:"
 #:for dim in range(1, maxdim+1)
                IF (ndims_tensor(tensor) >= ${dim}$) THEN
-                  WRITE (output_unit, '(/T8,A,1X,I1,A,1X)', advance='no') 'Dim', ${dim}$, ':'
+                  WRITE (unit_nr_prv, '(/T8,A,1X,I1,A,1X)', advance='no') 'Dim', ${dim}$, ':'
                   DO iblk = 1, SIZE(proc_dist_${dim}$)
-                     WRITE (output_unit, '(I3,1X)', advance='no') proc_dist_${dim}$ (iblk)
+                     WRITE (unit_nr_prv, '(I3,1X)', advance='no') proc_dist_${dim}$ (iblk)
                   ENDDO
                ENDIF
 #:endfor
             ENDIF
-            WRITE (output_unit, *)
+            WRITE (unit_nr_prv, *)
          ENDIF
       ENDIF
 
    END SUBROUTINE
 
-   SUBROUTINE dbcsr_t_write_tensor_dist(tensor, output_unit)
+   SUBROUTINE dbcsr_t_write_tensor_dist(tensor, unit_nr)
       !! Write info on tensor distribution & load balance
       TYPE(dbcsr_t_type), INTENT(IN) :: tensor
-      INTEGER, INTENT(IN)            :: output_unit
+      INTEGER, INTENT(IN)            :: unit_nr
       INTEGER                        :: nproc, myproc, nblock_max, nelement_max
       INTEGER(KIND=int_8)            :: nblock_sum, nelement_sum, nblock_tot
-      INTEGER                        :: nblock, nelement
+      INTEGER                        :: nblock, nelement, unit_nr_prv
       INTEGER                        :: mp_comm
       INTEGER, DIMENSION(2)          :: tmp
       INTEGER, DIMENSION(ndims_tensor(tensor)) :: bdims
       REAL(KIND=real_8)              :: occupation
 
       mp_comm = tensor%pgrid%mp_comm_2d
+      unit_nr_prv = prep_output_unit(unit_nr)
+      IF (unit_nr_prv == 0) RETURN
+
       CALL mp_environ(nproc, myproc, mp_comm)
 
       nblock = dbcsr_t_get_num_blocks(tensor)
@@ -137,15 +146,15 @@ CONTAINS
       occupation = -1.0_real_8
       IF (nblock_tot .NE. 0) occupation = 100.0_real_8*REAL(nblock_sum, real_8)/REAL(nblock_tot, real_8)
 
-      IF (output_unit > 0) THEN
-         WRITE (output_unit, "(T2,A)") &
+      IF (unit_nr_prv > 0) THEN
+         WRITE (unit_nr_prv, "(T2,A)") &
             "DISTRIBUTION OF "//TRIM(tensor%name)
-         WRITE (output_unit, "(T15,A,T68,I13)") "Number of non-zero blocks:", nblock_sum
-         WRITE (output_unit, "(T15,A,T75,F6.2)") "Percentage of non-zero blocks:", occupation
-         WRITE (output_unit, "(T15,A,T68,I13)") "Average number of blocks per CPU:", (nblock_sum + nproc - 1)/nproc
-         WRITE (output_unit, "(T15,A,T68,I13)") "Maximum number of blocks per CPU:", nblock_max
-         WRITE (output_unit, "(T15,A,T68,I13)") "Average number of matrix elements per CPU:", (nelement_sum + nproc - 1)/nproc
-         WRITE (output_unit, "(T15,A,T68,I13)") "Maximum number of matrix elements per CPU:", nelement_max
+         WRITE (unit_nr_prv, "(T15,A,T68,I13)") "Number of non-zero blocks:", nblock_sum
+         WRITE (unit_nr_prv, "(T15,A,T75,F6.2)") "Percentage of non-zero blocks:", occupation
+         WRITE (unit_nr_prv, "(T15,A,T68,I13)") "Average number of blocks per CPU:", (nblock_sum + nproc - 1)/nproc
+         WRITE (unit_nr_prv, "(T15,A,T68,I13)") "Maximum number of blocks per CPU:", nblock_max
+         WRITE (unit_nr_prv, "(T15,A,T68,I13)") "Average number of matrix elements per CPU:", (nelement_sum + nproc - 1)/nproc
+         WRITE (unit_nr_prv, "(T15,A,T68,I13)") "Maximum number of matrix elements per CPU:", nelement_max
       ENDIF
 
    END SUBROUTINE
@@ -284,4 +293,16 @@ CONTAINS
          CALL dbcsr_tas_write_split_info(pgrid%tas_split_info, unit_nr)
       ENDIF
    END SUBROUTINE
+
+   FUNCTION prep_output_unit(unit_nr) RESULT(unit_nr_out)
+      INTEGER, INTENT(IN), OPTIONAL :: unit_nr
+      INTEGER                       :: unit_nr_out
+
+      IF (PRESENT(unit_nr)) THEN
+         unit_nr_out = unit_nr
+      ELSE
+         unit_nr_out = 0
+      ENDIF
+
+   END FUNCTION
 END MODULE

--- a/src/tensors/dbcsr_tensor_test.F
+++ b/src/tensors/dbcsr_tensor_test.F
@@ -22,21 +22,11 @@ MODULE dbcsr_tensor_test
       dbcsr_t_reserve_blocks, dbcsr_t_get_stored_coordinates, dbcsr_t_put_block, &
       dbcsr_t_contract, dbcsr_t_inverse_order
    USE dbcsr_tensor_block, ONLY: block_nd
-   USE dbcsr_tensor_types, ONLY: dbcsr_t_create, &
-                                 dbcsr_t_destroy, &
-                                 dbcsr_t_type, &
-                                 dbcsr_t_distribution_type, &
-                                 dbcsr_t_distribution_destroy, &
-                                 dims_tensor, &
-                                 ndims_tensor, &
-                                 dbcsr_t_distribution_new, &
-                                 dbcsr_t_nd_mp_comm, &
-                                 dbcsr_t_get_data_type, &
-                                 mp_environ_pgrid, &
-                                 dbcsr_t_pgrid_type, &
-                                 dbcsr_t_pgrid_create, &
-                                 dbcsr_t_pgrid_destroy, &
-                                 dbcsr_t_get_info
+   USE dbcsr_tensor_types, ONLY: &
+      dbcsr_t_create, dbcsr_t_destroy, dbcsr_t_type, dbcsr_t_distribution_type, dbcsr_t_distribution_destroy, &
+      dims_tensor, ndims_tensor, dbcsr_t_distribution_new, dbcsr_t_nd_mp_comm, dbcsr_t_get_data_type, &
+      mp_environ_pgrid, dbcsr_t_pgrid_type, dbcsr_t_pgrid_create, dbcsr_t_pgrid_destroy, dbcsr_t_get_info, &
+      dbcsr_t_default_distvec
    USE dbcsr_tensor_io, ONLY: &
       dbcsr_t_write_blocks, dbcsr_t_write_block_indices
    USE dbcsr_kinds, ONLY: ${uselist(dtype_float_prec)}$, &
@@ -63,7 +53,6 @@ MODULE dbcsr_tensor_test
 
    PUBLIC :: &
       dbcsr_t_setup_test_tensor, &
-      dbcsr_t_random_dist, &
       dbcsr_t_contract_test, &
       dbcsr_t_test_formats, &
       dbcsr_t_checksum
@@ -284,8 +273,10 @@ CONTAINS
 #:for dim in range(1, maxdim+1)
             IF (${dim}$ <= ndims) THEN
                nblks = SIZE(blk_size_${dim}$)
-               CALL dbcsr_t_random_dist(dist1_${dim}$, nblks, pdims(${dim}$))
-               CALL dbcsr_t_random_dist(dist2_${dim}$, nblks, pdims(${dim}$))
+               ALLOCATE (dist1_${dim}$ (nblks))
+               ALLOCATE (dist2_${dim}$ (nblks))
+               CALL dbcsr_t_default_distvec(nblks, pdims(${dim}$), blk_size_${dim}$, dist1_${dim}$)
+               CALL dbcsr_t_default_distvec(nblks, pdims(${dim}$), blk_size_${dim}$, dist2_${dim}$)
             ENDIF
 #:endfor
 
@@ -374,20 +365,6 @@ CONTAINS
          ENDDO
       ENDDO
       CALL dbcsr_t_pgrid_destroy(comm_nd)
-   END SUBROUTINE
-
-   SUBROUTINE dbcsr_t_random_dist(dist_array, dist_size, nbins)
-      INTEGER, DIMENSION(:), INTENT(OUT), ALLOCATABLE    :: dist_array
-      INTEGER, INTENT(IN)                                :: dist_size, nbins
-
-      INTEGER                                            :: i
-
-      ALLOCATE (dist_array(dist_size))
-      !CALL RANDOM_NUMBER (dist_array)
-      DO i = 1, dist_size
-         dist_array(i) = MODULO(nbins - i, nbins)
-      END DO
-
    END SUBROUTINE
 
    SUBROUTINE dbcsr_t_setup_test_tensor(tensor, mp_comm, enumerate, ${varlist("blk_ind")}$)
@@ -659,7 +636,7 @@ CONTAINS
 
       mp_comm = tensor_1%pgrid%mp_comm_2d
       CALL mp_environ(numnodes, mynode, mp_comm)
-      io_unit = 0
+      io_unit = -1
       IF (mynode .EQ. 0) io_unit = unit_nr
 
       cs_1 = dbcsr_t_checksum(tensor_1)

--- a/src/tensors/dbcsr_tensor_types.F
+++ b/src/tensors/dbcsr_tensor_types.F
@@ -39,10 +39,10 @@ MODULE dbcsr_tensor_types
    USE dbcsr_tas_split, ONLY: &
       dbcsr_tas_create_split_rows_or_cols, dbcsr_tas_release_info, dbcsr_tas_info_hold, &
       dbcsr_tas_create_split, dbcsr_tas_get_split_info
-   USE dbcsr_kinds, ONLY: default_string_length, int_8
+   USE dbcsr_kinds, ONLY: default_string_length, int_8, dp
    USE dbcsr_mpiwrap, ONLY: &
       mp_cart_create, mp_cart_rank, mp_environ, mp_dims_create, mp_comm_free, mp_comm_dup, mp_sum, mp_max
-   USE dbcsr_tas_global, ONLY: dbcsr_tas_distribution, dbcsr_tas_rowcol_data
+   USE dbcsr_tas_global, ONLY: dbcsr_tas_distribution, dbcsr_tas_rowcol_data, dbcsr_tas_default_distvec
    USE dbcsr_allocate_wrap, ONLY: allocate_any
    USE dbcsr_data_types, ONLY: dbcsr_scalar_type
    USE dbcsr_operations, ONLY: dbcsr_scale
@@ -95,7 +95,8 @@ MODULE dbcsr_tensor_types
       dbcsr_t_nblks_local, &
       dbcsr_t_nblks_total, &
       dbcsr_t_blk_size, &
-      dbcsr_t_max_nblks_local
+      dbcsr_t_max_nblks_local, &
+      dbcsr_t_default_distvec
 
    TYPE dbcsr_t_pgrid_type
       TYPE(nd_to_2d_mapping)                  :: nd_index_grid
@@ -551,9 +552,12 @@ CONTAINS
    END SUBROUTINE dbcsr_t_nd_mp_free
 
    SUBROUTINE dbcsr_t_distribution_new(dist, pgrid, ${varlist("nd_dist")}$)
+      !! Create a tensor distribution.
       TYPE(dbcsr_t_distribution_type), INTENT(OUT)    :: dist
       TYPE(dbcsr_t_pgrid_type), INTENT(IN)            :: pgrid
+         !! process grid
       INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL     :: ${varlist("nd_dist")}$
+         !! distribution vectors for all tensor dimensions
       INTEGER, DIMENSION(ndims_mapping_row(pgrid%nd_index_grid)) :: map1_2d
       INTEGER, DIMENSION(ndims_mapping_column(pgrid%nd_index_grid)) :: map2_2d
       INTEGER :: ndims
@@ -574,7 +578,6 @@ CONTAINS
       INTEGER, DIMENSION(:), INTENT(IN)               :: map2_2d
          !! which nd-indices map to second matrix index and in which order
       INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL     :: ${varlist("nd_dist")}$
-         !! distribution vector for first and second dimension
       LOGICAL, INTENT(IN), OPTIONAL                   :: own_comm
          !! whether distribution should own communicator
       INTEGER                                         :: ndims, comm_2d
@@ -1553,5 +1556,20 @@ CONTAINS
       blk_count = INT(blk_count_total/nproc*max_load_imbalance)
 
    END FUNCTION
+
+   SUBROUTINE dbcsr_t_default_distvec(nblk, nproc, blk_size, dist)
+      !! get a load-balanced and randomized distribution along one tensor dimension
+      INTEGER, INTENT(IN)                                :: nblk
+         !! number of blocks (along one tensor dimension)
+      INTEGER, INTENT(IN)                                :: nproc
+         !! number of processes (along one process grid dimension)
+      INTEGER, DIMENSION(nblk), INTENT(IN)                :: blk_size
+         !! block sizes
+      INTEGER, DIMENSION(nblk), INTENT(OUT)               :: dist
+         !! distribution
+
+      CALL dbcsr_tas_default_distvec(nblk, nproc, blk_size, dist)
+
+   END SUBROUTINE
 
 END MODULE

--- a/tests/dbcsr_tas_unittest.F
+++ b/tests/dbcsr_tas_unittest.F
@@ -48,7 +48,7 @@ PROGRAM dbcsr_tas_unittest
 
    CALL mp_environ(numnodes, mynode, mp_comm)
 
-   io_unit = 0
+   io_unit = -1
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
    CALL dbcsr_init_lib(mp_comm, io_unit)
@@ -93,34 +93,34 @@ PROGRAM dbcsr_tas_unittest
       TRIM(Ct%matrix%name), dbcsr_tas_nblkrows_total(Ct), 'X', dbcsr_tas_nblkcols_total(Ct)
    CALL dbcsr_tas_write_split_info(dbcsr_tas_info(Ct), io_unit, name="Ct")
 
-   CALL dbcsr_tas_test_mm('N', 'N', 'N', B, A, Ct_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('T', 'N', 'N', Bt, A, Ct_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('N', 'T', 'N', B, At, Ct_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('T', 'T', 'N', Bt, At, Ct_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('N', 'N', 'T', B, A, C_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('T', 'N', 'T', Bt, A, C_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('N', 'T', 'T', B, At, C_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('T', 'T', 'T', Bt, At, C_out, unit_nr=default_output_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('N', 'N', 'N', B, A, Ct_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('T', 'N', 'N', Bt, A, Ct_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('N', 'T', 'N', B, At, Ct_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('T', 'T', 'N', Bt, At, Ct_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('N', 'N', 'T', B, A, C_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('T', 'N', 'T', Bt, A, C_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('N', 'T', 'T', B, At, C_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('T', 'T', 'T', Bt, At, C_out, unit_nr=io_unit, filter_eps=filter_eps)
 
-   CALL dbcsr_tas_test_mm('N', 'N', 'N', A, C, Bt_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('T', 'N', 'N', At, C, Bt_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('N', 'T', 'N', A, Ct, Bt_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('T', 'T', 'N', At, Ct, Bt_out, unit_nr=default_output_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('N', 'N', 'N', A, C, Bt_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('T', 'N', 'N', At, C, Bt_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('N', 'T', 'N', A, Ct, Bt_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('T', 'T', 'N', At, Ct, Bt_out, unit_nr=io_unit, filter_eps=filter_eps)
 
-   CALL dbcsr_tas_test_mm('N', 'N', 'T', A, C, B_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('T', 'N', 'T', At, C, B_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('N', 'T', 'T', A, Ct, B_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('T', 'T', 'T', At, Ct, B_out, unit_nr=default_output_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('N', 'N', 'T', A, C, B_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('T', 'N', 'T', At, C, B_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('N', 'T', 'T', A, Ct, B_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('T', 'T', 'T', At, Ct, B_out, unit_nr=io_unit, filter_eps=filter_eps)
 
-   CALL dbcsr_tas_test_mm('N', 'N', 'N', C, B, At_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('T', 'N', 'N', Ct, B, At_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('N', 'T', 'N', C, Bt, At_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('T', 'T', 'N', Ct, Bt, At_out, unit_nr=default_output_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('N', 'N', 'N', C, B, At_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('T', 'N', 'N', Ct, B, At_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('N', 'T', 'N', C, Bt, At_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('T', 'T', 'N', Ct, Bt, At_out, unit_nr=io_unit, filter_eps=filter_eps)
 
-   CALL dbcsr_tas_test_mm('N', 'N', 'T', C, B, A_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('T', 'N', 'T', Ct, B, A_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('N', 'T', 'T', C, Bt, A_out, unit_nr=default_output_unit, filter_eps=filter_eps)
-   CALL dbcsr_tas_test_mm('T', 'T', 'T', Ct, Bt, A_out, unit_nr=default_output_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('N', 'N', 'T', C, B, A_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('T', 'N', 'T', Ct, B, A_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('N', 'T', 'T', C, Bt, A_out, unit_nr=io_unit, filter_eps=filter_eps)
+   CALL dbcsr_tas_test_mm('T', 'T', 'T', Ct, Bt, A_out, unit_nr=io_unit, filter_eps=filter_eps)
 
    CALL dbcsr_tas_destroy(A)
    CALL dbcsr_tas_destroy(At)

--- a/tests/dbcsr_tensor_unittest.F
+++ b/tests/dbcsr_tensor_unittest.F
@@ -20,21 +20,12 @@ PROGRAM dbcsr_tensor_unittest
                             mp_world_finalize, &
                             mp_world_init
    USE dbcsr_tensor_test, ONLY: dbcsr_t_contract_test, &
-                                dbcsr_t_random_dist, &
                                 dbcsr_t_setup_test_tensor, &
                                 dbcsr_t_test_formats
-   USE dbcsr_tensor_types, ONLY: dbcsr_t_create, &
-                                 dbcsr_t_destroy, &
-                                 dbcsr_t_distribution_destroy, &
-                                 dbcsr_t_distribution_new, &
-                                 dbcsr_t_distribution_type, &
-                                 dbcsr_t_nd_mp_comm, &
-                                 dbcsr_t_type, &
-                                 dbcsr_t_pgrid_type, &
-                                 dbcsr_t_pgrid_create, &
-                                 dbcsr_t_get_info, &
-                                 dbcsr_t_pgrid_destroy, &
-                                 ndims_tensor
+   USE dbcsr_tensor_types, ONLY: &
+      dbcsr_t_create, dbcsr_t_destroy, dbcsr_t_distribution_destroy, dbcsr_t_distribution_new, &
+      dbcsr_t_distribution_type, dbcsr_t_nd_mp_comm, dbcsr_t_type, dbcsr_t_pgrid_type, &
+      dbcsr_t_pgrid_create, dbcsr_t_get_info, dbcsr_t_pgrid_destroy, ndims_tensor, dbcsr_t_default_distvec
    USE dbcsr_data_methods, ONLY: dbcsr_scalar
    USE dbcsr_kinds, ONLY: real_8
 #include "base/dbcsr_base_uses.f90"
@@ -70,7 +61,7 @@ PROGRAM dbcsr_tensor_unittest
    CALL mp_environ(numnodes, mynode, mp_comm)
 
    ! set standard output parameters
-   io_unit = 0
+   io_unit = -1
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
    ! initialize libdbcsr
@@ -103,7 +94,7 @@ PROGRAM dbcsr_tensor_unittest
       blk_ind_2(:) = [1, 3, 11, 15, 4, 17, 21,   6,  9, 13, 19,  7] !&
 
       ! Test tensor formats
-      CALL dbcsr_t_test_formats(ndims, mp_comm, default_output_unit, verbose, &
+      CALL dbcsr_t_test_formats(ndims, mp_comm, io_unit, verbose, &
                                 blk_size_1=size_1, blk_size_2=size_2, &
                                 blk_ind_1=blk_ind_1, blk_ind_2=blk_ind_2)
 
@@ -137,7 +128,7 @@ PROGRAM dbcsr_tensor_unittest
       blk_ind_3(:) = [1, 3, 3, 2, 3, 2] !&
 
       ! Test tensor formats
-      CALL dbcsr_t_test_formats(ndims, mp_comm, default_output_unit, verbose, &
+      CALL dbcsr_t_test_formats(ndims, mp_comm, io_unit, verbose, &
                                 blk_size_1=size_1, blk_size_2=size_2, blk_size_3=size_3, &
                                 blk_ind_1=blk_ind_1, blk_ind_2=blk_ind_2, blk_ind_3=blk_ind_3)
 
@@ -174,7 +165,7 @@ PROGRAM dbcsr_tensor_unittest
       blk_ind_4(:) = [3, 2, 3, 1, 1, 2,  1,  3,  2,  2,  3, 1, 3, 2, 1, 1, 3, 2,  2] !&
 
       ! Test tensor formats
-      CALL dbcsr_t_test_formats(ndims, mp_comm, default_output_unit, verbose, &
+      CALL dbcsr_t_test_formats(ndims, mp_comm, io_unit, verbose, &
                                 blk_size_1=size_1, blk_size_2=size_2, blk_size_3=size_3, blk_size_4=size_4, &
                                 blk_ind_1=blk_ind_1, blk_ind_2=blk_ind_2, blk_ind_3=blk_ind_3, blk_ind_4=blk_ind_4)
 
@@ -275,25 +266,40 @@ PROGRAM dbcsr_tensor_unittest
       CALL dbcsr_t_pgrid_create(mp_comm, pdims_3d, pgrid_3d)
       CALL dbcsr_t_pgrid_create(mp_comm, pdims_2d, pgrid_2d)
 
-      CALL dbcsr_t_random_dist(dist1_1, nblks_1, pdims_3d(1))
-      CALL dbcsr_t_random_dist(dist1_2, nblks_2, pdims_3d(2))
-      CALL dbcsr_t_random_dist(dist1_3, nblks_3, pdims_3d(3))
+      ALLOCATE (dist1_1(nblks_1))
+      CALL dbcsr_t_default_distvec(nblks_1, pdims_3d(1), size_1, dist1_1)
+      ALLOCATE (dist1_2(nblks_2))
+      CALL dbcsr_t_default_distvec(nblks_2, pdims_3d(2), size_2, dist1_2)
+      ALLOCATE (dist1_3(nblks_3))
+      CALL dbcsr_t_default_distvec(nblks_3, pdims_3d(3), size_3, dist1_3)
 
-      CALL dbcsr_t_random_dist(dist2_1, nblks_3, pdims_2d(1))
-      CALL dbcsr_t_random_dist(dist2_2, nblks_4, pdims_2d(2))
+      ALLOCATE (dist2_1(nblks_3))
+      CALL dbcsr_t_default_distvec(nblks_3, pdims_2d(1), size_3, dist2_1)
+      ALLOCATE (dist2_2(nblks_4))
+      CALL dbcsr_t_default_distvec(nblks_4, pdims_2d(2), size_4, dist2_2)
 
-      CALL dbcsr_t_random_dist(dist3_1, nblks_1, pdims_3d(1))
-      CALL dbcsr_t_random_dist(dist3_2, nblks_2, pdims_3d(2))
-      CALL dbcsr_t_random_dist(dist3_3, nblks_4, pdims_3d(3))
+      ALLOCATE (dist3_1(nblks_1))
+      CALL dbcsr_t_default_distvec(nblks_1, pdims_3d(1), size_1, dist3_1)
+      ALLOCATE (dist3_2(nblks_2))
+      CALL dbcsr_t_default_distvec(nblks_2, pdims_3d(2), size_2, dist3_2)
+      ALLOCATE (dist3_3(nblks_4))
+      CALL dbcsr_t_default_distvec(nblks_4, pdims_3d(3), size_4, dist3_3)
 
-      CALL dbcsr_t_random_dist(dist4_1, nblks_1, pdims_4d(1))
-      CALL dbcsr_t_random_dist(dist4_2, nblks_2, pdims_4d(2))
-      CALL dbcsr_t_random_dist(dist4_3, nblks_4, pdims_4d(3))
-      CALL dbcsr_t_random_dist(dist4_4, nblks_5, pdims_4d(4))
+      ALLOCATE (dist4_1(nblks_1))
+      CALL dbcsr_t_default_distvec(nblks_1, pdims_4d(1), size_1, dist4_1)
+      ALLOCATE (dist4_2(nblks_2))
+      CALL dbcsr_t_default_distvec(nblks_2, pdims_4d(2), size_2, dist4_2)
+      ALLOCATE (dist4_3(nblks_4))
+      CALL dbcsr_t_default_distvec(nblks_4, pdims_4d(3), size_4, dist4_3)
+      ALLOCATE (dist4_4(nblks_5))
+      CALL dbcsr_t_default_distvec(nblks_5, pdims_4d(4), size_5, dist4_4)
 
-      CALL dbcsr_t_random_dist(dist5_1, nblks_3, pdims_3d(1))
-      CALL dbcsr_t_random_dist(dist5_2, nblks_4, pdims_3d(2))
-      CALL dbcsr_t_random_dist(dist5_3, nblks_5, pdims_3d(3))
+      ALLOCATE (dist5_1(nblks_3))
+      CALL dbcsr_t_default_distvec(nblks_3, pdims_3d(1), size_3, dist5_1)
+      ALLOCATE (dist5_2(nblks_4))
+      CALL dbcsr_t_default_distvec(nblks_4, pdims_3d(2), size_4, dist5_2)
+      ALLOCATE (dist5_3(nblks_5))
+      CALL dbcsr_t_default_distvec(nblks_5, pdims_3d(3), size_5, dist5_3)
 
 !--------------------------------------------------------------------------------------------------!
 ! Test 4: Testing tensor contraction (12|3)x(3|4)=(12|4)                                           !
@@ -320,13 +326,14 @@ PROGRAM dbcsr_tensor_unittest
 
       CALL dbcsr_t_setup_test_tensor(tensor_A, mp_comm, .FALSE., blk_ind_1_1, blk_ind_2_1, blk_ind_3_1)
       CALL dbcsr_t_setup_test_tensor(tensor_B, mp_comm, .FALSE., blk_ind_3_2, blk_ind_4_2)
+
       CALL dbcsr_t_setup_test_tensor(tensor_C, mp_comm, .FALSE., blk_ind_1_3, blk_ind_2_3, blk_ind_4_3)
 
       CALL dbcsr_t_contract_test(dbcsr_scalar(0.9_real_8), tensor_A, tensor_B, dbcsr_scalar(0.1_real_8), tensor_C, &
                                  [3], [2, 1], &
                                  [1], [2], &
                                  [2, 1], [3], &
-                                 default_output_unit, &
+                                 io_unit, &
                                  log_verbose=verbose, &
                                  write_int=.TRUE.)
 
@@ -370,7 +377,7 @@ PROGRAM dbcsr_tensor_unittest
                                  [3], [1, 2], &
                                  [1], [2], &
                                  [1, 2], [3], &
-                                 default_output_unit, &
+                                 io_unit, &
                                  log_verbose=verbose, &
                                  write_int=.TRUE.)
 
@@ -421,7 +428,7 @@ PROGRAM dbcsr_tensor_unittest
                                  [1], [2], &
                                  [3], [1, 2], &
                                  [3], [1, 2], &
-                                 default_output_unit, &
+                                 io_unit, &
                                  bounds_1=bounds, &
                                  log_verbose=verbose, &
                                  write_int=.TRUE.)
@@ -476,7 +483,7 @@ PROGRAM dbcsr_tensor_unittest
                                  [3], [1, 2], &
                                  [2], [1], &
                                  [1, 2], [3], &
-                                 default_output_unit, &
+                                 io_unit, &
                                  bounds_2=bounds, &
                                  log_verbose=verbose, &
                                  write_int=.TRUE.)
@@ -539,7 +546,7 @@ PROGRAM dbcsr_tensor_unittest
                                  [2, 1], [3], &
                                  [2, 1], [3, 4], &
                                  [1], [2, 3], &
-                                 default_output_unit, &
+                                 io_unit, &
                                  bounds_1=bounds_1, &
                                  bounds_3=bounds_2, &
                                  log_verbose=verbose, &
@@ -585,7 +592,7 @@ PROGRAM dbcsr_tensor_unittest
                                  [2, 1], [3], &
                                  [2, 1], [3, 4], &
                                  [1], [2, 3], &
-                                 default_output_unit, &
+                                 io_unit, &
                                  log_verbose=verbose, &
                                  write_int=.TRUE.)
 
@@ -629,7 +636,7 @@ PROGRAM dbcsr_tensor_unittest
                                  [1, 2], [3], &
                                  [1, 2], [3, 4], &
                                  [1], [2, 3], &
-                                 default_output_unit, &
+                                 io_unit, &
                                  log_verbose=verbose, &
                                  write_int=.TRUE.)
 
@@ -673,7 +680,7 @@ PROGRAM dbcsr_tensor_unittest
                                  [2, 1], [4, 3], &
                                  [2, 1], [3], &
                                  [3, 2], [1], &
-                                 default_output_unit, &
+                                 io_unit, &
                                  log_verbose=verbose, &
                                  write_int=.TRUE.)
 
@@ -717,7 +724,7 @@ PROGRAM dbcsr_tensor_unittest
                                  [2, 1], [3, 4], &
                                  [2, 1], [3], &
                                  [2, 3], [1], &
-                                 default_output_unit, &
+                                 io_unit, &
                                  log_verbose=verbose, &
                                  write_int=.TRUE.)
 
@@ -761,7 +768,7 @@ PROGRAM dbcsr_tensor_unittest
                                  [1], [2, 3], &
                                  [3], [1, 2], &
                                  [3, 4], [1, 2], &
-                                 default_output_unit, &
+                                 io_unit, &
                                  log_verbose=verbose, &
                                  write_int=.TRUE.)
 


### PR DESCRIPTION
This pr introduces an improved default distribution for tensors for internal and external use (new API function `dbcsr_t_default_distvec`). The algorithm is competitive with `make_basic_distribution` in CP2K (tested with `H2O-dft-ls.inp` benchmark).

The tensor API now departs from the design decision of DBCSR to leave the distribution up to the user. IMO it would be very useful to provide a default distribution in the DBCSR API and not just for tensors.