### PR TITLE
ocl: collection of minor fixes and improvements

### DIFF
--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -362,14 +362,14 @@ int c_dbcsr_acc_finalize(void)
 #if defined(_OPENMP) && defined(ACC_OPENCL_THREADLOCAL_CONTEXT)
 #   pragma omp parallel
     if (context != c_dbcsr_acc_opencl_context) {
-      ACC_OPENCL_CHECK(clReleaseContext(c_dbcsr_acc_opencl_context),
-        "release context", result);
+      const cl_context thread_context = c_dbcsr_acc_opencl_context;
       c_dbcsr_acc_opencl_context = NULL;
+      clReleaseContext(thread_context); /* quiet error */
     }
 #endif
+    c_dbcsr_acc_opencl_context = NULL;
     ACC_OPENCL_CHECK(clReleaseContext(context),
       "release context", result);
-    c_dbcsr_acc_opencl_context = NULL;
 #if defined(__DBCSR_ACC)
     /* DBCSR may call c_dbcsr_acc_init as well as libsmm_acc_init() since both interface are used.
      * libsmm_acc_init may privately call c_dbcsr_acc_init (as it depends on the ACC interface).

--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -72,7 +72,7 @@
 # define ACC_OPENCL_EVENT(A) ((cl_event*)(A))
 #endif
 
-#if !defined(ACC_OPENCL_THREADLOCAL_CONTEXT) && /*WORKAROUND*/!defined(__DBCSR_ACC)
+#if !defined(ACC_OPENCL_THREADLOCAL_CONTEXT) && /*WORKAROUND*/!defined(__DBCSR_ACC) && 0
 # define ACC_OPENCL_THREADLOCAL_CONTEXT
 #endif
 #if !defined(ACC_OPENCL_STREAM_PRIORITIES) && 1

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -83,7 +83,7 @@ class SmmTuner(MeasurementInterface):
         return performance
         """
         config = desired_result.configuration.data
-        run_cmd = "{} CHECK={} {}={} {}={} {}={} {}/{} 0 0 {} {} {}".format(
+        run_cmd = "{} CHECK={} {}={} {}={} {}={} {}/{} 0 {} {} {} {}".format(
             "OMP_PROC_BIND=TRUE",
             self.args.check,
             "OPENCL_LIBSMM_SMM_BATCHSIZE",
@@ -94,6 +94,7 @@ class SmmTuner(MeasurementInterface):
             config["BN"],
             self.exepath,
             self.exename,
+            self.args.r,
             self.args.m,
             self.args.n,
             self.args.k,
@@ -261,6 +262,15 @@ if __name__ == "__main__":
         nargs="?",
         dest="mb",
         help="Maximum (mini-)batch size (BS)",
+    )
+    argparser.add_argument(
+        "-r",
+        "--repetitions",
+        type=int,
+        default=0,
+        nargs="?",
+        dest="r",
+        help="Repetitions per experiment",
     )
     argparser.add_argument(
         "-s",


### PR DESCRIPTION
* Made libsmm_acc_transpose retry building a kernel if WG-size is exceeded (TODO: introduce tiles).
* Disabled thread-local context. Quiet error(s) when releasing thread-local contexts.
* Avoid potential compilation error if cl_khr_int64_base_atomics is not supported.
* Repetitions per experiment (tune_multiply.py).
* Skip adding zeros (atomic add).