### PR TITLE
Type conversion compilation error fix

### DIFF
--- a/src/tensors/dbcsr_tensor_api_c.F
+++ b/src/tensors/dbcsr_tensor_api_c.F
@@ -537,7 +537,7 @@ CONTAINS
       CALL c_f_pointer(c_tensor, tensor)
 
       CALL dbcsr_t_get_block(tensor, c_ind + 1, c_sizes, c_block, found)
-      c_found = found
+      c_found = logical(found, kind=c_bool)
 
    END SUBROUTINE
 #:endfor
@@ -723,7 +723,7 @@ CONTAINS
       LOGICAL(kind=c_bool)                               :: c_dbcsr_t_iterator_blocks_left
 
       CALL c_f_pointer(c_iterator, iterator)
-      c_dbcsr_t_iterator_blocks_left = dbcsr_t_iterator_blocks_left(iterator)
+      c_dbcsr_t_iterator_blocks_left = logical(dbcsr_t_iterator_blocks_left(iterator), kind=c_bool)
 
    END FUNCTION
 
@@ -1072,7 +1072,7 @@ CONTAINS
                                        c_dims1_2d, c_dims2_2d, &
                                        c_map1_2d, c_map2_2d, c_map_nd, &
                                        base, col_major)
-         c_col_major = col_major
+         c_col_major = logical(col_major, kind=c_bool)
       ELSE
          CALL dbcsr_t_get_mapping_info(tensor%nd_index_blk, ndim_nd, ndim1_2d, &
                                        ndim2_2d, c_dims_2d_i8, c_dims_2d, c_dims_nd, &

--- a/src/tensors/dbcsr_tensor_api_c.F
+++ b/src/tensors/dbcsr_tensor_api_c.F
@@ -537,7 +537,7 @@ CONTAINS
       CALL c_f_pointer(c_tensor, tensor)
 
       CALL dbcsr_t_get_block(tensor, c_ind + 1, c_sizes, c_block, found)
-      c_found = logical(found, kind=c_bool)
+      c_found = LOGICAL(found, kind=c_bool)
 
    END SUBROUTINE
 #:endfor
@@ -723,7 +723,7 @@ CONTAINS
       LOGICAL(kind=c_bool)                               :: c_dbcsr_t_iterator_blocks_left
 
       CALL c_f_pointer(c_iterator, iterator)
-      c_dbcsr_t_iterator_blocks_left = logical(dbcsr_t_iterator_blocks_left(iterator), kind=c_bool)
+      c_dbcsr_t_iterator_blocks_left = LOGICAL(dbcsr_t_iterator_blocks_left(iterator), kind=c_bool)
 
    END FUNCTION
 
@@ -1072,7 +1072,7 @@ CONTAINS
                                        c_dims1_2d, c_dims2_2d, &
                                        c_map1_2d, c_map2_2d, c_map_nd, &
                                        base, col_major)
-         c_col_major = logical(col_major, kind=c_bool)
+         c_col_major = LOGICAL(col_major, kind=c_bool)
       ELSE
          CALL dbcsr_t_get_mapping_info(tensor%nd_index_blk, ndim_nd, ndim1_2d, &
                                        ndim2_2d, c_dims_2d_i8, c_dims_2d, c_dims_nd, &


### PR DESCRIPTION
When compiling DBCSR on Mac OS 10.15.6 I encounter an error. I am using the following cmake line:
```
cmake .. -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
```
gfortran, gcc, and g++ are all GNU version 10.2.0.

The error is:
```
/Users/wddawson/Documents/NTPoly/Bench/dbcsr/build/src/tensors/dbcsr_tensor_api_c.F:2943:23:

 2943 |          c_col_major = col_major
      |                       1
Error: Possible change of value in conversion from LOGICAL(4) to LOGICAL(1) at (1) [-Werror=conversion]
/Users/wddawson/Documents/NTPoly/Bench/dbcsr/build/src/tensors/dbcsr_tensor_api_c.F:2417:39:

 2417 |       c_dbcsr_t_iterator_blocks_left = dbcsr_t_iterator_blocks_left(iterator)
      |                                       1
Error: Possible change of value in conversion from LOGICAL(4) to LOGICAL(1) at (1) [-Werror=conversion]
/Users/wddawson/Documents/NTPoly/Bench/dbcsr/build/src/tensors/dbcsr_tensor_api_c.F:1870:16:

 1870 |       c_found = found
      |                1
Error: Possible change of value in conversion from LOGICAL(4) to LOGICAL(1) at (1) [-Werror=conversion]
/Users/wddawson/Documents/NTPoly/Bench/dbcsr/build/src/tensors/dbcsr_tensor_api_c.F:1846:16:

 1846 |       c_found = found
      |                1
Error: Possible change of value in conversion from LOGICAL(4) to LOGICAL(1) at (1) [-Werror=conversion]
/Users/wddawson/Documents/NTPoly/Bench/dbcsr/build/src/tensors/dbcsr_tensor_api_c.F:1822:16:

 1822 |       c_found = found
      |                1
Error: Possible change of value in conversion from LOGICAL(4) to LOGICAL(1) at (1) [-Werror=conversion]
/Users/wddawson/Documents/NTPoly/Bench/dbcsr/build/src/tensors/dbcsr_tensor_api_c.F:1798:16:

 1798 |       c_found = found
      |                1
Error: Possible change of value in conversion from LOGICAL(4) to LOGICAL(1) at (1) [-Werror=conversion]
/Users/wddawson/Documents/NTPoly/Bench/dbcsr/build/src/tensors/dbcsr_tensor_api_c.F:1774:16:

 1774 |       c_found = found
      |                1
Error: Possible change of value in conversion from LOGICAL(4) to LOGICAL(1) at (1) [-Werror=conversion]
/Users/wddawson/Documents/NTPoly/Bench/dbcsr/build/src/tensors/dbcsr_tensor_api_c.F:1750:16:

 1750 |       c_found = found
      |                1
Error: Possible change of value in conversion from LOGICAL(4) to LOGICAL(1) at (1) [-Werror=conversion]
/Users/wddawson/Documents/NTPoly/Bench/dbcsr/build/src/tensors/dbcsr_tensor_api_c.F:1726:16:

 1726 |       c_found = found
      |                1
Error: Possible change of value in conversion from LOGICAL(4) to LOGICAL(1) at (1) [-Werror=conversion]
/Users/wddawson/Documents/NTPoly/Bench/dbcsr/build/src/tensors/dbcsr_tensor_api_c.F:1702:16:

 1702 |       c_found = found
      |                1
Error: Possible change of value in conversion from LOGICAL(4) to LOGICAL(1) at (1) [-Werror=conversion]
/Users/wddawson/Documents/NTPoly/Bench/dbcsr/build/src/tensors/dbcsr_tensor_api_c.F:1678:16:

 1678 |       c_found = found
      |                1
Error: Possible change of value in conversion from LOGICAL(4) to LOGICAL(1) at (1) [-Werror=conversion]
/Users/wddawson/Documents/NTPoly/Bench/dbcsr/build/src/tensors/dbcsr_tensor_api_c.F:1654:16:

 1654 |       c_found = found
      |                1
Error: Possible change of value in conversion from LOGICAL(4) to LOGICAL(1) at (1) [-Werror=conversion]
/Users/wddawson/Documents/NTPoly/Bench/dbcsr/build/src/tensors/dbcsr_tensor_api_c.F:1630:16:

 1630 |       c_found = found
      |                1
Error: Possible change of value in conversion from LOGICAL(4) to LOGICAL(1) at (1) [-Werror=conversion]
/Users/wddawson/Documents/NTPoly/Bench/dbcsr/build/src/tensors/dbcsr_tensor_api_c.F:1606:16:

 1606 |       c_found = found
      |                1
Error: Possible change of value in conversion from LOGICAL(4) to LOGICAL(1) at (1) [-Werror=conversion]
f951: some warnings being treated as errors
make[2]: *** [src/CMakeFiles/dbcsr_c.dir/tensors/dbcsr_tensor_api_c.F.o] Error 1
make[1]: *** [src/CMakeFiles/dbcsr_c.dir/all] Error 2
make: *** [all] Error 2
```

It seemed reasonable to me to fix this by simply doing an explicit cast from logical to c_bool, as I have included in this pull request. Please let me know if there are any ways I can improve it, or alternative routes that should be taken. 