### PR TITLE
Tensors/TAS: remove `=> NULL()` pointer initializations

### DIFF
--- a/src/tas/dbcsr_tas_base.F
+++ b/src/tas/dbcsr_tas_base.F
@@ -165,7 +165,7 @@ CONTAINS
 
       TYPE(dbcsr_tas_split_info)                     :: info
 
-      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS     :: row_blk_size_vec => NULL(), col_blk_size_vec => NULL()
+      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS     :: row_blk_size_vec, col_blk_size_vec
       INTEGER                                        :: nrows, ncols, irow, col, icol, row
       CHARACTER(LEN=*), PARAMETER                    :: routineN = 'dbcsr_tas_create_new', &
                                                         routineP = moduleN//':'//routineN
@@ -366,8 +366,8 @@ CONTAINS
 
       TYPE(dbcsr_tas_split_info)                       :: split_info_prv
 
-      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS       :: row_dist_vec => NULL()
-      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS       :: col_dist_vec => NULL()
+      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS       :: row_dist_vec
+      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS       :: col_dist_vec
       TYPE(dbcsr_mp_obj)                               :: mp_environ_tmp
       INTEGER                                          :: nrows, ncols, irow, col, icol, row, &
                                                           split_rowcol, nsplit, handle
@@ -529,8 +529,8 @@ CONTAINS
 
       INTEGER                                            :: handle
       INTEGER(KIND=int_8)                                :: col, row
-      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS         :: col_dist_vec => NULL(), col_size_vec => NULL(), &
-                                                            row_dist_vec => NULL(), row_size_vec => NULL()
+      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS         :: col_dist_vec, col_size_vec, &
+                                                            row_dist_vec, row_size_vec
       LOGICAL                                            :: tr
       TYPE(dbcsr_data_obj)                               :: block
       TYPE(dbcsr_distribution_obj)                       :: dist
@@ -621,7 +621,7 @@ CONTAINS
       INTEGER                                            :: col, data_type, handle, numnodes, row
       INTEGER(KIND=int_8)                                :: nbcols, nbrows
       INTEGER, DIMENSION(2)                              :: pcoord, pdims
-      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS         :: col_blk_size => NULL(), row_blk_size => NULL()
+      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS         :: col_blk_size, row_blk_size
       LOGICAL                                            :: tr
       TYPE(dbcsr_data_obj)                               :: block
       TYPE(dbcsr_distribution_obj)                       :: dbcsr_dist
@@ -630,6 +630,7 @@ CONTAINS
       TYPE(dbcsr_tas_dist_arb)                             :: col_dist_obj, row_dist_obj
       TYPE(dbcsr_tas_distribution_type)                    :: dist
 
+      NULLIFY (col_blk_size, row_blk_size)
       CALL timeset(routineN, handle)
       CALL mp_environ(numnodes, pdims, pcoord, info%mp_comm)
       CALL dbcsr_get_info(matrix_dbcsr, distribution=dbcsr_dist, name=name, data_type=data_type, &
@@ -1006,8 +1007,9 @@ CONTAINS
       TYPE(dbcsr_tas_split_info)                                      :: info
       INTEGER                                                         :: numnodes, irow, icol
       INTEGER, DIMENSION(2)                                           :: pdims, pcoord
-      INTEGER, DIMENSION(:), POINTER                                  :: local_rows_local => NULL(), local_cols_local => NULL()
+      INTEGER, DIMENSION(:), POINTER                                  :: local_rows_local, local_cols_local
 
+      NULLIFY (local_rows_local, local_cols_local)
       CALL dbcsr_get_info(matrix%matrix, nblkrows_local=nblkrows_local, nblkcols_local=nblkcols_local, &
                           nfullrows_local=nfullrows_local, nfullcols_local=nfullcols_local, &
                           local_rows=local_rows_local, local_cols=local_cols_local, &

--- a/src/tas/dbcsr_tas_io.F
+++ b/src/tas/dbcsr_tas_io.F
@@ -117,7 +117,7 @@ CONTAINS
       INTEGER(KIND=int_8)              :: nblock_tot, nblock_p_sum, nelement_p_sum, nelement_s_max, &
                                           nblock_s, nelement_s, nblock_s_max
       REAL(KIND=real_8)                :: occupation
-      INTEGER, DIMENSION(:), POINTER   :: rowdist => NULL(), coldist => NULL()
+      INTEGER, DIMENSION(:), POINTER   :: rowdist, coldist
       INTEGER                          :: split_rowcol, icol, irow, unit_nr_prv
 
       unit_nr_prv = prep_output_unit(unit_nr)

--- a/src/tas/dbcsr_tas_reshape_ops.F
+++ b/src/tas/dbcsr_tas_reshape_ops.F
@@ -278,8 +278,8 @@ CONTAINS
 
       INTEGER                                            :: data_type, nblkcols, nblkrows
       INTEGER, DIMENSION(2)                              :: pcoord, pdims
-      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size => NULL(), col_dist => NULL(), &
-                                                            row_blk_size => NULL(), row_dist => NULL()
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, col_dist, &
+                                                            row_blk_size, row_dist
       TYPE(dbcsr_distribution_obj)                       :: dbcsr_dist
       TYPE(dbcsr_tas_dist_arb), TARGET                     :: dir_dist
       TYPE(dbcsr_tas_dist_repl), TARGET                    :: repl_dist
@@ -311,6 +311,8 @@ CONTAINS
                                      routineP = moduleN//':'//routineN
 
       INTEGER :: handle, handle2
+
+      NULLIFY (col_blk_size, row_blk_size)
 
       CALL timeset(routineN, handle)
 
@@ -691,7 +693,7 @@ CONTAINS
       LOGICAL, INTENT(IN), OPTIONAL :: transposed
 
 #:for dparam, dtype, dsuffix in dtype_float_list
-      ${dtype}$, DIMENSION(:, :), POINTER :: block_${dsuffix}$ => NULL()
+      ${dtype}$, DIMENSION(:, :), POINTER :: block_${dsuffix}$
 #:endfor
 
       SELECT CASE (buffer%data_type)
@@ -713,7 +715,7 @@ CONTAINS
       LOGICAL :: valid
       INTEGER, DIMENSION(2) :: sizes
 #:for dparam, dtype, dsuffix in dtype_float_list
-      ${dtype}$, DIMENSION(:, :), POINTER :: data_${dsuffix}$ => NULL()
+      ${dtype}$, DIMENSION(:, :), POINTER :: data_${dsuffix}$
 #:endfor
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'block_buffer_get_next_area_block', &

--- a/src/tas/dbcsr_tas_split.F
+++ b/src/tas/dbcsr_tas_split.F
@@ -456,7 +456,7 @@ CONTAINS
    SUBROUTINE dbcsr_tas_info_hold(split_info)
       TYPE(dbcsr_tas_split_info), INTENT(IN)             :: split_info
 
-      INTEGER, POINTER                                   :: ref => NULL()
+      INTEGER, POINTER                                   :: ref
 
       IF (split_info%refcount < 1) THEN
          DBCSR_ABORT("can not hold non-existing split_info")

--- a/src/tas/dbcsr_tas_test.F
+++ b/src/tas/dbcsr_tas_test.F
@@ -182,8 +182,8 @@ CONTAINS
       INTEGER                                            :: mp_comm, comm_dbcsr
       TYPE(dbcsr_distribution_obj)                       :: dist_a, dist_b, dist_c
       INTEGER, DIMENSION(2)                              :: npdims, myploc
-      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS         :: cd_a => NULL(), cd_b => NULL(), cd_c => NULL(), &
-                                                            rd_a => NULL(), rd_b => NULL(), rd_c => NULL()
+      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS         :: cd_a, cd_b, cd_c, &
+                                                            rd_a, rd_b, rd_c
       TYPE(dbcsr_mp_obj)                                 :: mp_environ_tmp
 
       INTEGER, DIMENSION(:), POINTER, CONTIGUOUS         :: row_blk_size, col_blk_size
@@ -293,8 +293,8 @@ CONTAINS
       INTEGER                                            :: comm_dbcsr, io_unit, mp_comm, mynode, &
                                                             numnodes
       INTEGER, DIMENSION(2)                              :: myploc, npdims
-      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS         :: cd_a => NULL(), cd_b => NULL(), cd_c => NULL(), &
-                                                            rd_a => NULL(), rd_b => NULL(), rd_c => NULL()
+      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS         :: cd_a, cd_b, cd_c, &
+                                                            rd_a, rd_b, rd_c
       REAL(KIND=real_8)                                  :: norm, rc_cs, sq_cs
       TYPE(dbcsr_distribution_obj)                       :: dist_a, dist_b, dist_c
       TYPE(dbcsr_mp_obj)                                 :: mp_environ_tmp

--- a/src/tensors/dbcsr_tensor.F
+++ b/src/tensors/dbcsr_tensor.F
@@ -122,8 +122,8 @@ CONTAINS
          !! crop tensor data: start and end index for each tensor dimension
       INTEGER, INTENT(IN), OPTIONAL                  :: unit_nr
 
-      TYPE(dbcsr_t_type), POINTER                    :: in_tmp_1 => NULL(), in_tmp_2 => NULL(), &
-                                                        in_tmp_3 => NULL(), out_tmp_1 => NULL()
+      TYPE(dbcsr_t_type), POINTER                    :: in_tmp_1, in_tmp_2, &
+                                                        in_tmp_3, out_tmp_1
       INTEGER                                        :: handle, unit_nr_prv
       INTEGER, DIMENSION(:), ALLOCATABLE             :: map1_in_1, map1_in_2, map2_in_1, map2_in_2
 
@@ -301,7 +301,7 @@ CONTAINS
 
       INTEGER, DIMENSION(2)                              :: ind_2d
       REAL(KIND=real_8), ALLOCATABLE, DIMENSION(:, :)    :: block_arr
-      REAL(KIND=real_8), DIMENSION(:, :), POINTER        :: block => NULL()
+      REAL(KIND=real_8), DIMENSION(:, :), POINTER        :: block
       TYPE(dbcsr_iterator_type)                          :: iter
       LOGICAL                                            :: tr
 
@@ -311,6 +311,8 @@ CONTAINS
 
       CALL timeset(routineN, handle)
       DBCSR_ASSERT(tensor_out%valid)
+
+      NULLIFY (block)
 
       IF (dbcsr_has_symmetry(matrix_in)) THEN
          ALLOCATE (matrix_in_desym)

--- a/src/tensors/dbcsr_tensor_block.F
+++ b/src/tensors/dbcsr_tensor_block.F
@@ -590,7 +590,6 @@ CONTAINS
       LOGICAL, PARAMETER :: debug = .FALSE.
       INTEGER :: i
 
-      NULLIFY (block_2d)
       new_block = .FALSE.
 
       IF (debug) THEN
@@ -668,14 +667,14 @@ CONTAINS
          !! whether block was found
 
       INTEGER(KIND=int_8), DIMENSION(2)                     :: ind_2d
-      ${dtype}$, DIMENSION(:, :), POINTER, CONTIGUOUS       :: block_2d_ptr => NULL()
+      ${dtype}$, DIMENSION(:, :), POINTER, CONTIGUOUS       :: block_2d_ptr
       LOGICAL                                               :: tr
       INTEGER                                               :: i
       ${dtype}$, DIMENSION(${shape_colon(ndim)}$), POINTER  :: block_ptr
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_get_${ndim}$d_block_${dsuffix}$', &
                                      routineP = moduleN//':'//routineN
 
-      NULLIFY (block_2d_ptr, block_ptr)
+      NULLIFY (block_2d_ptr)
 
       ind_2d(:) = get_2d_indices_tensor(tensor%nd_index_blk, ind)
 

--- a/src/tensors/dbcsr_tensor_types.F
+++ b/src/tensors/dbcsr_tensor_types.F
@@ -705,7 +705,7 @@ CONTAINS
       !! when no longer needed)
 
       TYPE(dbcsr_t_distribution_type), INTENT(IN) :: dist
-      INTEGER, POINTER                            :: ref => NULL()
+      INTEGER, POINTER                            :: ref
 
       IF (dist%refcount < 1) THEN
          DBCSR_ABORT("can not hold non-existing tensor distribution")
@@ -846,7 +846,7 @@ CONTAINS
       !! when no longer needed)
 
       TYPE(dbcsr_t_type), INTENT(IN) :: tensor
-      INTEGER, POINTER :: ref => NULL()
+      INTEGER, POINTER :: ref
 
       IF (tensor%refcount < 1) THEN
          DBCSR_ABORT("can not hold non-existing tensor")
@@ -958,8 +958,8 @@ CONTAINS
       INTEGER                                     :: comm_2d, data_type
       TYPE(dbcsr_distribution_type)                :: matrix_dist
       TYPE(dbcsr_t_distribution_type)             :: dist
-      INTEGER, DIMENSION(:), POINTER              :: row_blk_size => NULL(), col_blk_size => NULL()
-      INTEGER, DIMENSION(:), POINTER              :: col_dist => NULL(), row_dist => NULL()
+      INTEGER, DIMENSION(:), POINTER              :: row_blk_size, col_blk_size
+      INTEGER, DIMENSION(:), POINTER              :: col_dist, row_dist
       INTEGER                                   :: handle
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_create_matrix', &
                                      routineP = moduleN//':'//routineN
@@ -967,6 +967,8 @@ CONTAINS
       INTEGER, DIMENSION(2)                     :: pdims_2d
 
       CALL timeset(routineN, handle)
+
+      NULLIFY (row_blk_size, col_blk_size, col_dist, row_dist)
       IF (PRESENT(name)) THEN
          name_in = name
       ELSE


### PR DESCRIPTION
implicit save variables are shared and thus not thread-safe

This fixes #344