### PR TITLE
Feature: call `timeset` inside libsmm acc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ add_fypp_sources(DBCSR_SRCS
   acc/dbcsr_acc_hostmem.F
   acc/dbcsr_acc_init.F
   acc/dbcsr_acc_stream.F
+  acc/dbcsr_acc_timings.F
   acc/hipblaswrap/dbcsr_hipblas.F
   base/dbcsr_base_hooks.F
   base/dbcsr_kinds.F
@@ -109,9 +110,9 @@ set(DBCSR_ACC_SRCS
   acc/acc_dev.cpp
   acc/acc_error.cpp
   acc/acc_event.cpp
+  acc/acc_init.cpp
   acc/acc_mem.cpp
   acc/acc_stream.cpp
-  acc/acc_init.cpp
   )
 
 set(DBCSR_CUDA_SRCS

--- a/src/acc/dbcsr_acc_device.F
+++ b/src/acc/dbcsr_acc_device.F
@@ -31,10 +31,10 @@ MODULE dbcsr_acc_device
 
       END FUNCTION acc_get_ndevices_cu
 
-      FUNCTION acc_set_active_device_cu(dev_id) RESULT(istat) &
+      FUNCTION acc_set_active_device_cu(device_id) RESULT(istat) &
          BIND(C, name="acc_set_active_device")
          IMPORT
-         INTEGER(KIND=C_INT), INTENT(IN), VALUE   :: dev_id
+         INTEGER(KIND=C_INT), INTENT(IN), VALUE   :: device_id
          INTEGER(KIND=C_INT)                      :: istat
 
       END FUNCTION acc_set_active_device_cu
@@ -66,23 +66,22 @@ CONTAINS
 #endif
    END FUNCTION dbcsr_acc_get_ndevices
 
-   SUBROUTINE dbcsr_acc_set_active_device(dev_id)
+   SUBROUTINE dbcsr_acc_set_active_device(device_id)
       !! Set active accelerator device
 
-      INTEGER :: dev_id
-         !! device ID
+      INTEGER :: device_id
 
 #if defined (__DBCSR_ACC)
       INTEGER :: istat
 
-!$OMP PARALLEL DEFAULT(NONE) PRIVATE(istat) SHARED(dev_id)
-      istat = acc_set_active_device_cu(dev_id)
+!$OMP PARALLEL DEFAULT(NONE) PRIVATE(istat) SHARED(device_id)
+      istat = acc_set_active_device_cu(device_id)
       IF (istat /= 0) &
          DBCSR_ABORT("acc_set_active_device: failed")
 !$OMP END PARALLEL
 
 #else
-      MARK_USED(dev_id)
+      MARK_USED(device_id)
       DBCSR_ABORT("__DBCSR_ACC not compiled in")
 #endif
    END SUBROUTINE dbcsr_acc_set_active_device

--- a/src/acc/dbcsr_acc_devmem.F
+++ b/src/acc/dbcsr_acc_devmem.F
@@ -249,7 +249,6 @@ CONTAINS
       !! Returns a logical, which indicates if the given devmem is allocated.
 
       TYPE(acc_devmem_type), INTENT(IN)                  :: this
-         !! device memory
       LOGICAL                                            :: res
          !! true if device memory is allocated, false otherwise
 
@@ -260,7 +259,6 @@ CONTAINS
       !! Returns size of given devmem in terms of item count (not bytes!)
 
       TYPE(acc_devmem_type), INTENT(IN)                  :: this
-         !! device memory
       INTEGER                                            :: res
          !! size of device memory (item count)
 
@@ -286,7 +284,6 @@ CONTAINS
       !! Returns C-pointer to data of given devmem.
 
       TYPE(acc_devmem_type), INTENT(IN)                  :: this
-         !! device memory
       TYPE(C_PTR)                                        :: res
          !! C-pointer to data of given devmem
 
@@ -300,10 +297,8 @@ CONTAINS
       !! Allocates a given devmem.
 
       TYPE(acc_devmem_type), INTENT(INOUT)     :: this
-         !! device memory
       TYPE(acc_devmem_type), INTENT(IN)        :: pointee
       INTEGER, INTENT(IN)                      :: size_in_bytes, lb_in_bytes
-         !! size in bytes
 
 #if ! defined (__DBCSR_ACC)
       MARK_USED(this)
@@ -354,9 +349,7 @@ CONTAINS
       !! Allocates a given devmem.
 
       TYPE(acc_devmem_type), INTENT(INOUT)     :: this
-         !! device memory
       INTEGER, INTENT(IN)                      :: size_in_bytes
-         !! size in bytes
 
 #if ! defined (__DBCSR_ACC)
       MARK_USED(this)
@@ -383,7 +376,6 @@ CONTAINS
       !! Deallocates a given devmem.
 
       TYPE(acc_devmem_type), INTENT(INOUT) :: this
-         !! device memory
 
 #if ! defined (__DBCSR_ACC)
       MARK_USED(this)
@@ -411,7 +403,6 @@ CONTAINS
       !! Sets entries in given devmem to zero, asynchronously.
 
       TYPE(acc_devmem_type), INTENT(INOUT) :: this
-         !! device memory
       INTEGER, INTENT(IN), OPTIONAL        :: first_byte, last_byte
          !! begin of region to zero, defaults to 1 if not given.
          !! end of region to zero, defaults to size if not given.
@@ -458,11 +449,8 @@ CONTAINS
       !! Helper-routine performing actuall host2dev transfers.
 
       TYPE(acc_devmem_type), INTENT(IN)                  :: this
-         !! device memory
       TYPE(C_PTR)                                        :: hostmem_cptr
-         !! host memory
       INTEGER, INTENT(IN)                                :: n_bytes
-         !! number of bytes
       TYPE(acc_stream_type), INTENT(IN)                  :: stream
          !! stream used for memory transfer
 
@@ -489,13 +477,9 @@ CONTAINS
       !! Helper-routine performing actual dev2host transfers.
 
       TYPE(acc_devmem_type), INTENT(IN)                  :: this
-         !! device memory
       TYPE(C_PTR)                                        :: hostmem_cptr
-         !! host memory
       INTEGER, INTENT(IN)                                :: n_bytes
-         !! number of bytes
       TYPE(acc_stream_type), INTENT(IN)                  :: stream
-         !! stream used for memory transfer
 
       CHARACTER(len=*), PARAMETER :: routineN = 'dev2host_raw', routineP = moduleN//':'//routineN
 
@@ -531,11 +515,8 @@ CONTAINS
       !! Transfers 1D fortran-array from host to GPU devmem.
 
       TYPE(acc_devmem_type), INTENT(IN)        :: this
-         !! device memory
       ${type}$, DIMENSION(:), POINTER          :: hostmem
-         !! host memory
       TYPE(acc_stream_type), INTENT(IN)        :: stream
-         !! stream
 
 #if ! defined (__DBCSR_ACC)
       MARK_USED(this)
@@ -551,11 +532,8 @@ CONTAINS
       !! Transfers 2D fortran-array from host to GPU devmem.
 
       TYPE(acc_devmem_type), INTENT(IN)        :: this
-         !! device memory
       ${type}$, DIMENSION(:, :), POINTER       :: hostmem
-         !! host memory
       TYPE(acc_stream_type), INTENT(IN)        :: stream
-         !! stream
 
 #if ! defined (__DBCSR_ACC)
       MARK_USED(this)
@@ -571,11 +549,8 @@ CONTAINS
       !! Transfers GPU devmem to 1D fortran-array.
 
       TYPE(acc_devmem_type), INTENT(IN)        :: this
-         !! device memory
       ${type}$, DIMENSION(:), POINTER          :: hostmem
-         !! host memory
       TYPE(acc_stream_type), INTENT(IN)        :: stream
-         !! stream
 
 #if ! defined (__DBCSR_ACC)
       MARK_USED(this)

--- a/src/acc/dbcsr_acc_event.F
+++ b/src/acc/dbcsr_acc_event.F
@@ -100,9 +100,7 @@ CONTAINS
       !! Because of fortran circular dependency restriction this can not go into acc_stream.F
 
       TYPE(acc_stream_type), INTENT(IN) :: stream
-         !! stream
       TYPE(acc_event_type), INTENT(IN)  :: event
-         !! event
 
 #if ! defined (__DBCSR_ACC)
       MARK_USED(stream)
@@ -127,9 +125,7 @@ CONTAINS
       !! Fortran-wrapper for recording a CUDA/HIP event.
 
       TYPE(acc_event_type), INTENT(IN)  :: this
-         !! event
       TYPE(acc_stream_type), INTENT(IN) :: stream
-         !! stream
 
 #if ! defined (__DBCSR_ACC)
       MARK_USED(this)
@@ -155,7 +151,6 @@ CONTAINS
 
       TYPE(acc_event_type), &
          INTENT(INOUT)                          :: this
-         !! event
 
 #if ! defined (__DBCSR_ACC)
       MARK_USED(this)
@@ -176,7 +171,6 @@ CONTAINS
 
       TYPE(acc_event_type), &
          INTENT(INOUT)                          :: this
-         !! event
 
 #if ! defined (__DBCSR_ACC)
       MARK_USED(this)
@@ -196,7 +190,6 @@ CONTAINS
       !! Fortran-wrapper for querying a CUDA/HIP event's status.
 
       TYPE(acc_event_type), INTENT(IN)         :: this
-         !! event
       LOGICAL                                  :: res
          !! true if event has occurred, false otherwise
 
@@ -219,7 +212,6 @@ CONTAINS
       !! Fortran-wrapper for waiting for the completion of a HIP/CUDA event.
 
       TYPE(acc_event_type), INTENT(IN)  :: this
-         !! event
 
 #if ! defined (__DBCSR_ACC)
       MARK_USED(this)

--- a/src/acc/dbcsr_acc_init.F
+++ b/src/acc/dbcsr_acc_init.F
@@ -42,7 +42,6 @@ MODULE dbcsr_acc_init
 CONTAINS
 
    SUBROUTINE acc_init()
-      !! Fortran-wrapper for acc_init
 
 #if ! defined (__DBCSR_ACC)
       DBCSR_ABORT("__DBCSR_ACC not compiled in.")
@@ -55,7 +54,6 @@ CONTAINS
    END SUBROUTINE acc_init
 
    SUBROUTINE acc_finalize()
-      !! Fortran-wrapper for acc_finalize
 
 #if ! defined (__DBCSR_ACC)
       DBCSR_ABORT("__DBCSR_ACC not compiled in.")

--- a/src/acc/dbcsr_acc_stream.F
+++ b/src/acc/dbcsr_acc_stream.F
@@ -108,11 +108,8 @@ CONTAINS
       !! Fortran-wrapper for creation of a CUDA/HIP stream.
 
       TYPE(acc_stream_type), INTENT(OUT) :: this
-         !! stream
       CHARACTER(LEN=*), INTENT(IN)             :: name
-         !! stream name
       INTEGER, INTENT(IN), OPTIONAL            :: priority
-         !! stream priority
 
 #if ! defined (__DBCSR_ACC)
       MARK_USED(this)
@@ -141,7 +138,6 @@ CONTAINS
 
       TYPE(acc_stream_type), &
          INTENT(INOUT)                          :: this
-         !! stream
 
 #if ! defined (__DBCSR_ACC)
       MARK_USED(this)
@@ -162,7 +158,6 @@ CONTAINS
 
       TYPE(acc_stream_type), &
          INTENT(IN)                             :: this
-         !! stream
 
 #if ! defined (__DBCSR_ACC)
       MARK_USED(this)
@@ -181,8 +176,6 @@ CONTAINS
       !! Fortran-wrapper for getting CUDA/HIP streams' priority range.
 
       INTEGER, INTENT(OUT)                     :: least, greatest
-         !! least priority
-         !! greatest priroity
 
 #if ! defined (__DBCSR_ACC)
       least = -1; greatest = -1 ! assign intent-out arguments to silence compiler warnings
@@ -199,8 +192,6 @@ CONTAINS
       !! Checks if two streams are equal
 
       TYPE(acc_stream_type), INTENT(IN) :: this, other
-         !! first stream
-         !! second stream
       LOGICAL                                  :: res
          !! true if equal, false otherwise
 #if ! defined (__DBCSR_ACC)
@@ -216,7 +207,6 @@ CONTAINS
       !! Checks if a streams is associated
 
       TYPE(acc_stream_type), INTENT(IN) :: this
-         !! stream
       LOGICAL                                  :: res
          !! true if associated, false otherwise
 #if ! defined (__DBCSR_ACC)

--- a/src/acc/dbcsr_acc_timings.F
+++ b/src/acc/dbcsr_acc_timings.F
@@ -1,0 +1,61 @@
+!--------------------------------------------------------------------------------------------------!
+! Copyright (C) by the DBCSR developers group - All rights reserved                                !
+! This file is part of the DBCSR library.                                                          !
+!                                                                                                  !
+! For information on the license, see the LICENSE file.                                            !
+! For further information please visit https://dbcsr.cp2k.org                                      !
+! SPDX-License-Identifier: GPL-2.0+                                                                !
+!--------------------------------------------------------------------------------------------------!
+
+MODULE dbcsr_acc_timings
+   !! Accelerator support
+#if defined (__DBCSR_ACC)
+   USE ISO_C_BINDING, ONLY: C_INT, C_CHAR, C_PTR, C_F_POINTER
+#endif
+#include "base/dbcsr_base_uses.f90"
+
+   IMPLICIT NONE
+
+   PRIVATE
+
+   CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'dbcsr_acc_timings'
+
+CONTAINS
+
+   SUBROUTINE dbcsr_timeset_F(routineN, routineN_len, handle) BIND(C, name="dbcsr_timeset")
+
+      TYPE(C_PTR), INTENT(IN)                :: routineN
+      INTEGER(KIND=C_INT), INTENT(IN)        :: routineN_len
+      INTEGER(KIND=C_INT), INTENT(OUT)       :: handle
+
+      CHARACTER, POINTER                     :: a(:)
+      CHARACTER(len=routineN_len)            :: routineName
+      INTEGER                                :: i
+
+      CALL C_F_POINTER(routineN, a, [routineN_len])
+
+      ! Convert character array to scalar character string
+      DO i = 1, routineN_len
+         routineName(i:i) = a(i)
+      END DO
+
+#if ! defined (__DBCSR_ACC)
+      DBCSR_ABORT("__DBCSR_ACC not compiled in.")
+#else
+      CALL timeset(routineName, handle)
+#endif
+
+   END SUBROUTINE dbcsr_timeset_F
+
+   SUBROUTINE dbcsr_timestop_F(handle) BIND(C, name="dbcsr_timestop")
+
+      INTEGER(KIND=C_INT), INTENT(IN)        :: handle
+
+#if ! defined (__DBCSR_ACC)
+      DBCSR_ABORT("__DBCSR_ACC not compiled in.")
+#else
+      CALL timestop(handle)
+#endif
+   END SUBROUTINE dbcsr_timestop_F
+
+END MODULE dbcsr_acc_timings

--- a/src/acc/dbcsr_acc_timings.F
+++ b/src/acc/dbcsr_acc_timings.F
@@ -9,9 +9,7 @@
 
 MODULE dbcsr_acc_timings
    !! Accelerator support
-#if defined (__DBCSR_ACC)
-   USE ISO_C_BINDING, ONLY: C_INT, C_CHAR, C_PTR, C_F_POINTER
-#endif
+   USE ISO_C_BINDING, ONLY: C_INT, C_PTR, C_F_POINTER
 #include "base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -24,7 +22,7 @@ CONTAINS
 
    SUBROUTINE dbcsr_timeset_F(routineN, routineN_len, handle) BIND(C, name="dbcsr_timeset")
 
-      TYPE(C_PTR), INTENT(IN)                :: routineN
+      TYPE(C_PTR), INTENT(IN)      :: routineN
       INTEGER(KIND=C_INT), INTENT(IN)        :: routineN_len
       INTEGER(KIND=C_INT), INTENT(OUT)       :: handle
 
@@ -34,12 +32,14 @@ CONTAINS
 
       CALL C_F_POINTER(routineN, a, [routineN_len])
 
-      ! Convert character array to scalar character string
+      ! Convert character array "a" to scalar character string
+      ! "routineName"
       DO i = 1, routineN_len
          routineName(i:i) = a(i)
       END DO
 
 #if ! defined (__DBCSR_ACC)
+      MARK_USED(handle)
       DBCSR_ABORT("__DBCSR_ACC not compiled in.")
 #else
       CALL timeset(routineName, handle)
@@ -52,6 +52,7 @@ CONTAINS
       INTEGER(KIND=C_INT), INTENT(IN)        :: handle
 
 #if ! defined (__DBCSR_ACC)
+      MARK_USED(handle)
       DBCSR_ABORT("__DBCSR_ACC not compiled in.")
 #else
       CALL timestop(handle)

--- a/src/acc/libsmm_acc/libsmm_acc.cpp
+++ b/src/acc/libsmm_acc/libsmm_acc.cpp
@@ -153,7 +153,7 @@ inline void jit_kernel(ACC_DRV(function)& kern_func, libsmm_acc_algo algo, int t
                           std::to_string(threads) + ", " + std::to_string(grouping) + ", " + std::to_string(minblocks) + ">";
             break;
         default:
-            printf("\nerror: algorithm number %i is not encoded.", algo);
+            printf("\nERROR: algorithm number %i is not encoded.\n", algo);
             exit(1);
     }
 

--- a/src/acc/libsmm_acc/libsmm_acc.cpp
+++ b/src/acc/libsmm_acc/libsmm_acc.cpp
@@ -47,6 +47,17 @@
 
 
 //===========================================================================
+void timeset(std::string routine_name, int& handle){
+    const char* routine_name_ = routine_name.c_str();
+    int routine_name_length  = routine_name.length();
+    dbcsr_timeset(&routine_name_, &routine_name_length, &handle);
+}
+
+void timestop(int handle){
+    dbcsr_timestop(&handle);
+}
+
+//===========================================================================
 inline int launch_kernel_from_handle(ACC_DRV(function) const& kern_func, int nblks, int threads, ACC_DRV(stream) stream, void** args){
 
     ACC_DRV_CALL(
@@ -97,6 +108,9 @@ inline void validate_kernel(ACC_DRV(function)& kern_func, ACC_DRV(stream) stream
 
 //===========================================================================
 inline void jit_kernel(ACC_DRV(function)& kern_func, libsmm_acc_algo algo, int tile_m, int tile_n, int w, int v, int threads, int grouping, int minblocks, int m, int n, int k){
+    std::string routineN = "jit_kernel_multiply";
+    int handle;
+    timeset(routineN, handle);
 
     // Get the code and the lowered name corresponding the kernel to launch
     std::string kernel_code = smm_acc_common; // prepend include file content to code
@@ -183,6 +197,8 @@ inline void jit_kernel(ACC_DRV(function)& kern_func, libsmm_acc_algo algo, int t
 
     // Destroy program
     ACC_RTC_CALL(DestroyProgram, (&kernel_program));
+
+    timestop(handle);
 }
 
 
@@ -278,6 +294,10 @@ extern "C" int libsmm_acc_process (const libsmm_acc_stack_descriptor_type *param
 //===========================================================================
 void jit_transpose_handle(ACC_DRV(function)& kern_func, int m, int n){
 
+    std::string routineN = "jit_kernel_transpose";
+    int handle;
+    timeset(routineN, handle);
+
     // Create nvrtcProgram
     ACC_RTC(Program) kernel_program;
     std::string transpose_code = smm_acc_common + smm_acc_transpose;
@@ -320,6 +340,8 @@ void jit_transpose_handle(ACC_DRV(function)& kern_func, int m, int n){
 
     // Destroy program
     ACC_RTC_CALL(DestroyProgram, (&kernel_program));
+
+    timestop(handle);
 }
 
 

--- a/src/acc/libsmm_acc/libsmm_acc.h
+++ b/src/acc/libsmm_acc/libsmm_acc.h
@@ -23,6 +23,12 @@
 #include <unordered_map>
 #include <vector>
 
+extern "C" void dbcsr_timeset(const char** routineN, int* routineN_len, int* handle);
+void timeset(std::string routine_name, int& handle);
+
+extern "C" void dbcsr_timestop(int* handle);
+void timestop(int handle);
+
 enum libsmm_acc_algo {
     largeDB1 = 1,
     largeDB2 = 2,

--- a/src/core/dbcsr_timings.F
+++ b/src/core/dbcsr_timings.F
@@ -276,7 +276,8 @@ CONTAINS
 
       IF (handle /= cs_entry%routine_id) THEN
          PRINT *, "list_size(timer_env%callstack) ", list_size(timer_env%callstack), &
-            " handle ", handle, " list_size(timers_stack) ", list_size(timers_stack)
+            " list_size(timers_stack) ", list_size(timers_stack), &
+            " got handle ", handle, " expected routineid ", cs_entry%routine_id
          DBCSR_ABORT('mismatched timestop '//TRIM(r_stat%routineN)//' in routine timestop')
       END IF
 


### PR DESCRIPTION
### Add timer facilities to C++ code

Now `jit_kernel_multiply` and `jit_kernel_transpose` appear in DBCSR's timing section, presenting information on the JIT overhead and helping to diagnose possible performance issues.