### PR TITLE
ocl-misc: improved Makefile and tune_multiply.py

### DIFF
--- a/src/acc/acc_bench_smm.c
+++ b/src/acc/acc_bench_smm.c
@@ -282,7 +282,7 @@ int main(int argc, char* argv[])
             }
           }
         }
-        printf("max.error: eps=%g (%g != %g)\n", relerror / nr, a, b);
+        printf("max.error: %g (%g != %g)\n", relerror / nr, a, b);
         if (0 < check && (nr * check) < relerror) result = EXIT_FAILURE;
       }
     }

--- a/src/acc/acc_bench_smm.c
+++ b/src/acc/acc_bench_smm.c
@@ -73,6 +73,7 @@ int main(int argc, char* argv[])
   const int nc = (0 < inc ? MIN(inc, stack_size) : MAX(stack_size / 16, 1));
   const int na = (0 < ina ? ina : (10 * nc));
   const int nb = (0 < inb ? inb : (10 * nc));
+  const int nr = nrepeat * nc;
 #if defined(ALIGNMENT) && (0 < ALIGNMENT)
   const int ma = (int)ROUNDUP2(sizeof(ELEM_TYPE) * m, ALIGNMENT);
   const int ka = (int)ROUNDUP2(sizeof(ELEM_TYPE) * k, ALIGNMENT);
@@ -140,12 +141,12 @@ int main(int argc, char* argv[])
 #if defined(_OPENMP)
 #   pragma omp for
 #endif
-    for (i = 0; i < na; ++i) INIT_MAT(ELEM_TYPE, i/*seed*/ + 42, &amat_hst[i*mk], m, k, 1.0 / (nc * na));
+    for (i = 0; i < na; ++i) INIT_MAT(ELEM_TYPE, i/*seed*/ + 42, &amat_hst[i*mk], m, k, 1.0 / (nr * na));
 #if defined(_OPENMP)
 #   pragma omp for
 #endif
     for (i = 0; i < nb; ++i) {
-      INIT_MAT(ELEM_TYPE, i/*seed*/ + 24, &bmat_hst[i*kn], k, n, 1.0 / (nc * nb));
+      INIT_MAT(ELEM_TYPE, i/*seed*/ + 24, &bmat_hst[i*kn], k, n, 1.0 / (nr * nb));
       trans_hst[i] = i * kn;
     }
   }
@@ -281,9 +282,8 @@ int main(int argc, char* argv[])
             }
           }
         }
-        relerror /= (nc * nrepeat); /* normalize error */
-        printf("max.error: rel=%g (%g != %g)\n", relerror, a, b);
-        if (0 < check && check < relerror) result = EXIT_FAILURE;
+        printf("max.error: eps=%g (%g != %g)\n", relerror / nr, a, b);
+        if (0 < check && (nr * check) < relerror) result = EXIT_FAILURE;
       }
     }
     libxsmm_free(gold_hst);

--- a/src/acc/cuda/Makefile
+++ b/src/acc/cuda/Makefile
@@ -47,6 +47,10 @@ CFLAGS := -fPIC \
   -D__CUDA \
   $(NULL)
 
+ifneq (,$(ELEM_TYPE))
+  CFLAGS += -DELEM_TYPE=$(ELEM_TYPE)
+endif
+
 ifeq (1,$(INTEL))
   CXX := icpc
   CC := icc

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -24,6 +24,10 @@ CFLAGS := -fPIC \
   -D__OPENCL \
   $(NULL)
 
+ifneq (,$(ELEM_TYPE))
+  CFLAGS += -DELEM_TYPE=$(ELEM_TYPE)
+endif
+
 ifeq (1,$(INTEL))
   CXX := icpc
   CC := icc

--- a/src/acc/opencl/smm/README.md
+++ b/src/acc/opencl/smm/README.md
@@ -49,7 +49,7 @@ Auto tuning code for performance is a practical way to find the "best" setting f
 
 For the OpenCL based LIBSMM, `OPENCL_LIBSMM_SMM_BATCHSIZE`, `OPENCL_LIBSMM_SMM_BLOCK_M`, and `OPENCL_LIBSMM_SMM_BLOCK_N` are explored using [OpenTuner](http://opentuner.org/). The script [tune_multiply.py](https://github.com/cp2k/dbcsr/blob/develop/src/acc/opencl/smm/tune_multiply.py) leverages the `acc_bench_smm` benchmark by parsing console output (timing, data type, etc.). This way, the tuning is implemented without being intermingled with the subject being tuned.
 
-**NOTE**: To toggle between tuning single-precision (SP) and double-precision (DP), the `ELEM_TYPE` in [acc_bench_smm.c](https://github.com/cp2k/dbcsr/blob/develop/src/acc/acc_bench_smm.c#L26) can be edited. Auto-tuned parameters for SP and DP can both be embedded into the final application and are picked up correctly at runtime.
+**NOTE**: To toggle between tuning single-precision (SP) and double-precision (DP), the `ELEM_TYPE` in [acc_bench_smm.c](https://github.com/cp2k/dbcsr/blob/develop/src/acc/acc_bench_smm.c#L26) can be edited or the command to build the backend can be adjusted (`make ELEM_TYPE=float`). Auto-tuned parameters for SP and DP can both be embedded into the final application and are picked up correctly at runtime.
 
 To build the benchmarks:
 
@@ -87,7 +87,7 @@ The script finally writes a JSON-file with a filename like `tune_multiply-float-
 
 ## Optimized Kernels
 
-JSON-files in the above mentioned smm-directory are automatically summarized into a CSV-file (can be disabled). Parameters achieved with single-precision (SP) and double-precision (DP) can be safely combined. However, care must be taken to not summarize unrelated results like for different devices or after (major) kernel changes. The CSV-file contains a header-row with column names, and the content is automatically incorporated into LIBSMM by the next clean (re-)build.
+JSON-files in the above mentioned smm-directory are automatically summarized into a CSV-file (can be disabled). Parameters achieved with single-precision (SP), double-precision (DP), or from different devices can be safely combined. However, care must still be taken to not summarize unrelated results, e.g., after (major) source code changes. The CSV-file is automatically incorporated into LIBSMM by the next clean (re-)build. The format of the CSV-file is assumed to contain column names in the first row (header).
 
 ```bash
 cd src/acc/opencl

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -317,7 +317,7 @@ if __name__ == "__main__":
         default=0,
         nargs="?",
         dest="s",
-        help="Size of batch (\"stacksize\")",
+        help='Size of batch ("stacksize")',
     )
     argparser.add_argument(
         "-c",

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -107,7 +107,7 @@ class SmmTuner(MeasurementInterface):
         return performance
         """
         config = desired_result.configuration.data
-        run_cmd = "{} CHECK={} {}={} {}={} {}={} {}/{} 0 {} {} {} {}".format(
+        run_cmd = "{} CHECK={} {}={} {}={} {}={} {}/{} {} {} {} {} {}".format(
             "OMP_PROC_BIND=TRUE OPENCL_LIBSMM_SMM_PARAMS=0",
             self.args.check,
             "OPENCL_LIBSMM_SMM_BATCHSIZE",
@@ -119,6 +119,7 @@ class SmmTuner(MeasurementInterface):
             self.exepath,
             self.exename,
             self.args.r,
+            self.args.s,
             self.args.m,
             self.args.n,
             self.args.k,
@@ -311,6 +312,15 @@ if __name__ == "__main__":
     )
     argparser.add_argument(
         "-s",
+        "--batchsize",
+        type=int,
+        default=0,
+        nargs="?",
+        dest="s",
+        help="Size of batch (\"stacksize\")",
+    )
+    argparser.add_argument(
+        "-c",
         "--csv-separator",
         type=(lambda c: c if isinstance(c, str) and 1 == len(c) else False),
         default=";",
@@ -319,7 +329,7 @@ if __name__ == "__main__":
         help="Separator used in CSV-file",
     )
     argparser.add_argument(
-        "-c",
+        "-o",
         "--csv-filename",
         type=str,
         default="tune_multiply.csv",


### PR DESCRIPTION
* Avoid normalizing the relative error but consider it in a normalized fashion (acc_bench_smm).
* Revised short command line arguments. Introduced argument to customize size of SMM-batch.
* Fixed taking custom number of repetitions into account.
* Introduced ELEM_TYPE build key (make ELEM_TYPE=float).
* Slightly revised documentation.