### PR TITLE
Remove gpu arch passed to hiprtc

### DIFF
--- a/src/acc/libsmm_acc/libsmm_acc.cpp
+++ b/src/acc/libsmm_acc/libsmm_acc.cpp
@@ -152,8 +152,8 @@ inline void jit_kernel(ACC_DRV(function)& kern_func, libsmm_acc_algo algo, int t
     const char *compileOptions[] = {"-D__CUDA", "-w", ARCH_OPTION};
     size_t nOptions = 3;
 #else
-    const char *compileOptions[] = {"-D__HIP", ARCH_OPTION};
-    size_t nOptions = 2;
+    const char *compileOptions[] = {"-D__HIP"};
+    size_t nOptions = 1;
 #endif
     ACC_RTC_CALL(CompileProgram, (kernel_program, nOptions, compileOptions));
 
@@ -364,8 +364,8 @@ void jit_transpose_handle(ACC_DRV(function)& kern_func, int m, int n){
     const char *compileOptions[] = {"-D__CUDA", "-w", ARCH_OPTION};
     size_t nOptions = 3;
 #else
-    const char *compileOptions[] = {"-D__HIP", ARCH_OPTION};
-    size_t nOptions = 2;
+    const char *compileOptions[] = {"-D__HIP"};
+    size_t nOptions = 1;
 #endif
     ACC_RTC_CALL(CompileProgram, (kernel_program, nOptions, compileOptions));
 


### PR DESCRIPTION
JIT compilation fails in DBCSR with newer rocm versions (>=4.1)
because there is a mismatch detected between the target id passed to
hiprtcCompileProgram and what hiprtc already passes by default.

hiprtcCompileProgram now honors compile options passed to it. It
also by default has always passed the target ids of the default
device to the compiler, so we don't have to pass this architecture
string as a compile option again. This also helps avoid any
changes to DBCSR when target ids are modified for future AMD GPUs.