### PR TITLE
ocl-verbose: improved previously introduced data collection (verbose mode)

### DIFF
--- a/src/acc/opencl/README.md
+++ b/src/acc/opencl/README.md
@@ -23,7 +23,7 @@ Runtime settings are made by the means of environment variables (implemented in 
 * `ACC_OPENCL_VERBOSE`: verbosity level (integer) with console output on `stderr`.
     * `ACC_OPENCL_VERBOSE=1`: outputs the number of devices found and the name of the selected device.
     * `ACC_OPENCL_VERBOSE=2`: outputs the duration needed to generate a requested kernel.
-    * `ACC_OPENCL_VERBOSE=3`: outputs host-side measured performance of kernels (geometric mean).
+    * `ACC_OPENCL_VERBOSE=3`: outputs device-side measured performance of kernels (geometric mean).
     * `ACC_OPENCL_VERBOSE=4`: outputs device-side performance of kernels (every launch profiled).
 
 The OpenCL backend enumerates and orders devices primarily by device-kind (GPU, CPU, and others in that order) and by memory capacity (secondary criterion). Device IDs are zero-based as per ACC interface (and less than what is permitted/returned by `acc_get_ndevices`).

--- a/src/acc/opencl/smm/README.md
+++ b/src/acc/opencl/smm/README.md
@@ -23,7 +23,7 @@ Runtime settings are made by the means of environment variables (implemented in 
 * `ACC_OPENCL_VERBOSE`: verbosity level (integer) with console output on `stderr`.
     * `ACC_OPENCL_VERBOSE=1`: outputs the number of devices found and the name of the selected device.
     * `ACC_OPENCL_VERBOSE=2`: outputs the duration needed to generate a requested kernel.
-    * `ACC_OPENCL_VERBOSE=3`: outputs host-side measured performance of kernels (geometric mean).
+    * `ACC_OPENCL_VERBOSE=3`: outputs device-side measured performance of kernels (geometric mean).
     * `ACC_OPENCL_VERBOSE=4`: outputs device-side performance of kernels (every launch profiled).
 
 For tranposing matrices:

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -56,7 +56,7 @@ typedef struct opencl_libsmm_trans_t {
   /* ACC_OPENCL_VERBOSE: perf. counters */
   double membw_sumlog, membw_comp;
   size_t nexec;
-  int size[5];
+  int size[7];
 } opencl_libsmm_trans_t;
 
 /** Type for querying SMM-kernel configuration. */
@@ -74,7 +74,7 @@ typedef struct opencl_libsmm_smm_t {
   /* ACC_OPENCL_VERBOSE: perf. counters */
   double gflops_sumlog, gflops_comp;
   size_t nexec;
-  int size[5];
+  int size[7];
 } opencl_libsmm_smm_t;
 
 /** Type to collect statistics about tuned SMM-kernels */


### PR DESCRIPTION
* Revert back to profiling the OpenCL queue rather than host-side/asynchronous launch timing.
* Adjusted console/verbose output format (stacksize).
* Avoid unnecessary profiling or data collection.