### PR TITLE
Removed non-compiling dead code. Avoid unused variable warning

### DIFF
--- a/tests/dbcsr_tensor_test.cpp
+++ b/tests/dbcsr_tensor_test.cpp
@@ -21,11 +21,6 @@
 #include <tensors/dbcsr_tensor.h>
 #include <complex.h>
 
-const int dbcsr_type_real_4 = 1;
-const int dbcsr_type_real_8 = 3;
-const int dbcsr_type_complex_4 = 5;
-const int dbcsr_type_complex_8 = 7;
-
 //-------------------------------------------------------------------------------------------------!
 // Testing the tensor contraction (13|2)x(54|21)=(3|45)
 // and several other functions, to make sure there are not any segmentation faults
@@ -39,13 +34,6 @@ template <typename T>
 T get_rand_real() {
 
     return dis(gen);
-
-}
-
-template <typename T>
-T get_rand_complex() {
-
-    return dis(gen) + dis(gen) * I;
 
 }
 


### PR DESCRIPTION
The test in question looks like behind the original plan (support for complex-valued matrices). The issue could not been reproduced even when using clang (default compiler under BSD). However, the problematic code was removed (unused).