### PR TITLE
ocl-insights: improved/extended output (ACC_OPENCL_VERBOSE)

### DIFF
--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -25,7 +25,7 @@ if [ ! -d "${HOME}/libxsmm" ]; then
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout 146dd2685e36e31f06690c5b581373a59540ae31
+git checkout 66bab63ee6c7565b725e1fb70f66cdb2fa507250
 make -j
 cd ..
 

--- a/src/acc/opencl/README.md
+++ b/src/acc/opencl/README.md
@@ -23,8 +23,8 @@ Runtime settings are made by the means of environment variables (implemented in 
 * `ACC_OPENCL_VERBOSE`: verbosity level (integer) with console output on `stderr`.
     * `ACC_OPENCL_VERBOSE=1`: outputs the number of devices found and the name of the selected device.
     * `ACC_OPENCL_VERBOSE=2`: outputs the duration needed to generate a requested kernel.
-    * `ACC_OPENCL_VERBOSE=3`: outputs device-side performance of kernels (geometric mean).
-    * `ACC_OPENCL_VERBOSE=4`: outputs device-side performance of kernels (every execution).
+    * `ACC_OPENCL_VERBOSE=3`: outputs host-side measured performance of kernels (geometric mean).
+    * `ACC_OPENCL_VERBOSE=4`: outputs device-side performance of kernels (every launch profiled).
 
 The OpenCL backend enumerates and orders devices primarily by device-kind (GPU, CPU, and others in that order) and by memory capacity (secondary criterion). Device IDs are zero-based as per ACC interface (and less than what is permitted/returned by `acc_get_ndevices`).
 

--- a/src/acc/opencl/acc_opencl_mem.c
+++ b/src/acc/opencl/acc_opencl_mem.c
@@ -15,7 +15,7 @@
 #if defined(_WIN32)
 # include <Windows.h>
 #else
-# if !defined(__linux__)
+# if !defined(__linux__) && defined(__APPLE__) && defined(__MACH__)
 #   include <sys/types.h>
 #   include <sys/sysctl.h>
 # endif
@@ -305,20 +305,20 @@ int c_dbcsr_acc_opencl_info_devmem(cl_device_id device,
 # else
   const long page_size = 4096;
 # endif
+  long pages_free = 0, pages_total = 0;
 # if defined(__linux__)
 #   if defined(_SC_PHYS_PAGES)
-  const long pages_total = sysconf(_SC_PHYS_PAGES);
+  pages_total = sysconf(_SC_PHYS_PAGES);
 #   else
-  const long pages_total = 0;
+  pages_total = 0;
 #   endif
 #   if defined(_SC_AVPHYS_PAGES)
-  const long pages_free = sysconf(_SC_AVPHYS_PAGES);
+  pages_free = sysconf(_SC_AVPHYS_PAGES);
 #   else
-  const long pages_free = pages_total;
+  pages_free = pages_total;
 #   endif
-# else
+# elif defined(__APPLE__) && defined(__MACH__)
   /*const*/ size_t size_pages_free = sizeof(const long), size_pages_total = sizeof(const long);
-  long pages_free = 0, pages_total = 0;
   ACC_OPENCL_EXPECT(0, sysctlbyname("hw.memsize", &pages_total, &size_pages_total, NULL, 0));
   if (0 < page_size) pages_total /= page_size;
   if (0 != sysctlbyname("vm.page_free_count", &pages_free, &size_pages_free, NULL, 0)) {

--- a/src/acc/opencl/smm/README.md
+++ b/src/acc/opencl/smm/README.md
@@ -23,19 +23,19 @@ Runtime settings are made by the means of environment variables (implemented in 
 * `ACC_OPENCL_VERBOSE`: verbosity level (integer) with console output on `stderr`.
     * `ACC_OPENCL_VERBOSE=1`: outputs the number of devices found and the name of the selected device.
     * `ACC_OPENCL_VERBOSE=2`: outputs the duration needed to generate a requested kernel.
-    * `ACC_OPENCL_VERBOSE=3`: outputs device-side performance of kernels (geometric mean).
-    * `ACC_OPENCL_VERBOSE=4`: outputs device-side performance of kernels (every execution).
+    * `ACC_OPENCL_VERBOSE=3`: outputs host-side measured performance of kernels (geometric mean).
+    * `ACC_OPENCL_VERBOSE=4`: outputs device-side performance of kernels (every launch profiled).
 
 For tranposing matrices:
 
 * `OPENCL_LIBSMM_TRANS_BUILDOPTS`: character string with build options (compile and link) supplied to the OpenCL runtime compiler.
-* `OPENCL_LIBSMM_TRANS_INPLACE`: Boolean value (zero or non-zero integer) for inplace matrix transpose not relying on local memory.
+* `OPENCL_LIBSMM_TRANS_INPLACE`: Boolean value (zero or non-zero integer) for inplace matrix transpose (no local memory needed).
 * `OPENCL_LIBSMM_TRANS_BLOCK_M`: non-negative integer number (less/equal than the M-extent) denoting the blocksize in M-direction.
 
 For multiplying matrices:
 
 * `OPENCL_LIBSMM_SMM_BUILDOPTS`: character string with build options (compile and link) supplied to the OpenCL runtime compiler.
-* `OPENCL_LIBSMM_SMM_ATOMICS`: selects the kind of atomic operation used for global memory updates ("cmpxchg", "xchg"), or disables atomic updates ("0"). The latter is to quantify the impact of atomic operations rather than for achieving correct results.
+* `OPENCL_LIBSMM_SMM_ATOMICS`: selects the kind of atomic operation used for global memory updates ("xchg", "cmpxchg", "cmpxchg2"), or disables atomic updates ("0"). The latter is to quantify the impact of atomic operations rather than for achieving correct results.
 * `OPENCL_LIBSMM_SMM_BATCHSIZE`: non-negative integer number denoting the intr-kernel (mini-)batchsize mainly used to amortize atomic updates of data in global/main memory. The remainder with respect to the "stacksize" is handled by the kernel.
 * `OPENCL_LIBSMM_SMM_BLOCK_M`: non-negative integer number (less/equal than the M-extent) denoting the blocksize in M-direction.
 * `OPENCL_LIBSMM_SMM_BLOCK_N`: non-negative integer number (less/equal than the N-extent) denoting the blocksize in N-direction.

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -56,6 +56,7 @@ typedef struct opencl_libsmm_trans_t {
   /* ACC_OPENCL_VERBOSE: perf. counters */
   double membw_sumlog, membw_comp;
   size_t nexec;
+  int size[5];
 } opencl_libsmm_trans_t;
 
 /** Type for querying SMM-kernel configuration. */
@@ -73,14 +74,23 @@ typedef struct opencl_libsmm_smm_t {
   /* ACC_OPENCL_VERBOSE: perf. counters */
   double gflops_sumlog, gflops_comp;
   size_t nexec;
+  int size[5];
 } opencl_libsmm_smm_t;
+
+/** Type to collect statistics about tuned SMM-kernels */
+typedef struct opencl_libsmm_perfest_t {
+  double gf_ai_sratio_max, gf_ai_sratio_sumlog, gf_ai_sratio_kahan;
+  double gf_ai_dratio_max, gf_ai_dratio_sumlog, gf_ai_dratio_kahan;
+  size_t scount, dcount;
+} opencl_libsmm_perfest_t;
 
 /** If buffers are hinted for non-concurrent writes aka "OpenCL constant". */
 int opencl_libsmm_use_cmem(cl_device_id device);
 
 /* Tokenize parambuf and initialize key/value pair. */
 int opencl_libsmm_read_params(char* parambuf,
-  opencl_libsmm_smmkey_t* key, opencl_libsmm_smm_t* value);
+  opencl_libsmm_smmkey_t* key, opencl_libsmm_smm_t* value,
+  opencl_libsmm_perfest_t* perfest);
 
 #if defined(OPENCL_LIBSMM_DEBUG) && defined(_DEBUG)
 void opencl_libsmm_print_matrix(FILE* ostream, const char* label,

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -22,6 +22,7 @@ import json
 import glob
 import sys
 import re
+import os
 
 
 class SmmTuner(MeasurementInterface):
@@ -171,6 +172,10 @@ class SmmTuner(MeasurementInterface):
                         len(merged), len(filenames), self.args.csvfile
                     )
                 )
+            elif glob.glob(self.args.csvfile):
+                backup = "{}.bak".format(self.args.csvfile)
+                print("Renamed {} to {}.".format(self.args.csvfile, backup))
+                os.rename(self.args.csvfile, backup)
 
     def save_final_config(self, configuration):
         """called at the end of tuning"""


### PR DESCRIPTION
* Record and print the (running median of the) stack_size (SMM/transpose kernels).
* Estimate per-kernel (device-)performance from the embedded parameters (auto-tuning).
* Introduced opencl_libsmm_perfest_t to support opencl_libsmm_read_params.
* Rely on geometric mean for performance estimate.

Other

* Delete/backup existing CSV-file if no JSON-file was found (tune_multiply.py).
* Updated documentation (minor).
* Avoid C++ keyword in C code.
* Improved portability.