### PR TITLE
minor tweaks for some OpenMP synchronization

### DIFF
--- a/src/block/dbcsr_block_access.F
+++ b/src/block/dbcsr_block_access.F
@@ -885,9 +885,14 @@ CONTAINS
                      data_block, found, data_block2)
 
       IF (.NOT. found) THEN
+#if defined(_OPENMP) && (200711 <= _OPENMP)
+!$OMP ATOMIC WRITE
+         matrix%valid = .FALSE.
+#else
 !$OMP CRITICAL (critical_reserve_block2d)
          matrix%valid = .FALSE.
 !$OMP END CRITICAL (critical_reserve_block2d)
+#endif
          matrix%wms(iw)%lastblk = matrix%wms(iw)%lastblk + 1
          matrix%wms(iw)%datasize = matrix%wms(iw)%datasize + row_size*col_size
       ELSE
@@ -1093,9 +1098,8 @@ CONTAINS
          IF (.NOT. found) THEN
             matrix%wms(iw)%datasize = matrix%wms(iw)%datasize + nze
          ENDIF
-!$OMP CRITICAL (dbcsr_put_block_critical)
+!$OMP ATOMIC WRITE
          matrix%valid = .FALSE.
-!$OMP END CRITICAL (dbcsr_put_block_critical)
       ENDIF
       IF (PRESENT(flop)) flop = flop + my_flop
    END SUBROUTINE dbcsr_put_block_${nametype1}$

--- a/src/block/dbcsr_iterator_operations.F
+++ b/src/block/dbcsr_iterator_operations.F
@@ -443,7 +443,7 @@ CONTAINS
       TYPE(dbcsr_iterator), INTENT(INOUT)                :: iterator
          !! the iterator
 
-      INTEGER                                            :: ithread, my_old_row, next_row, p
+      INTEGER                                            :: ithread, my_old_row, p
       LOGICAL                                            :: advance, jumped_row
 
 !   ---------------------------------------------------------------------------
@@ -466,9 +466,7 @@ CONTAINS
                IF (jumped_row) THEN
 !$OMP                 CRITICAL (crit_common_pos)
                   ! Set the common_pos to the next available row.
-                  next_row = MAX(iterator%common_pos + 1, iterator%row)
-                  next_row = next_row - iterator%common_pos
-                  iterator%common_pos = iterator%common_pos + next_row
+                  iterator%common_pos = MAX(iterator%row, iterator%common_pos + 1)
                   iterator%row = iterator%common_pos
 !$OMP                 END CRITICAL (crit_common_pos)
                   IF (iterator%row .GT. iterator%nblkrows_total) THEN


### PR DESCRIPTION
Rely on OpenMP atomic when writing matrix%valid property. Reduced code in "crit_common_pos" critical section.