### PR TITLE
ocl verbose: profile queues and performance output

### DIFF
--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -24,7 +24,7 @@ if [ ! -d "${HOME}/libxsmm" ]; then
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout 05cab50ec6f11a86c15c0ed511c5a9066c613dfb
+git checkout ecf2ec969ca42756ed3ca9f928d7409126a57161
 make -j
 cd ..
 

--- a/src/acc/acc.h
+++ b/src/acc/acc.h
@@ -22,7 +22,7 @@ extern "C" {
 #endif
 
 /** types */
-typedef int acc_bool_t;
+typedef int c_dbcsr_acc_bool_t;
 
 /** initialization and finalization */
 int c_dbcsr_acc_init(void);
@@ -46,7 +46,7 @@ int c_dbcsr_acc_stream_wait_event(void* stream, void* event);
 int c_dbcsr_acc_event_create(void** event_p);
 int c_dbcsr_acc_event_destroy(void* event);
 int c_dbcsr_acc_event_record(void* event, void* stream);
-int c_dbcsr_acc_event_query(void* event, acc_bool_t* has_occurred);
+int c_dbcsr_acc_event_query(void* event, c_dbcsr_acc_bool_t* has_occurred);
 int c_dbcsr_acc_event_synchronize(void* event);
 
 /** memory */

--- a/src/acc/acc_bench_smm.c
+++ b/src/acc/acc_bench_smm.c
@@ -208,10 +208,10 @@ int main(int argc, char* argv[])
 #   else
     const char transb = 'N';
     printf("transpose: %.1f ms %.1f GFLOPS/s\n", 1000.0 * (duration + transpose) / nrepeat,
-      ((size_t)2 * m * n * k) * stack_size / ((duration + transpose) * (1ULL << 30) / nrepeat));
+      ((size_t)2 * m * n * k) * stack_size / ((duration + transpose) * 1E9 / nrepeat));
 #   endif
     printf("device: %.1f ms %.1f GFLOPS/s\n", 1000.0 * duration / nrepeat,
-      ((size_t)2 * m * n * k) * stack_size / (duration * (1ULL << 30) / nrepeat));
+      ((size_t)2 * m * n * k) * stack_size / (duration * 1E9 / nrepeat));
     memset(gold_hst, 0, sizeof(ELEM_TYPE) * mn * nc);
     for (r = 0; r < warmup; ++r) {
       libxsmm_gemm_batch_omp(LIBXSMM_GEMM_PRECISION(ELEM_TYPE), LIBXSMM_GEMM_PRECISION(ELEM_TYPE),
@@ -230,7 +230,7 @@ int main(int argc, char* argv[])
     }
     duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
     printf("host: %.1f ms %.1f GFLOPS/s\n", 1000.0 * duration / nrepeat,
-      ((size_t)2 * m * n * k) * stack_size / (duration * (1ULL << 30) / nrepeat));
+      ((size_t)2 * m * n * k) * stack_size / (duration * 1E9 / nrepeat));
     /* transfer result from device to host for validation */
     CHECK(c_dbcsr_acc_memcpy_d2h(cmat_dev, cmat_hst, sizeof(ELEM_TYPE) * mn * nc, stream), &result);
     CHECK(c_dbcsr_acc_stream_sync(stream), &result);
@@ -271,7 +271,7 @@ int main(int argc, char* argv[])
 # endif
   if (EXIT_SUCCESS == result) {
     printf("device: %.1f ms %.1f GFLOPS/s\n", 1000.0 * duration / nrepeat,
-      ((size_t)2 * m * n * k) * stack_size / (duration * (1ULL << 30) / nrepeat));
+      ((size_t)2 * m * n * k) * stack_size / (duration * 1E9 / nrepeat));
   }
 #endif
   CHECK(c_dbcsr_acc_host_mem_deallocate(stack_hst, stream), NULL);

--- a/src/acc/acc_libsmm.h
+++ b/src/acc/acc_libsmm.h
@@ -29,14 +29,14 @@ typedef enum libsmm_acc_data_t {
 
 int libsmm_acc_init(void);
 int libsmm_acc_finalize(void);
-acc_bool_t libsmm_acc_is_thread_safe(void);
+c_dbcsr_acc_bool_t libsmm_acc_is_thread_safe(void);
 
 int libsmm_acc_transpose(const int* dev_trs_stack, int offset, int stack_size,
   void* dev_data, libsmm_acc_data_t datatype, int m, int n, int max_kernel_dim, void* stream);
 
 int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, int stack_size,
   int nparams, libsmm_acc_data_t datatype, const void* dev_a_data, const void* dev_b_data, void* dev_c_data,
-  int m_max, int n_max, int k_max, int max_kernel_dim, acc_bool_t def_mnk, void* stack_stream, void* c_stream);
+  int m_max, int n_max, int k_max, int max_kernel_dim, c_dbcsr_acc_bool_t def_mnk, void* stack_stream, void* c_stream);
 
 #if defined(__cplusplus)
 }

--- a/src/acc/cuda/Makefile
+++ b/src/acc/cuda/Makefile
@@ -13,6 +13,7 @@ OBJSMM := $(SRCSMM:.cpp=.o)
 INCALL := $(INCACC) $(INCSMM)
 
 LIBXSMMROOT ?= $(wildcard ../../../../libxsmm)
+LIBXSMMROOT ?= $(wildcard $(HOME)/libxsmm)
 NVCC ?= $(shell which nvcc 2>/dev/null)
 CUDA_PATH ?= $(if $(NVCC),$(abspath $(dir $(NVCC))/..))
 UNAME := $(shell uname)

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -10,6 +10,7 @@ KERNEL := $(wildcard smm/kernels/*.cl)
 INCALL := $(INCACC) $(INCSMM)
 
 LIBXSMMROOT ?= $(wildcard ../../../../libxsmm)
+LIBXSMMROOT ?= $(wildcard $(HOME)/libxsmm)
 UNAME := $(shell uname)
 INTEL ?= 0
 DEV ?= 0

--- a/src/acc/opencl/README.md
+++ b/src/acc/opencl/README.md
@@ -20,9 +20,11 @@ Runtime settings are made by the means of environment variables (implemented in 
 * `ACC_OPENCL_DEVTYPE`: character string matching the device-kind like "cpu", "gpu", or another kind if neither CPU or GPU.
 * `ACC_OPENCL_DEVICE`: non-negative integer number to select a device from the (internally enumerated) list of devices.
 * `ACC_OPENCL_VENDOR`: character string matching the vendor of the OpenCL device in an case-insensitive fashion, e.g., "intel".
-* `ACC_OPENCL_VERBOSE`: verbosity level (integer).
-    * `ACC_OPENCL_VERBOSE=1`: outputs (stderr) the number of devices found and the name of the selected device.
-    * `ACC_OPENCL_VERBOSE=2`: outputs (stderr) the duration needed to generate a requested kernel.
+* `ACC_OPENCL_VERBOSE`: verbosity level (integer) with console output on `stderr`.
+    * `ACC_OPENCL_VERBOSE=1`: outputs the number of devices found and the name of the selected device.
+    * `ACC_OPENCL_VERBOSE=2`: outputs the duration needed to generate a requested kernel.
+    * `ACC_OPENCL_VERBOSE=3`: outputs device-side performance of kernels (geometric mean).
+    * `ACC_OPENCL_VERBOSE=4`: outputs device-side performance of kernels (every execution).
 
 The OpenCL backend enumerates and orders devices primarily by device-kind (GPU, CPU, and others in that order) and by memory capacity (secondary criterion). Device IDs are zero-based as per ACC interface (and less than what is permitted/returned by `acc_get_ndevices`).
 

--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -301,7 +301,6 @@ int c_dbcsr_acc_init(void)
             }
           }
 #endif
-#if defined(ACC_OPENCL_MEM_ASYNC)
           if (EXIT_SUCCESS == result) {
             const char *const env = getenv("ACC_OPENCL_ASYNC_MEMOPS");
             if (NULL == env) {
@@ -310,9 +309,7 @@ int c_dbcsr_acc_init(void)
             }
             else c_dbcsr_acc_opencl_options.async_memops = (0 != atoi(env));
           }
-          else
-#endif
-          c_dbcsr_acc_opencl_options.async_memops = CL_FALSE;
+          else c_dbcsr_acc_opencl_options.async_memops = CL_FALSE;
 #if defined(ACC_OPENCL_SVM)
           if (EXIT_SUCCESS == result) {
             const char *const env = getenv("ACC_OPENCL_SVM");

--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -37,7 +37,7 @@
 extern "C" {
 #endif
 
-c_dbcsr_acc_opencl_options_t c_dbcsr_acc_opencl_options;
+c_dbcsr_acc_opencl_config_t c_dbcsr_acc_opencl_config;
 int c_dbcsr_acc_opencl_ndevices;
 cl_device_id c_dbcsr_acc_opencl_devices[ACC_OPENCL_DEVICES_MAXCOUNT];
 cl_context c_dbcsr_acc_opencl_context;
@@ -284,7 +284,7 @@ int c_dbcsr_acc_init(void)
         if (EXIT_SUCCESS == result) {
           const char *const env_verbose = getenv("ACC_OPENCL_VERBOSE");
           cl_device_id active_device;
-          c_dbcsr_acc_opencl_options.verbosity = (NULL == env_verbose ? 0 : atoi(env_verbose));
+          c_dbcsr_acc_opencl_config.verbosity = (NULL == env_verbose ? 0 : atoi(env_verbose));
           result = c_dbcsr_acc_opencl_set_active_device(device_id, &active_device);
 #if defined(_OPENMP) && defined(ACC_OPENCL_THREADLOCAL_CONTEXT)
           if (EXIT_SUCCESS == result) {
@@ -302,25 +302,23 @@ int c_dbcsr_acc_init(void)
           }
 #endif
           if (EXIT_SUCCESS == result) {
+            const int cl_nonv = (EXIT_SUCCESS != c_dbcsr_acc_opencl_device_vendor(active_device, "nvidia"));
             const char *const env = getenv("ACC_OPENCL_ASYNC_MEMOPS");
-            if (NULL == env) {
-              const int confirmation = c_dbcsr_acc_opencl_device_vendor(active_device, "nvidia");
-              c_dbcsr_acc_opencl_options.async_memops = (EXIT_SUCCESS != confirmation);
-            }
-            else c_dbcsr_acc_opencl_options.async_memops = (0 != atoi(env));
-          }
-          else c_dbcsr_acc_opencl_options.async_memops = CL_FALSE;
+            c_dbcsr_acc_opencl_config.async_memops = (NULL == env ? cl_nonv : (0 != atoi(env)));
+            c_dbcsr_acc_opencl_config.record_event = (cl_nonv
+              ? c_dbcsr_acc_opencl_enqueue_marker /* validation errors -> barrier */
+              : c_dbcsr_acc_opencl_enqueue_barrier);
 #if defined(ACC_OPENCL_SVM)
-          if (EXIT_SUCCESS == result) {
-            const char *const env = getenv("ACC_OPENCL_SVM");
-            int level_major = 0;
-            c_dbcsr_acc_opencl_options.svm_interop = (NULL == env || 0 != atoi(env)) &&
-              (EXIT_SUCCESS == c_dbcsr_acc_opencl_device_level(active_device,
-                &level_major, NULL/*level_minor*/) && 2 <= level_major);
-          }
-          else
+            { const char *const env = getenv("ACC_OPENCL_SVM");
+              int level_major = 0;
+              c_dbcsr_acc_opencl_config.svm_interop = (NULL == env || 0 != atoi(env)) &&
+                (EXIT_SUCCESS == c_dbcsr_acc_opencl_device_level(active_device,
+                  &level_major, NULL/*level_minor*/) && 2 <= level_major);
+            }
+#else
+            c_dbcsr_acc_opencl_config.svm_interop = CL_FALSE;
 #endif
-          c_dbcsr_acc_opencl_options.svm_interop = CL_FALSE;
+          }
         }
       }
       else { /* mark as initialized */
@@ -331,10 +329,10 @@ int c_dbcsr_acc_init(void)
       c_dbcsr_acc_opencl_ndevices = -1;
     }
 #if defined(__DBCSR_ACC)
-    /* DBCSR shall call acc_init as well as libsmm_acc_init (since both interfaces are used).
-     * Also, libsmm_acc_init may privately call acc_init (as it depends on the ACC interface).
-     * The implementation of acc_init should hence be safe against "over initialization".
-     * However, DBCSR only calls acc_init (and expects an implicit libsmm_acc_init).
+    /* DBCSR shall call c_dbcsr_acc_init as well as libsmm_acc_init (since both interfaces are used).
+     * Also, libsmm_acc_init may privately call c_dbcsr_acc_init (as it depends on the ACC interface).
+     * The implementation of c_dbcsr_acc_init should hence be safe against "over initialization".
+     * However, DBCSR only calls c_dbcsr_acc_init (and expects an implicit libsmm_acc_init).
      */
     if (EXIT_SUCCESS == result) {
       result = libsmm_acc_init();
@@ -373,10 +371,10 @@ int c_dbcsr_acc_finalize(void)
       "release context", result);
     c_dbcsr_acc_opencl_context = NULL;
 #if defined(__DBCSR_ACC)
-    /* DBCSR may call acc_init() as well as libsmm_acc_init() since both interface are used.
-     * libsmm_acc_init may privately call acc_init (as it depends on the ACC interface).
-     * The implementation of acc_init() should be safe against "over initialization".
-     * However, DBCSR only calls acc_init() and expects an implicit libsmm_acc_init().
+    /* DBCSR may call c_dbcsr_acc_init as well as libsmm_acc_init() since both interface are used.
+     * libsmm_acc_init may privately call c_dbcsr_acc_init (as it depends on the ACC interface).
+     * The implementation of c_dbcsr_acc_init should be safe against "over initialization".
+     * However, DBCSR only calls c_dbcsr_acc_init and expects an implicit libsmm_acc_init().
      */
     if (EXIT_SUCCESS == result) {
       result = libsmm_acc_finalize();
@@ -406,7 +404,7 @@ int c_dbcsr_acc_get_ndevices(int* ndevices)
 {
   int result;
 #if defined(__DBCSR_ACC)
-  /* DBCSR calls acc_get_ndevices before calling acc_init(). */
+  /* DBCSR calls c_dbcsr_acc_get_ndevices before calling c_dbcsr_acc_init. */
   result = c_dbcsr_acc_init();
   if (EXIT_SUCCESS == result)
 #endif
@@ -432,15 +430,8 @@ int c_dbcsr_acc_opencl_device(void* stream, cl_device_id* device)
       sizeof(cl_device_id), device, NULL), "retrieve device from queue", result);
   }
   else if (NULL != c_dbcsr_acc_opencl_context) {
-#if !defined(NDEBUG)
-    size_t n = sizeof(cl_device_id);
-    ACC_OPENCL_CHECK(clGetContextInfo(c_dbcsr_acc_opencl_context, CL_CONTEXT_DEVICES,
-      sizeof(cl_device_id), device, &n), "retrieve id of active device", result);
-#else
     ACC_OPENCL_CHECK(clGetContextInfo(c_dbcsr_acc_opencl_context, CL_CONTEXT_DEVICES,
       sizeof(cl_device_id), device, NULL), "retrieve id of active device", result);
-#endif
-    assert(EXIT_SUCCESS != result || sizeof(cl_device_id) == n/*single-device context*/);
   }
   else {
     *device = NULL;
@@ -545,12 +536,14 @@ int c_dbcsr_acc_opencl_set_active_device(int device_id, cl_device_id* device)
       ? c_dbcsr_acc_opencl_device(NULL/*stream*/, &current_id)
       : EXIT_FAILURE;
     if (EXIT_SUCCESS == result && active_id != current_id) {
+      const cl_context context = c_dbcsr_acc_opencl_context;
       cl_platform_id platform = NULL;
       ACC_OPENCL_CHECK(clGetDeviceInfo(active_id, CL_DEVICE_PLATFORM,
         sizeof(cl_platform_id), &platform, NULL),
         "query device platform", result);
-      if (NULL != c_dbcsr_acc_opencl_context) {
-        ACC_OPENCL_CHECK(clReleaseContext(c_dbcsr_acc_opencl_context),
+      if (NULL != context) {
+        c_dbcsr_acc_opencl_context = NULL;
+        ACC_OPENCL_CHECK(clReleaseContext(context),
           "release context", result);
       }
       if (EXIT_SUCCESS == result) {
@@ -561,22 +554,17 @@ int c_dbcsr_acc_opencl_set_active_device(int device_id, cl_device_id* device)
 #endif
         cl_context_properties properties[] = {
           CL_CONTEXT_PLATFORM, 0/*placeholder*/,
-          /* insert other properties in front of below property */
-          CL_CONTEXT_INTEROP_USER_SYNC, CL_FALSE, /* TODO */
           0 /* end of properties */
         };
         properties[1] = (long)platform;
         c_dbcsr_acc_opencl_context = clCreateContext(properties,
           1/*num_devices*/, &active_id, notify, NULL/* user_data*/, &result);
         if (CL_INVALID_VALUE == result) { /* retry */
-          const size_t n = sizeof(properties) / sizeof(*properties);
-          assert(3 <= n);
-          properties[n-3] = 0;
-          c_dbcsr_acc_opencl_context = clCreateContext(0 != properties[0] ? properties : NULL,
+          c_dbcsr_acc_opencl_context = clCreateContext(NULL/*properties*/,
             1/*num_devices*/, &active_id, notify, NULL/* user_data*/, &result);
         }
         if (EXIT_SUCCESS == result) {
-          if (0 != c_dbcsr_acc_opencl_options.verbosity) {
+          if (0 != c_dbcsr_acc_opencl_config.verbosity) {
             char buffer[ACC_OPENCL_BUFFERSIZE];
             if (CL_SUCCESS == clGetDeviceInfo(active_id, CL_DEVICE_NAME,
               ACC_OPENCL_BUFFERSIZE, buffer, NULL))

--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -77,18 +77,6 @@
 #if !defined(ACC_OPENCL_STREAM_PRIORITIES) && 1
 # define ACC_OPENCL_STREAM_PRIORITIES
 #endif
-#if !defined(ACC_OPENCL_STREAM_SYNCFLUSH) && 0
-# define ACC_OPENCL_STREAM_FINISH
-#endif
-#if !defined(ACC_OPENCL_EVENT_BARRIER) && 0
-# define ACC_OPENCL_EVENT_BARRIER
-#endif
-#if !defined(ACC_OPENCL_MEM_ASYNC) && 1
-# define ACC_OPENCL_MEM_ASYNC
-#endif
-#if !defined(ACC_OPENCL_DEBUG) && 0
-# define ACC_OPENCL_DEBUG
-#endif
 #if !defined(ACC_OPENCL_SVM) && 0
 # if defined(CL_VERSION_2_0)
 #   define ACC_OPENCL_SVM

--- a/src/acc/opencl/acc_opencl_event.c
+++ b/src/acc/opencl/acc_opencl_event.c
@@ -12,11 +12,7 @@
 #include <assert.h>
 
 #if defined(CL_VERSION_1_2)
-# if defined(ACC_OPENCL_EVENT_BARRIER)
-#   define ACC_OPENCL_ENQUEUE_EVENT(QUEUE, EVENT) clEnqueueBarrierWithWaitList(QUEUE, 0, NULL, EVENT)
-# else
-#   define ACC_OPENCL_ENQUEUE_EVENT(QUEUE, EVENT) clEnqueueMarkerWithWaitList(QUEUE, 0, NULL, EVENT)
-# endif
+# define ACC_OPENCL_ENQUEUE_EVENT(QUEUE, EVENT) clEnqueueMarkerWithWaitList(QUEUE, 0, NULL, EVENT)
 #else
 # define ACC_OPENCL_ENQUEUE_EVENT(QUEUE, EVENT) clEnqueueMarker(QUEUE, EVENT)
 #endif
@@ -99,17 +95,11 @@ int c_dbcsr_acc_event_query(void* event, acc_bool_t* has_occurred)
   int result = EXIT_SUCCESS;
   cl_int status = CL_COMPLETE;
   if (NULL != event) {
-#if defined(ACC_OPENCL_STREAM_SYNCFLUSH)
-    ACC_OPENCL_CHECK(clFlush(*ACC_OPENCL_STREAM(stream)), "flush stream", result);
-#endif
     ACC_OPENCL_CHECK(clGetEventInfo(*ACC_OPENCL_EVENT(event), CL_EVENT_COMMAND_EXECUTION_STATUS,
       sizeof(cl_int), &status, NULL), "retrieve event status", result);
   }
   assert(NULL != has_occurred);
   *has_occurred = (CL_COMPLETE == status || 0 > status);
-#if defined(ACC_OPENCL_DEBUG) && defined(_DEBUG)
-  fprintf(stderr, "c_dbcsr_acc_event_query(%p, %i)\n", event, *has_occurred);
-#endif
   ACC_OPENCL_RETURN(result);
 }
 
@@ -118,9 +108,6 @@ int c_dbcsr_acc_event_synchronize(void* event)
 { /* Waits on the host-side. */
   int result = EXIT_SUCCESS;
   assert(NULL != event);
-#if defined(ACC_OPENCL_DEBUG) && defined(_DEBUG)
-  fprintf(stderr, "c_dbcsr_acc_event_synchronize(%p)\n", event);
-#endif
   ACC_OPENCL_CHECK(clWaitForEvents(1, ACC_OPENCL_EVENT(event)),
     "synchronize event", result);
   ACC_OPENCL_RETURN(result);

--- a/src/acc/opencl/acc_opencl_stream.c
+++ b/src/acc/opencl/acc_opencl_stream.c
@@ -71,7 +71,7 @@ int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int priority)
       properties[4] = 0; /* terminator */
     }
 #endif
-    if (3 <= c_dbcsr_acc_opencl_options.verbosity || 0 > c_dbcsr_acc_opencl_options.verbosity) {
+    if (3 <= c_dbcsr_acc_opencl_config.verbosity || 0 > c_dbcsr_acc_opencl_config.verbosity) {
       properties[1] = CL_QUEUE_PROFILING_ENABLE;
     }
     result = c_dbcsr_acc_opencl_stream_create(&queue, name, properties);

--- a/src/acc/opencl/acc_opencl_stream.c
+++ b/src/acc/opencl/acc_opencl_stream.c
@@ -17,16 +17,12 @@
     clCreateCommandQueueWithProperties(CTX, DEV, PROPS, RESULT)
 #else
 # define ACC_OPENCL_CREATE_COMMAND_QUEUE(CTX, DEV, PROPS, RESULT) \
-    clCreateCommandQueue(CTX, DEV, /* avoid warning about unused argument */ \
-      (cl_command_queue_properties)(0 & (NULL != (PROPS) ? (((cl_int*)(PROPS))[0]) : 0)), RESULT)
+    clCreateCommandQueue(CTX, DEV, (cl_command_queue_properties) \
+      (NULL != (PROPS) ? ((PROPS)[1]) : 0), RESULT)
 #endif
 
 #if defined(CL_VERSION_1_2)
-# if defined(ACC_OPENCL_EVENT_BARRIER)
-#   define ACC_OPENCL_WAIT_EVENT(QUEUE, EVENT) clEnqueueBarrierWithWaitList(QUEUE, 1, EVENT, NULL)
-# else
-#   define ACC_OPENCL_WAIT_EVENT(QUEUE, EVENT) clEnqueueMarkerWithWaitList(QUEUE, 1, EVENT, NULL)
-# endif
+# define ACC_OPENCL_WAIT_EVENT(QUEUE, EVENT) clEnqueueMarkerWithWaitList(QUEUE, 1, EVENT, NULL)
 #else
 # define ACC_OPENCL_WAIT_EVENT(QUEUE, EVENT) clEnqueueWaitForEvents(QUEUE, 1, EVENT)
 #endif
@@ -59,27 +55,26 @@ int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int priority)
 {
   cl_int result = EXIT_SUCCESS;
   if (NULL != c_dbcsr_acc_opencl_context) {
+    ACC_OPENCL_COMMAND_QUEUE_PROPERTIES properties[8] = {
+      CL_QUEUE_PROPERTIES, 0/*placeholder*/,
+      0 /* terminator */
+    };
     cl_command_queue queue = NULL;
 #if !defined(ACC_OPENCL_STREAM_PRIORITIES) || !defined(CL_QUEUE_PRIORITY_KHR)
     ACC_OPENCL_UNUSED(priority);
 #else
     if (0 <= priority) {
-      ACC_OPENCL_COMMAND_QUEUE_PROPERTIES properties[] = {
-        CL_QUEUE_PRIORITY_KHR, 0/*placeholder filled-in below*/,
-        0 /* terminator */
-      };
-      properties[1] = (CL_QUEUE_PRIORITY_HIGH_KHR <= priority && CL_QUEUE_PRIORITY_LOW_KHR >= priority)
-        ? priority : ((CL_QUEUE_PRIORITY_HIGH_KHR + CL_QUEUE_PRIORITY_LOW_KHR) / 2);
-      result = c_dbcsr_acc_opencl_stream_create(&queue, name, properties);
+      properties[2] = CL_QUEUE_PRIORITY_KHR;
+      properties[3] = ((  CL_QUEUE_PRIORITY_HIGH_KHR <= priority
+                        && CL_QUEUE_PRIORITY_LOW_KHR >= priority)
+        ? priority : CL_QUEUE_PRIORITY_MED_KHR);
+      properties[4] = 0; /* terminator */
     }
-    else
 #endif
-    {
-      ACC_OPENCL_COMMAND_QUEUE_PROPERTIES properties[] = {
-        0 /* terminator */
-      };
-      result = c_dbcsr_acc_opencl_stream_create(&queue, name, properties);
+    if (3 <= c_dbcsr_acc_opencl_options.verbosity || 0 > c_dbcsr_acc_opencl_options.verbosity) {
+      properties[1] = CL_QUEUE_PROFILING_ENABLE;
     }
+    result = c_dbcsr_acc_opencl_stream_create(&queue, name, properties);
     assert(NULL != stream_p);
     if (EXIT_SUCCESS == result) {
       assert(NULL != queue);
@@ -165,9 +160,6 @@ int c_dbcsr_acc_stream_sync(void* stream)
 { /* Blocks the host-thread. */
   int result = EXIT_SUCCESS;
   assert(NULL != stream);
-#if defined(ACC_OPENCL_DEBUG) && defined(_DEBUG)
-  fprintf(stderr, "c_dbcsr_acc_stream_sync(%p)\n", stream);
-#endif
   ACC_OPENCL_CHECK(clFinish(*ACC_OPENCL_STREAM(stream)),
     "synchronize stream", result);
   ACC_OPENCL_RETURN(result);
@@ -178,12 +170,6 @@ int c_dbcsr_acc_stream_wait_event(void* stream, void* event)
 { /* Wait for an event (device-side). */
   int result = EXIT_SUCCESS;
   assert(NULL != stream && NULL != event);
-#if defined(ACC_OPENCL_DEBUG) && defined(_DEBUG)
-  fprintf(stderr, "c_dbcsr_acc_stream_wait_event(%p, %p)\n", stream, event);
-#endif
-#if defined(ACC_OPENCL_STREAM_SYNCFLUSH)
-  ACC_OPENCL_CHECK(clFlush(*ACC_OPENCL_STREAM(stream)), "flush stream", result);
-#endif
   ACC_OPENCL_CHECK(ACC_OPENCL_WAIT_EVENT(*ACC_OPENCL_STREAM(stream), ACC_OPENCL_EVENT(event)),
     "wait for an event", result);
   ACC_OPENCL_RETURN(result);

--- a/src/acc/opencl/smm/README.md
+++ b/src/acc/opencl/smm/README.md
@@ -20,9 +20,11 @@ Runtime settings are made by the means of environment variables (implemented in 
 * `ACC_OPENCL_DEVTYPE`: character string matching the device-kind like "cpu", "gpu", or another kind if neither CPU or GPU.
 * `ACC_OPENCL_DEVICE`: non-negative integer number to select a device from the (internally enumerated) list of devices.
 * `ACC_OPENCL_VENDOR`: character string matching the vendor of the OpenCL device in an case-insensitive fashion, e.g., "intel".
-* `ACC_OPENCL_VERBOSE`: verbosity level (integer).
-    * `ACC_OPENCL_VERBOSE=1`: outputs (stderr) the number of devices found and the name of the selected device.
-    * `ACC_OPENCL_VERBOSE=2`: outputs (stderr) the duration needed to generate a requested kernel.
+* `ACC_OPENCL_VERBOSE`: verbosity level (integer) with console output on `stderr`.
+    * `ACC_OPENCL_VERBOSE=1`: outputs the number of devices found and the name of the selected device.
+    * `ACC_OPENCL_VERBOSE=2`: outputs the duration needed to generate a requested kernel.
+    * `ACC_OPENCL_VERBOSE=3`: outputs device-side performance of kernels (geometric mean).
+    * `ACC_OPENCL_VERBOSE=4`: outputs device-side performance of kernels (every execution).
 
 For tranposing matrices:
 

--- a/src/acc/opencl/smm/kernels/transpose.cl
+++ b/src/acc/opencl/smm/kernels/transpose.cl
@@ -16,17 +16,17 @@ kernel void FN(GLOBAL const int *restrict trs_stack, int trs_offset, global T *r
   const int index = get_local_id(0);
 #if (SM != SN) || (0 == INPLACE)
   /* local memory buffer */
-  local T buf[SM*SN];
+  local T buf[SM][SN];
 #endif
 
 #if (SWG == SM)
   const int m = index;
 # if (SM != SN) || (0 == INPLACE)
   /* copy matrix elements into local buffer */
-  for (int n = 0; n < SN; ++n) buf[SN*m+n] = mat[SN*m+n];
+  for (int n = 0; n < SN; ++n) buf[m][n] = mat[SM*n+m];
   barrier(CLK_LOCAL_MEM_FENCE);
   /* overwrite matrix elements (gather) */
-  for (int n = 0; n < SN; ++n) mat[SN*m+n] = buf[SM*n+m];
+  for (int n = 0; n < SN; ++n) mat[SN*m+n] = buf[m][n];
 # else
   for (int n = 0; n < m; ++n) {
     const int i = SM * n + m;
@@ -43,13 +43,13 @@ kernel void FN(GLOBAL const int *restrict trs_stack, int trs_offset, global T *r
 # if (SM != SN) || (0 == INPLACE)
   /* copy matrix elements into local buffer */
   for (int m = m0; m < m1; ++m) {
-    for (int n = 0; n < SN; ++n) buf[SN*m+n] = mat[SN*m+n];
+    for (int n = 0; n < SN; ++n) buf[m][n] = mat[SM*n+m];
   }
   barrier(CLK_LOCAL_MEM_FENCE);
 # endif
   for (int m = m0; m < m1; ++m) {
 # if (SM != SN) || (0 == INPLACE)
-    for (int n = 0; n < SN; ++n) prv[n] = buf[SM*n+m];
+    for (int n = 0; n < SN; ++n) prv[n] = buf[m][n];
     /* overwrite matrix elements (gather) */
     for (int n = 0; n < SN; ++n) mat[SN*m+n] = prv[n];
 # else

--- a/src/acc/opencl/smm/opencl_libsmm.c
+++ b/src/acc/opencl/smm/opencl_libsmm.c
@@ -56,9 +56,9 @@
 extern "C" {
 #endif
 
-int opencl_libsmm_initialized;
 volatile int opencl_libsmm_lock_trans[OPENCL_LIBSMM_NLOCKS_TRANS];
 volatile int opencl_libsmm_lock_smm[OPENCL_LIBSMM_NLOCKS_SMM];
+int opencl_libsmm_initialized;
 
 
 int opencl_libsmm_use_cmem(cl_device_id device)
@@ -149,10 +149,10 @@ int libsmm_acc_init(void)
   /* multiple calls to libsmm_acc_init are not considered as an error */
   if (1 == LIBXSMM_ATOMIC_ADD_FETCH(&opencl_libsmm_initialized, 1, LIBXSMM_ATOMIC_RELAXED)) {
 #if !defined(__DBCSR_ACC)
-    /* DBCSR shall call acc_init as well as libsmm_acc_init (since both interfaces are used).
-     * Also, libsmm_acc_init may privately call acc_init (as it depends on the ACC interface).
-     * The implementation of acc_init should hence be safe against "over initialization".
-     * However, DBCSR only calls acc_init (and expects an implicit libsmm_acc_init).
+    /* DBCSR shall call c_dbcsr_acc_init as well as libsmm_acc_init (since both interfaces are used).
+     * Also, libsmm_acc_init may privately call c_dbcsr_acc_init (as it depends on the ACC interface).
+     * The implementation of c_dbcsr_acc_init should hence be safe against "over initialization".
+     * However, DBCSR only calls c_dbcsr_acc_init (and expects an implicit libsmm_acc_init).
      */
     if (EXIT_SUCCESS == result) {
       result = c_dbcsr_acc_init();
@@ -214,8 +214,8 @@ int libsmm_acc_init(void)
 int libsmm_acc_finalize(void)
 {
   /* Routine libsmm_acc_init is called in master thread inside of parallel region
-   * However, libsmm_acc_finalize is indirectly called (acc_finalize) inside of a
-   * parallel region (not just the master thread).
+   * However, libsmm_acc_finalize is indirectly called (c_dbcsr_acc_finalize)
+   * inside of a parallel region (not just the master thread).
    */
 #if defined(_OPENMP)
   /* initialization/finalization is not meant to be thread-safe */
@@ -237,7 +237,7 @@ int libsmm_acc_finalize(void)
       /* opencl_libsmm_trans_t/opencl_libsmm_smm_t carry cl_kernel as 1st data member */
       const cl_kernel kernel = *(const cl_kernel*)regentry;
       if (NULL != kernel) {
-        if (3 == c_dbcsr_acc_opencl_options.verbosity) {
+        if (3 == c_dbcsr_acc_opencl_config.verbosity) {
           char fname[OPENCL_LIBSMM_KERNELNAME_MAXSIZE];
           ACC_OPENCL_CHECK(clGetKernelInfo(kernel, CL_KERNEL_FUNCTION_NAME,
             ACC_OPENCL_BUFFERSIZE, fname, NULL), "retrieve function name", result);
@@ -267,12 +267,12 @@ int libsmm_acc_finalize(void)
     }
   }
 #endif
-  /* acc_finalize is not called since it can be used independently */
+  /* c_dbcsr_acc_finalize is not called since it can be used independently */
   return result;
 }
 
 
-acc_bool_t libsmm_acc_is_thread_safe(void)
+c_dbcsr_acc_bool_t libsmm_acc_is_thread_safe(void)
 {
   /* match DBCSR's threading level */
 #if defined(_OPENMP)
@@ -370,7 +370,7 @@ int libsmm_acc_transpose(const int* dev_trs_stack, int offset, int stack_size,
                   new_config.wgsize = (size_t)wgsize;
                   config = (opencl_libsmm_trans_t*)OPENCL_LIBSMM_REGISTER(&key, sizeof(key),
                     sizeof(new_config), &new_config);
-                  if (2 <= c_dbcsr_acc_opencl_options.verbosity || 0 > c_dbcsr_acc_opencl_options.verbosity) {
+                  if (2 <= c_dbcsr_acc_opencl_config.verbosity || 0 > c_dbcsr_acc_opencl_config.verbosity) {
                     const double duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
                     fprintf(stderr, "INFO ACC/OpenCL: %ix%i transpose-kernel generated in %.1f ms\n",
                       m, n, 1000.0 * duration);
@@ -391,7 +391,7 @@ int libsmm_acc_transpose(const int* dev_trs_stack, int offset, int stack_size,
     }
     assert((NULL != config && NULL != config->kernel && 0 < config->wgsize) || EXIT_SUCCESS != result);
     if (EXIT_SUCCESS == result) {
-      cl_event event, *const perf_event = ((0 <= c_dbcsr_acc_opencl_options.verbosity && 3 > c_dbcsr_acc_opencl_options.verbosity) ? NULL : &event);
+      cl_event event, *const perf_event = ((0 <= c_dbcsr_acc_opencl_config.verbosity && 3 > c_dbcsr_acc_opencl_config.verbosity) ? NULL : &event);
       const size_t work_size = config->wgsize * stack_size;
       const int typesize = (dbcsr_type_real_8 == datatype ? 8
         : (dbcsr_type_real_4 == datatype ? 4 : 0/*unknown*/));
@@ -445,7 +445,7 @@ int libsmm_acc_transpose(const int* dev_trs_stack, int offset, int stack_size,
             libxsmm_kahan_sum(log(membw), &config->membw_sumlog, &config->membw_comp);
             ++config->nexec;
 #endif
-            if (4 <= c_dbcsr_acc_opencl_options.verbosity || 0 > c_dbcsr_acc_opencl_options.verbosity) {
+            if (4 <= c_dbcsr_acc_opencl_config.verbosity || 0 > c_dbcsr_acc_opencl_config.verbosity) {
               fprintf(stderr, "INFO ACC/OpenCL: %ix%i transpose-kernel achieved %.1f GB/s%s\n", m, n, membw,
                 dbcsr_type_real_8 == datatype ? " (DP)" : (dbcsr_type_real_4 == datatype ? " (SP)" : ""));
             }
@@ -509,15 +509,16 @@ int libsmm_acc_transpose(const int* dev_trs_stack, int offset, int stack_size,
 
 int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, int stack_size,
   int nparams, libsmm_acc_data_t datatype, const void* dev_a_data, const void* dev_b_data, void* dev_c_data,
-  int m_max, int n_max, int k_max, int max_kernel_dim, acc_bool_t def_mnk, void* stream, void* c_stream)
+  int m_max, int n_max, int k_max, int max_kernel_dim, c_dbcsr_acc_bool_t def_mnk, void* stream, void* c_stream)
 {
   int result = EXIT_SUCCESS;
+  const int mnk = m_max * n_max * k_max;
   ACC_OPENCL_UNUSED(c_stream); /* TODO */
   assert(0 == stack_size || (NULL != host_param_stack && NULL != dev_param_stack
     && NULL != dev_a_data && NULL != dev_b_data && NULL != dev_c_data));
   assert(0 < nparams && 0 < max_kernel_dim && NULL != stream);
   assert(0 <= stack_size && 0 <= m_max && 0 <= n_max && 0 <= k_max);
-  if ((
+  if (0 < stack_size && (
 #if defined(OPENCL_LIBSMM_F64)
       dbcsr_type_real_8 == datatype
 #else
@@ -529,11 +530,14 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
 #else
       0
 #endif
-    ) &&
-    0 < stack_size && def_mnk/*homogeneous*/ &&
-    0 < m_max && m_max <= max_kernel_dim &&
-    0 < n_max && n_max <= max_kernel_dim &&
-    0 < k_max && k_max <= max_kernel_dim)
+    )
+    && 1 <= mnk
+#if 1
+    && mnk <= (max_kernel_dim * max_kernel_dim * max_kernel_dim)
+#else
+    && m_max <= max_kernel_dim && n_max <= max_kernel_dim && k_max <= max_kernel_dim
+#endif
+    && def_mnk/*homogeneous*/)
   {
     const libxsmm_timer_tickint start = libxsmm_timer_tick();
     opencl_libsmm_smm_t* config;
@@ -686,7 +690,7 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
                       config->wgsize = (size_t)wgsize;
                       config->bs = bs; config->bm = bm; config->bn = bn;
                       config->kernel = new_config.kernel;
-                      if (2 <= c_dbcsr_acc_opencl_options.verbosity || 0 > c_dbcsr_acc_opencl_options.verbosity) {
+                      if (2 <= c_dbcsr_acc_opencl_config.verbosity || 0 > c_dbcsr_acc_opencl_config.verbosity) {
                         const double duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
                         fprintf(stderr, "INFO ACC/OpenCL: %ix%ix%i %sSMM-kernel generated in %.1f ms\n",
                           m_max, n_max, k_max, default_params ? "" : "tuned ", 1000.0 * duration);
@@ -723,7 +727,7 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
         && 1 <= config->bs && 0 < config->bm && 0 < config->bn
         && 0 < config->wgsize));
     if (EXIT_SUCCESS == result) {
-      cl_event event, *const perf_event = ((0 <= c_dbcsr_acc_opencl_options.verbosity && 3 > c_dbcsr_acc_opencl_options.verbosity) ? NULL : &event);
+      cl_event event, *const perf_event = ((0 <= c_dbcsr_acc_opencl_config.verbosity && 3 > c_dbcsr_acc_opencl_config.verbosity) ? NULL : &event);
       /* adjust overall stacksize according to intra-kernel batchsize */
       const size_t work_size = ((stack_size + config->bs - 1) / config->bs) * config->wgsize;
 #if defined(OPENCL_LIBSMM_DEBUG_SMM)
@@ -753,11 +757,11 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
         gold = (char*)libxsmm_aligned_scratch(csize, 0/*auto-align*/);
         btrn = (char*)libxsmm_aligned_scratch(k_max * n_max * typesize, 0/*auto-align*/);
         if (NULL != desc && NULL != ainp && NULL != binp && NULL != test && NULL != gold && NULL != btrn) {
-          ACC_OPENCL_CHECK(acc_memcpy_d2h(dev_a_data, ainp, asize, stream),
+          ACC_OPENCL_CHECK(c_dbcsr_acc_memcpy_d2h(dev_a_data, ainp, asize, stream),
             "transfer debug a-data", result);
-          ACC_OPENCL_CHECK(acc_memcpy_d2h(dev_b_data, binp, bsize, stream),
+          ACC_OPENCL_CHECK(c_dbcsr_acc_memcpy_d2h(dev_b_data, binp, bsize, stream),
             "transfer debug b-data", result);
-          ACC_OPENCL_CHECK(acc_memcpy_d2h(dev_c_data, gold, csize, stream),
+          ACC_OPENCL_CHECK(c_dbcsr_acc_memcpy_d2h(dev_c_data, gold, csize, stream),
             "transfer debug c-data", result);
           kernel = libxsmm_xmmdispatch(desc);
           assert(NULL != kernel.xmm);
@@ -801,7 +805,7 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
             libxsmm_kahan_sum(log(gflops), &config->gflops_sumlog, &config->gflops_comp);
             ++config->nexec;
 #endif
-            if (4 <= c_dbcsr_acc_opencl_options.verbosity || 0 > c_dbcsr_acc_opencl_options.verbosity) {
+            if (4 <= c_dbcsr_acc_opencl_config.verbosity || 0 > c_dbcsr_acc_opencl_config.verbosity) {
               fprintf(stderr, "INFO ACC/OpenCL: %ix%ix%i SMM-kernel achieved %.1f GFLOPS/s%s\n", m_max, n_max, k_max, gflops,
                 dbcsr_type_real_8 == datatype ? " (DP)" : (dbcsr_type_real_4 == datatype ? " (SP)" : ""));
             }
@@ -810,11 +814,11 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
         LIBXSMM_ATOMIC_RELEASE(lock, LIBXSMM_ATOMIC_RELAXED);
       }
 #if defined(OPENCL_LIBSMM_DEBUG_SMM)
-      ACC_OPENCL_CHECK(acc_memcpy_d2h(dev_c_data, test, csize, stream),
+      ACC_OPENCL_CHECK(c_dbcsr_acc_memcpy_d2h(dev_c_data, test, csize, stream),
         "transfer debug test", result);
 #endif
 #if defined(OPENCL_LIBSMM_DEBUG_SMM)
-      ACC_OPENCL_CHECK(acc_stream_sync(stream), "sync stream", result);
+      ACC_OPENCL_CHECK(c_dbcsr_acc_stream_sync(stream), "sync stream", result);
 #endif
 #if defined(OPENCL_LIBSMM_DEBUG_SMM)
       if (EXIT_SUCCESS == result) {

--- a/src/acc/opencl/smm/opencl_libsmm.c
+++ b/src/acc/opencl/smm/opencl_libsmm.c
@@ -35,6 +35,15 @@
 #if !defined(OPENCL_LIBSMM_DEBUG_SMM) && defined(OPENCL_LIBSMM_DEBUG)
 # define OPENCL_LIBSMM_DEBUG_SMM
 #endif
+#if !defined(OPENCL_LIBSMM_KERNELNAME_MAXSIZE)
+# define OPENCL_LIBSMM_KERNELNAME_MAXSIZE 48
+#endif
+#if !defined(OPENCL_LIBSMM_KERNELNAME_TRANS)
+# define OPENCL_LIBSMM_KERNELNAME_TRANS "trans"
+#endif
+#if !defined(OPENCL_LIBSMM_KERNELNAME_SMM)
+# define OPENCL_LIBSMM_KERNELNAME_SMM "smm"
+#endif
 #if !defined(OPENCL_LIBSMM_NLOCKS_TRANS)
 # define OPENCL_LIBSMM_NLOCKS_TRANS 16
 #endif
@@ -218,9 +227,44 @@ int libsmm_acc_finalize(void)
 #else
   int result = EXIT_SUCCESS;
 #endif
-#if 0
+#if LIBXSMM_VERSION3(1, 16, 1) <= LIBXSMM_VERSION3(LIBXSMM_VERSION_MAJOR, \
+    LIBXSMM_VERSION_MINOR, LIBXSMM_VERSION_UPDATE) && 1159 <= LIBXSMM_VERSION_PATCH
   /* multiple calls to libsmm_acc_finalize are not considered as an error */
   if (0 == LIBXSMM_ATOMIC_SUB_FETCH(&opencl_libsmm_initialized, 1, LIBXSMM_ATOMIC_RELAXED)) {
+    const void* regkey = NULL;
+    const void* regentry = libxsmm_get_registry_begin(LIBXSMM_KERNEL_KIND_USER, &regkey);
+    for (; NULL != regentry; regentry = libxsmm_get_registry_next(regentry, &regkey)) {
+      /* opencl_libsmm_trans_t/opencl_libsmm_smm_t carry cl_kernel as 1st data member */
+      const cl_kernel kernel = *(const cl_kernel*)regentry;
+      if (NULL != kernel) {
+        if (3 == c_dbcsr_acc_opencl_options.verbosity) {
+          char fname[OPENCL_LIBSMM_KERNELNAME_MAXSIZE];
+          ACC_OPENCL_CHECK(clGetKernelInfo(kernel, CL_KERNEL_FUNCTION_NAME,
+            ACC_OPENCL_BUFFERSIZE, fname, NULL), "retrieve function name", result);
+          if (EXIT_SUCCESS == result) {
+            if (NULL != strstr(fname, OPENCL_LIBSMM_KERNELNAME_TRANS)) { /* trans-kernel */
+              const opencl_libsmm_transkey_t *const desc = (const opencl_libsmm_transkey_t*)regkey;
+              const opencl_libsmm_trans_t *const entry = (const opencl_libsmm_trans_t*)regentry;
+              if (0 < entry->nexec) {
+                fprintf(stderr, "INFO ACC/OpenCL: %ix%i transpose-kernel achieved %.1f GB/s%s\n",
+                  desc->m, desc->n, exp(entry->membw_sumlog / entry->nexec),
+                  dbcsr_type_real_8 == desc->type ? " (DP)" : (dbcsr_type_real_4 == desc->type ? " (SP)" : ""));
+              }
+            }
+            else if (NULL != strstr(fname, OPENCL_LIBSMM_KERNELNAME_SMM)) { /* SMM-kernel */
+              const opencl_libsmm_smmkey_t *const desc = (const opencl_libsmm_smmkey_t*)regkey;
+              const opencl_libsmm_smm_t *const entry = (const opencl_libsmm_smm_t*)regentry;
+              if (0 < entry->nexec) {
+                fprintf(stderr, "INFO ACC/OpenCL: %ix%ix%i SMM-kernel achieved %.1f GFLOPS/s%s\n",
+                  desc->m, desc->n, desc->k, exp(entry->gflops_sumlog / entry->nexec),
+                  dbcsr_type_real_8 == desc->type ? " (DP)" : (dbcsr_type_real_4 == desc->type ? " (SP)" : ""));
+              }
+            }
+          }
+        }
+        ACC_OPENCL_CHECK(clReleaseKernel(kernel), "release kernel", result);
+      }
+    }
   }
 #endif
   /* acc_finalize is not called since it can be used independently */
@@ -267,8 +311,10 @@ int libsmm_acc_transpose(const int* dev_trs_stack, int offset, int stack_size,
     key.type = datatype; key.m = m; key.n = n; /* initialize key */
     config = (opencl_libsmm_trans_t*)OPENCL_LIBSMM_DISPATCH(&key, sizeof(key));
     if (NULL == config) {
-      char build_options[ACC_OPENCL_BUFFERSIZE], fname[32];
-      int nchar = ACC_OPENCL_SNPRINTF(fname, sizeof(fname), "xtrans%ix%i", m, n);
+      char build_options[ACC_OPENCL_BUFFERSIZE], fname[OPENCL_LIBSMM_KERNELNAME_MAXSIZE];
+      int nchar = ACC_OPENCL_SNPRINTF(fname, sizeof(fname),
+        /* kernel name are meant to be unambiguous (BLAS-typeprefix and kernelsize) */
+        "x" OPENCL_LIBSMM_KERNELNAME_TRANS "%ix%i", m, n);
       if (0 < nchar && (int)sizeof(fname) > nchar) {
         cl_device_id active_device;
         result = c_dbcsr_acc_opencl_device(stream, &active_device);
@@ -323,7 +369,7 @@ int libsmm_acc_transpose(const int* dev_trs_stack, int offset, int stack_size,
                   new_config.wgsize = (size_t)wgsize;
                   config = (opencl_libsmm_trans_t*)OPENCL_LIBSMM_REGISTER(&key, sizeof(key),
                     sizeof(new_config), &new_config);
-                  if (1 < c_dbcsr_acc_opencl_options.verbosity || 0 > c_dbcsr_acc_opencl_options.verbosity) {
+                  if (2 <= c_dbcsr_acc_opencl_options.verbosity || 0 > c_dbcsr_acc_opencl_options.verbosity) {
                     const double duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
                     fprintf(stderr, "INFO ACC/OpenCL: %ix%i transpose-kernel generated in %.1f ms\n",
                       m, n, 1000.0 * duration);
@@ -344,13 +390,14 @@ int libsmm_acc_transpose(const int* dev_trs_stack, int offset, int stack_size,
     }
     assert((NULL != config && NULL != config->kernel && 0 < config->wgsize) || EXIT_SUCCESS != result);
     if (EXIT_SUCCESS == result) {
+      cl_event event, *const perf_event = ((0 <= c_dbcsr_acc_opencl_options.verbosity && 3 > c_dbcsr_acc_opencl_options.verbosity) ? NULL : &event);
       const size_t work_size = config->wgsize * stack_size;
+      const int typesize = (dbcsr_type_real_8 == datatype ? 8
+        : (dbcsr_type_real_4 == datatype ? 4 : 0/*unknown*/));
 #if defined(OPENCL_LIBSMM_DEBUG_TRANS)
       const int offset_stack_size = offset + stack_size;
       int *const stack = (int*)libxsmm_aligned_scratch(sizeof(int) * offset_stack_size, 0/*auto-align*/);
       char *imat = NULL, *omat = NULL, *gold = NULL;
-      const int typesize = (dbcsr_type_real_8 == datatype ? 8
-        : (dbcsr_type_real_4 == datatype ? 4 : 0/*unknown*/));
       size_t data_size;
       if (NULL != stack && CL_SUCCESS == clGetMemObjectInfo(*ACC_OPENCL_MEM(dev_data),
         CL_MEM_SIZE, sizeof(size_t), &data_size, NULL))
@@ -380,15 +427,37 @@ int libsmm_acc_transpose(const int* dev_trs_stack, int offset, int stack_size,
         ACC_OPENCL_CHECK(clSetKernelArg(config->kernel, 2, sizeof(cl_mem), ACC_OPENCL_MEM(dev_data)),
           "set matrix-data argument of transpose kernel", result);
         ACC_OPENCL_CHECK(clEnqueueNDRangeKernel(*ACC_OPENCL_STREAM(stream),
-          config->kernel, 1/*work_dim*/, NULL, &work_size, &config->wgsize, 0, NULL, NULL),
+          config->kernel, 1/*work_dim*/, NULL, &work_size, &config->wgsize, 0, NULL, perf_event),
           "launch transpose kernel", result);
+        /* eventually update performance counters inside of locked region */
+        if (NULL != perf_event) {
+          cl_ulong begin, end;
+          double membw;
+          clWaitForEvents(1, perf_event);
+          ACC_OPENCL_CHECK(clGetEventProfilingInfo(*perf_event, CL_PROFILING_COMMAND_START, sizeof(cl_ulong), &begin, NULL),
+            "query kernel start time", result);
+          ACC_OPENCL_CHECK(clGetEventProfilingInfo(*perf_event, CL_PROFILING_COMMAND_END, sizeof(cl_ulong), &end, NULL),
+            "query kernel end time", result);
+          if (EXIT_SUCCESS == result) {
+            membw = ((double)stack_size * (typesize * m * n) * (1ULL << 30) * 1E-9) / LIBXSMM_DELTA(begin, end);
+#if LIBXSMM_VERSION3(1, 16, 1) <= LIBXSMM_VERSION3(LIBXSMM_VERSION_MAJOR, \
+    LIBXSMM_VERSION_MINOR, LIBXSMM_VERSION_UPDATE) && 1159 <= LIBXSMM_VERSION_PATCH
+            libxsmm_kahan_sum(log(membw), &config->membw_sumlog, &config->membw_err);
+            ++config->nexec;
+#endif
+            if (4 <= c_dbcsr_acc_opencl_options.verbosity || 0 > c_dbcsr_acc_opencl_options.verbosity) {
+              fprintf(stderr, "INFO ACC/OpenCL: %ix%i transpose-kernel achieved %.1f GB/s%s\n", m, n, membw,
+                dbcsr_type_real_8 == datatype ? " (DP)" : (dbcsr_type_real_4 == datatype ? " (SP)" : ""));
+            }
+          }
+        }
         LIBXSMM_ATOMIC_RELEASE(lock, LIBXSMM_ATOMIC_RELAXED);
       }
 #if defined(OPENCL_LIBSMM_DEBUG_TRANS)
       ACC_OPENCL_CHECK(c_dbcsr_acc_memcpy_d2h(dev_data, omat, data_size, stream),
         "transfer debug test", result);
 #endif
-#if defined(OPENCL_LIBSMM_DEBUG_TRANS) || defined(OPENCL_LIBSMM_SYNC)
+#if defined(OPENCL_LIBSMM_DEBUG_TRANS)
       ACC_OPENCL_CHECK(c_dbcsr_acc_stream_sync(stream), "sync stream", result);
 #endif
 #if defined(OPENCL_LIBSMM_DEBUG_TRANS)
@@ -473,8 +542,10 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
     key.type = datatype; key.m = m_max; key.n = n_max; key.k = k_max; /* initialize key */
     config = (opencl_libsmm_smm_t*)OPENCL_LIBSMM_DISPATCH(&key, sizeof(key));
     if (NULL == config || NULL == config->kernel) {
-      char build_options[ACC_OPENCL_BUFFERSIZE], fname[48];
-      int nchar = ACC_OPENCL_SNPRINTF(fname, sizeof(fname), "xmm%ix%ix%i", m_max, n_max, k_max);
+      char build_options[ACC_OPENCL_BUFFERSIZE], fname[OPENCL_LIBSMM_KERNELNAME_MAXSIZE];
+      int nchar = ACC_OPENCL_SNPRINTF(fname, sizeof(fname),
+        /* kernel name are meant to be unambiguous (BLAS-typeprefix and kernelsize) */
+        "x" OPENCL_LIBSMM_KERNELNAME_SMM "%ix%ix%i", m_max, n_max, k_max);
       const char* extensions = NULL;
       if (0 < nchar && (int)sizeof(fname) > nchar) {
         cl_device_id active_device;
@@ -614,7 +685,7 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
                       config->wgsize = (size_t)wgsize;
                       config->bs = bs; config->bm = bm; config->bn = bn;
                       config->kernel = new_config.kernel;
-                      if (1 < c_dbcsr_acc_opencl_options.verbosity || 0 > c_dbcsr_acc_opencl_options.verbosity) {
+                      if (2 <= c_dbcsr_acc_opencl_options.verbosity || 0 > c_dbcsr_acc_opencl_options.verbosity) {
                         const double duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
                         fprintf(stderr, "INFO ACC/OpenCL: %ix%ix%i %sSMM-kernel generated in %.1f ms\n",
                           m_max, n_max, k_max, default_params ? "" : "tuned ", 1000.0 * duration);
@@ -651,6 +722,7 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
         && 1 <= config->bs && 0 < config->bm && 0 < config->bn
         && 0 < config->wgsize));
     if (EXIT_SUCCESS == result) {
+      cl_event event, *const perf_event = ((0 <= c_dbcsr_acc_opencl_options.verbosity && 3 > c_dbcsr_acc_opencl_options.verbosity) ? NULL : &event);
       /* adjust overall stacksize according to intra-kernel batchsize */
       const size_t work_size = ((stack_size + config->bs - 1) / config->bs) * config->wgsize;
 #if defined(OPENCL_LIBSMM_DEBUG_SMM)
@@ -711,15 +783,37 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
             "set stacksize argument of SMM-kernel", result);
         }
         ACC_OPENCL_CHECK(clEnqueueNDRangeKernel(*ACC_OPENCL_STREAM(stream),
-          config->kernel, 1/*work_dim*/, NULL, &work_size, &config->wgsize, 0, NULL, NULL),
+          config->kernel, 1/*work_dim*/, NULL, &work_size, &config->wgsize, 0, NULL, perf_event),
           "launch SMM-kernel", result);
+        /* eventually update performance counters inside of locked region */
+        if (NULL != perf_event) {
+          cl_ulong begin, end;
+          double gflops;
+          clWaitForEvents(1, perf_event);
+          ACC_OPENCL_CHECK(clGetEventProfilingInfo(*perf_event, CL_PROFILING_COMMAND_START, sizeof(cl_ulong), &begin, NULL),
+            "query kernel start time", result);
+          ACC_OPENCL_CHECK(clGetEventProfilingInfo(*perf_event, CL_PROFILING_COMMAND_END, sizeof(cl_ulong), &end, NULL),
+            "query kernel end time", result);
+          if (EXIT_SUCCESS == result) {
+            gflops = (2.0 * m_max * n_max * k_max * stack_size) / LIBXSMM_DELTA(begin, end);
+#if LIBXSMM_VERSION3(1, 16, 1) <= LIBXSMM_VERSION3(LIBXSMM_VERSION_MAJOR, \
+    LIBXSMM_VERSION_MINOR, LIBXSMM_VERSION_UPDATE) && 1159 <= LIBXSMM_VERSION_PATCH
+            libxsmm_kahan_sum(log(gflops), &config->gflops_sumlog, &config->gflops_err);
+            ++config->nexec;
+#endif
+            if (4 <= c_dbcsr_acc_opencl_options.verbosity || 0 > c_dbcsr_acc_opencl_options.verbosity) {
+              fprintf(stderr, "INFO ACC/OpenCL: %ix%ix%i SMM-kernel achieved %.1f GFLOPS/s%s\n", m_max, n_max, k_max, gflops,
+                dbcsr_type_real_8 == datatype ? " (DP)" : (dbcsr_type_real_4 == datatype ? " (SP)" : ""));
+            }
+          }
+        }
         LIBXSMM_ATOMIC_RELEASE(lock, LIBXSMM_ATOMIC_RELAXED);
       }
 #if defined(OPENCL_LIBSMM_DEBUG_SMM)
       ACC_OPENCL_CHECK(acc_memcpy_d2h(dev_c_data, test, csize, stream),
         "transfer debug test", result);
 #endif
-#if defined(OPENCL_LIBSMM_DEBUG_SMM) || defined(OPENCL_LIBSMM_SYNC)
+#if defined(OPENCL_LIBSMM_DEBUG_SMM)
       ACC_OPENCL_CHECK(acc_stream_sync(stream), "sync stream", result);
 #endif
 #if defined(OPENCL_LIBSMM_DEBUG_SMM)

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -52,7 +52,7 @@ typedef struct opencl_libsmm_trans_t {
   cl_kernel kernel; /* must be the 1st data member */
   size_t wgsize;
   /* ACC_OPENCL_VERBOSE: perf. counters */
-  double membw_sumlog, membw_err;
+  double membw_sumlog, membw_comp;
   size_t nexec;
 } opencl_libsmm_trans_t;
 
@@ -69,7 +69,7 @@ typedef struct opencl_libsmm_smm_t {
   /* parameters (either pretuned or determined) */
   int bs, bm, bn;
   /* ACC_OPENCL_VERBOSE: perf. counters */
-  double gflops_sumlog, gflops_err;
+  double gflops_sumlog, gflops_comp;
   size_t nexec;
 } opencl_libsmm_smm_t;
 

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -27,9 +27,6 @@
 #if !defined(OPENCL_LIBSMM_DEBUG) && 0
 # define OPENCL_LIBSMM_DEBUG
 #endif
-#if !defined(OPENCL_LIBSMM_SYNC) && 0
-# define OPENCL_LIBSMM_SYNC
-#endif
 #if !defined(OPENCL_LIBSMM_CMEM) && 1
 # define OPENCL_LIBSMM_CMEM
 #endif
@@ -44,30 +41,36 @@
 extern "C" {
 #endif
 
-/** Type for querying transpose kernel/configuration. */
+/** Type for querying transpose kernel configuration. */
 typedef struct opencl_libsmm_transkey_t {
-  libsmm_acc_data_t type;
+  libsmm_acc_data_t type; /* must be the 1st data member */
   int m, n;
 } opencl_libsmm_transkey_t;
 
-/** Type for transpose kernel/configuration. */
+/** Type for transpose kernel configuration. */
 typedef struct opencl_libsmm_trans_t {
-  cl_kernel kernel;
+  cl_kernel kernel; /* must be the 1st data member */
   size_t wgsize;
+  /* ACC_OPENCL_VERBOSE: perf. counters */
+  double membw_sumlog, membw_err;
+  size_t nexec;
 } opencl_libsmm_trans_t;
 
-/** Type for querying SMM-kernel/configuration. */
+/** Type for querying SMM-kernel configuration. */
 typedef struct opencl_libsmm_smmkey_t {
-  libsmm_acc_data_t type;
+  libsmm_acc_data_t type; /* must be the 1st data member */
   int m, n, k;
 } opencl_libsmm_smmkey_t;
 
-/** Type for SMM-kernel/configuration. */
+/** Type for SMM-kernel configuration. */
 typedef struct opencl_libsmm_smm_t {
-  cl_kernel kernel;
+  cl_kernel kernel; /* must be the 1st data member */
   size_t wgsize;
-  /* tuned parameters for SMM-kernels */
+  /* parameters (either pretuned or determined) */
   int bs, bm, bn;
+  /* ACC_OPENCL_VERBOSE: perf. counters */
+  double gflops_sumlog, gflops_err;
+  size_t nexec;
 } opencl_libsmm_smm_t;
 
 /** If buffers are hinted for non-concurrent writes aka "OpenCL constant". */

--- a/tests/dbcsr_acc_test.c
+++ b/tests/dbcsr_acc_test.c
@@ -166,7 +166,7 @@ int main(int argc, char* argv[])
 #endif
   for (i = 0; i < ACC_EVENT_MAXCOUNT; ++i) ACC_CHECK(c_dbcsr_acc_event_create(event + i));
   for (i = 0; i < ACC_EVENT_MAXCOUNT; ++i) {
-    acc_bool_t has_occurred = 0;
+    c_dbcsr_acc_bool_t has_occurred = 0;
     ACC_CHECK(c_dbcsr_acc_event_query(event[i], &has_occurred));
     ACC_CHECK(has_occurred ? EXIT_SUCCESS : EXIT_FAILURE);
   }
@@ -190,7 +190,7 @@ int main(int argc, char* argv[])
 #endif
     const size_t offset = tid * mem_chunk, mem_rest = mem_alloc - offset;
     const size_t size = (mem_chunk <= mem_rest ? mem_chunk : mem_rest);
-    acc_bool_t has_occurred = 0;
+    c_dbcsr_acc_bool_t has_occurred = 0;
     ACC_CHECK(c_dbcsr_acc_memset_zero(dev_mem, offset, size, s));
     /* can enqueue multiple/duplicate copies for the same memory region */
     ACC_CHECK(c_dbcsr_acc_memcpy_d2h(dev_mem, host_mem, mem_alloc, s));


### PR DESCRIPTION
Implemented geometric mean of kernel performance (presented at end of execution/program)

* Perf. measurement is based on profiling OpenCL's queues (flushes queue for every measurement).
* Generally show "performance" rather than execution time (for more meaningful values).
* Higher log-level/s: print performance for every kernel execution.
* Updated documentation accordingly.

Other changes:

* Cleanup: Removed some compile-time settings (due to corresponding runtime setting or due to default state).
* Benchmarks: fixed calculation which was incorrectly introduced by copy/pasting from transpose benchmark.
* OCLBE: implemented profiling queue events (ACC_OPENCL_VERBOSE=3 and higher). Code cleanup.
* Kernels: avoid dynamically indexing private arrays (registers).
* Libsmm: release kernels (libsmm_acc_finalize).
* Makefile: Search HOME directory (libxsmm).