### PR TITLE
ocl-bench-doc: non-default active device for acc_bench drivers and documentation

### DIFF
--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -25,7 +25,7 @@ if [ ! -d "${HOME}/libxsmm" ]; then
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout fe2f3bb289cb79a208fdcafecbb3977f82caa415
+git checkout 471f136b0f8a05534ccd0a86dcf4429caec5e170
 make -j
 cd ..
 

--- a/src/acc/README.md
+++ b/src/acc/README.md
@@ -19,6 +19,8 @@ The code for both the OpenCL backends is enabled with a build-time macro (`__OPE
 
 Two stand-alone drivers (only depending on above mentioned interfaces) can be built locally and in a rather self-contained fashion, i.e., no DBCSR library is needed (except runtime libraries such as CUDA, HIP, OpenCL/LIBXSMM). For OpenCL, a folder `libxsmm` parallel to DBCSR's root directory (`dbcsr`) is expected to be present and prebuilt (`make` in LIBXSMM's root directory is enough). To build the driver code, change into the respective backend folder (`cuda` or `opencl`), and invoke `make` (`DBG=0|1|2`, and a few other key-value pairs are optional). When building the code is completed, change back into the parent folder and invoke either `acc_bench_trans` or `acc_bench_smm`.
 
+**NOTE**: To activate a certain device, an environment variable `DEVICE` can be used. For example, `DEVICE=1 ./acc_bench_trans` activates the second device (at least two devices must be discovered).
+
 The drivers support a few command line options (_nrepeat_, _stack_size_, _m_, _n_, ...). Command line arguments are positional but allow `0` as placeholder to access the default value (`acc_bench_smm 0 0 5 13 5` performs the default number of repetitions with the default stacksize when running the 5x13x5-kernel). For example, running the tranpose benchmark may look like:
 
 ```bash

--- a/src/acc/acc_bench_smm.c
+++ b/src/acc/acc_bench_smm.c
@@ -88,6 +88,8 @@ int main(int argc, char* argv[])
 #else
   const int warmup = 0;
 #endif
+  const char *const env_device = getenv("DEVICE");
+  const int device = ((NULL == env_device || '\0' == *env_device) ? 0 : atoi(env_device));
   int *stack_hst = NULL, *stack_dev = NULL, *trans_hst = NULL, *trans_dev = NULL;
   ELEM_TYPE *amat_hst = NULL, *bmat_hst = NULL, *cmat_hst = NULL;
   ELEM_TYPE *amat_dev = NULL, *bmat_dev = NULL, *cmat_dev = NULL;
@@ -112,13 +114,14 @@ int main(int argc, char* argv[])
   /* note: libsmm_acc_init() may imply acc_init() */
   CHECK(libsmm_acc_init(), &result);
   CHECK(c_dbcsr_acc_get_ndevices(&ndevices), &result);
-  if (0 < ndevices) {
+  if (0 < ndevices && EXIT_SUCCESS == c_dbcsr_acc_set_active_device(device)) {
 #if defined(_DEBUG)
-    fprintf(stderr, "number of devices found: %i\n", ndevices);
+    fprintf(stderr, "Activated device %i of %i.\n", device, ndevices);
 #endif
   }
   else {
-    fprintf(stderr, "No ACC-device found!\n");
+    if (0 < ndevices) fprintf(stderr, "No ACC-device found!\n");
+    else fprintf(stderr, "Failed to activate device %i of %i!\n", device, ndevices);
 #if !defined(__CUDA)
     CHECK(libsmm_acc_finalize(), NULL);
 #endif

--- a/src/acc/opencl/README.md
+++ b/src/acc/opencl/README.md
@@ -17,7 +17,7 @@ An application of compile-time settings (and perhaps a valuable contribution) mi
 Runtime settings are made by the means of environment variables (implemented in `acc_opencl.c`):
 
 * `ACC_OPENCL_DEVSPLIT`: integer enabling devices to be split into subdevices (non-zero/default: enabled, zero: disabled).
-* `ACC_OPENCL_DEVTYPE`: character string matching the device-kind like "cpu", "gpu", or another kind if neither CPU or GPU.
+* `ACC_OPENCL_DEVTYPE`: character string selecting "cpu", "gpu", "all" (unfiltered), or any other string (neither CPU or GPU).
 * `ACC_OPENCL_DEVICE`: non-negative integer number to select a device from the (internally enumerated) list of devices.
 * `ACC_OPENCL_VENDOR`: character string matching the vendor of the OpenCL device in an case-insensitive fashion, e.g., "intel".
 * `ACC_OPENCL_VERBOSE`: verbosity level (integer) with console output on `stderr`.

--- a/src/acc/opencl/smm/README.md
+++ b/src/acc/opencl/smm/README.md
@@ -17,7 +17,7 @@ The `OPENCL_LIBSMM_DEBUG` compile-time setting enables side-by-side validation o
 Runtime settings are made by the means of environment variables (implemented in `acc_opencl.c`). There are two categories (for the two major functions) like matrix transpose (`OPENCL_LIBSMM_TRANS_*`) and matrix multiplication (`OPENCL_LIBSMM_SMM_*`). Common settings are (see OpenCL backend documentation for more details):
 
 * `ACC_OPENCL_DEVSPLIT`: integer enabling devices to be split into subdevices (non-zero/default: enabled, zero: disabled).
-* `ACC_OPENCL_DEVTYPE`: character string matching the device-kind like "cpu", "gpu", or another kind if neither CPU or GPU.
+* `ACC_OPENCL_DEVTYPE`: character string selecting "cpu", "gpu", "all" (unfiltered), or any other string (neither CPU or GPU).
 * `ACC_OPENCL_DEVICE`: non-negative integer number to select a device from the (internally enumerated) list of devices.
 * `ACC_OPENCL_VENDOR`: character string matching the vendor of the OpenCL device in an case-insensitive fashion, e.g., "intel".
 * `ACC_OPENCL_VERBOSE`: verbosity level (integer) with console output on `stderr`.
@@ -26,7 +26,7 @@ Runtime settings are made by the means of environment variables (implemented in 
     * `ACC_OPENCL_VERBOSE=3`: outputs device-side measured performance of kernels (geometric mean).
     * `ACC_OPENCL_VERBOSE=4`: outputs device-side performance of kernels (every launch profiled).
 
-For tranposing matrices (implemented in `opencl_libsmm.c`):
+For transposing matrices (implemented in `opencl_libsmm.c`):
 
 * `OPENCL_LIBSMM_TRANS_BUILDOPTS`: character string with build options (compile and link) supplied to the OpenCL runtime compiler.
 * `OPENCL_LIBSMM_TRANS_INPLACE`: Boolean value (zero or non-zero integer) for in-place matrix transpose (no local memory needed).

--- a/src/acc/opencl/smm/opencl_libsmm.c
+++ b/src/acc/opencl/smm/opencl_libsmm.c
@@ -927,7 +927,7 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
                 ? getenv("OPENCL_LIBSMM_SMM_BN") : getenv("OPENCL_LIBSMM_SMM_BLOCK_N"));
               /* TODO: load parameters from file (auto-tuned) */
               const int batchsize = ((NULL == env_batchsize || '\0' == *env_batchsize)
-                ? (NULL == config ? 32/*default*/ : config->bs) : atoi(env_batchsize));
+                ? (NULL == config ? 24/*default*/ : config->bs) : atoi(env_batchsize));
               const int blockm = ((NULL == env_blockm || '\0' == *env_blockm)
                 ? (NULL == config ? m_max/*default*/ : config->bm) : atoi(env_blockm));
               const int blockn = ((NULL == env_blockn || '\0' == *env_blockn)

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -287,7 +287,7 @@ if __name__ == "__main__":
         "-bs",
         "--initial-bs",
         type=int,
-        default=32,
+        default=24,
         nargs="?",
         dest="bs",
         help="Initial (mini-)batch size (BS)",


### PR DESCRIPTION
* Documented environment variable DEVICE for acc_bench drivers.
* Allow to set active device per environment variable (DEVICE).
* Clarified ACC_OPENCL_DEVTYPE (OpenCL BE documentation).
* Adjusted default (OpenCL BE).
* Updated LIBXSMM (Daint-CI).