### PR TITLE
Docker image maintenance

### DIFF
--- a/.github/workflows/docker-build-env.yml
+++ b/.github/workflows/docker-build-env.yml
@@ -41,3 +41,18 @@ jobs:
           workdir: tools/docker
           dockerfile: Dockerfile.build-env-latest-gcc
           tags: "latest"
+
+  docker-build-env-rocm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Publish Gitlab Image
+        uses: elgohr/Publish-Docker-Github-Action@2.12
+        with:
+          name: dbcsr/build-env-rocm-ubuntu-20.04
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          workdir: tools/docker
+          dockerfile: Dockerfile.build-env-rocm
+          tags: "latest"

--- a/.github/workflows/testing-linux.yml
+++ b/.github/workflows/testing-linux.yml
@@ -84,7 +84,7 @@ jobs:
   build-on-rocm:
     runs-on: ubuntu-latest
     container:
-      image: shoshijak/build-env-rocm:1.0
+      image: dbcsr/build-env-rocm-ubuntu-20.04:latest
 
     strategy:
       matrix:

--- a/tools/docker/Dockerfile.build-env-latest-gcc
+++ b/tools/docker/Dockerfile.build-env-latest-gcc
@@ -21,8 +21,8 @@ ENV LANG en_US.utf8
 RUN ln -sf python3 /usr/bin/python
 
 # Debian is at CMake 3.13 and Ninja 1.8
-ARG cmake_version=3.17.0
-ARG ninja_version=1.10.0
+ARG cmake_version=3.17.5
+ARG ninja_version=1.10.2
 
 RUN set -ex ; \
     curl -LsS https://github.com/Kitware/CMake/releases/download/v${cmake_version}/cmake-${cmake_version}-Linux-x86_64.tar.gz | tar --strip-components=1 -xz -C /usr/local ; \

--- a/tools/docker/Dockerfile.build-env-rocm
+++ b/tools/docker/Dockerfile.build-env-rocm
@@ -1,43 +1,24 @@
-FROM rocm/dev-ubuntu-18.04:latest
+FROM rocm/dev-ubuntu-20.04:4.0.1
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 # install compilers, libraries & co
-RUN apt-get update
-RUN apt-get install -y \
-        locales \
-        gfortran \
-        gcc-7 \
-        g++-7 \
-        llvm-7-dev \
-        llvm-7-tools \
-        mpich \
-        libomp-7-dev \
+RUN apt-get update -qq \
+    && apt-get install --no-install-recommends -qq \
+        ca-certificates \
+        gfortran g++ gcc \
+        git \
+        hipblas \
         libmpich-dev \
-        libopenblas-dev \
-        wget
-
-# install rocm libraries
-RUN wget -q -O - http://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
-RUN echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
-RUN apt-get update
-RUN apt-get install -y \
-        rocm-dev \
+        libopenblas-openmp-dev \
+        mpich \
+        ninja-build \
         rocblas \
         rocsolver \
-        hipblas
-
-# install git 2.18+
-RUN apt-get install -y software-properties-common
-RUN add-apt-repository ppa:git-core/ppa
-RUN apt-get install -y git
-
-# install ninja
-RUN apt-get install -y wget
-RUN wget https://github.com/Kitware/ninja/releases/download/v1.10.0.gfb670.kitware.jobserver-1/ninja-1.10.0.gfb670.kitware.jobserver-1_x86_64-linux-gnu.tar.gz
-RUN tar -xzvf ninja-1.10.0.gfb670.kitware.jobserver-1_x86_64-linux-gnu.tar.gz
-ENV PATH="/ninja-1.10.0.gfb670.kitware.jobserver-1_x86_64-linux-gnu:${PATH}"
-
-# install cmake
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-3.17.0-Linux-x86_64.tar.gz
-RUN tar -xzvf cmake-3.17.0-Linux-x86_64.tar.gz
-ENV PATH="/cmake-3.17.0-Linux-x86_64/bin:${PATH}"
+        wget \
+        python3-pip \
+    && rm -rf /var/lib/apt/lists/* \
+    && wget -qO- "https://cmake.org/files/v3.17/cmake-3.17.5-Linux-x86_64.tar.gz" | \
+       tar --strip-components=1 -xz -C /usr/local \
+    && pip3 install fypp
 

--- a/tools/docker/Dockerfile.build-env-ubuntu
+++ b/tools/docker/Dockerfile.build-env-ubuntu
@@ -39,7 +39,7 @@ ENV LANG en_US.utf8
 RUN ln -s python3 /usr/bin/python
 
 ARG libxsmm_version=1.16.1
-ARG cmake_version=3.17.0
+ARG cmake_version=3.17.5
 
 RUN set -ex && \
     pip3 install \

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -34,14 +34,13 @@ $ docker build -t dbcsr/build-env-ubuntu-20.04 -f Dockerfile.build-env-ubuntu .
 
 ## ROCm Build Environment
 
-The image is based on Ubuntu 18.04 and contains:
+The image `dbcsr/build-env-rocm-ubuntu-20.04` contains:
 
 * GNU Fortran Compiler
 * OpenBLAS
 * MPICH
 * CMake (recent version)
 * Ninja (recent version)
-* Git 2.18+
-* ROCm
-* ROCm libraries (rocblas, rocsolver, hipblas)
+* Git
+* ROCm (hip, rocblas, rocsolver, hipblas)
 


### PR DESCRIPTION
Closes #430 

- Bump cmake patch version
- Bump the rocm image to use 4.0.1 (seems like 4.0 == 4.0.0)
- Periodically build the ROCm Docker image
- Start using the new image
