### PR TITLE
ACC benchmarks and code cleanup

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -15,7 +15,7 @@ add_custom_target(
   COMMAND "${FORD_EXE}" "${FORD_PROJECT_FILE}"
   VERBATIM)
 add_dependencies(doc doc_copy_tests)
-if (WITH_C_API)
+if (WITH_C_API AND WITH_EXAMPLES)
   add_dependencies(doc doc_copy_examples)
 endif ()
 add_dependencies(doc fypp) # only depend on the fypp step to avoid building

--- a/src/acc/acc_bench.h
+++ b/src/acc/acc_bench.h
@@ -1,0 +1,64 @@
+/*------------------------------------------------------------------------------------------------*
+ * Copyright (C) by the DBCSR developers group - All rights reserved                              *
+ * This file is part of the DBCSR library.                                                        *
+ *                                                                                                *
+ * For information on the license, see the LICENSE file.                                          *
+ * For further information please visit https://dbcsr.cp2k.org                                    *
+ * SPDX-License-Identifier: GPL-2.0+                                                              *
+ *------------------------------------------------------------------------------------------------*/
+#ifndef DBCSR_ACC_BENCH_H
+#define DBCSR_ACC_BENCH_H
+
+#include <stdlib.h>
+#include <assert.h>
+
+#if !defined(MIN)
+# define MIN(A, B) ((A) < (B) ? (A) : (B))
+#endif
+#if !defined(MAX)
+# define MAX(A, B) ((B) < (A) ? (A) : (B))
+#endif
+
+#if !defined(INLINE) && (defined(__cplusplus) || \
+    (defined(__STDC_VERSION__) && (199901L <= __STDC_VERSION__) /*C99*/))
+# define INLINE inline
+#else
+# define INLINE
+#endif
+
+#define INIT_MAT(ELEM_TYPE, SEED, MAT, M, N, SCALE) do { \
+  const double init_mat_seed1_ = (SCALE) * (SEED) + (SCALE); \
+  int init_mat_i_, init_mat_j_; \
+  for (init_mat_i_ = 0; init_mat_i_ < (N); ++init_mat_i_) { \
+    for (init_mat_j_ = 0; init_mat_j_ < (M); ++init_mat_j_) { \
+      const int init_mat_k_ = init_mat_i_ * (M) + init_mat_j_; \
+      ((ELEM_TYPE*)(MAT))[init_mat_k_] = (ELEM_TYPE)(init_mat_seed1_ * (init_mat_k_ + 1)); \
+    } \
+  } \
+} while(0)
+
+
+/* artificial stack-setup for DBCSR/ACC benchmarks */
+static INLINE void init_stack(int* stack, int stack_size,
+  int mn, int mk, int kn, int nc, int na, int nb)
+{
+  /* navg matrix products are accumulated into a C-matrix */
+  int navg = stack_size / nc;
+  int nimb = MAX(1, navg - 4); /* imbalance */
+  int i = 0, c = 0, ntop = 0;
+  assert(0 < nc && nc <= stack_size);
+  while (i < stack_size) {
+    const int next = c + 1;
+    ntop += navg + (rand() % (2 * nimb) - nimb);
+    if (stack_size < ntop) ntop = stack_size;
+    for (;i < ntop; ++i) { /* setup one-based indexes */
+      const int a = rand() % na, b = rand() % nb;
+      *stack++ = a * mk + 1; /* A-index */
+      *stack++ = b * kn + 1; /* B-index */
+      *stack++ = c * mn + 1; /* C-index */
+    }
+    if (next < nc) c = next;
+  }
+}
+
+#endif /*DBCSR_ACC_BENCH_H*/

--- a/src/acc/libsmm_acc/libsmm_acc.cpp
+++ b/src/acc/libsmm_acc/libsmm_acc.cpp
@@ -63,7 +63,7 @@ inline void validate_kernel(ACC_DRV(function)& kern_func, ACC_DRV(stream) stream
     memset(h->mat_c, 0, h->n_c * m * n * sizeof(double));
     matInit(h->mat_a, h->n_a, m, k, 42);
     matInit(h->mat_b, h->n_b, k, n, 24);
-    stackInit(h->stack, h->n_stack, h->n_c, h->mat_c, h->n_a, h->mat_a, h->n_b, h->mat_b, m, n, k);
+    stackInit(h->stack, h->n_stack, h->n_c, h->n_a, h->n_b, m, n, k);
 
     stackCalc(h->stack, h->n_stack, h->mat_c, h->mat_a, h->mat_b, m, n, k);
     double sumCPU = checkSum(h->mat_c, h->n_c, m, n);

--- a/src/acc/libsmm_acc/libsmm_acc_benchmark.cpp
+++ b/src/acc/libsmm_acc/libsmm_acc_benchmark.cpp
@@ -14,7 +14,7 @@
 #include "libsmm_acc_benchmark.h"
 #include "parameters.h"
 #include "parameters_utils.h"
-#include "../acc_libsmm.h"
+#include "../acc_bench.h"
 
 
 //===========================================================================

--- a/src/acc/libsmm_acc/libsmm_acc_benchmark.cpp
+++ b/src/acc/libsmm_acc/libsmm_acc_benchmark.cpp
@@ -14,6 +14,7 @@
 #include "libsmm_acc_benchmark.h"
 #include "parameters.h"
 #include "parameters_utils.h"
+#include "../acc_libsmm.h"
 
 
 //===========================================================================
@@ -111,41 +112,10 @@ void matInit(double* mat, int mat_n, int x, int y, int seed){
 //===========================================================================
 // initialize the task list ("stack" in DBCSR lingo)
 // for each of the result matrices we have a random number
-void stackInit(int *stack, int n_stack, int n_c, double* mat_c,
-               int n_a, double * mat_a, int n_b, double* mat_b,
+void stackInit(int *stack, int n_stack, int n_c, int n_a, int n_b,
                int mat_m, int mat_n, int mat_k){
 
-  if(n_stack < n_c){
-    printf("Error: n_stack < n_c\n");
-    exit(1);
-  }
-
-  // on average, we have n_avg matrix products contributing to a result mat_c
-  int n_avg = n_stack / n_c;
-
-  int n_imbalance = std::max(1, n_avg-4);
-
-  int c = 0;
-  int n_top = 0;
-  int p = 0;
-
- int* s = stack;
-  while( p < n_stack ){
-    if(c >= n_c) c = n_c-1;
-
-    n_top += n_avg + (rand() % (2*n_imbalance) - n_imbalance);
-    if(n_top > n_stack) n_top = n_stack;
-
-    for(;p < n_top; p++){
-     int a = rand() % n_a;
-     int b = rand() % n_b;
-
-     *s++ =  a * mat_m * mat_k + 1;        // A_src
-     *s++ =  b * mat_k * mat_n + 1;        // B_src
-     *s++ =  c * mat_m * mat_n + 1;        // C_dst
-    }
-    c++;
- }
+  init_stack(stack, n_stack, mat_m * mat_n, mat_m * mat_k, mat_k * mat_n, n_c, n_a, n_b);
 }
 
 
@@ -298,7 +268,7 @@ int libsmm_acc_benchmark(libsmm_acc_benchmark_t* h,
 
  if(h->mode == tune)
      printf("Initializing ...\n");
- stackInit(h->stack, h->n_stack, h->n_c, h->mat_c, h->n_a, h->mat_a, h->n_b, h->mat_b, mat_m, mat_n, mat_k);
+ stackInit(h->stack, h->n_stack, h->n_c, h->n_a, h->n_b, mat_m, mat_n, mat_k);
 
  // Actually, we would have to calculate the stack n_iter times.
  // We cheat by simply scaling the results of a single stack calculation.

--- a/src/acc/libsmm_acc/libsmm_acc_benchmark.h
+++ b/src/acc/libsmm_acc/libsmm_acc_benchmark.h
@@ -50,8 +50,7 @@ typedef struct {
 
 void matInit(double* mat, int mat_n, int x, int y, int seed);
 
-void stackInit(int *stack, int n_stack, int n_c, double* mat_c,
-               int n_a, double * mat_a, int n_b, double* mat_b,
+void stackInit(int *stack, int n_stack, int n_c, int n_a, int n_b,
                int mat_m, int mat_n, int mat_k);
 void stackInitTransp(int *stack, int n_stack, int mat_m, int mat_n);
 

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -19,6 +19,7 @@ CFLAGS := -fPIC \
   -Wall -Wextra -pedantic \
   -Wno-overlength-strings \
   -Wno-variadic-macros \
+  -Wno-unused-function \
   -Wno-long-long \
   -D__OPENCL \
   $(NULL)
@@ -74,21 +75,25 @@ ifneq (0,$(SYM))
 endif
 
 ifneq (0,$(OMP))
-ifneq (0,$(INTEL))
-  CFLAGS += -qopenmp
-  LDFLAGS += -qopenmp
-else ifneq (Darwin,$(UNAME))
-  CFLAGS += -fopenmp
-  LDFLAGS += -fopenmp
-else # macOS
-  CFLAGS += -Xpreprocessor -fopenmp
-  LDFLAGS += -lomp
-endif
-endif
-
-ifneq (,$(LIBXSMMROOT))
-  LDFLAGS := -pthread $(LDFLAGS) -L$(LIBXSMMROOT)/lib -lxsmmext -lxsmm -lxsmmnoblas -ldl -lm
-  CFLAGS += -pthread -D__LIBXSMM -I$(LIBXSMMROOT)/include
+  ifneq (0,$(INTEL))
+    CFLAGS += -qopenmp
+    LDFLAGS += -qopenmp
+  else ifneq (Darwin,$(UNAME))
+    CFLAGS += -fopenmp
+    LDFLAGS += -fopenmp
+  else # macOS
+    CFLAGS += -Xpreprocessor -fopenmp
+    LDFLAGS += -lomp
+  endif
+  ifneq (,$(LIBXSMMROOT))
+    LDFLAGS := -pthread $(LDFLAGS) -L$(LIBXSMMROOT)/lib -lxsmmext -lxsmm -lxsmmnoblas -ldl -lm
+    CFLAGS += -pthread -D__LIBXSMM -I$(LIBXSMMROOT)/include
+  endif
+else
+  ifneq (,$(LIBXSMMROOT))
+    LDFLAGS := -pthread $(LDFLAGS) -L$(LIBXSMMROOT)/lib -lxsmm -lxsmmnoblas -ldl -lm
+    CFLAGS += -pthread -D__LIBXSMM -I$(LIBXSMMROOT)/include
+  endif
 endif
 
 ifeq (Darwin,$(UNAME))

--- a/src/core/dbcsr_config.F
+++ b/src/core/dbcsr_config.F
@@ -97,10 +97,10 @@ MODULE dbcsr_config
       INTEGER  :: num_layers_3D = 1
       LOGICAL  :: use_comm_thread = .TRUE.
       INTEGER  :: comm_thread_load = 100
-#if !defined (__DBCSR_ACC)
-      LOGICAL  :: mm_densification = .TRUE.
-#else
+#if defined (__DBCSR_ACC)
       LOGICAL  :: mm_densification = .FALSE.
+#else
+      LOGICAL  :: mm_densification = .TRUE.
 #endif
       INTEGER  :: multrec_limit = 512
       INTEGER  :: accdrv_priority_streams = 4

--- a/src/mm/dbcsr_acc_operations.F
+++ b/src/mm/dbcsr_acc_operations.F
@@ -52,11 +52,8 @@ MODULE dbcsr_acc_operations
          INTEGER(KIND=C_INT), INTENT(IN), VALUE   :: max_kernel_dim, def_mnk
          TYPE(C_PTR), VALUE                       :: stack_stream_ptr, c_stream_ptr
          INTEGER(KIND=C_INT)                      :: istat
-
       END FUNCTION libsmm_acc_process_cu
-   END INTERFACE
 
-   INTERFACE
       FUNCTION libsmm_acc_transpose_cu(trs_stack, offset, nblks, buffer, &
                                        data_type, m, n, max_kernel_dim, stream_ptr) &
          RESULT(istat) &
@@ -69,33 +66,31 @@ MODULE dbcsr_acc_operations
          INTEGER(KIND=C_INT), INTENT(IN), VALUE   :: max_kernel_dim
          TYPE(C_PTR), VALUE                       :: stream_ptr
          INTEGER(KIND=C_INT)                      :: istat
-
       END FUNCTION libsmm_acc_transpose_cu
    END INTERFACE
 #endif
 
 CONTAINS
 
-   SUBROUTINE dbcsr_acc_do_mm_stack(param_stack_host, param_stack_dev, stack_size, datatype, &
-      !! Launch an accelerated kernel for processing a stack.
+   SUBROUTINE dbcsr_acc_do_mm_stack(param_stack_host, param_stack_dev, stack_size, data_type, &
                                     a_data, b_data, c_data, m_max, n_max, k_max, def_mnk, &
                                     stack_stream, c_stream, success)
+      !! Launch an accelerated kernel for processing a stack.
       INTEGER, DIMENSION(:, :), TARGET, INTENT(IN) :: param_stack_host
       TYPE(acc_devmem_type), INTENT(IN)            :: param_stack_dev
       INTEGER, INTENT(IN)                          :: stack_size
-      INTEGER, INTENT(IN)                          :: datatype
+      INTEGER, INTENT(IN)                          :: data_type
       TYPE(acc_devmem_type), INTENT(IN)            :: a_data, b_data
       TYPE(acc_devmem_type), INTENT(INOUT)         :: c_data
       INTEGER, INTENT(IN)                          :: m_max, n_max, k_max
       LOGICAL, INTENT(IN)                          :: def_mnk
       TYPE(acc_stream_type), INTENT(IN)            :: stack_stream, c_stream
       LOGICAL, INTENT(INOUT)                       :: success
-
 #if ! defined (__DBCSR_ACC)
       MARK_USED(param_stack_host)
       MARK_USED(param_stack_dev)
       MARK_USED(stack_size)
-      MARK_USED(datatype)
+      MARK_USED(data_type)
       MARK_USED(a_data)
       MARK_USED(b_data)
       MARK_USED(c_data)
@@ -108,7 +103,6 @@ CONTAINS
       MARK_USED(success)
       DBCSR_ABORT("__DBCSR_ACC not compiled in.")
 #else
-
       CHARACTER(len=*), PARAMETER :: routineN = 'dbcsr_acc_do_mm_stack'
 
       INTEGER                                  :: error_handle, istat
@@ -128,7 +122,7 @@ CONTAINS
                                     acc_devmem_cptr(param_stack_dev), &
                                     INT(stack_size, KIND=C_INT), &
                                     INT(dbcsr_ps_width, KIND=C_INT), &
-                                    INT(datatype, KIND=C_INT), &
+                                    INT(data_type, KIND=C_INT), &
                                     acc_devmem_cptr(a_data), &
                                     acc_devmem_cptr(b_data), &
                                     acc_devmem_cptr(c_data), &
@@ -144,28 +138,26 @@ CONTAINS
 #endif
    END SUBROUTINE dbcsr_acc_do_mm_stack
 
-   SUBROUTINE dbcsr_acc_transpose(trs_stack, offset, nblks, datatype, buffer, m, n, stream)
+   SUBROUTINE dbcsr_acc_transpose(trs_stack, offset, nblks, data_type, buffer, m, n, stream)
       !! Launch an accelerated transpose kernel
       TYPE(acc_devmem_type), INTENT(IN)        :: trs_stack
       INTEGER, INTENT(IN)                      :: offset
       INTEGER, INTENT(IN)                      :: nblks
-      INTEGER, INTENT(IN)                      :: datatype
+      INTEGER, INTENT(IN)                      :: data_type
       TYPE(acc_devmem_type), INTENT(IN)        :: buffer
       INTEGER, INTENT(IN)                      :: m, n
       TYPE(acc_stream_type), INTENT(IN)        :: stream
-
 #if ! defined (__DBCSR_ACC)
       MARK_USED(trs_stack)
       MARK_USED(offset)
       MARK_USED(nblks)
-      MARK_USED(datatype)
+      MARK_USED(data_type)
       MARK_USED(buffer)
       MARK_USED(m)
       MARK_USED(n)
       MARK_USED(stream)
       DBCSR_ABORT("__DBCSR_ACC not compiled in.")
 #else
-
       CHARACTER(len=*), PARAMETER :: routineN = 'dbcsr_acc_transpose'
 
       INTEGER                                  :: error_handle, istat
@@ -180,7 +172,7 @@ CONTAINS
                                          INT(offset, KIND=C_INT), &
                                          INT(nblks, KIND=C_INT), &
                                          acc_devmem_cptr(buffer), &
-                                         INT(datatype, KIND=C_INT), &
+                                         INT(data_type, KIND=C_INT), &
                                          INT(m, KIND=C_INT), &
                                          INT(n, KIND=C_INT), &
                                          INT(max_kernel_dim, KIND=C_INT), &

--- a/src/mm/dbcsr_mm_common.F
+++ b/src/mm/dbcsr_mm_common.F
@@ -444,7 +444,7 @@ CONTAINS
                   trs_stack=trs_stackbuf%d%acc_devmem, &
                   offset=offsets(mi, ni), &
                   nblks=counters(mi, ni), &
-                  datatype=matrix%data_type, &
+                  data_type=matrix%data_type, &
                   buffer=matrix%data_area%d%acc_devmem, &
                   m=m, n=n, &
                   stream=trs_stackbuf%d%memory_type%acc_stream)

--- a/src/mm/dbcsr_mm_sched.F
+++ b/src/mm/dbcsr_mm_sched.F
@@ -23,9 +23,7 @@ MODULE dbcsr_mm_sched
                            has_acc
    USE dbcsr_data_methods, ONLY: dbcsr_data_ensure_size, &
                                  dbcsr_data_get_size
-   USE dbcsr_kinds, ONLY: int_4, &
-                          int_8, &
-                          real_8
+   USE dbcsr_kinds, ONLY: int_4, int_8, real_8
    USE dbcsr_mm_accdrv, ONLY: &
       dbcsr_mm_accdrv_barrier, dbcsr_mm_accdrv_dev2host_init, dbcsr_mm_accdrv_finalize, &
       dbcsr_mm_accdrv_init, dbcsr_mm_accdrv_lib_finalize, dbcsr_mm_accdrv_lib_init, &
@@ -272,8 +270,8 @@ CONTAINS
    END SUBROUTINE dbcsr_mm_sched_barrier
 
    SUBROUTINE dbcsr_mm_sched_process(this, left, right, stack_data, &
-      !! Processes a given stack.
                                      stack_fillcount, stack_descr)
+      !! Processes a given stack.
       TYPE(dbcsr_mm_sched_type), INTENT(INOUT)           :: this
       TYPE(dbcsr_type), INTENT(IN)                       :: left, right
       INTEGER, DIMENSION(:, :), POINTER                  :: stack_data

--- a/tests/dbcsr_performance_driver.F
+++ b/tests/dbcsr_performance_driver.F
@@ -43,15 +43,12 @@ PROGRAM dbcsr_performance_driver
 
    !***************************************************************************************
 
-   !
    ! initialize mpi
    CALL mp_world_init(mp_comm)
 
-   !
    ! Number of nodes and rankid
    CALL mp_environ(numnodes, mynode, mp_comm)
 
-   !
    ! read and distribute input args
    IF (mynode .EQ. 0) CALL dbcsr_test_read_args(narg, args)
    CALL mp_bcast(narg, 0, mp_comm)
@@ -59,7 +56,6 @@ PROGRAM dbcsr_performance_driver
    IF (narg .LT. 1) &
       DBCSR_ABORT("nargs not correct")
 
-   !
    ! setup the mp environment
    IF (atoi(args(1)) .LE. 0) THEN
       npdims(:) = 0
@@ -82,12 +78,10 @@ PROGRAM dbcsr_performance_driver
                      myprow=myploc(1), mypcol=myploc(2))
    DEALLOCATE (pgrid)
 
-   !
    ! set standard output parameters
    io_unit = 0
    IF (mynode .EQ. mp_env%mp%source) io_unit = default_output_unit
 
-   !
    ! initialize libdbcsr
    CALL dbcsr_init_lib(mp_comm, io_unit)
 
@@ -97,11 +91,9 @@ PROGRAM dbcsr_performance_driver
    ! Check for MPI-RMA algorithm
    CALL dbcsr_set_config(use_mpi_rma=atol(args(2)))
 
-   !
    ! print DBCSR configuration
    CALL dbcsr_print_config(io_unit)
 
-   !
    ! select the operation
    SELECT CASE (args(3))
    CASE ('dbcsr_multiply')
@@ -110,27 +102,21 @@ PROGRAM dbcsr_performance_driver
       DBCSR_ABORT("operation not found")
    END SELECT
 
-   !
    ! finalize libdbcsr errors
    CALL timestop(handle)
 
-   !
    ! clean mp environment
    CALL dbcsr_mp_release(mp_env)
 
-   !
    ! free comm
    CALL mp_comm_free(group)
 
-   !
    ! print statistics
    CALL dbcsr_print_statistics(.true., "test.callgraph")
 
-   !
    ! finalize DBCSR
    CALL dbcsr_finalize_lib()
-   !
-   !
+
    ! finalize mpi
    CALL mp_world_finalize()
 

--- a/tests/dbcsr_tensor_unittest.F
+++ b/tests/dbcsr_tensor_unittest.F
@@ -811,7 +811,6 @@ PROGRAM dbcsr_tensor_unittest
    ! finalize libdbcsr
    CALL dbcsr_finalize_lib()
 
-   !
    ! finalize mpi
    CALL mp_world_finalize()
 

--- a/tests/dbcsr_test_csr_conversions.F
+++ b/tests/dbcsr_test_csr_conversions.F
@@ -9,6 +9,7 @@
 
 PROGRAM dbcsr_test_csr_conversions
    !! Testing DBCSR to CSR conversion with random matrices
+   USE dbcsr_kinds, ONLY: dp, real_8
    USE dbcsr_api, ONLY: &
       dbcsr_convert_csr_to_dbcsr, dbcsr_convert_dbcsr_to_csr, &
       dbcsr_csr_create_from_dbcsr, dbcsr_csr_destroy, &
@@ -18,8 +19,6 @@ PROGRAM dbcsr_test_csr_conversions
       dbcsr_init_lib, dbcsr_nblkcols_total, dbcsr_nblkrows_total, dbcsr_norm, &
       dbcsr_norm_maxabsnorm, dbcsr_put_block, dbcsr_release, dbcsr_to_csr_filter, dbcsr_type, &
       dbcsr_type_no_symmetry, dbcsr_type_real_8, dbcsr_print_statistics
-   USE dbcsr_kinds, ONLY: dp, &
-                          real_8
    USE dbcsr_machine, ONLY: default_output_unit
    USE dbcsr_mpiwrap, ONLY: mp_bcast, &
                             mp_cart_create, &

--- a/tests/dbcsr_unittest1.F
+++ b/tests/dbcsr_unittest1.F
@@ -61,12 +61,11 @@ PROGRAM dbcsr_unittest_1
    CALL dbcsr_mp_new(mp_env, group, pgrid, mynode, numnodes, &
                      myprow=myploc(1), mypcol=myploc(2))
    DEALLOCATE (pgrid)
-   !
+
    ! set standard output parameters
    io_unit = 0
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
-   !
    ! initialize libdbcsr
    CALL dbcsr_init_lib(mp_comm, io_unit)
 

--- a/tests/dbcsr_unittest1.F
+++ b/tests/dbcsr_unittest1.F
@@ -42,9 +42,6 @@ PROGRAM dbcsr_unittest_1
 
    !***************************************************************************************
 
-   !
-
-   !
    ! initialize mpi
    CALL mp_world_init(mp_comm)
 
@@ -302,11 +299,10 @@ PROGRAM dbcsr_unittest_1
    ! end of test cases ---------------------------------------------------------
 
    CALL timestop(handle)
-   !
+
    ! clean mp environment
    CALL dbcsr_mp_release(mp_env)
 
-   !
    ! finalize mpi
    CALL mp_comm_free(group)
 
@@ -314,8 +310,5 @@ PROGRAM dbcsr_unittest_1
    ! finalize libdbcsr
    CALL dbcsr_finalize_lib()
    CALL mp_world_finalize()
-
-   !
-   ! finalize libdbcsr errors
 
 END PROGRAM dbcsr_unittest_1

--- a/tests/dbcsr_unittest2.F
+++ b/tests/dbcsr_unittest2.F
@@ -59,16 +59,15 @@ PROGRAM dbcsr_unittest_2
    CALL dbcsr_mp_new(mp_env, group, pgrid, mynode, numnodes, &
                      myprow=myploc(1), mypcol=myploc(2))
    DEALLOCATE (pgrid)
-   !
+
    ! set standard output parameters
    io_unit = 0
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
-   !
    ! initialize libdbcsr
    CALL dbcsr_init_lib(mp_comm, io_unit)
 
-   !
+
    ! initialize libdbcsr errors
    CALL timeset(routineN, handle)
 

--- a/tests/dbcsr_unittest2.F
+++ b/tests/dbcsr_unittest2.F
@@ -42,7 +42,6 @@ PROGRAM dbcsr_unittest_2
 
    !***************************************************************************************
 
-   !
    ! initialize mpi
    CALL mp_world_init(mp_comm)
 
@@ -66,7 +65,6 @@ PROGRAM dbcsr_unittest_2
 
    ! initialize libdbcsr
    CALL dbcsr_init_lib(mp_comm, io_unit)
-
 
    ! initialize libdbcsr errors
    CALL timeset(routineN, handle)
@@ -109,15 +107,12 @@ PROGRAM dbcsr_unittest_2
 
    ! end of test cases ---------------------------------------------------------
 
-   !
    ! finalize libdbcsr errors
    CALL timestop(handle)
 
-   !
    ! clean mp environment
    CALL dbcsr_mp_release(mp_env)
 
-   !
    ! finalize mpi
    CALL mp_comm_free(group)
 

--- a/tests/dbcsr_unittest3.F
+++ b/tests/dbcsr_unittest3.F
@@ -59,15 +59,14 @@ PROGRAM dbcsr_unittest_3
    CALL dbcsr_mp_new(mp_env, group, pgrid, mynode, numnodes, &
                      myprow=myploc(1), mypcol=myploc(2))
    DEALLOCATE (pgrid)
-   !
+
    ! set standard output parameters
    io_unit = 0
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
-   !
    ! initialize libdbcsr
    CALL dbcsr_init_lib(mp_comm, io_unit)
-   !
+
    ! initialize libdbcsr errors
    CALL timeset(routineN, handle)
 

--- a/tests/dbcsr_unittest3.F
+++ b/tests/dbcsr_unittest3.F
@@ -42,7 +42,6 @@ PROGRAM dbcsr_unittest_3
 
    !***************************************************************************************
 
-   !
    ! initialize mpi
    CALL mp_world_init(mp_comm)
 
@@ -76,7 +75,6 @@ PROGRAM dbcsr_unittest_3
 
    ! multiply ------------------------------------------------------------------
 
-   ! ...
    CALL dbcsr_test_multiplies("blocks_1_3_4", &
                               group, mp_env, npdims, io_unit, matrix_sizes=(/496, 48, 48/), &
                               sparsities=(/0.5_dp, 0.5_dp, 0.5_dp/), retain_sparsity=.FALSE., &
@@ -122,15 +120,12 @@ PROGRAM dbcsr_unittest_3
 
    ! end of test cases ---------------------------------------------------------
 
-   !
    ! finalize libdbcsr errors
    CALL timestop(handle)
 
-   !
    ! clean mp environment
    CALL dbcsr_mp_release(mp_env)
 
-   !
    ! finalize mpi
    CALL mp_comm_free(group)
 

--- a/tests/dbcsr_unittest4.F
+++ b/tests/dbcsr_unittest4.F
@@ -40,7 +40,6 @@ PROGRAM dbcsr_unittest
 
    CHARACTER(len=*), PARAMETER :: routineN = 'dbcsr_unittest'
 
-   !
    ! initialize mpi
    CALL mp_world_init(mp_comm)
 
@@ -90,11 +89,10 @@ PROGRAM dbcsr_unittest
                                          sparsity=0.0_dp, bs_m=[1, 4], bs_n=[1, 4], do_exact_comparison=.TRUE.) &
              .AND. success
    CALL timestop(handle)
-   !
+
    ! clean mp environment
    CALL dbcsr_mp_release(mp_env)
 
-   !
    ! finalize mpi
    CALL mp_comm_free(group)
 
@@ -103,7 +101,6 @@ PROGRAM dbcsr_unittest
    CALL dbcsr_finalize_lib()
    CALL mp_world_finalize()
 
-   !
    ! finalize libdbcsr errors
    IF (.NOT. success) &
       ERROR STOP "one or more tests failed"

--- a/tests/dbcsr_unittest4.F
+++ b/tests/dbcsr_unittest4.F
@@ -58,12 +58,10 @@ PROGRAM dbcsr_unittest
                      myprow=myploc(1), mypcol=myploc(2))
    DEALLOCATE (pgrid)
 
-   !
    ! set standard output parameters
    io_unit = 0
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
-   !
    ! initialize DBCSR
    CALL dbcsr_init_lib(mp_comm, io_unit)
 


### PR DESCRIPTION
ACC benchmark drivers (SMM and Transpose)

* Improved validation output and reintroduced error margin (ACC_BENCH_SMM_EPSILON).
* Validation still does not control result code unless CHECK is given
* (CHECK=1 is a real number "1.0" scaling the ACC_BENCH_SMM_EPSILON).
* Wrap libxsmm_itrans_batch depending on whether OpenMP is present or not.
* OpenMP-parallel data initialization and code cleanup (INIT_MAT).
* Made OpenMP runtime optional (and libxsmmext library).

Use consistent stack-initialization for CUDA/HIP and OpenCL benchmarks

* Made init_stack and INIT_MAT available (acc_bench.h).
* Removed unused arguments of stackInit function.

Other

* Target doc_copy_examples does not exist if WITH_EXAMPLES=OFF.
* Marked libsmm_acc_process as extern "C" (CUDA/HIP backend).
* Code cleanup (comments, empty lines/comments, etc).