### PR TITLE
ocl: expose multiple tiles/subdevices as devices

### DIFF
--- a/src/acc/opencl/README.md
+++ b/src/acc/opencl/README.md
@@ -16,9 +16,10 @@ An application of compile-time settings (and perhaps a valuable contribution) mi
 
 Runtime settings are made by the means of environment variables (implemented in `acc_opencl.c`). There are variables for chosing an OpenCL device:
 
-* `ACC_OPENCL_VENDOR`: character string matching the vendor of the OpenCL device in an case-insensitive fashion, e.g., "intel".
+* `ACC_OPENCL_DEVSPLIT`: integer enabling devices to be split into subdevices (non-zero: enabled, default/zero: disabled).
 * `ACC_OPENCL_DEVTYPE`: character string matching the device-kind like "cpu", "gpu", or another kind if neither CPU or GPU.
 * `ACC_OPENCL_DEVICE`: non-negative integer number to select a device from the (internally enumerated) list of devices.
+* `ACC_OPENCL_VENDOR`: character string matching the vendor of the OpenCL device in an case-insensitive fashion, e.g., "intel".
 * `ACC_OPENCL_VERBOSE`: verbosity level (integer).
     * `ACC_OPENCL_VERBOSE=1`: outputs (stderr) the number of devices found and the name of the selected device.
     * `ACC_OPENCL_VERBOSE=2`: outputs (stderr) the duration needed to generate a requested kernel.

--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -257,7 +257,7 @@ int c_dbcsr_acc_init(void)
                 break;
               }
               /* prune number of devices to capture GPUs only */
-              else if (CL_DEVICE_TYPE_ALL == type && CL_DEVICE_TYPE_GPU == itype) {
+              else if (CL_DEVICE_TYPE_ALL == type && CL_DEVICE_TYPE_GPU == itype && device_id <= (int)i) {
                 result = clGetDeviceInfo(c_dbcsr_acc_opencl_devices[i],
                     CL_DEVICE_NAME, ACC_OPENCL_BUFFERSIZE, buffer, NULL);
                 if (CL_SUCCESS == result /* prune for homogeneous set of GPUs */

--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -203,6 +203,7 @@ int c_dbcsr_acc_init(void)
                   c_dbcsr_acc_opencl_devices + c_dbcsr_acc_opencl_ndevices, NULL),
                   "split device into subdevices", result);
                 if (EXIT_SUCCESS == result) {
+                  ACC_OPENCL_CHECK(clReleaseDevice(devices[j]), "release device", result);
                   c_dbcsr_acc_opencl_ndevices += n;
                 }
                 else break;

--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -47,7 +47,7 @@
 # define ACC_OPENCL_BUFFERSIZE (8 << 10/*8KB*/)
 #endif
 #if !defined(ACC_OPENCL_DEVICES_MAXCOUNT)
-# define ACC_OPENCL_DEVICES_MAXCOUNT 32
+# define ACC_OPENCL_DEVICES_MAXCOUNT 256
 #endif
 
 /* can depend on OpenCL implementation */

--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -216,9 +216,9 @@ typedef struct c_dbcsr_acc_opencl_info_hostptr_t {
 c_dbcsr_acc_opencl_info_hostptr_t* c_dbcsr_acc_opencl_info_hostptr(void* memory);
 /** Get host-pointer associated with device-memory (acc_dev_mem_allocate). */
 void* c_dbcsr_acc_opencl_get_hostptr(cl_mem memory);
-/** Information about amount of device memory. */
+/** Amount of device memory; local memory is only non-zero if separate from global. */
 int c_dbcsr_acc_opencl_info_devmem(cl_device_id device,
-  size_t* mem_free, size_t* mem_total);
+  size_t* mem_free, size_t* mem_total, size_t* mem_local);
 /** Return the pointer to the 1st match of "b" in "a", or NULL (no match). */
 const char* c_dbcsr_acc_opencl_stristr(const char* a, const char* b);
 /** Get active device (can be thread/queue-specific). */

--- a/src/acc/opencl/smm/README.md
+++ b/src/acc/opencl/smm/README.md
@@ -16,9 +16,10 @@ The `OPENCL_LIBSMM_DEBUG` compile-time setting enables side-by-side validation o
 
 Runtime settings are made by the means of environment variables (implemented in `opencl_libsmm.c`). There are two categories (for the two major functions) like matrix transpose (`OPENCL_LIBSMM_TRANS_*`) and matrix multiplication (`OPENCL_LIBSMM_SMM_*`). Common settings are (see OpenCL backend documentation for more details):
 
-* `ACC_OPENCL_VENDOR`: character string matching the vendor of the OpenCL device in an case-insensitive fashion, e.g., "intel".
+* `ACC_OPENCL_DEVSPLIT`: integer enabling devices to be split into subdevices (non-zero: enabled, default/zero: disabled).
 * `ACC_OPENCL_DEVTYPE`: character string matching the device-kind like "cpu", "gpu", or another kind if neither CPU or GPU.
 * `ACC_OPENCL_DEVICE`: non-negative integer number to select a device from the (internally enumerated) list of devices.
+* `ACC_OPENCL_VENDOR`: character string matching the vendor of the OpenCL device in an case-insensitive fashion, e.g., "intel".
 * `ACC_OPENCL_VERBOSE`: verbosity level (integer).
     * `ACC_OPENCL_VERBOSE=1`: outputs (stderr) the number of devices found and the name of the selected device.
     * `ACC_OPENCL_VERBOSE=2`: outputs (stderr) the duration needed to generate a requested kernel.
@@ -61,17 +62,17 @@ cd src/acc/opencl/smm
 pip install -r requirements.txt
 ```
 
-The OpenTuner script supports several command line arguments (`tune_multiply.py --help`); defaults are reasonable with `--stop-after` of interest for adjustment, e.g., `--stop-after=300` to finish in five minutes (without limit, OpenTuner decides when the process is finished). A single kernel can be selected by M, N, and K parameters (GEMM), e.g., `M=15`, `N=5`, and `K=7`:
+The OpenTuner script supports several command line arguments (`tune_multiply.py --help`). For example, `--stop-after=300` can be interest to finish in five minutes (without a limit, OpenTuner decides when the auto-tuning process is finished). A single kernel can be selected by M, N, and K parameters (GEMM), e.g., `M=15`, `N=5`, and `K=7`:
 
 ```bash
-./tune_multiply.py 13 5 7
+./tune_multiply.py 13 5 7 --no-dups
 ```
 
 **NOTE**: If multiple different kernels are tuned using `tune_multiply.py`, it is advisible to delete the `opentuner.db` directory prior to a new kernel otherwise auto-tuning is potentially (mis-)guided by information which was collected for a different kernel (`tune_multiply.sh` does this automatically).
 
 The OpenTuner script implements multiple objectives ("cost"), primarily "accuracy" (maximized) and a secondary objective "size" (minimized). The former represents the achieved performance (GFLOPS/s) while the latter represents an artificial kernel requirement (just to prefer one parameter set over another in case of similar performance). The console output looks like:
 
-```
+```text
 [    15s]    INFO opentuner.search.plugin.DisplayPlugin: tests=8, best {'BS': 32, 'BM': 6, 'BN': 1}, cost accuracy=28.80000000, size=1.0, found by UniformGreedyMutation
 [    27s]    INFO opentuner.search.plugin.DisplayPlugin: tests=19, best {'BS': 48, 'BM': 8, 'BN': 1}, cost accuracy=32.20000000, size=1.0, found by UniformGreedyMutation
 [    40s]    INFO opentuner.search.plugin.DisplayPlugin: tests=31, best {'BS': 48, 'BM': 8, 'BN': 1}, cost accuracy=32.20000000, size=1.0, found by UniformGreedyMutation
@@ -116,7 +117,7 @@ To tune multiple kernels in a convenient fashion, a triplet specification can be
 
 Triplets are used to conveniently describe multiple kernels. A triplet specification consists of comma-separated groups of M,N,K-extents, i.e., matrix shapes according to GEMM. For example:
 
-```
+```text
 4 10 15, 6 7 8, 23
 ```
 

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -140,14 +140,6 @@ class SmmTuner(MeasurementInterface):
                 + str(round(self.gflops))
                 + "gflops.json"
             )
-            print(
-                "Result achieving "
-                + str(self.gflops)
-                + " GFLOPS/s ("
-                + self.typename
-                + ") was written to "
-                + ofilename
-            )
             # extend result for easier reuse later
             config = configuration.data
             config["GFLOPS"] = self.gflops
@@ -155,13 +147,29 @@ class SmmTuner(MeasurementInterface):
             config["M"] = self.args.m
             config["N"] = self.args.n
             config["K"] = self.args.k
+            filenames = glob.glob("*.json")
+            if not filenames and glob.glob(self.args.csvfile):
+                print(
+                    "WARNING: no JSON file found but (unrelated?) "
+                    + self.args.csvfile
+                    + " exists!"
+                )
             # self.manipulator().save_to_file(config, ofilename)
             with open(ofilename, "w") as ofile:
                 json.dump(config, ofile)
                 ofile.write("\n")  # append newline at EOF
+                print(
+                    "Result achieving "
+                    + str(self.gflops)
+                    + " GFLOPS/s ("
+                    + self.typename
+                    + ") was written to "
+                    + ofilename
+                )
+                if ofilename not in filenames:
+                    filenames.append(ofilename)
             # merge all JSONs into a single CSV file
             if self.args.csvfile:
-                filenames = glob.glob("*.json")
                 merged = dict()
                 for ifilename in filenames:
                     with open(ifilename, "r") as ifile:

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -99,7 +99,7 @@ class SmmTuner(MeasurementInterface):
             + " "
             + str(self.args.n)
             + " "
-            + str(max(self.args.k, 1))
+            + str(self.args.k)
         )
         run_result = self.call_program(run_cmd)
         if 0 == run_result["returncode"]:

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -30,6 +30,9 @@ class SmmTuner(MeasurementInterface):
         Define the search space by creating a
         ConfigurationManipulator
         """
+        if self.args.merge:
+            self.merge_into_csv(glob.glob("*.json"))
+            exit(0)
         self.exepath = "../.."
         self.exename = "acc_bench_smm"
         run_result = self.call_program(self.exepath + "/" + self.exename + " 1 1 1")
@@ -124,6 +127,59 @@ class SmmTuner(MeasurementInterface):
         else:  # return non-competitive/bad result in case of an error
             return Result(time=float("inf"), accuracy=0.0, size=100.0)
 
+    def merge_into_csv(self, filenames):
+        """merge all JSONs into a single CSV file"""
+        if self.args.csvfile:
+            merged = dict()
+            for ifilename in filenames:
+                with open(ifilename, "r") as ifile:
+                    data = json.load(ifile)
+                    try:
+                        key = (data["TYPEID"], data["M"], data["N"], data["K"])
+                        value = (
+                            data["GFLOPS"],
+                            data["BS"],
+                            data["BM"],
+                            data["BN"],
+                            ifilename,
+                        )
+                        if key not in merged:
+                            merged[key] = value
+                        else:
+                            if merged[key][0] < value[0]:
+                                ifilename = merged[key][-1]
+                                merged[key] = value
+                            print(
+                                "Worse result "
+                                + ifilename
+                                + " ignored when merging CSV file"
+                            )
+                    except KeyError:
+                        print(
+                            "Malformed " + ifilename + " ignored when merging CSV file"
+                        )
+                        pass
+            if bool(merged):
+                with open(self.args.csvfile, "w") as ofile:
+                    ofile.write(  # CSV header line
+                        self.args.csvsep.join(
+                            ["TYPEID", "M", "N", "K", "GFLOPS", "BS", "BM", "BN"]
+                        )
+                        + "\n"
+                    )
+                    for key, value in merged.items():  # CSV data lines
+                        strkey = self.args.csvsep.join([str(k) for k in key])
+                        strval = self.args.csvsep.join([str(v) for v in value[:-1]])
+                        ofile.write(strkey + self.args.csvsep + strval + "\n")
+                print(
+                    "Merged "
+                    + str(len(merged))
+                    + " of "
+                    + str(len(filenames))
+                    + " JSONs into "
+                    + self.args.csvfile
+                )
+
     def save_final_config(self, configuration):
         """called at the end of tuning"""
         if 0 < self.gflops:
@@ -168,59 +224,7 @@ class SmmTuner(MeasurementInterface):
                 )
                 if ofilename not in filenames:
                     filenames.append(ofilename)
-            # merge all JSONs into a single CSV file
-            if self.args.csvfile:
-                merged = dict()
-                for ifilename in filenames:
-                    with open(ifilename, "r") as ifile:
-                        data = json.load(ifile)
-                        try:
-                            key = (data["TYPEID"], data["M"], data["N"], data["K"])
-                            value = (
-                                data["GFLOPS"],
-                                data["BS"],
-                                data["BM"],
-                                data["BN"],
-                                ifilename,
-                            )
-                            if key not in merged:
-                                merged[key] = value
-                            else:
-                                if merged[key][0] < value[0]:
-                                    ifilename = merged[key][-1]
-                                    merged[key] = value
-                                print(
-                                    "Worse result "
-                                    + ifilename
-                                    + " ignored when merging CSV file"
-                                )
-                        except KeyError:
-                            print(
-                                "Malformed "
-                                + ifilename
-                                + " ignored when merging CSV file"
-                            )
-                            pass
-                if bool(merged):
-                    with open(self.args.csvfile, "w") as ofile:
-                        ofile.write(  # CSV header line
-                            self.args.csvsep.join(
-                                ["TYPEID", "M", "N", "K", "GFLOPS", "BS", "BM", "BN"]
-                            )
-                            + "\n"
-                        )
-                        for key, value in merged.items():  # CSV data lines
-                            strkey = self.args.csvsep.join([str(k) for k in key])
-                            strval = self.args.csvsep.join([str(v) for v in value[:-1]])
-                            ofile.write(strkey + self.args.csvsep + strval + "\n")
-                    print(
-                        "Merged "
-                        + str(len(merged))
-                        + " of "
-                        + str(len(filenames))
-                        + " JSONs into "
-                        + self.args.csvfile
-                    )
+                    self.merge_into_csv(filenames)
 
     def handle_sigint(self, signum, frame):
         """handles SIGINT or CTRL-C"""
@@ -301,6 +305,14 @@ if __name__ == "__main__":
         nargs="?",
         dest="csvfile",
         help="Generate CSV-file",
+    )
+    argparser.add_argument(
+        "-m",
+        "--csv-merge-only",
+        action="store_true",
+        default=False,
+        dest="merge",
+        help="Merge JSONs into CSV, and terminate",
     )
     argparser.add_argument(
         "-v",

--- a/src/acc/opencl/smm/tune_multiply.sh
+++ b/src/acc/opencl/smm/tune_multiply.sh
@@ -93,6 +93,8 @@ if [ "${SED}" ] && [ "${LS}" ] && [ "${RM}" ] && [ "${WC}" ]; then
   NJSONS=$(${LS} -1 ./*.json 2>/dev/null | ${WC} -l)
   if [ "0" != "${NJSONS}" ]; then
     echo "Already found ${NJSONS} (unrelated?) JSON-files."
+  elif [ -e tune_multiply.csv ]; then
+    echo "No JSON file found but (unrelated?) tune_multiply.csv exists."
   fi
   SLEEP=$(command -v sleep)
   if [ "${DELAY}" ] && [ "${SLEEP}" ]; then


### PR DESCRIPTION
Attempt to (optionally) split devices into subdevices (`ACC_OPENCL_DEVSPLIT`). This enables CP2K/DBCSR to load MPI-ranks onto subdevices (simply discovered as devices as per `c_dbcsr_acc_get_ndevices`). Note such device is treated as an aggregate device by default and `ACC_OPENCL_DEVSPLIT` is completely optional.

* Raised ACC_OPENCL_DEVICES_MAXCOUNT to better accommodate subdevices.
* Minor rephrase; removed red boxes around verbatim section (documentation).
* Documented ACC_OPENCL_DEVSPLIT.

Unrelated: avoid warning about (invalid) "#pragma OPENCL EXTENSION all: enable" (it can only be "disable" according to OpenCL spec.). However, for some OpenCL stacks this comes handy and without this warning. Main point is most platforms enable all extensions by default but at least one not.