### PR TITLE
ocl-misc: various/minor SMM-kernel improvements and fixes

### DIFF
--- a/src/acc/cuda/Makefile
+++ b/src/acc/cuda/Makefile
@@ -27,17 +27,21 @@ ifeq (,$(PYTHON))
 endif
 
 ifeq ($(WITH_GPU),K20X)
- ARCH_NUMBER = 35
+  ARCH_NUMBER = 35
 else ifeq ($(WITH_GPU),K40)
- ARCH_NUMBER = 35
+  ARCH_NUMBER = 35
 else ifeq ($(WITH_GPU),K80)
- ARCH_NUMBER = 37
+  ARCH_NUMBER = 37
 else ifeq ($(WITH_GPU),P100)
- ARCH_NUMBER = 60
+  ARCH_NUMBER = 60
 else ifeq ($(WITH_GPU),V100)
- ARCH_NUMBER = 70
+  ARCH_NUMBER = 70
+else ifeq ($(WITH_GPU),A100)
+  # TODO: update when tuned parameters for A100 available
+  override WITH_GPU := V100
+  ARCH_NUMBER = 80
 else ifeq (,$(ARCH_NUMBER))
- $(error Unknown ARCH_NUMBER since WITH_GPU="$(WITH_GPU)" is not recognized)
+  $(error Unknown ARCH_NUMBER since WITH_GPU="$(WITH_GPU)" is not recognized)
 endif
 
 CFLAGS := -fPIC \

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -103,12 +103,16 @@ endif
 ifeq (Darwin,$(UNAME))
   LDFLAGS += -framework OpenCL
 else
+  ifeq (,$(CUDATOOLKIT_HOME))
+    CUDATOOLKIT_HOME := $(NVSDKCOMPUTE_ROOT)
+  endif
+  ifeq (,$(CUDATOOLKIT_HOME))
+    NVCC := $(shell which nvcc 2>/dev/null)
+    CUDATOOLKIT_HOME := $(if $(NVCC),$(abspath $(dir $(NVCC))/..))
+  endif
   ifneq (,$(CUDATOOLKIT_HOME))
     CFLAGS += -I$(CUDATOOLKIT_HOME)/include
     LDFLAGS += -L$(CUDATOOLKIT_HOME)/lib64
-  else ifneq (,$(NVSDKCOMPUTE_ROOT))
-    CFLAGS += -I$(NVSDKCOMPUTE_ROOT)/include
-    LDFLAGS += -L$(NVSDKCOMPUTE_ROOT)/lib64
   endif
   LDFLAGS += -lOpenCL
 endif

--- a/src/acc/opencl/smm/opencl_libsmm.c
+++ b/src/acc/opencl/smm/opencl_libsmm.c
@@ -989,11 +989,11 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
                 assert(1 <= bs && 0 < bm && 0 < bn && NULL != atomic_expr);
                 nchar = ACC_OPENCL_SNPRINTF(build_options, sizeof(build_options),
                   "%s -cl-fast-relaxed-math -cl-no-signed-zeros -cl-denorms-are-zero -DFMA=fma"
-                  " -DGLOBAL=%s -DFN=%s -DSM=%i -DSN=%i -DSK=%i -DBM=%i -DBN=%i -DBS=%i -DT=%s"
+                  " -DGLOBAL=%s -DFN=%s -DSM=%i -DSN=%i -DSK=%i -DBM=%i -DBN=%i -DBS=%i -DT=%s -DTN=%i"
                   " %s -D\"ATOMIC_ADD_GLOBAL(A,B)=%s\" %s",
                   (NULL == env_options || '\0' == *env_options) ? "" : env_options,
                   EXIT_SUCCESS != opencl_libsmm_use_cmem(active_device) ? "global" : "constant",
-                  fname, m_max, n_max, k_max, bm, bn, bs, tname, atomic_ops, atomic_expr,
+                  fname, m_max, n_max, k_max, bm, bn, bs, tname, datatype, atomic_ops, atomic_expr,
                   NULL == atomic_expr2 ? "" : atomic_expr2);
                 if (0 >= nchar || (int)sizeof(build_options) <= nchar) result = EXIT_FAILURE;
               }


### PR DESCRIPTION
* Introduced type-id for kernel-code (TN), and adjusted atomic_add_global_xchg code-path (PTX).
* Removed unnecessary barrier and made another (necessary) barrier conditional (at compile-time).
* Makefiles: Improved detecting OpenCL, use ARCH_NUMBER=80 if WITH_GPU=A100 (rely on V100-params).
* Fixed and adjusted ATOMIC_ADD2_GLOBAL code-path.