### PR TITLE
TAS: minor tweak ensuring square DBCSR grids

### DIFF
--- a/src/tas/dbcsr_tas_split.F
+++ b/src/tas/dbcsr_tas_split.F
@@ -54,7 +54,7 @@ MODULE dbcsr_tas_split
 
    INTEGER, PARAMETER :: rowsplit = 1, colsplit = 2
    REAL(real_8), PARAMETER :: default_pdims_accept_ratio = 1.2_real_8
-   REAL(real_8), PARAMETER :: default_nsplit_accept_ratio = 1.5_real_8
+   REAL(real_8), PARAMETER :: default_nsplit_accept_ratio = 3.0_real_8
 
    INTERFACE dbcsr_tas_mp_comm
       MODULE PROCEDURE dbcsr_tas_mp_comm

--- a/src/tensors/dbcsr_tensor_api.F
+++ b/src/tensors/dbcsr_tensor_api.F
@@ -43,7 +43,7 @@ MODULE dbcsr_tensor_api
    USE dbcsr_tensor_index, ONLY: &
       dbcsr_t_get_mapping_info
    USE dbcsr_tensor_io, ONLY: &
-      dbcsr_t_write_split_info, dbcsr_t_write_blocks
+      dbcsr_t_write_tensor_info, dbcsr_t_write_split_info, dbcsr_t_write_blocks, dbcsr_t_write_tensor_dist
 
    IMPLICIT NONE
 
@@ -91,6 +91,8 @@ MODULE dbcsr_tensor_api
    PUBLIC :: dbcsr_t_get_mapping_info
    PUBLIC :: dbcsr_t_write_split_info
    PUBLIC :: dbcsr_t_write_blocks
+   PUBLIC :: dbcsr_t_write_tensor_dist
+   PUBLIC :: dbcsr_t_write_tensor_info
    PUBLIC :: dbcsr_t_mp_dims_create
    PUBLIC :: dbcsr_t_batched_contract_init
    PUBLIC :: dbcsr_t_batched_contract_finalize


### PR DESCRIPTION
The optimizations introduced in a7ab9d7a64f2e98624bb3c57a86dcb3ee842b54d
led to often non-square process grids, causing an overhead in memory
usage.

Unrelated: make tensor routines for output public.