### PR TITLE
Update some versions in the docs

### DIFF
--- a/docs/guide/2-user-guide/1-installation/1-cmake-build-recipes.md
+++ b/docs/guide/2-user-guide/1-installation/1-cmake-build-recipes.md
@@ -158,8 +158,8 @@ selected BLAS/LAPACK library accordingly (e.g. drop the `_mpi`, or `_mp`).
 
 ### CCE and libsci-cray
 
-Verified on CSCS' Piz Daint with CCE 9.0.2 and cray-libsci 19.06.1,
-using CMake 3.14.5.
+Verified on CSCS' Piz Daint with CCE 10.0.2 and cray-libsci 20.06.1,
+using CMake 3.18.4.
 
 1. Make sure that the `PrgEnv-cray` module is loaded:
 
@@ -180,8 +180,8 @@ using CMake 3.14.5.
 
 ### Intel Compiler and libsci-cray
 
-Verified on CSCS' Piz Daint with Intel 19.01 and cray-libsci 19.06.1,
-using CMake 3.14.5.
+Verified on CSCS' Piz Daint with Intel 19.1 and cray-libsci 20.06.1,
+using CMake 3.18.4.
 
 1. Make sure that the `PrgEnv-intel` module is loaded:
 
@@ -202,8 +202,8 @@ using CMake 3.14.5.
 
 ### GNU Compiler and libsci-cray
 
-Verified on CSCS' Piz Daint with GNU 8.3.0 and cray-libsci 19.06.1,
-using CMake 3.14.5.
+Verified on CSCS' Piz Daint with GNU 8.3.0 and cray-libsci 20.06.1,
+using CMake 3.18.4.
 
 1. Make sure that the `PrgEnv-gnu` module is loaded:
 

--- a/docs/guide/2-user-guide/1-installation/3-using-dbcsr-in-a-cmake-project.md
+++ b/docs/guide/2-user-guide/1-installation/3-using-dbcsr-in-a-cmake-project.md
@@ -22,7 +22,7 @@ an alternative base installation path for DBCSR instead:
 In your project's CMake you can then easily search for the DBCSR library:
 
 ```cmake
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.17)
 
 enable_language(Fortran C CXX)  # only request the required language
 

--- a/docs/guide/2-user-guide/1-installation/index.md
+++ b/docs/guide/2-user-guide/1-installation/index.md
@@ -6,7 +6,7 @@ title: Install
 
 You need:
 
-* [CMake](https://cmake.org/) (3.12+)
+* [CMake](https://cmake.org/) (3.17+)
 * GNU make or Ninja
 * Fortran compiler which supports at least Fortran 2008 (including the TS 29113 when using the C-bindings)
 * BLAS+LAPACK implementation (reference, OpenBLAS and MKL have been tested. Note: DBCSR linked to OpenBLAS 0.3.6 gives wrong results on Power9 architectures.)

--- a/docs/guide/2-user-guide/1-installation/index.md
+++ b/docs/guide/2-user-guide/1-installation/index.md
@@ -86,9 +86,17 @@ export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${HOME}/libxsmm/lib"
 
 For build recipes on different platforms, make sure to also read the [CMake Build Recipes](./1-cmake-build-recipes.html).
 
-### Using Python in a virtual environment
+### Building with spack
 
-If Python is desired from a virtual environment and the CMake version below v3.15, then the python interpreter shall be specified manually using `cmake -DPython_EXECUTABLE=/path/to/python`.
+DBCSR and its dependencies can be built with the [spack package manager](https://github.com/spack/spack):
+
+```
+spack install dbcsr +openmp +mpi +cuda cuda_arch=70
+spack install dbcsr +openmp +mpi +rocm amdgpu_target=gfx906
+spack install dbcsr +openmp +mpi +opencl ^cuda
+```
+
+See `spack info dbcsr` for all supported variants.
 
 ### C/C++ Interface
 


### PR DESCRIPTION
CMake 3.17 is now a requirement, and the Daint installation info was outdated.

Should we also add `spack install` instructions? There is no mention of it, but basically what I want is:

```shell
spack install dbcsr +rocm              # will build a lot of things including llvm-amdgpu and rocblas
spack install dbcsr +cuda              # will just download cuda
spack install dbcsr +opencl ^cuda      # possible since yesterday
spack install dbcsr +opencl ^amdopencl # there is an AMD developer wrapping this package, to be released soon
```
