### PR TITLE
oclreg: use tuned parameters if device matches original target

### DIFF
--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -25,7 +25,7 @@ if [ ! -d "${HOME}/libxsmm" ]; then
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout af0dcb9018ed1f92173d60bc04dcf00a4e1854f1
+git checkout 1f4c05b3c3163316ee5619fd668f1a88d4d66ab0
 make -j
 cd ..
 

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -23,13 +23,6 @@ CFLAGS := -fPIC \
   -D__OPENCL \
   $(NULL)
 
-ifneq (0,$(DEV))
-  CFLAGS := -std=c89 $(CFLAGS)
-  CFLAGS += -Wno-unused-parameter
-else
-  CFLAGS := -std=c99 $(CFLAGS)
-endif
-
 ifeq (1,$(INTEL))
   CXX := icpc
   CC := icc
@@ -46,6 +39,21 @@ else
   else
     AR := ar
   endif
+endif
+
+ifneq (0,$(DEV))
+  ifeq (1,$(DEV))
+    CFLAGS := -std=c89 $(CFLAGS)
+    CFLAGS += -Wno-unused-parameter
+  else ifeq (clang,$(CC))
+    #LDFLAGS := --analyze $(LDFLAGS)
+    CFLAGS := --analyze $(CFLAGS)
+    CC := clang++
+  else
+    CC := $(CXX)
+  endif
+else
+  CFLAGS := -std=c99 $(CFLAGS)
 endif
 
 ifneq (0,$(DBG))

--- a/src/acc/opencl/smm/kernels/multiply.cl
+++ b/src/acc/opencl/smm/kernels/multiply.cl
@@ -55,8 +55,8 @@ inline void atomic_add_global_cmpxchg2(global volatile float2* dst, float2 inc)
 #endif
 
 
-kernel void FN(global T *restrict cmat,
-  GLOBAL const T *restrict amat, GLOBAL const T *restrict bmat,
+kernel void FN(global T *restrict cdata,
+  GLOBAL const T *restrict adata, GLOBAL const T *restrict bdata,
 #if (1 < BS)
   GLOBAL const int *restrict param_stack, int stack_size)
 #else
@@ -68,21 +68,21 @@ kernel void FN(global T *restrict cmat,
   /* indexes given by param_stack are one-based */
   int c0 = params[2] - 1;
 #if (1 < BS)
-  int a1 = -1, b1 = -1;
+  int b1 = -1;
 #endif
-  global T *restrict cwg = cmat + c0;
+  global T *restrict c = cdata + c0;
 
-  local T a[SM][SK];
-  T am[SK];
+  T amk[SK];
 #if (SWG != SN)
-  T b[SK][BN];
+  T bkn[SK][BN];
 # if (1 < BS)
-  T c[BM][BN] = {{ 0 }};
+  T cmn[BM][BN] = {{ 0 }};
 # endif
 #else
-  T bn[SK];
+  local T awg[SM][SK];
+  T bkn[SK];
 # if (1 < BS)
-  T c[SM] = { 0 };
+  T cmn[SM] = { 0 };
 # endif
 #endif
 
@@ -98,7 +98,7 @@ kernel void FN(global T *restrict cmat,
     const int n0 = (idx - im * NBN) * BN;
     const int n1 = min(n0 + BN, SN);
 #else
-    const int bm = (SM + SWG - 1) / SWG;
+    const int bm = (SM + SN - 1) / SN;
     const int m0 = idx * bm, m1 = min(m0 + bm, SM);
     const int n = idx;
 #endif
@@ -108,28 +108,26 @@ kernel void FN(global T *restrict cmat,
 #else
     const int a0 = params[0] - 1, b0 = params[1] - 1;
 #endif
+    GLOBAL const T *const restrict a = adata + a0;
 
-    { /* transpose A-matrix into local buffer */
-      GLOBAL const T *const restrict awg = amat + a0;
-      for (int m = m0; m < m1; ++m) {
-        for (int k = 0; k < SK; ++k) a[m][k] = awg[SM*k+m];
-      }
-#if (1 < BS)
-      a1 = a0;
-#endif
+#if (SWG == SN)
+    /* transpose A-matrix into local buffer */
+    for (int m = m0; m < m1; ++m) {
+      for (int k = 0; k < SK; ++k) awg[m][k] = a[SM*k+m];
     }
+#endif
 
     /* avoiding to load same B-tile seems to be not beneficial */
 #if (1 < BS) && 0
     if (b0 != b1)
 #endif
     { /* copy B-matrix into private buffer */
-      GLOBAL const T *const restrict bwg = bmat + b0;
+      GLOBAL const T *const restrict b = bdata + b0;
       for (int k = 0; k < SK; ++k) {
 #if (SWG != SN)
-        for (int n = n0; n < n1; ++n) b[k][n-n0] = bwg[SN*k+n];
+        for (int n = n0; n < n1; ++n) bkn[k][n-n0] = b[SN*k+n];
 #else
-        bn[k] = bwg[SN*k+n];
+        bkn[k] = b[SN*k+n];
 #endif
       }
 #if (1 < BS)
@@ -137,65 +135,64 @@ kernel void FN(global T *restrict cmat,
 #endif
     }
 
-    { /* calculate private result-tile */
-      barrier(CLK_LOCAL_MEM_FENCE);
+    /* calculate private result-tile */
 #if (SWG != SN)
-      for (int m = m0; m < m1; ++m) {
-        for (int k = 0; k < SK; ++k) am[k] = a[m][k];
-        for (int n = n0; n < n1; ++n) {
-          T r = 0;
-          for (int k = 0; k < SK; ++k) r = FMA(am[k], b[k][n-n0], r);
-# if (1 < BS)
-          c[m-m0][n-n0] += r;
-# else
-          if (0 != r) ATOMIC_ADD_GLOBAL(&cwg[SM*n+m], r);
-# endif
-        }
-      }
-#else
-      for (int m = 0; m < SM; ++m) {
+    for (int m = m0; m < m1; ++m) {
+      for (int k = 0; k < SK; ++k) amk[k] = a[SM*k+m];
+      for (int n = n0; n < n1; ++n) {
         T r = 0;
-        for (int k = 0; k < SK; ++k) am[k] = a[m][k];
-        for (int k = 0; k < SK; ++k) r = FMA(am[k], bn[k], r);
+        for (int k = 0; k < SK; ++k) r = FMA(amk[k], bkn[k][n-n0], r);
 # if (1 < BS)
-        c[m] += r;
+        cmn[m-m0][n-n0] += r;
 # else
-        if (0 != r) ATOMIC_ADD_GLOBAL(&cwg[SM*n+m], r);
+        if (0 != r) ATOMIC_ADD_GLOBAL(&c[SM*n+m], r);
 # endif
       }
-#endif
     }
+#else
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int m = 0; m < SM; ++m) {
+      T r = 0;
+      for (int k = 0; k < SK; ++k) amk[k] = awg[m][k];
+      for (int k = 0; k < SK; ++k) r = FMA(amk[k], bkn[k], r);
+# if (1 < BS)
+      cmn[m] += r;
+# else
+      if (0 != r) ATOMIC_ADD_GLOBAL(&c[SM*n+m], r);
+# endif
+    }
+#endif
 
 #if (1 < BS)
     if (c0 != c1) { /* copy private tile to global memory */
 # if (SWG != SN)
       for (int m = 0; m < BM; ++m) for (int n = 0; n < BN; ++n) {
         const int gm = m + m0, gn = n + n0;
-        if (gm < SM && gn < SN && 0 != c[m][n]) {
-          ATOMIC_ADD_GLOBAL(&cwg[SM*gn+gm], c[m][n]);
-          c[m][n] = 0; /* reset */
+        if (gm < SM && gn < SN && 0 != cmn[m][n]) {
+          ATOMIC_ADD_GLOBAL(&c[SM*gn+gm], cmn[m][n]);
+          cmn[m][n] = 0; /* reset */
         }
       }
 # else
 #   if defined(ATOMIC_ADD2_GLOBAL)
       for (int m = 0; m < SM; m += 2) {
-        float2 *const restrict r = (float2*)(c + m);
+        float2 *const restrict r = (float2*)(cmn + m);
         if (0 != r) {
-          ATOMIC_ADD2_GLOBAL((global volatile float2*)(cwg + SM * n + m), *r);
+          ATOMIC_ADD2_GLOBAL((global volatile float2*)(c + SM * n + m), *r);
           *r = 0; /* reset */
         }
       }
 #   else
       for (int m = 0; m < SM; ++m) {
-        if (0 != c[m]) {
-          ATOMIC_ADD_GLOBAL(&cwg[SM*n+m], c[m]);
-          c[m] = 0; /* reset */
+        if (0 != cmn[m]) {
+          ATOMIC_ADD_GLOBAL(&c[SM*n+m], cmn[m]);
+          cmn[m] = 0; /* reset */
         }
       }
 #   endif
 # endif
       /* next iteration */
-      cwg = cmat + c1;
+      c = cdata + c1;
       c0 = c1;
     }
     barrier(CLK_LOCAL_MEM_FENCE);

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -24,7 +24,7 @@
 # define OPENCL_LIBSMM_TRANS_INPLACE
 #endif
 #if !defined(OPENCL_LIBSMM_PARAMS_DELIMS)
-# define OPENCL_LIBSMM_PARAMS_DELIMS ";, \t|/"
+# define OPENCL_LIBSMM_PARAMS_DELIMS ";,\t|/"
 #endif
 #if !defined(OPENCL_LIBSMM_DEBUG) && 0
 # define OPENCL_LIBSMM_DEBUG 1
@@ -63,6 +63,8 @@ typedef struct opencl_libsmm_trans_t {
 typedef struct opencl_libsmm_smmkey_t {
   libsmm_acc_data_t type; /* must be the 1st data member */
   int m, n, k;
+  /* device that matches configuration (parameters) */
+  const char* device; /* must be the last data member */
 } opencl_libsmm_smmkey_t;
 
 /** Type for SMM-kernel configuration. */
@@ -87,10 +89,14 @@ typedef struct opencl_libsmm_perfest_t {
 /** If buffers are hinted for non-concurrent writes aka "OpenCL constant". */
 int opencl_libsmm_use_cmem(cl_device_id device);
 
-/* Tokenize parambuf and initialize key/value pair. */
+/** Tokenize parambuf and initialize key/value pair. */
 int opencl_libsmm_read_params(char* parambuf,
   opencl_libsmm_smmkey_t* key, opencl_libsmm_smm_t* value,
-  opencl_libsmm_perfest_t* perfest);
+  opencl_libsmm_perfest_t* perfest,
+  char* const* device);
+
+/** Get active device and configuration name. */
+int opencl_libsmm_device(void* stream, cl_device_id* device, const char** config);
 
 #if defined(OPENCL_LIBSMM_DEBUG) && defined(_DEBUG)
 void opencl_libsmm_print_matrix(FILE* ostream, const char* label,


### PR DESCRIPTION
* Additional/alternative tunable names (OPENCL_LIBSMM_SMM_~): BS, BM, BN.
* Introduced DEV=2 to perform static code-analysis (Makefile).
* Only load device-specific/matching tuned parameters.
* Kernel code cleanup (renamed variables, etc).
* Updated LIBXSMM (Daint-CI/OpenCL).

acc_opencl.sh
* Handle empty DEVICE column, Windows newline (CSV), and prefer OPENCL_LIBSMM_PARAMS_DEVICE=NULL if unknown.
* Only attempt to delete the OFILE if it is a header-file (not a pseudo file like /dev/stdout).
* Include device name used to tune parameters (OPENCL_LIBSMM_PARAMS_DEVICE).
* Account for macOS' wordcount command (which adds leading spaces).
* Check/limit to single/consistent device (parameter collection).
* Disallow space character as separator (CSV file).
* Handle an optional DEVICE column in CSV-file.

tune_multiply.py
* Adjusted default such that --no-dups is active.
* Include device name in JSON files and CSV file.
* Handle an optional DEVICE column in CSV-file.
* Use label for unique database session.
* Leave device name empty if unknown.