### PR TITLE
Revised ACC interface

### DIFF
--- a/src/acc/acc.h
+++ b/src/acc/acc.h
@@ -16,17 +16,7 @@ extern "C" {
 #endif
 
 /** types */
-typedef void acc_stream_t;
-typedef void acc_event_t;
 typedef int acc_bool_t;
-
-typedef enum acc_data_t {
-  ACC_DATA_F64 = 3,
-  ACC_DATA_F32 = 1,
-  ACC_DATA_C64 = 7,
-  ACC_DATA_C32 = 5,
-  ACC_DATA_UNKNOWN = -1
-} acc_data_t;
 
 /** initialization and finalization */
 int acc_init(void);
@@ -34,33 +24,35 @@ int acc_finalize(void);
 void acc_clear_errors(void);
 
 /** devices */
-int acc_get_ndevices(int* n_devices);
+int acc_get_ndevices(int* ndevices);
 int acc_set_active_device(int device_id);
 
 /** streams */
 int acc_stream_priority_range(int* least, int* greatest);
-int acc_stream_create(acc_stream_t** stream_p, const char* name, int priority);
-int acc_stream_destroy(acc_stream_t* stream);
-int acc_stream_sync(acc_stream_t* stream);
-int acc_stream_wait_event(acc_stream_t* stream, acc_event_t* event);
+int acc_stream_create(void** stream_p, const char* name,
+  /** lower number is higher priority */
+  int priority);
+int acc_stream_destroy(void* stream);
+int acc_stream_sync(void* stream);
+int acc_stream_wait_event(void* stream, void* event);
 
 /** events */
-int acc_event_create(acc_event_t** event_p);
-int acc_event_destroy(acc_event_t* event);
-int acc_event_record(acc_event_t* event, acc_stream_t* stream);
-int acc_event_query(acc_event_t* event, acc_bool_t* has_occurred);
-int acc_event_synchronize(acc_event_t* event);
+int acc_event_create(void** event_p);
+int acc_event_destroy(void* event);
+int acc_event_record(void* event, void* stream);
+int acc_event_query(void* event, acc_bool_t* has_occurred);
+int acc_event_synchronize(void* event);
 
 /** memory */
-int acc_dev_mem_allocate(void** dev_mem, size_t n);
+int acc_dev_mem_allocate(void** dev_mem, size_t nbytes);
 int acc_dev_mem_deallocate(void* dev_mem);
 int acc_dev_mem_set_ptr(void** dev_mem, void* other, size_t lb);
-int acc_host_mem_allocate(void** host_mem, size_t n, acc_stream_t* stream);
-int acc_host_mem_deallocate(void* host_mem, acc_stream_t* stream);
-int acc_memcpy_h2d(const void* host_mem, void* dev_mem, size_t count, acc_stream_t* stream);
-int acc_memcpy_d2h(const void* dev_mem, void* host_mem, size_t count, acc_stream_t* stream);
-int acc_memcpy_d2d(const void* devmem_src, void* devmem_dst, size_t count, acc_stream_t* stream);
-int acc_memset_zero(void* dev_mem, size_t offset, size_t length, acc_stream_t* stream);
+int acc_host_mem_allocate(void** host_mem, size_t nbytes, void* stream);
+int acc_host_mem_deallocate(void* host_mem, void* stream);
+int acc_memcpy_h2d(const void* host_mem, void* dev_mem, size_t nbytes, void* stream);
+int acc_memcpy_d2h(const void* dev_mem, void* host_mem, size_t nbytes, void* stream);
+int acc_memcpy_d2d(const void* devmem_src, void* devmem_dst, size_t nbytes, void* stream);
+int acc_memset_zero(void* dev_mem, size_t offset, size_t nbytes, void* stream);
 int acc_dev_mem_info(size_t* mem_free, size_t* mem_total);
 
 #if defined(__cplusplus)

--- a/src/acc/acc_libsmm.h
+++ b/src/acc/acc_libsmm.h
@@ -11,24 +11,32 @@
 
 #include "acc.h"
 
+#define DBCSR_CONCATENATE(A, B) A##B
+#define DBCSR_TYPE(T) DBCSR_CONCATENATE(DBCSR_TYPE_, T)
+#define DBCSR_TYPE_double dbcsr_type_real_8
+#define DBCSR_TYPE_float dbcsr_type_real_4
+
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
 
-typedef struct libsmm_acc_stack_descriptor_type {
-  int m, n, k, max_m, max_n, max_k;
-  acc_bool_t defined_mnk;
-} libsmm_acc_stack_descriptor_type;
+typedef enum libsmm_acc_data_t {
+  dbcsr_type_real_4 = 1,
+  dbcsr_type_real_8 = 3,
+  dbcsr_type_complex_4 = 5,
+  dbcsr_type_complex_8 = 7
+} libsmm_acc_data_t;
 
-extern "C" int libsmm_acc_init(void);
+int libsmm_acc_init(void);
 acc_bool_t libsmm_acc_is_thread_safe(void);
 
-int libsmm_acc_transpose(const int* dev_trs_stack, int offset, int nblks,
-  void* dev_data, acc_data_t datatype, int m, int n, int max_kernel_dim, acc_stream_t* stream);
+int libsmm_acc_transpose(const int* dev_trs_stack, int offset, int stack_size,
+  void* dev_data, libsmm_acc_data_t datatype, int m, int n, int max_kernel_dim, void* stream);
 
-extern "C" int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, int stack_size,
-  int nparams, acc_data_t datatype, const void* dev_a_data, const void* dev_b_data, void* dev_c_data,
-  int m_max, int n_max, int k_max, int max_kernel_dim, acc_bool_t def_mnk, acc_stream_t* stream);
+int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, int stack_size,
+  int nparams, libsmm_acc_data_t datatype, const void* dev_a_data, const void* dev_b_data, void* dev_c_data,
+  int m_max, int n_max, int k_max, int max_kernel_dim, acc_bool_t def_mnk, void* stream);
 
 #if defined(__cplusplus)
 }

--- a/src/acc/cuda/acc_cuda.h
+++ b/src/acc/cuda/acc_cuda.h
@@ -65,7 +65,7 @@
   do {                                                            \
     cublasStatus_t result = ACC_BLAS(func) args;                  \
     if (result != CUBLAS_STATUS_SUCCESS) {                        \
-      char* error_name = "CUBLAS_ERRROR";                         \
+      const char* error_name = "CUBLAS_ERRROR";                   \
       if (result == CUBLAS_STATUS_NOT_INITIALIZED){               \
         error_name = "CUBLAS_STATUS_NOT_INITIALIZED";             \
       } else if (result == CUBLAS_STATUS_ALLOC_FAILED){           \

--- a/src/acc/hip/acc_hip.h
+++ b/src/acc/hip/acc_hip.h
@@ -54,7 +54,7 @@
   do {                                                            \
     hipblasStatus_t result = ACC_BLAS(func) args;                 \
     if (result != HIPBLAS_STATUS_SUCCESS) {                       \
-      char* error_name = "HIPBLAS_ERRROR";                        \
+      const char* error_name = "HIPBLAS_ERRROR";                  \
       if (result == HIPBLAS_STATUS_NOT_INITIALIZED){              \
         error_name = "HIPBLAS_STATUS_NOT_INITIALIZED ";           \
       } else if (result == HIPBLAS_STATUS_ALLOC_FAILED){          \

--- a/src/acc/libsmm_acc/libsmm_acc_init.cpp
+++ b/src/acc/libsmm_acc/libsmm_acc_init.cpp
@@ -18,8 +18,9 @@
 std::vector<ACC_BLAS(Handle_t)*> acc_blashandles;
 
 
+#if !defined(NO_DBCSR_TIMESET)
 //===========================================================================
-void timeset(std::string routine_name, int& handle){
+void timeset(const std::string& routine_name, int& handle){
     const char* routine_name_ = routine_name.c_str();
     int routine_name_length  = routine_name.length();
     dbcsr_timeset(&routine_name_, &routine_name_length, &handle);
@@ -28,7 +29,7 @@ void timeset(std::string routine_name, int& handle){
 void timestop(int handle){
     dbcsr_timestop(&handle);
 }
-
+#endif
 
 //===========================================================================
 int libsmm_acc_gpu_blas_init(){
@@ -54,25 +55,28 @@ int libsmm_acc_gpu_blas_init(){
 
 //===========================================================================
 int libsmm_acc_init() {
+#if !defined(NO_DBCSR_TIMESET)
     std::string routineN = "libsmm_acc_init";
     int handle;
     timeset(routineN, handle);
-
+#endif
     // check warp size consistency
     libsmm_acc_check_gpu_warp_size_consistency();
     libsmm_acc_gpu_blas_init();
-
+#if !defined(NO_DBCSR_TIMESET)
     timestop(handle);
+#endif
     return 0;
 }
 
 
 //===========================================================================
 int libsmm_acc_finalize() {
+#if !defined(NO_DBCSR_TIMESET)
     std::string routineN = "libsmm_acc_finalize";
     int handle;
     timeset(routineN, handle);
-
+#endif
     // deallocate memory for acc_blas handles
 #if defined _OPENMP
     int nthreads = omp_get_num_threads();
@@ -85,8 +89,9 @@ int libsmm_acc_finalize() {
     for(int i = 0; i < nthreads; i++){
         acc_blas_destroy(acc_blashandles[i]);
     }
-
+#if !defined(NO_DBCSR_TIMESET)
     timestop(handle);
+#endif
     return 0;
 }
 

--- a/src/acc/libsmm_acc/libsmm_acc_init.h
+++ b/src/acc/libsmm_acc/libsmm_acc_init.h
@@ -15,11 +15,13 @@
 #include <vector>
 #include <string>
 
+#if !defined(NO_DBCSR_TIMESET)
 extern "C" void dbcsr_timeset(const char** routineN, int* routineN_len, int* handle);
-void timeset(std::string routine_name, int& handle);
+void timeset(const std::string& routine_name, int& handle);
 
 extern "C" void dbcsr_timestop(int* handle);
 void timestop(int handle);
+#endif
 
 extern "C" int libsmm_acc_init (void);
 


### PR DESCRIPTION
Introduced enumeration libsmm_acc_data_t collecting macro symbols like dbcsr_type_real_8 (LIBSMM/ACC interface); this is for reusing the same definitions in every backend implementation (centralized type definition). Cleanup ACC/main interface. Prevent compilation warning about non-const string literal (CUDA/HIP header). Introduced NO_DBCSR_TIMESET to get rid of circular dependency (simplifies Makefile for upcoming changes/sample/driver code).

Note: CUDA/HIP build may need revisit; currently the ACC/CUDA backend depends on LIBSMM/ACC due to initialization code (previously the dependency edge was supposedly limited to the other way around: LIBSMM uses backend). Further, CUDA/HIP backend now not only depends on LIBSMM/ACC but also on DBCSR main library due to timeset functionality.