### PR TITLE
ocl-perf: closed perf gap between OpenCL and CUDA

### DIFF
--- a/src/acc/acc_bench_smm.c
+++ b/src/acc/acc_bench_smm.c
@@ -42,8 +42,8 @@
 #endif
 
 #define ACC_BENCH_SMM_EPSILON(T) DBCSR_CONCATENATE(ACC_BENCH_SMM_EPSILON_, T)
-#define ACC_BENCH_SMM_EPSILON_double 5E-18
-#define ACC_BENCH_SMM_EPSILON_float 5E-8
+#define ACC_BENCH_SMM_EPSILON_double 5E-6
+#define ACC_BENCH_SMM_EPSILON_float 5E-6
 
 #define ROUNDUP2(N, NPOT) ((((unsigned long long)N) + ((NPOT) - 1)) & ~((NPOT) - 1))
 #define CHECK(EXPR, RPTR) if ((NULL != ((const void*)(RPTR)) && EXIT_SUCCESS != *((const int*)(RPTR))) || \
@@ -114,7 +114,7 @@ int main(int argc, char* argv[])
   /* note: libsmm_acc_init() may imply acc_init() */
   CHECK(libsmm_acc_init(), &result);
   CHECK(c_dbcsr_acc_get_ndevices(&ndevices), &result);
-  if (0 < ndevices && EXIT_SUCCESS == c_dbcsr_acc_set_active_device(device)) {
+  if (0 < ndevices && (0 == device || EXIT_SUCCESS == c_dbcsr_acc_set_active_device(device))) {
 #if defined(_DEBUG)
     fprintf(stderr, "Activated device %i of %i.\n", device, ndevices);
 #endif

--- a/src/acc/acc_bench_trans.c
+++ b/src/acc/acc_bench_trans.c
@@ -98,7 +98,7 @@ int main(int argc, char* argv[])
   /* note: libsmm_acc_init() may imply acc_init() */
   CHECK(libsmm_acc_init(), &result);
   CHECK(c_dbcsr_acc_get_ndevices(&ndevices), &result);
-  if (0 < ndevices && EXIT_SUCCESS == c_dbcsr_acc_set_active_device(device)) {
+  if (0 < ndevices && (0 == device || EXIT_SUCCESS == c_dbcsr_acc_set_active_device(device))) {
 #if defined(_DEBUG)
     fprintf(stderr, "Activated device %i of %i.\n", device, ndevices);
 #endif

--- a/src/acc/opencl/acc_opencl.sh
+++ b/src/acc/opencl/acc_opencl.sh
@@ -51,7 +51,7 @@ if [ "${BASENAME}" ] && [ "${SED}" ] && [ "${RM}" ]; then
             if [ "${CPP}" ] && \
                [ "$(${CPP} -dD -P -fpreprocessed "${IFILE}" 2>/dev/null >/dev/null && echo "OK")" ];
             then
-              ${CPP} -dD -P -fpreprocessed "${IFILE}"
+              ${CPP} -dD -P -fpreprocessed "${IFILE}" 2>/dev/null
             else # fallback to sed
               ${SED} -r ':a;s%(.*)/\*.*\*/%\1%;ta;/\/\*/!b;N;ba' "${IFILE}"
             fi | \

--- a/src/acc/opencl/smm/kernels/multiply.cl
+++ b/src/acc/opencl/smm/kernels/multiply.cl
@@ -7,6 +7,21 @@
  * SPDX-License-Identifier: GPL-2.0+                                                              *
  *------------------------------------------------------------------------------------------------*/
 
+#if (200/*CL_VERSION_2_0*/ <= __OPENCL_VERSION__)
+# define UNROLL(N) __attribute__((opencl_unroll_hint(N)))
+#else
+# define UNROLL(N)
+#endif
+#if defined(__NV_CL_C_VERSION)
+# define UNROLL_NV(N) UNROLL(N)
+#else
+# define UNROLL_NV(N)
+#endif
+#if 0
+# define COPY_B
+#endif
+
+#define BMN ((SM + SN - 1) / SN)
 /* number of M-blocks */
 #define NBM ((SM + BM - 1) / BM)
 /* number of N-blocks */
@@ -61,6 +76,7 @@ inline void atomic_add_global_cmpxchg2(global volatile float2* dst, float2 inc)
 #endif
 
 
+__attribute__((reqd_work_group_size(SWG, 1, 1)))
 kernel void FN(global T *restrict cdata,
   GLOBAL const T *restrict adata, GLOBAL const T *restrict bdata,
 #if (1 < BS)
@@ -79,74 +95,90 @@ kernel void FN(global T *restrict cdata,
   global T *restrict c = cdata + c0;
 
 #if (SWG != SN)
-  T amk[SK], bkn[SK][BN];
+  T amk[SK];
+# if defined(COPY_B)
+  T bkn[SK][BN];
+# endif
 # if (1 < BS)
   T cmn[BM][BN] = {{ 0 }};
 # endif
+  const int m0 = (idx / NBN) * BM, m1 = min(m0 + BM, SM);
+  const int n0 = (idx % NBN) * BN, n1 = min(n0 + BN, SN);
 #else
   local T awg[SM][SK];
+# if defined(COPY_B)
   T bkn[SK];
+# endif
 # if (1 < BS)
   T cmn[SM] = { 0 };
+# endif
+# if (SM != SN)
+  const int m0 = idx * BMN, m1 = min(m0 + BMN, SM);
 # endif
 #endif
 
   /* intra-kernel mini-batch of SMMs */
 #if (1 < BS)
   const int batchsize = min(BS, stack_size - BS * gid);
-  for (int i = 0; i < batchsize; ++i)
-#endif
-  {
-#if (SWG != SN)
-    const int im = idx / NBN;
-    const int m0 = im * BM, m1 = min(m0 + BM, SM);
-    const int n0 = (idx - im * NBN) * BN;
-    const int n1 = min(n0 + BN, SN);
-#else
-    const int bm = (SM + SN - 1) / SN;
-    const int m0 = idx * bm, m1 = min(m0 + bm, SM);
-    const int n = idx;
-#endif
-#if (1 < BS)
+  UNROLL(1)
+  for (int i = 0; i < batchsize; ++i) {
     const int c1 = (i < (batchsize - 1) ? (params[3*i+5] - 1) : -1);
     const int a0 = params[3*i+0] - 1, b0 = params[3*i+1] - 1;
 #else
-    const int a0 = params[0] - 1, b0 = params[1] - 1;
+  { const int a0 = params[0] - 1, b0 = params[1] - 1;
 #endif
     GLOBAL const T *const restrict a = adata + a0;
+    GLOBAL const T *const restrict b = bdata + b0;
 
-#if (SWG == SN)
     /* transpose A-matrix into local buffer */
+#if (SWG == SN)
+# if (SM != SN)
+    UNROLL(BMN)
     for (int m = m0; m < m1; ++m) {
+# else
+    { const int m = idx;
+# endif
+      UNROLL(SK)
       for (int k = 0; k < SK; ++k) awg[m][k] = a[SM*k+m];
     }
 #endif
 
     /* avoiding to load same B-tile seems to be not beneficial */
-#if (1 < BS) && 0
+#if defined(COPY_B)
+# if (1 < BS) && 0
     if (b0 != b1)
-#endif
+# endif
     { /* copy B-matrix into private buffer */
-      GLOBAL const T *const restrict b = bdata + b0;
+      UNROLL(SK)
       for (int k = 0; k < SK; ++k) {
-#if (SWG != SN)
+# if (SWG != SN)
+        UNROLL_NV(BN)
         for (int n = n0; n < n1; ++n) bkn[k][n-n0] = b[SN*k+n];
-#else
-        bkn[k] = b[SN*k+n];
-#endif
+# else
+        bkn[k] = b[SN*k+idx];
+# endif
       }
-#if (1 < BS)
+# if (1 < BS)
       b1 = b0;
-#endif
+# endif
     }
+#endif
 
     /* calculate private result-tile */
 #if (SWG != SN)
+    /*UNROLL(BM)*/
     for (int m = m0; m < m1; ++m) {
+      UNROLL(SK)
       for (int k = 0; k < SK; ++k) amk[k] = a[SM*k+m];
+      /*UNROLL(BN)*/
       for (int n = n0; n < n1; ++n) {
         T r = 0;
+        UNROLL(SK)
+# if defined(COPY_B)
         for (int k = 0; k < SK; ++k) r = FMA(amk[k], bkn[k][n-n0], r);
+# else
+        for (int k = 0; k < SK; ++k) r = FMA(amk[k], b[SN*k+n], r);
+# endif
 # if (1 < BS)
         cmn[m-m0][n-n0] += r;
 # else
@@ -156,42 +188,59 @@ kernel void FN(global T *restrict cdata,
     }
 #else
 # if (1 < SWG)
+    /* finish copy-transpose */
     barrier(CLK_LOCAL_MEM_FENCE);
 # endif
+    UNROLL_NV(SM)
     for (int m = 0; m < SM; ++m) {
 # if (1 < BS)
-      for (int k = 0; k < SK; ++k) cmn[m] = FMA(awg[m][k], bkn[k], cmn[m]);
+      T r = cmn[m];
 # else
       T r = 0;
+# endif
+      UNROLL(SK)
+# if defined(COPY_B)
       for (int k = 0; k < SK; ++k) r = FMA(awg[m][k], bkn[k], r);
-      if (0 != r) ATOMIC_ADD_GLOBAL(&c[SM*n+m], r);
+# else
+      for (int k = 0; k < SK; ++k) r = FMA(awg[m][k], b[SN*k+idx], r);
+# endif
+# if (1 < BS)
+      cmn[m] = r;
+# else
+      if (0 != r) ATOMIC_ADD_GLOBAL(&c[SM*idx+m], r);
 # endif
     }
 #endif
 
 #if (1 < BS)
-    if (c0 != c1) { /* copy private tile to global memory */
+    if (c0 != c1) { /* apply private tile to global memory */
 # if (SWG != SN)
-      for (int m = 0; m < BM; ++m) for (int n = 0; n < BN; ++n) {
-        const int gm = m + m0, gn = n + n0;
-        if (gm < SM && gn < SN && 0 != cmn[m][n]) {
-          ATOMIC_ADD_GLOBAL(&c[SM*gn+gm], cmn[m][n]);
-          cmn[m][n] = 0; /* reset */
+      UNROLL(1)
+      for (int m = 0; m < BM; ++m) {
+        UNROLL(BN)
+        for (int n = 0; n < BN; ++n) {
+          const int gm = m + m0, gn = n + n0;
+          if (gm < SM && gn < SN && 0 != cmn[m][n]) {
+            ATOMIC_ADD_GLOBAL(&c[SM*gn+gm], cmn[m][n]);
+            cmn[m][n] = 0; /* reset */
+          }
         }
       }
 # else
 #   if defined(ATOMIC_ADD2_GLOBAL)
+      UNROLL(SM)
       for (int m = 0; m < SM; m += 2) {
         /*if (0 != cmn[m] && 0 != cmn[m+1])*/ {
           const float2 r2 = (float2)(cmn[m], cmn[m+1]);
-          ATOMIC_ADD2_GLOBAL((global volatile float2*)(c + SM * n + m), r2);
+          ATOMIC_ADD2_GLOBAL((global volatile float2*)(c + SM * idx + m), r2);
           cmn[m] = cmn[m+1] = 0; /* reset */
         }
       }
 #   else
+      UNROLL(SM)
       for (int m = 0; m < SM; ++m) {
         if (0 != cmn[m]) {
-          ATOMIC_ADD_GLOBAL(&c[SM*n+m], cmn[m]);
+          ATOMIC_ADD_GLOBAL(&c[SM*idx+m], cmn[m]);
           cmn[m] = 0; /* reset */
         }
       }


### PR DESCRIPTION
* Apparently, performance can be significantly better even against auto-tuned CUDA kernels.
* While prime kernels like 23x23x23 can still be improved, perf. seems to be mostly on par.

Details
* tune_multiply.py: updated documentation and mention merge/update functionality.
* multiply.cl: introduced COPY_B (and disabled copying B-tile into private memory).
* multiply.cl: reqd_work_group_size (known at compile-time).
* multiply.cl: several improvements targting Nvidia GPUs.
* multiply.cl: no opencl_unroll_hint before OpenCL 2.0.
* multiply.cl: hint unrolling/not unrolling loops.
* multiply.cl: licm some loop-bound calculation.
* multiply.cl: improved A-transpose loop.
* acc_bench_smm: adjusted acceptable error margins.
* acc_bench_*: dev-id only if non-zero (non-default).
* acc_opencl.sh: suppress bogus message (cpp).