### PR TITLE
Feature: transpose blocks of dim>80 with cu/hipblas

### DIFF
--- a/src/acc/acc_libsmm.h
+++ b/src/acc/acc_libsmm.h
@@ -31,12 +31,13 @@ typedef enum libsmm_acc_data_t {
 int libsmm_acc_init(void);
 acc_bool_t libsmm_acc_is_thread_safe(void);
 
-int libsmm_acc_transpose(const int* dev_trs_stack, int offset, int stack_size,
-  void* dev_data, libsmm_acc_data_t datatype, int m, int n, int max_kernel_dim, void* stream);
+int libsmm_acc_transpose(const int* host_trs_stack, const int* dev_trs_stack, int offset,
+  int stack_size, void* dev_data, libsmm_acc_data_t datatype, int m, int n, int max_kernel_dim,
+  void* stream);
 
 int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, int stack_size,
   int nparams, libsmm_acc_data_t datatype, const void* dev_a_data, const void* dev_b_data, void* dev_c_data,
-  int m_max, int n_max, int k_max, int max_kernel_dim, acc_bool_t def_mnk, void* stack_stream, void* c_stream);
+  int m_max, int n_max, int k_max, acc_bool_t def_mnk, void* stack_stream, void* c_stream);
 
 #if defined(__cplusplus)
 }

--- a/src/acc/cuda/acc_blas.h
+++ b/src/acc/cuda/acc_blas.h
@@ -32,4 +32,8 @@ int acc_blas_dgemm(ACC_BLAS(Handle_t) *handle, char transa, char transb,
                    const double *a_data, const double *b_data, double *c_data,
                    double alpha, double beta, ACC(Stream_t) *stream);
 
+/****************************************************************************/
+int acc_blas_transpose(ACC_BLAS(Handle_t) *handle, int m, int n, int offset,
+                       double *data, ACC(Stream_t) *stream);
+
 #endif /* ACC_BLAS_H */

--- a/src/acc/cuda/acc_cuda.h
+++ b/src/acc/cuda/acc_cuda.h
@@ -65,24 +65,24 @@
   do {                                                            \
     cublasStatus_t result = ACC_BLAS(func) args;                  \
     if (result != CUBLAS_STATUS_SUCCESS) {                        \
-      const char* error_name = "CUBLAS_ERRROR";                   \
+      printf("\nCUBLAS ERROR: %s failed with error ", #func);     \
       if (result == CUBLAS_STATUS_NOT_INITIALIZED){               \
-        error_name = "CUBLAS_STATUS_NOT_INITIALIZED";             \
+        printf("%s\n", "CUBLAS_STATUS_NOT_INITIALIZED");          \
       } else if (result == CUBLAS_STATUS_ALLOC_FAILED){           \
-        error_name = "CUBLAS_STATUS_ALLOC_FAILED";                \
+        printf("%s\n", "CUBLAS_STATUS_ALLOC_FAILED");             \
       } else if (result == CUBLAS_STATUS_INVALID_VALUE){          \
-        error_name = "CUBLAS_STATUS_INVALID_VALUE";               \
+        printf("%s\n", "CUBLAS_STATUS_INVALID_VALUE");            \
       } else if (result == CUBLAS_STATUS_ARCH_MISMATCH){          \
-        error_name = "CUBLAS_STATUS_ARCH_MISMATCH";               \
+        printf("%s\n", "CUBLAS_STATUS_ARCH_MISMATCH");            \
       } else if (result == CUBLAS_STATUS_MAPPING_ERROR){          \
-        error_name = "CUBLAS_STATUS_MAPPING_ERROR";               \
+        printf("%s\n", "CUBLAS_STATUS_MAPPING_ERROR");            \
       } else if (result == CUBLAS_STATUS_EXECUTION_FAILED){       \
-        error_name = "CUBLAS_STATUS_EXECUTION_FAILED";            \
+        printf("%s\n", "CUBLAS_STATUS_EXECUTION_FAILED");         \
       } else if (result == CUBLAS_STATUS_INTERNAL_ERROR){         \
-        error_name = "CUBLAS_STATUS_INTERNAL_ERROR";              \
+        printf("%s\n", "CUBLAS_STATUS_INTERNAL_ERROR");           \
+      } else {                                                    \
+        printf("%s\n", "CUBLAS_ERRROR");                          \
       }                                                           \
-      printf("\nCUBLAS ERROR: %s failed with error %s\n",         \
-             #func, error_name);                                  \
       exit(1);                                                    \
     }                                                             \
   } while(0)

--- a/src/acc/hip/acc_hip.h
+++ b/src/acc/hip/acc_hip.h
@@ -54,28 +54,28 @@
   do {                                                            \
     hipblasStatus_t result = ACC_BLAS(func) args;                 \
     if (result != HIPBLAS_STATUS_SUCCESS) {                       \
-      const char* error_name = "HIPBLAS_ERRROR";                  \
+      printf("\nHIPBLAS ERROR: %s failed with error ", #func);    \
       if (result == HIPBLAS_STATUS_NOT_INITIALIZED){              \
-        error_name = "HIPBLAS_STATUS_NOT_INITIALIZED ";           \
+        printf("%s\n", "HIPBLAS_STATUS_NOT_INITIALIZED");         \
       } else if (result == HIPBLAS_STATUS_ALLOC_FAILED){          \
-        error_name = "HIPBLAS_STATUS_ALLOC_FAILED ";              \
+        printf("%s\n", "HIPBLAS_STATUS_ALLOC_FAILED");            \
       } else if (result == HIPBLAS_STATUS_INVALID_VALUE){         \
-        error_name = "HIPBLAS_STATUS_INVALID_VALUE ";             \
+        printf("%s\n", "HIPBLAS_STATUS_INVALID_VALUE");           \
       } else if (result == HIPBLAS_STATUS_MAPPING_ERROR){         \
-        error_name = "HIPBLAS_STATUS_MAPPING_ERROR ";             \
+        printf("%s\n", "HIPBLAS_STATUS_MAPPING_ERROR");           \
       } else if (result == HIPBLAS_STATUS_EXECUTION_FAILED){      \
-        error_name = "HIPBLAS_STATUS_EXECUTION_FAILED ";          \
+        printf("%s\n", "HIPBLAS_STATUS_EXECUTION_FAILED");        \
       } else if (result == HIPBLAS_STATUS_INTERNAL_ERROR){        \
-        error_name = "HIPBLAS_STATUS_INTERNAL_ERROR ";            \
+        printf("%s\n", "HIPBLAS_STATUS_INTERNAL_ERROR");          \
       } else if (result == HIPBLAS_STATUS_NOT_SUPPORTED){         \
-        error_name = "HIPBLAS_STATUS_NOT_SUPPORTED ";             \
+        printf("%s\n", "HIPBLAS_STATUS_NOT_SUPPORTED");           \
       } else if (result == HIPBLAS_STATUS_ARCH_MISMATCH){         \
-        error_name = "HIPBLAS_STATUS_ARCH_MISMATCH ";             \
+        printf("%s\n", "HIPBLAS_STATUS_ARCH_MISMATCH");           \
       } else if (result == HIPBLAS_STATUS_HANDLE_IS_NULLPTR){     \
-        error_name = "HIPBLAS_STATUS_HANDLE_IS_NULLPTR ";         \
+        printf("%s\n", "HIPBLAS_STATUS_HANDLE_IS_NULLPTR");       \
+      } else {                                                    \
+        printf("%s\n", "HIPBLAS_ERRROR");                         \
       }                                                           \
-      printf("\nHIPBLAS ERROR: %s failed with error %s\n",        \
-             #func, error_name);                                  \
       exit(1);                                                    \
     }                                                             \
   } while(0)

--- a/src/acc/libsmm_acc/libsmm_acc.cpp
+++ b/src/acc/libsmm_acc/libsmm_acc.cpp
@@ -222,7 +222,7 @@ kernel_map_iterator add_kernel_handle_to_jitted_kernels(ACC_DRV(function) kern_f
 
 
 //===========================================================================
-int libsmm_acc_process_blas(const int *param_stack, int stack_size, ACC_DRV(stream) stream, int m, int n, int k, int max_kernel_dim, const double *a_data, const double *b_data, double *c_data, std::vector<ACC_BLAS(Handle_t)*> handles = acc_blashandles){
+int libsmm_acc_process_blas(const int *param_stack, int stack_size, ACC_DRV(stream) stream, int m, int n, int k, const double *a_data, const double *b_data, double *c_data, std::vector<ACC_BLAS(Handle_t)*> handles = acc_blashandles){
 
 #if defined _OPENMP
     int ithread = omp_get_thread_num();
@@ -233,7 +233,7 @@ int libsmm_acc_process_blas(const int *param_stack, int stack_size, ACC_DRV(stre
     int istat = 0;
 
     char transb = 'N';
-    if(n <= max_kernel_dim && k <= max_kernel_dim){
+    if(n <= ACC_BLAS_BLOCK_DIM && k <= ACC_BLAS_BLOCK_DIM){
         transb = 'T';
     }
 
@@ -298,13 +298,13 @@ int libsmm_acc_process_d(const int* param_stack, int stack_size, ACC_DRV(stream)
 
 
 //===========================================================================
-int libsmm_acc_process (const int* param_stack_host, const int *param_stack_dev, int stack_size, int nparams, libsmm_acc_data_t datatype, const void *a_data, const void *b_data, void *c_data, int m, int n, int k, int max_kernel_dim, int def_mnk, void *stack_stream, void *c_stream){
+int libsmm_acc_process (const int* param_stack_host, const int *param_stack_dev, int stack_size, int nparams, libsmm_acc_data_t datatype, const void *a_data, const void *b_data, void *c_data, int m, int n, int k, int def_mnk, void *stack_stream, void *c_stream){
     if(def_mnk!=1)
         return -1; // inhomogeneous stacks not supported
     if(datatype==dbcsr_type_real_8) {
-      if(m>max_kernel_dim || n>max_kernel_dim || k>max_kernel_dim)
+      if(m>ACC_BLAS_BLOCK_DIM || n>ACC_BLAS_BLOCK_DIM || k>ACC_BLAS_BLOCK_DIM)
         // maximum size over any dimension
-        return (libsmm_acc_process_blas ((const int *) param_stack_host, stack_size, *((ACC_DRV(stream) *) c_stream), m, n, k, max_kernel_dim, (const double *) a_data, (const double *) b_data, (double *) c_data));
+        return (libsmm_acc_process_blas ((const int *) param_stack_host, stack_size, *((ACC_DRV(stream) *) c_stream), m, n, k, (const double *) a_data, (const double *) b_data, (double *) c_data));
       else
         return (libsmm_acc_process_d ((const int *) param_stack_dev, stack_size, *((ACC_DRV(stream) *) stack_stream), m, n, k, (const double *) a_data, (const double *) b_data, (double *) c_data));
     }
@@ -401,6 +401,33 @@ void jit_transpose_handle(ACC_DRV(function)& kern_func, int m, int n){
 
 
 //===========================================================================
+int libsmm_acc_transpose_blas(const int *trs_stack_offset, int offset, int stack_size, double *buffer, int m, int n, ACC_DRV(stream) stream){
+
+#if defined _OPENMP
+    int ithread = omp_get_thread_num();
+#else
+    int ithread = 0;
+#endif
+
+    int istat = 0;
+
+    //if(n <= ACC_BLAS_BLOCK_DIM && k <= ACC_BLAS_BLOCK_DIM){ } // TODO
+
+    for(int stack_entry = 0; stack_entry < stack_size; stack_entry++){
+        istat = acc_blas_transpose(acc_blashandles[ithread],
+                                   m, n,
+                                   trs_stack_offset[stack_entry] - 1, // IDK?? TODO
+                                   buffer,
+                                   &stream);
+        ACC_API_CALL(StreamSynchronize, (stream));
+    }
+    ACC_API_CALL(StreamSynchronize, (stream));
+
+    return istat;
+}
+
+
+//===========================================================================
 int libsmm_acc_transpose_d(const int *trs_stack, int offset, int stack_size,
                            double *buffer, int m, int n, ACC_DRV(stream) stream) {
 
@@ -443,10 +470,10 @@ int libsmm_acc_transpose_d(const int *trs_stack, int offset, int stack_size,
 
 
 //===========================================================================
-extern "C" int libsmm_acc_transpose (const int *trs_stack, int offset, int stack_size, void *buffer, libsmm_acc_data_t datatype, int m, int n, int max_kernel_dim, void* stream) {
+extern "C" int libsmm_acc_transpose (const int *trs_stack_host, const int *trs_stack_dev, int offset, int stack_size, void *buffer, libsmm_acc_data_t datatype, int m, int n, int max_kernel_dim, void* stream) {
     if(datatype != dbcsr_type_real_8)
         return 0; // transpose not needed
-    if(m>max_kernel_dim || n>max_kernel_dim)
-      return 0; // maximum size over any dimension
-    return libsmm_acc_transpose_d(trs_stack, offset, stack_size, (double *) buffer, m, n, *((ACC_DRV(stream) *) stream));
+    if(m>ACC_BLAS_BLOCK_DIM || n>ACC_BLAS_BLOCK_DIM)
+      return libsmm_acc_transpose_blas(trs_stack_host, offset, stack_size, (double *) buffer, m, n, *((ACC_DRV(stream) *) stream));
+    return libsmm_acc_transpose_d(trs_stack_dev, offset, stack_size, (double *) buffer, m, n, *((ACC_DRV(stream) *) stream));
 }

--- a/src/acc/libsmm_acc/libsmm_acc.h
+++ b/src/acc/libsmm_acc/libsmm_acc.h
@@ -54,7 +54,8 @@ int libsmm_acc_process_d(const int *param_stack_dev, int stack_size,
 
 static std::unordered_map<Triplet, ACC_DRV(function)> transpose_handles;
 
-int libsmm_acc_transpose_d(const int *trs_stack, int offset, int nblks, double *buffer,
+int libsmm_acc_transpose_d(const int *trs_stack_dev,
+                           int offset, int nblks, double *buffer,
                            int m, int n, ACC_DRV(stream) stream);
 
 #endif /*LIBSMM_ACC_H*/

--- a/src/acc/libsmm_acc/libsmm_acc_benchmark.cpp
+++ b/src/acc/libsmm_acc/libsmm_acc_benchmark.cpp
@@ -375,9 +375,9 @@ int libsmm_acc_benchmark_transpose_(int n_stack, int* stack, int* d_stack,
                                     int n, int mat_m, int mat_n,
                                     ACC_DRV(event) start, ACC_DRV(event) stop, char** kernel_descr,
                                     TransposeLauncher* launcher){
- if(mat_m > MAX_BLOCK_DIM || mat_n > MAX_BLOCK_DIM){
+ if(mat_m > ACC_BLAS_BLOCK_DIM || mat_n > ACC_BLAS_BLOCK_DIM){
      printf("Cannot transpose matrices with dimensions above %i, got (%i x %i)\n",
-            MAX_BLOCK_DIM, mat_m, mat_n);
+            ACC_BLAS_BLOCK_DIM, mat_m, mat_n);
      exit(1);
  }
 

--- a/src/acc/libsmm_acc/libsmm_acc_benchmark.h
+++ b/src/acc/libsmm_acc/libsmm_acc_benchmark.h
@@ -18,7 +18,8 @@
 
 #include "../acc_libsmm.h"
 
-#define MAX_BLOCK_DIM 80
+/* Above ACC_BLAS_BLOCK_DIM, batches are transposed using hip/cublas, rather than libsmm_acc's custom kernel */
+#define ACC_BLAS_BLOCK_DIM 80
 
 typedef int (*KernelLauncher)(const int *param_stack_dev, int stack_size,
                               ACC_DRV(stream) stream, int m, int n, int k,

--- a/src/core/dbcsr_config.F
+++ b/src/core/dbcsr_config.F
@@ -120,8 +120,6 @@ MODULE dbcsr_config
 
    TYPE(dbcsr_config_type), PROTECTED, SAVE :: dbcsr_cfg = dbcsr_config_type() ! defaults
 
-   ! Max dimension for any block dimension
-   INTEGER, PARAMETER :: max_kernel_dim = 80
    ! Accelerator active device, default to -1, i.e. no device
    INTEGER, PARAMETER :: default_accdrv_active_device_id = -1
    INTEGER :: accdrv_active_device_id = default_accdrv_active_device_id
@@ -129,7 +127,6 @@ MODULE dbcsr_config
    PUBLIC :: dbcsr_cfg, has_MPI, has_acc, default_resize_factor
    PUBLIC :: mm_driver_blas, mm_driver_matmul, mm_driver_smm, mm_driver_xsmm, mm_driver_auto
    PUBLIC :: dbcsr_set_config, dbcsr_get_default_config, dbcsr_print_config
-   PUBLIC :: max_kernel_dim
    PUBLIC :: get_accdrv_active_device_id, set_accdrv_active_device_id, reset_accdrv_active_device_id
 
 CONTAINS

--- a/src/mm/dbcsr_acc_operations.F
+++ b/src/mm/dbcsr_acc_operations.F
@@ -18,7 +18,6 @@ MODULE dbcsr_acc_operations
    USE dbcsr_acc_stream, ONLY: acc_stream_cptr, &
                                acc_stream_type, &
                                acc_stream_synchronize
-   USE dbcsr_config, ONLY: max_kernel_dim
    USE dbcsr_mm_types, ONLY: dbcsr_ps_width
    USE dbcsr_kinds, ONLY: real_8, dp
    USE dbcsr_types, ONLY: dbcsr_type_real_8
@@ -39,7 +38,7 @@ MODULE dbcsr_acc_operations
    INTERFACE
       FUNCTION libsmm_acc_process_cu(param_stack_host, param_stack_dev, stack_size, nparams, &
                                      data_type, a_data, b_data, c_data, m_max, &
-                                     n_max, k_max, max_kernel_dim, def_mnk, &
+                                     n_max, k_max, def_mnk, &
                                      stack_stream_ptr, c_stream_ptr) &
          RESULT(istat) &
          BIND(C, name="libsmm_acc_process")
@@ -49,7 +48,7 @@ MODULE dbcsr_acc_operations
          INTEGER(KIND=C_INT), INTENT(IN), VALUE   :: stack_size, nparams, data_type
          TYPE(C_PTR), INTENT(IN), VALUE           :: a_data, b_data, c_data
          INTEGER(KIND=C_INT), INTENT(IN), VALUE   :: m_max, n_max, k_max
-         INTEGER(KIND=C_INT), INTENT(IN), VALUE   :: max_kernel_dim, def_mnk
+         INTEGER(KIND=C_INT), INTENT(IN), VALUE   :: def_mnk
          TYPE(C_PTR), VALUE                       :: stack_stream_ptr, c_stream_ptr
          INTEGER(KIND=C_INT)                      :: istat
 
@@ -57,16 +56,16 @@ MODULE dbcsr_acc_operations
    END INTERFACE
 
    INTERFACE
-      FUNCTION libsmm_acc_transpose_cu(trs_stack, offset, nblks, buffer, &
-                                       data_type, m, n, max_kernel_dim, stream_ptr) &
+      FUNCTION libsmm_acc_transpose_cu(trs_stack_host, trs_stack_dev, offset, nblks, buffer, &
+                                       data_type, m, n, stream_ptr) &
          RESULT(istat) &
          BIND(C, name="libsmm_acc_transpose")
          IMPORT
-         TYPE(C_PTR), INTENT(IN), VALUE           :: trs_stack
+         TYPE(C_PTR), INTENT(IN), VALUE           :: trs_stack_host
+         TYPE(C_PTR), INTENT(IN), VALUE           :: trs_stack_dev
          INTEGER(KIND=C_INT), INTENT(IN), VALUE   :: offset, nblks
          TYPE(C_PTR), INTENT(IN), VALUE           :: buffer
          INTEGER(KIND=C_INT), INTENT(IN), VALUE   :: data_type, m, n
-         INTEGER(KIND=C_INT), INTENT(IN), VALUE   :: max_kernel_dim
          TYPE(C_PTR), VALUE                       :: stream_ptr
          INTEGER(KIND=C_INT)                      :: istat
 
@@ -113,7 +112,7 @@ CONTAINS
 
       INTEGER                                  :: error_handle, istat
       INTEGER(KIND=C_INT)                      :: mnk
-      INTEGER, DIMENSION(:, :), POINTER         :: param_stack_host_ptr
+      INTEGER, DIMENSION(:, :), POINTER        :: param_stack_host_ptr
 
       param_stack_host_ptr => param_stack_host(:, :)
 
@@ -135,8 +134,9 @@ CONTAINS
                                     INT(m_max, KIND=C_INT), &
                                     INT(n_max, KIND=C_INT), &
                                     INT(k_max, KIND=C_INT), &
-                                    INT(max_kernel_dim, KIND=C_INT), &
-                                    mnk, acc_stream_cptr(stack_stream), acc_stream_cptr(c_stream))
+                                    mnk, &
+                                    acc_stream_cptr(stack_stream), &
+                                    acc_stream_cptr(c_stream))
       IF (istat == 100) DBCSR_ABORT("failed due to accGetLastError().")
       success = (istat == 0) ! false if no suitable kernel was found
 
@@ -144,9 +144,10 @@ CONTAINS
 #endif
    END SUBROUTINE dbcsr_acc_do_mm_stack
 
-   SUBROUTINE dbcsr_acc_transpose(trs_stack, offset, nblks, datatype, buffer, m, n, stream)
+   SUBROUTINE dbcsr_acc_transpose(trs_stack_host, trs_stack_dev, offset, nblks, datatype, buffer, m, n, stream)
       !! Launch an accelerated transpose kernel
-      TYPE(acc_devmem_type), INTENT(IN)        :: trs_stack
+      INTEGER, DIMENSION(:), TARGET, INTENT(IN):: trs_stack_host
+      TYPE(acc_devmem_type), INTENT(IN)        :: trs_stack_dev
       INTEGER, INTENT(IN)                      :: offset
       INTEGER, INTENT(IN)                      :: nblks
       INTEGER, INTENT(IN)                      :: datatype
@@ -155,7 +156,8 @@ CONTAINS
       TYPE(acc_stream_type), INTENT(IN)        :: stream
 
 #if ! defined (__DBCSR_ACC)
-      MARK_USED(trs_stack)
+      MARK_USED(trs_stack_host)
+      MARK_USED(trs_stack_dev)
       MARK_USED(offset)
       MARK_USED(nblks)
       MARK_USED(datatype)
@@ -174,18 +176,15 @@ CONTAINS
       istat = 0
 
       ! Call batched in-place transpose in libsmm_acc
-      IF (m .LE. max_kernel_dim .AND. &
-          n .LE. max_kernel_dim) THEN
-         istat = libsmm_acc_transpose_cu(acc_devmem_cptr(trs_stack), &
-                                         INT(offset, KIND=C_INT), &
-                                         INT(nblks, KIND=C_INT), &
-                                         acc_devmem_cptr(buffer), &
-                                         INT(datatype, KIND=C_INT), &
-                                         INT(m, KIND=C_INT), &
-                                         INT(n, KIND=C_INT), &
-                                         INT(max_kernel_dim, KIND=C_INT), &
-                                         acc_stream_cptr(stream))
-      ENDIF
+      istat = libsmm_acc_transpose_cu(C_LOC(trs_stack_host), &
+                                      acc_devmem_cptr(trs_stack_dev), &
+                                      INT(offset, KIND=C_INT), &
+                                      INT(nblks, KIND=C_INT), &
+                                      acc_devmem_cptr(buffer), &
+                                      INT(datatype, KIND=C_INT), &
+                                      INT(m, KIND=C_INT), &
+                                      INT(n, KIND=C_INT), &
+                                      acc_stream_cptr(stream))
 
       IF (istat /= 0) DBCSR_ABORT("something went wrong.")
       IF (careful_mod) CALL timestop(error_handle)

--- a/src/mm/dbcsr_mm_common.F
+++ b/src/mm/dbcsr_mm_common.F
@@ -441,7 +441,8 @@ CONTAINS
                m = enum2row_blk_sizes(mi)
                n = enum2col_blk_sizes(ni)
                CALL dbcsr_acc_transpose( &
-                  trs_stack=trs_stackbuf%d%acc_devmem, &
+                  trs_stack_host=trs_stackbuf%d%i4, &
+                  trs_stack_dev=trs_stackbuf%d%acc_devmem, &
                   offset=offsets(mi, ni), &
                   nblks=counters(mi, ni), &
                   datatype=matrix%data_type, &


### PR DESCRIPTION
Up to now, DBCSR's GPU backend did not support the transposition of matrix blocks with dimension >80. This PR adds support for this via cu/hipblas. 