### PR TITLE
Stand-alone benchmarks and test for ACC/LIBSMM interface

### DIFF
--- a/src/acc/README.md
+++ b/src/acc/README.md
@@ -1,0 +1,22 @@
+# ACCerator Interfaces
+
+## Overview
+
+This folder contains the ISO_C_BINDING based Fortran code of DBCSR's [ACC-backend interface](https://github.com/cp2k/dbcsr/blob/develop/src/acc/acc.h) and [LIBSMM/ACC-interface](https://github.com/cp2k/dbcsr/blob/develop/src/acc/acc_libsmm.h). Further, two stand-alone sample codes are given exercising both interfaces (benchmarks).
+
+## Benchmarks
+
+Two stand-alone drivers (only depending on above mentioned interfaces) can be built locally and in a rather self-contained fashion, i.e., no DBCSR library is needed (except for runtime libraries such as OpenCL, and LIBXSMM for some auxiliary functionality). For LIBXSMM, a folder `libxsmm` parallel to DBCSR's root directory (`dbcsr`) is expected to be present and prebuilt (`make` in LIBXSMM's root directory is enough). To build the driver code, change into the respective backend folder (`cuda` or `opencl`), and invoke `make` (`DBG=0|1|2`, and a few other key-value pairs are optional). When building the code is completed, change back into the parent folder and invoke either `acc_bench_trans` or `acc_bench_smm`.
+
+The drivers support a few command line options (_nrepeat_, _stack_size_, _m_, _n_, ...); running the tranpose benchmark may look like:
+
+```bash
+$ OMP_PROC_BIND=TRUE ./acc_bench_trans 5 30000 23 23
+./acc_bench_trans 5 30000 23 23
+copy-in: 16.8 ms 7.4 GB/s
+device: 8.7 ms 14.2 GB/s
+host: 8.5 ms 14.5 GB/s
+errors: 0
+```
+
+For timing, comparison (host code), and validation, LIBXSMM is expected. The drivers exercise the respective backend as chosen to build the code.

--- a/src/acc/README.md
+++ b/src/acc/README.md
@@ -1,4 +1,4 @@
-# ACCerator Interfaces
+# ACCelerator Interfaces
 
 ## Overview
 

--- a/src/acc/acc_bench_smm.c
+++ b/src/acc/acc_bench_smm.c
@@ -1,0 +1,220 @@
+/*------------------------------------------------------------------------------------------------*
+ * Copyright (C) by the DBCSR developers group - All rights reserved                              *
+ * This file is part of the DBCSR library.                                                        *
+ *                                                                                                *
+ * For information on the license, see the LICENSE file.                                          *
+ * For further information please visit https://dbcsr.cp2k.org                                    *
+ * SPDX-License-Identifier: GPL-2.0+                                                              *
+ *------------------------------------------------------------------------------------------------*/
+#include "acc_libsmm.h"
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <stdio.h>
+
+#if defined(__LIBXSMM)
+# include <libxsmm.h>
+# define USE_LIBXSMM
+#endif
+
+#if !defined(ELEM_TYPE)
+# define ELEM_TYPE double
+#endif
+#if !defined(MAX_KERNEL_DIM)
+# define MAX_KERNEL_DIM 80
+#endif
+#if !defined(ALIGNMENT)
+# define ALIGNMENT 64
+#endif
+#if !defined(WARMUP)
+# define WARMUP 2
+#endif
+
+#define MIN(A, B) ((A) < (B) ? (A) : (B))
+#define MAX(A, B) ((B) < (A) ? (A) : (B))
+#define ROUNDUP2(N, NPOT) ((((unsigned long long)N) + ((NPOT) - 1)) & ~((NPOT) - 1))
+#define CHECK(EXPR, RPTR) if ((NULL != ((const void*)(RPTR)) && EXIT_SUCCESS != *((const int*)(RPTR))) || \
+  EXIT_SUCCESS != (NULL != ((const void*)(RPTR)) ? (*((int*)(RPTR)) = (EXPR)) : (EXPR))) assert(0)
+
+
+#if defined(_DEBUG) && defined(USE_LIBXSMM)
+static void print(FILE* ostream, const char* label, const ELEM_TYPE* mat, int m, int n);
+#endif
+
+static void init(int seed, ELEM_TYPE* dst, int m, int n);
+/* for comparison, adopt artificial stack-setup from other DBCSR/ACC benchmarks */
+static void init_stack(int* stack, int stack_size,
+  int mn, int mk, int kn, int nc, int na, int nb);
+
+
+int main(int argc, char* argv[])
+{
+  const int nrepeat = (1 < argc ? atoi(argv[1]) : 5);
+  const int stack_size = (2 < argc ? atoi(argv[2]) : 30000);
+  const int m = (3 < argc ? atoi(argv[3]) : 23);
+  const int n = (4 < argc ? atoi(argv[4]) : m);
+  const int k = (5 < argc ? atoi(argv[5]) : m);
+  const int nc = (6 < argc ? MIN(atoi(argv[6]), stack_size) : MAX(stack_size / 16, 1));
+  const int na = (7 < argc ? atoi(argv[7]) : (10 * nc));
+  const int nb = (8 < argc ? atoi(argv[8]) : (10 * nc));
+#if defined(ALIGNMENT) && (0 < ALIGNMENT)
+  const int ma = (int)ROUNDUP2(sizeof(ELEM_TYPE) * m, ALIGNMENT);
+  const int ka = (int)ROUNDUP2(sizeof(ELEM_TYPE) * k, ALIGNMENT);
+  const int mn = ma * n / (int)sizeof(ELEM_TYPE);
+  const int mk = ma * k / (int)sizeof(ELEM_TYPE);
+  const int kn = ka * n / (int)sizeof(ELEM_TYPE);
+#else
+  const int mn = m * n, mk = m * k, kn = k * n;
+#endif
+#if defined(WARMUP) && (0 < WARMUP) && !defined(_DEBUG)
+  const int warmup = WARMUP;
+#else
+  const int warmup = 0;
+#endif
+  int *stack_hst = NULL, *stack_dev = NULL;
+  ELEM_TYPE *amat_hst = NULL, *bmat_hst = NULL, *cmat_hst = NULL;
+  ELEM_TYPE *amat_dev = NULL, *bmat_dev = NULL, *cmat_dev = NULL;
+  int result = EXIT_SUCCESS, r, i;
+  void *stream = NULL;
+#if defined(USE_LIBXSMM)
+  libxsmm_timer_tickint start;
+  double duration;
+#endif
+  assert(m <= (mn / n) && 0 == (mn % n) && k <= (mk / k) && 0 == (mk % k) && n <= (kn / n) && 0 == (kn % n));
+  printf("%s%s%i %i %i %i %i\n", 0 < argc ? argv[0] : "", 0 < argc ? " " : "", nrepeat, stack_size, m, n, k);
+  CHECK(acc_init(), &result);
+  CHECK(acc_stream_create(&stream, "stream", -1/*default priority*/), &result);
+  CHECK(acc_host_mem_allocate((void**)&amat_hst, sizeof(ELEM_TYPE) * mk * stack_size, stream), &result);
+  CHECK(acc_host_mem_allocate((void**)&bmat_hst, sizeof(ELEM_TYPE) * kn * stack_size, stream), &result);
+  CHECK(acc_host_mem_allocate((void**)&cmat_hst, sizeof(ELEM_TYPE) * mn * stack_size, stream), &result);
+  CHECK(acc_host_mem_allocate((void**)&stack_hst, sizeof(int) * 3 * stack_size, stream), &result);
+  CHECK(acc_stream_sync(stream), &result); /* ensure host-data is allocated */
+  for (i = 0; i < stack_size; ++i) { /* initialize matrices */
+    init(i/*seed*/ + 42, &amat_hst[i*mk], m, k);
+    init(i/*seed*/ + 24, &bmat_hst[i*kn], k, n);
+  }
+  init_stack(stack_hst, stack_size, mn, mk, kn, nc, na, nb);
+  CHECK(acc_dev_mem_allocate((void**)&amat_dev, sizeof(ELEM_TYPE) * mk * stack_size), &result);
+  CHECK(acc_dev_mem_allocate((void**)&bmat_dev, sizeof(ELEM_TYPE) * kn * stack_size), &result);
+  CHECK(acc_dev_mem_allocate((void**)&cmat_dev, sizeof(ELEM_TYPE) * mn * stack_size), &result);
+  CHECK(acc_dev_mem_allocate((void**)&stack_dev, sizeof(int) * 3 * stack_size), &result);
+  CHECK(acc_memset_zero(cmat_dev, 0/*offset*/, sizeof(ELEM_TYPE) * mn * stack_size, stream), &result);
+#if defined(USE_LIBXSMM)
+  CHECK(acc_stream_sync(stream), &result);
+  start = libxsmm_timer_tick();
+#endif
+  CHECK(acc_memcpy_h2d(amat_hst, amat_dev, sizeof(ELEM_TYPE) * mk * stack_size, stream), &result);
+  CHECK(acc_memcpy_h2d(bmat_hst, bmat_dev, sizeof(ELEM_TYPE) * kn * stack_size, stream), &result);
+  CHECK(acc_memcpy_h2d(stack_hst, stack_dev, sizeof(int) * 3 * stack_size, stream), &result);
+#if defined(USE_LIBXSMM)
+  CHECK(acc_stream_sync(stream), &result);
+  duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
+  printf("copy-in: %.1f ms %.1f GB/s\n", 1000.0 * duration,
+    (sizeof(ELEM_TYPE) * (mk + kn) + sizeof(int) * 3)
+      * stack_size / (duration * (1ULL << 30)));
+#endif
+  /* warmup execution and prebuild JIT kernels */
+  for (r = 0; r < warmup; ++r) {
+    CHECK(libsmm_acc_process(stack_hst, stack_dev, stack_size, 3/*nparams*/, DBCSR_TYPE(ELEM_TYPE),
+      amat_dev, bmat_dev, cmat_dev, m, n, k, MAX_KERNEL_DIM, 1/*homogeneous*/, stream), &result);
+  }
+#if defined(USE_LIBXSMM)
+  CHECK(acc_stream_sync(stream), &result);
+  start = libxsmm_timer_tick();
+#endif
+  for (r = 0; r < nrepeat; ++r) {
+    /* GPU-kernel is limited to C += Ai * Bi^T (i.e., NT, for NN, all Bi must be transposed upfront) */
+    CHECK(libsmm_acc_process(stack_hst, stack_dev, stack_size, 3/*nparams*/, DBCSR_TYPE(ELEM_TYPE),
+      amat_dev, bmat_dev, cmat_dev, m, n, k, MAX_KERNEL_DIM, 1/*homogeneous*/, stream), &result);
+  }
+#if defined(USE_LIBXSMM)
+  CHECK(acc_stream_sync(stream), &result);
+  duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
+  if (EXIT_SUCCESS == result) {
+    const char transa = 'N', transb = 'T';
+    const ELEM_TYPE alpha = 1, beta = 1;
+    printf("device: %.1f ms %.1f GFLOPS/s\n", 1000.0 * duration / nrepeat,
+      ((size_t)2 * m * n * k) * stack_size / (duration * (1ULL << 30) / nrepeat));
+    memset(cmat_hst, 0, sizeof(ELEM_TYPE) * mn * stack_size);
+    start = libxsmm_timer_tick();
+    for (r = 0; r < nrepeat; ++r) {
+      /* CPU-kernel performs C += Ai * Bi^T to match result of GPU-kernel (NT may perform below NN) */
+      libxsmm_gemm_batch_omp(LIBXSMM_GEMM_PRECISION(ELEM_TYPE), LIBXSMM_GEMM_PRECISION(ELEM_TYPE),
+        &transa, &transb, m, n, k, &alpha, amat_hst, &m/*lda*/, bmat_hst, &k/*ldb*/,
+        &beta, cmat_hst, &m/*ldc*/, 1/*index_base*/, sizeof(int) * 3,
+        stack_hst + 0, stack_hst + 1, stack_hst + 2, stack_size);
+    }
+    duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
+    printf("host: %.1f ms %.1f GFLOPS/s\n", 1000.0 * duration / nrepeat,
+      ((size_t)2 * m * n * k) * stack_size / (duration * (1ULL << 30) / nrepeat));
+    /* transfer result from device back to host for validation */
+    CHECK(acc_memcpy_d2h(cmat_dev, cmat_hst, sizeof(ELEM_TYPE) * mn * stack_size, stream), &result);
+    CHECK(acc_stream_sync(stream), &result);
+    /* TODO: validation code TBD */
+  }
+#endif
+  CHECK(acc_host_mem_deallocate(stack_hst, stream), NULL);
+  CHECK(acc_host_mem_deallocate(amat_hst, stream), NULL);
+  CHECK(acc_host_mem_deallocate(bmat_hst, stream), NULL);
+  CHECK(acc_host_mem_deallocate(cmat_hst, stream), NULL);
+  CHECK(acc_dev_mem_deallocate(stack_dev), NULL);
+  CHECK(acc_dev_mem_deallocate(amat_dev), NULL);
+  CHECK(acc_dev_mem_deallocate(bmat_dev), NULL);
+  CHECK(acc_dev_mem_deallocate(cmat_dev), NULL);
+  CHECK(acc_stream_destroy(stream), NULL);
+  if (EXIT_SUCCESS != result) {
+    fprintf(stderr, "FAILED\n");
+  }
+  return result;
+}
+
+
+static void init(int seed, ELEM_TYPE* dst, int m, int n) {
+  int i, j;
+  for (i = 0; i < n; ++i) {
+    for (j = 0; j < m; ++j) {
+      const int k = i * m + j;
+      dst[k] = (ELEM_TYPE)((seed + 1) * (k + 1));
+    }
+  }
+}
+
+
+static void init_stack(int* stack, int stack_size,
+  int mn, int mk, int kn, int nc, int na, int nb)
+{
+  /* navg matrix products are accumulated into a C-matrix */
+  int navg = stack_size / nc;
+  int nimb = MAX(1, navg - 4); /* imbalance */
+  int i = 0, c = 0, ntop = 0;
+  assert(0 < nc && nc <= stack_size);
+  while (i < stack_size) {
+    const int next = c + 1;
+    ntop += navg + (rand() % (2 * nimb) - nimb);
+    if (stack_size < ntop) ntop = stack_size;
+    for (;i < ntop; ++i) { /* setup one-based indexes */
+      const int a = rand() % na, b = rand() % nb;
+      *stack++ = a * mk + 1; /* A-index */
+      *stack++ = b * kn + 1; /* B-index */
+      *stack++ = c * mn + 1; /* C-index */
+    }
+    if (next < nc) c = next;
+  }
+}
+
+
+#if defined(_DEBUG) && defined(USE_LIBXSMM)
+static void print(FILE* ostream, const char* label, const ELEM_TYPE* mat, int m, int n)
+{
+  int i, j;
+  const char *const s = (NULL != label ? label : "");
+  const int len = (int)strlen(s);
+  for (i = 0; i < n; ++i) {
+    if (0 < i) fprintf(ostream, "%*s", len, " "); else fprintf(ostream, "%s", s);
+    for (j = 0; j < m; ++j) {
+      fprintf(ostream, "%.2f ", mat[i*m+j]);
+    }
+    fprintf(ostream, "\n");
+  }
+}
+#endif

--- a/src/acc/acc_bench_trans.c
+++ b/src/acc/acc_bench_trans.c
@@ -1,0 +1,225 @@
+/*------------------------------------------------------------------------------------------------*
+ * Copyright (C) by the DBCSR developers group - All rights reserved                              *
+ * This file is part of the DBCSR library.                                                        *
+ *                                                                                                *
+ * For information on the license, see the LICENSE file.                                          *
+ * For further information please visit https://dbcsr.cp2k.org                                    *
+ * SPDX-License-Identifier: GPL-2.0+                                                              *
+ *------------------------------------------------------------------------------------------------*/
+#include "acc_libsmm.h"
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <stdio.h>
+
+#if defined(__LIBXSMM)
+# include <libxsmm.h>
+# define USE_LIBXSMM
+# if !defined(SHUFFLE) && 0
+#   define SHUFFLE
+# endif
+#endif
+
+#if !defined(ELEM_TYPE)
+# define ELEM_TYPE double
+#endif
+#if !defined(MAX_KERNEL_DIM)
+# define MAX_KERNEL_DIM 80
+#endif
+#if !defined(ALIGNMENT)
+# define ALIGNMENT 64
+#endif
+#if !defined(PRIORITY)
+# define PRIORITY
+#endif
+#if !defined(WARMUP)
+# define WARMUP 2
+#endif
+
+#define MAX(A, B) ((B) < (A) ? (A) : (B))
+#define ROUNDUP2(N, NPOT) ((((unsigned long long)N) + ((NPOT) - 1)) & ~((NPOT) - 1))
+#define CHECK(EXPR, RPTR) if ((NULL != ((const void*)(RPTR)) && EXIT_SUCCESS != *((const int*)(RPTR))) || \
+  EXIT_SUCCESS != (NULL != ((const void*)(RPTR)) ? (*((int*)(RPTR)) = (EXPR)) : (EXPR))) assert(0)
+
+
+#if defined(_DEBUG) && defined(USE_LIBXSMM)
+static void print(FILE* ostream, const char* label, const ELEM_TYPE* mat, int m, int n);
+#endif
+
+static void init(int seed, ELEM_TYPE* dst, int m, int n);
+static void swap(int* m, int* n) { int tmp = *m; *m = *n; *n = tmp; }
+
+
+int main(int argc, char* argv[])
+{
+  const int nrepeat = (1 < argc ? atoi(argv[1]) : 5), offset = 0;
+  const int nodd = (0 < nrepeat ? ((nrepeat & 1/*odd*/) ? nrepeat : (nrepeat - 1)) : 1);
+  const int stack_size = (2 < argc ? atoi(argv[2]) : 30000);
+  const int m = (3 < argc ? atoi(argv[3]) : 23);
+  const int n = (4 < argc ? atoi(argv[4]) : m);
+#if defined(ALIGNMENT) && (0 < ALIGNMENT)
+  const int mn = (int)ROUNDUP2(sizeof(ELEM_TYPE) * m, ALIGNMENT) * n / sizeof(ELEM_TYPE);
+#else
+  const int mn = m * n;
+#endif
+#if defined(SHUFFLE)
+  const size_t shuffle = libxsmm_shuffle((unsigned int)stack_size);
+#endif
+#if defined(WARMUP) && (0 < WARMUP) && !defined(_DEBUG)
+  const int warmup = MAX(WARMUP, 2) / 2 * 2;
+#else
+  const int warmup = 0;
+#endif
+#if defined(PRIORITY)
+  int priomin, priomax;
+#endif
+  int *stack_hst = NULL, *stack_dev = NULL;
+  ELEM_TYPE *mat_hst = NULL, *mat_dev = NULL;
+  int result = EXIT_SUCCESS, r, i, mm = m, nn = n;
+  void *stream = NULL;
+#if defined(USE_LIBXSMM)
+  libxsmm_timer_tickint start;
+  double duration;
+#endif
+  assert(m <= (mn / n) && 0 == (mn % n));
+  printf("%s%s%i %i %i %i\n", 0 < argc ? argv[0] : "", 0 < argc ? " " : "", nrepeat, stack_size, m, n);
+  CHECK(acc_init(), &result);
+#if defined(PRIORITY)
+  CHECK(acc_stream_priority_range(&priomin, &priomax), &result);
+  CHECK(acc_stream_create(&stream, "stream", (priomin + priomax) / 2), &result);
+#else
+  CHECK(acc_stream_create(&stream, "stream", -1/*default priority*/), &result);
+#endif
+  CHECK(acc_host_mem_allocate((void**)&mat_hst, sizeof(ELEM_TYPE) * mn * stack_size, stream), &result);
+  CHECK(acc_host_mem_allocate((void**)&stack_hst, sizeof(int) * stack_size, stream), &result);
+  CHECK(acc_stream_sync(stream), &result); /* ensure host-data is allocated */
+  for (i = 0; i < stack_size; ++i) { /* initialize matrices */
+    init(i/*seed*/, &mat_hst[i*mn], m, n);
+  }
+  for (i = 0; i < stack_size; ++i) { /* initialize indexes */
+#if defined(SHUFFLE)
+    const int j = mn * (int)((shuffle * i) % stack_size);
+#else
+    const int j = mn * i;
+#endif
+    stack_hst[i] = j;
+  }
+  CHECK(acc_dev_mem_allocate((void**)&mat_dev, sizeof(ELEM_TYPE) * mn * stack_size), &result);
+  CHECK(acc_dev_mem_allocate((void**)&stack_dev, sizeof(int) * stack_size), &result);
+#if defined(USE_LIBXSMM)
+  CHECK(acc_stream_sync(stream), &result);
+  start = libxsmm_timer_tick();
+#endif
+  CHECK(acc_memcpy_h2d(mat_hst, mat_dev, sizeof(ELEM_TYPE) * mn * stack_size, stream), &result);
+  CHECK(acc_memcpy_h2d(stack_hst, stack_dev, sizeof(int) * stack_size, stream), &result);
+#if defined(USE_LIBXSMM)
+  CHECK(acc_stream_sync(stream), &result);
+  duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
+  printf("copy-in: %.1f ms %.1f GB/s\n", 1000.0 * duration,
+    (sizeof(ELEM_TYPE) * mn + sizeof(int))
+      * stack_size / (duration * (1ULL << 30)));
+#endif
+  /* warmup execution and prebuild JIT kernels */
+  for (r = 0; r < warmup / 2; ++r) {
+    CHECK(libsmm_acc_transpose(stack_dev, offset, stack_size, mat_dev,
+      DBCSR_TYPE(ELEM_TYPE), m, n, MAX_KERNEL_DIM, stream), &result);
+    CHECK(libsmm_acc_transpose(stack_dev, offset, stack_size, mat_dev,
+      DBCSR_TYPE(ELEM_TYPE), n, m, MAX_KERNEL_DIM, stream), &result);
+  }
+#if defined(USE_LIBXSMM)
+  CHECK(acc_stream_sync(stream), &result);
+  start = libxsmm_timer_tick();
+#endif
+  for (r = 0; r < nodd; ++r) {
+    CHECK(libsmm_acc_transpose(stack_dev, offset, stack_size, mat_dev,
+      DBCSR_TYPE(ELEM_TYPE), mm, nn, MAX_KERNEL_DIM, stream), &result);
+    swap(&mm, &nn);
+  }
+#if defined(USE_LIBXSMM)
+  CHECK(acc_stream_sync(stream), &result);
+  duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
+  if (EXIT_SUCCESS == result) {
+    assert(0 < nodd && (nodd & 1/*odd*/));
+    printf("device: %.1f ms %.1f GB/s\n", 1000.0 * duration / nodd,
+      (sizeof(ELEM_TYPE) * mn + sizeof(int))
+        * stack_size / (duration * (1ULL << 30) / nodd));
+    mm = m; nn = n;
+    start = libxsmm_timer_tick();
+    for (r = 0; r < nodd; ++r) {
+      libxsmm_itrans_batch_omp(mat_hst, sizeof(ELEM_TYPE), mm, nn, mm, nn,
+        0/*index_base*/, sizeof(int)/*index_stride*/, stack_hst, stack_size);
+      swap(&mm, &nn);
+    }
+    duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
+    printf("host: %.1f ms %.1f GB/s\n", 1000.0 * duration / nodd,
+      (sizeof(ELEM_TYPE) * mn + sizeof(int))
+        * stack_size / (duration * (1ULL << 30) / nodd));
+    /* transfer result from device back to host for validation */
+    CHECK(acc_memcpy_d2h(mat_dev, mat_hst,
+      sizeof(ELEM_TYPE) * mn * stack_size, stream), &result);
+    CHECK(acc_stream_sync(stream), &result);
+    if (EXIT_SUCCESS == result) {
+      unsigned int nerrors = 0;
+      int j;
+      for (i = 0; i < stack_size; ++i) {
+        ELEM_TYPE gold[MAX_KERNEL_DIM*MAX_KERNEL_DIM];
+        const ELEM_TYPE *const test = mat_hst + mn * i;
+        init(i/*seed*/, gold, m, n);
+        libxsmm_itrans(gold, sizeof(ELEM_TYPE), m, n, m, n);
+        for (j = 0; j < (m * n); ++j) {
+          if (gold[j] != test[j]) {
+            ++nerrors;
+# if defined(_DEBUG)
+            print(stderr, "gold = ", gold, n, m);
+            print(stderr, "this = ", test, n, m);
+            init(i/*seed*/, gold, m, n);
+            print(stderr, "orig = ", gold, m, n);
+            fprintf(stderr, "\n");
+# endif
+            break;
+          }
+        }
+      }
+      printf("errors: %u\n", nerrors);
+      if (0 != nerrors) result = EXIT_FAILURE;
+    }
+  }
+#endif
+  CHECK(acc_host_mem_deallocate(stack_hst, stream), NULL);
+  CHECK(acc_host_mem_deallocate(mat_hst, stream), NULL);
+  CHECK(acc_dev_mem_deallocate(stack_dev), NULL);
+  CHECK(acc_dev_mem_deallocate(mat_dev), NULL);
+  CHECK(acc_stream_destroy(stream), NULL);
+  if (EXIT_SUCCESS != result) {
+    fprintf(stderr, "FAILED\n");
+  }
+  return result;
+}
+
+
+static void init(int seed, ELEM_TYPE* dst, int m, int n) {
+  int i, j;
+  for (i = 0; i < n; ++i) {
+    for (j = 0; j < m; ++j) {
+      const int k = i * m + j;
+      dst[k] = (ELEM_TYPE)((seed + 1) * (k + 1));
+    }
+  }
+}
+
+
+#if defined(_DEBUG) && defined(USE_LIBXSMM)
+static void print(FILE* ostream, const char* label, const ELEM_TYPE* mat, int m, int n)
+{
+  int i, j;
+  const char *const s = (NULL != label ? label : "");
+  const int len = (int)strlen(s);
+  for (i = 0; i < n; ++i) {
+    if (0 < i) fprintf(ostream, "%*s", len, " "); else fprintf(ostream, "%s", s);
+    for (j = 0; j < m; ++j) {
+      fprintf(ostream, "%.2f ", mat[i*m+j]);
+    }
+    fprintf(ostream, "\n");
+  }
+}
+#endif

--- a/src/acc/cuda/Makefile
+++ b/src/acc/cuda/Makefile
@@ -1,0 +1,163 @@
+INCACC := $(wildcard *.h*) ../acc.h
+SRCACC := $(wildcard *.cpp)
+OBJACC := $(SRCACC:.cpp=.o) acc_cublas.o
+
+GPUSMM := $(wildcard ../libsmm_acc/kernels/*.h*)
+INCSMM := $(wildcard ../libsmm_acc/*.h*) ../acc_libsmm.h \
+  ../libsmm_acc/smm_acc_kernels.h \
+  ../libsmm_acc/parameters.h \
+  $(NULL)
+SRCSMM := $(wildcard ../libsmm_acc/*.cpp)
+OBJSMM := $(SRCSMM:.cpp=.o)
+
+INCALL := $(INCACC) $(INCSMM)
+
+LIBXSMMROOT ?= $(wildcard ../../../../libxsmm)
+NVCC ?= $(shell which nvcc 2>/dev/null)
+CUDA_PATH ?= $(if $(NVCC),$(abspath $(dir $($(NVCC)))/..))
+UNAME := $(shell uname)
+WITH_GPU ?= V100
+INTEL ?= 0
+DEV ?= 0
+
+PYTHON := $(shell which python3 2>/dev/null)
+ifeq (,$(PYTHON))
+  PYTHON := $(shell which python 2>/dev/null)
+endif
+
+ifeq ($(WITH_GPU),K20X)
+ ARCH_NUMBER = 35
+else ifeq ($(WITH_GPU),K40)
+ ARCH_NUMBER = 35
+else ifeq ($(WITH_GPU),K80)
+ ARCH_NUMBER = 37
+else ifeq ($(WITH_GPU),P100)
+ ARCH_NUMBER = 60
+else ifeq ($(WITH_GPU),V100)
+ ARCH_NUMBER = 70
+else ifeq (,$(ARCH_NUMBER))
+ $(error Unknown ARCH_NUMBER since WITH_GPU="$(WITH_GPU)" is not recognized)
+endif
+
+CFLAGS := -fPIC \
+  -Wall -Wextra -pedantic \
+  -DARCH_NUMBER=$(ARCH_NUMBER) \
+  -DNO_DBCSR_TIMESET \
+  -D__CUDA \
+  $(NULL)
+
+ifeq (1,$(INTEL))
+  CXX := icpc
+  CC := icc
+  AR := xiar
+else ifneq (0,$(INTEL))
+  CXX := icpx
+  CC := icx
+  AR := xiar
+else
+  CXX := g++
+  CC := gcc
+  ifneq (Darwin,$(UNAME))
+    AR := gcc-ar
+  else
+    AR := ar
+  endif
+endif
+
+ifneq (0,$(DBG))
+  ifeq (,$(DBG))
+    CFLAGS += -O2
+  else
+    ifneq (1,$(DBG))
+      CFLAGS += -D_DEBUG
+    endif
+    CFLAGS += -O0
+  endif
+else
+  CFLAGS += -O2 -DNDEBUG
+  SYM := 0
+endif
+ifneq (0,$(SYM))
+  CFLAGS += -g
+endif
+
+ifneq (0,$(OMP))
+ifneq (0,$(INTEL))
+  CFLAGS += -qopenmp
+  LDFLAGS += -qopenmp
+else ifneq (Darwin,$(UNAME))
+  CFLAGS += -fopenmp
+  LDFLAGS += -fopenmp
+else # macOS
+  CFLAGS += -Xpreprocessor -fopenmp
+  LDFLAGS += -lomp
+endif
+endif
+
+ifneq (,$(LIBXSMMROOT))
+  LDFLAGS := -pthread $(LDFLAGS) -L$(LIBXSMMROOT)/lib -lxsmmext -lxsmm -lxsmmnoblas -ldl -lm
+  CFLAGS += -pthread -D__LIBXSMM -I$(LIBXSMMROOT)/include
+endif
+
+ifneq (0,$(DEV))
+  CXXFLAGS := -std=c++11 $(CFLAGS)
+  CFLAGS := -std=c89 $(CFLAGS)
+else
+  CXXFLAGS := $(CFLAGS)
+endif
+
+LDFLAGS += -L$(CUDA_PATH)/lib64 -lcudart -lcublas -lnvrtc -lcuda
+CFLAGS += -Wno-variadic-macros -Wno-long-long
+
+.PHONY: all
+all: ../dbcsr_acc.a ../dbcsr_acc_smm.a bench test
+
+.PHONY: bench
+bench: ../acc_bench_smm ../acc_bench_trans
+
+.PHONY: test
+test: ../dbcsr_acc_test
+
+../libsmm_acc/parameters.h: Makefile ../libsmm_acc/generate_parameters.py ../libsmm_acc/parameters/parameters_$(WITH_GPU).json
+	@cd ../libsmm_acc && $(PYTHON) ../libsmm_acc/generate_parameters.py --gpu_version=$(WITH_GPU) --base_dir=../libsmm_acc/parameters
+
+../libsmm_acc/smm_acc_kernels.h: $(GPUSMM) Makefile ../libsmm_acc/generate_kernels.py ../libsmm_acc/parameters/parameters_$(WITH_GPU).json
+	@cd ../libsmm_acc && $(PYTHON) ../libsmm_acc/generate_kernels.py ../libsmm_acc/kernels
+
+acc_cublas.o: acc_cublas.cu Makefile
+	$(NVCC) $(addprefix -Xcompiler $(NULL),$(CXXFLAGS)) -c $< -o $@
+
+../dbcsr_acc.a: $(OBJACC) acc_cublas.o ../libsmm_acc/libsmm_acc_init.o
+	$(AR) -rs $@ $^
+
+../dbcsr_acc_smm.a: $(OBJSMM)
+	$(AR) -rs $@ $^
+
+%.o: %.cpp $(INCALL) Makefile
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+acc_bench_smm.o: ../acc_bench_smm.c Makefile
+	$(CC) $(CFLAGS) -c $< -o $@
+../acc_bench_smm: acc_bench_smm.o ../dbcsr_acc_smm.a ../dbcsr_acc.a
+	$(CXX) $^ $(LDFLAGS) -o $@
+
+acc_bench_trans.o: ../acc_bench_trans.c Makefile
+	$(CC) $(CFLAGS) -c $< -o $@
+../acc_bench_trans: acc_bench_trans.o ../dbcsr_acc_smm.a ../dbcsr_acc.a
+	$(CXX) $^ $(LDFLAGS) -o $@
+
+dbcsr_acc_test.o: ../../../tests/dbcsr_acc_test.c Makefile
+	$(CC) $(CFLAGS) -c $< -o $@
+../dbcsr_acc_test: dbcsr_acc_test.o ../dbcsr_acc_smm.a ../dbcsr_acc.a
+	$(CXX) $^ $(LDFLAGS) -o $@
+
+.PHONY: clean
+clean:
+	@rm -f $(OBJACC) $(OBJSMM)
+	@rm -f acc_bench_smm.o acc_bench_trans.o dbcsr_acc_test.o
+
+.PHONY: realclean
+realclean: clean
+	@rm -f ../dbcsr_acc.a ../dbcsr_acc_smm.a
+	@rm -f ../acc_bench_smm ../acc_bench_trans
+	@rm -f ../dbcsr_acc_test

--- a/tests/dbcsr_acc_test.c
+++ b/tests/dbcsr_acc_test.c
@@ -1,0 +1,224 @@
+/*------------------------------------------------------------------------------------------------*
+ * Copyright (C) by the DBCSR developers group - All rights reserved                              *
+ * This file is part of the DBCSR library.                                                        *
+ *                                                                                                *
+ * For information on the license, see the LICENSE file.                                          *
+ * For further information please visit https://dbcsr.cp2k.org                                    *
+ * SPDX-License-Identifier: GPL-2.0+                                                              *
+ *------------------------------------------------------------------------------------------------*/
+#include "../src/acc/acc.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#if !defined(NDEBUG)
+# include <assert.h>
+#endif
+#if defined(_OPENMP)
+# include <omp.h>
+#endif
+
+#if !defined(ACC_STRING_MAXLEN)
+# define ACC_STRING_MAXLEN 32
+#endif
+#if !defined(ACC_STREAM_MAXCOUNT)
+# define ACC_STREAM_MAXCOUNT 16
+#endif
+#if !defined(ACC_EVENT_MAXCOUNT)
+# define ACC_EVENT_MAXCOUNT (16*ACC_STREAM_MAXCOUNT)
+#endif
+#if !defined(ACC_STREAM_MAXNTH_DESTROY)
+# define ACC_STREAM_MAXNTH_DESTROY 2
+#endif
+#if !defined(ACC_EVENT_MAXNTH_DESTROY)
+# define ACC_EVENT_MAXNTH_DESTROY 3
+#endif
+
+#if defined(NDEBUG)
+# define ACC_CHECK(RESULT) do { const int acc_check_result_ = (RESULT); \
+    if (EXIT_SUCCESS != acc_check_result_) exit(acc_check_result_); \
+  } while(0)
+# define PRINTF(A, ...)
+#else /* debug */
+# define ACC_CHECK(RESULT) assert(EXIT_SUCCESS == (RESULT))
+# define PRINTF(A, ...) printf(A, __VA_ARGS__)
+#endif
+
+
+/**
+ * This program tests the ACC interface (include/acc.h) for adhering to expectations.
+ * The expected behavior is to match the CUDA based implementation, which was available
+ * first. This test program can serve as a specification for other backends such as the
+ * OpenMP based backend. It may also be used to stress-test any backend including the
+ * CUDA based backend for thread-safety. Thread-safety is an implicit requirement
+ * induced by DBCSR (and CP2K). To test any backend (other than the OpenMP backend),
+ * the Makefile must be adjusted to link with the desired backend.
+ */
+int main(int argc, char* argv[])
+{
+  const int device = (1 < argc ? atoi(argv[1]) : 0);
+#if defined(_OPENMP)
+  const int max_nthreads = omp_get_max_threads();
+#else
+  const int max_nthreads = 1;
+#endif
+  const int cli_nthreads = (2 < argc ? atoi(argv[2]) : max_nthreads);
+  const int nthreads = ((0 < cli_nthreads && cli_nthreads <= max_nthreads) ? cli_nthreads : max_nthreads);
+  int priority[ACC_STREAM_MAXCOUNT], priomin, priomax, priospan;
+  int randnums[ACC_EVENT_MAXCOUNT], ndevices, i, nt;
+  void *stream[ACC_STREAM_MAXCOUNT], *s;
+  void *event[ACC_EVENT_MAXCOUNT];
+  const size_t mem_alloc = (16/*MB*/ << 20);
+  size_t mem_free, mem_total, mem_chunk;
+  void *host_mem, *dev_mem;
+
+  for (i = 0; i < ACC_EVENT_MAXCOUNT; ++i) {
+    randnums[i] = rand();
+  }
+
+  ACC_CHECK(acc_init());
+  ACC_CHECK(acc_get_ndevices(&ndevices));
+  PRINTF("ndevices: %i\n", ndevices);
+  /* continue tests even with no device */
+  if (0 <= device && device < ndevices) { /* not an error */
+    ACC_CHECK(acc_set_active_device(device));
+  }
+
+  ACC_CHECK(acc_dev_mem_info(&mem_free, &mem_total));
+  ACC_CHECK(mem_free <= mem_total ? EXIT_SUCCESS : EXIT_FAILURE);
+  PRINTF("device memory: free=%i MB total=%i MB\n",
+    (int)(mem_free >> 20), (int)(mem_total >> 20));
+
+  ACC_CHECK(acc_stream_priority_range(&priomin, &priomax));
+  priospan = 1 + priomin - priomax;
+  PRINTF("stream priority: lowest=%i highest=%i%s\n", priomin, priomax,
+    0 < priospan ? "" : " <-- WARNING: inconsistent values");
+
+  for (i = 0; i < ACC_STREAM_MAXCOUNT; ++i) {
+    priority[i] = priomax + (0 < priospan ? (randnums[i] % priospan) : 0);
+    stream[i] = NULL;
+  }
+  for (i = 0; i < ACC_EVENT_MAXCOUNT; ++i) {
+    event[i] = NULL;
+  }
+
+  /* create stream with NULL-name and low priority */
+  ACC_CHECK(acc_stream_create(&s, NULL/*name*/, priomin));
+  ACC_CHECK(acc_stream_destroy(s));
+  /* create stream with empty name and medium priority */
+  ACC_CHECK(acc_stream_create(&s, "", (priomin + priomax) / 2));
+  ACC_CHECK(acc_stream_destroy(s));
+  /* destroying NULL-stream shall be valid (just like delete/free) */
+  ACC_CHECK(acc_stream_destroy(NULL));
+
+#if defined(_OPENMP)
+# pragma omp parallel for num_threads(nthreads) private(i)
+#endif
+  for (i = 0; i < ACC_STREAM_MAXCOUNT; ++i) {
+    const int r = randnums[i] % ACC_STREAM_MAXCOUNT;
+    char name[ACC_STRING_MAXLEN]; /* thread-local */
+    const int n = sprintf(name, "%i", i);
+    ACC_CHECK((0 <= n && n < ACC_STRING_MAXLEN) ? EXIT_SUCCESS : EXIT_FAILURE);
+    ACC_CHECK(acc_stream_create(stream + i, name, priority[i]));
+    if (ACC_STREAM_MAXNTH_DESTROY * r < ACC_STREAM_MAXCOUNT) {
+      void *const si = stream[i]; stream[i] = NULL;
+      ACC_CHECK(acc_stream_destroy(si));
+    }
+  }
+
+#if defined(_OPENMP)
+# pragma omp parallel for num_threads(nthreads) private(i)
+#endif
+  for (i = 0; i < ACC_STREAM_MAXCOUNT; ++i) {
+    if (NULL == stream[i]) {
+      char name[ACC_STRING_MAXLEN]; /* thread-local */
+      const int n = sprintf(name, "%i", i);
+      ACC_CHECK((0 <= n && n < ACC_STRING_MAXLEN) ? EXIT_SUCCESS : EXIT_FAILURE);
+      ACC_CHECK(acc_stream_create(stream + i, name, priority[i]));
+    }
+    ACC_CHECK(acc_stream_destroy(stream[i]));
+  }
+
+  ACC_CHECK(acc_event_destroy(NULL));
+#if defined(_OPENMP)
+# pragma omp parallel for num_threads(nthreads) private(i)
+#endif
+  for (i = 0; i < ACC_EVENT_MAXCOUNT; ++i) {
+    const int r = randnums[i] % ACC_EVENT_MAXCOUNT;
+    ACC_CHECK(acc_event_create(event + i));
+    if (ACC_EVENT_MAXNTH_DESTROY * r < ACC_EVENT_MAXCOUNT) {
+      void *const ei = event[i]; event[i] = NULL;
+      ACC_CHECK(acc_event_destroy(ei));
+    }
+  }
+
+#if defined(_OPENMP)
+# pragma omp parallel for num_threads(nthreads) private(i)
+#endif
+  for (i = 0; i < ACC_EVENT_MAXCOUNT; ++i) {
+    if (NULL == event[i]) {
+      ACC_CHECK(acc_event_create(event + i));
+    }
+    ACC_CHECK(acc_event_destroy(event[i]));
+  }
+
+#if defined(_OPENMP)
+# pragma omp parallel for num_threads(nthreads) private(i)
+#endif
+  for (i = 0; i < ACC_EVENT_MAXCOUNT; ++i) ACC_CHECK(acc_event_create(event + i));
+  for (i = 0; i < ACC_EVENT_MAXCOUNT; ++i) {
+    acc_bool_t has_occurred = 0;
+    ACC_CHECK(acc_event_query(event[i], &has_occurred));
+    ACC_CHECK(has_occurred ? EXIT_SUCCESS : EXIT_FAILURE);
+  }
+
+  ACC_CHECK(acc_stream_create(&s, "stream", priomax));
+  ACC_CHECK(acc_host_mem_allocate(&host_mem, mem_alloc, s));
+  ACC_CHECK(acc_dev_mem_allocate(&dev_mem, mem_alloc));
+  ACC_CHECK(acc_stream_sync(s)); /* wait for completion */
+  memset(host_mem, 0xFF, mem_alloc); /* non-zero pattern */
+
+  nt = (nthreads < ACC_EVENT_MAXCOUNT ? nthreads : ACC_EVENT_MAXCOUNT);
+  mem_chunk = (mem_alloc + nt - 1) / nt;
+#if defined(_OPENMP)
+# pragma omp parallel num_threads(nt)
+#endif
+  {
+#if defined(_OPENMP)
+    const int tid = omp_get_thread_num();
+#else
+    const int tid = 0;
+#endif
+    const size_t offset = tid * mem_chunk, mem_rest = mem_alloc - offset;
+    const size_t size = (mem_chunk <= mem_rest ? mem_chunk : mem_rest);
+    acc_bool_t has_occurred = 0;
+    ACC_CHECK(acc_memset_zero(dev_mem, offset, size, s));
+    /* can enqueue multiple/duplicate copies for the same memory region */
+    ACC_CHECK(acc_memcpy_d2h(dev_mem, host_mem, mem_alloc, s));
+    ACC_CHECK(acc_event_query(event[tid], &has_occurred));
+    /* unrecorded event has no work to wait for, hence it occurred */
+    ACC_CHECK(has_occurred ? EXIT_SUCCESS : EXIT_FAILURE);
+    ACC_CHECK(acc_event_record(event[tid], s));
+    ACC_CHECK(acc_stream_wait_event(s, event[tid]));
+    ACC_CHECK(acc_event_synchronize(event[tid]));
+    ACC_CHECK(acc_event_query(event[tid], &has_occurred));
+    ACC_CHECK(has_occurred ? EXIT_SUCCESS : EXIT_FAILURE);
+  }
+
+  /* validate backwards from where the last transfers occurred */
+  for (i = (int)(mem_alloc - 1); 0 <= i; --i) {
+    ACC_CHECK(0 == ((char*)host_mem)[i] ? EXIT_SUCCESS : EXIT_FAILURE);
+  }
+  ACC_CHECK(acc_dev_mem_deallocate(dev_mem));
+  ACC_CHECK(acc_host_mem_deallocate(host_mem, s));
+  ACC_CHECK(acc_stream_destroy(s));
+
+#if defined(_OPENMP)
+# pragma omp parallel for num_threads(nthreads) private(i)
+#endif
+  for (i = 0; i < ACC_EVENT_MAXCOUNT; ++i) ACC_CHECK(acc_event_destroy(event[i]));
+
+  acc_clear_errors(); /* no result code */
+  ACC_CHECK(acc_finalize());
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Added some test code (carry-forward from OpenMP/backend experiments), which exercises the ACC interface in an abstract fashion (backend agnostic); building this test may be integrated later with CMake infrastructure. Added two benchmark drivers (matrix transpose and multiplication). Added Makefile to build test and driver in a stand-alone fashion using the CUDA based backend (please note, the Makefile is not as sophisticated as the CMake based tool chain, however, it is meant to be simple or easy to adjust for the local environment).