### PR TITLE
ocl-tune: detect and avoid bank-conflicts, improved auto-tuning process

### DIFF
--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -25,7 +25,7 @@ if [ ! -d "${HOME}/libxsmm" ]; then
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout 62bbeaa4816985c015bc65396ffe6f3c63e21260
+git checkout 68c8822941b9b93fb562b7e44381e6973ed09ba9
 make -j
 cd ..
 

--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -25,7 +25,7 @@ if [ ! -d "${HOME}/libxsmm" ]; then
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout 68c8822941b9b93fb562b7e44381e6973ed09ba9
+git checkout 5fd40afe1546ba2b6e7f7cc5db9853fe925491fc
 make -j
 cd ..
 

--- a/src/acc/acc_bench_smm.c
+++ b/src/acc/acc_bench_smm.c
@@ -313,7 +313,8 @@ int main(int argc, char* argv[])
               }
             }
           }
-          printf("max.error: %g (%g != %g)\n", relerror / nr, a, b);
+          printf("max.error: %g", relerror / nr);
+          if (0 < abserror) printf(" (%g != %g)\n", a, b); else printf("\n");
           if (0 < check && (nr * check) < relerror) result = EXIT_FAILURE;
         }
       }

--- a/src/acc/cuda/Makefile
+++ b/src/acc/cuda/Makefile
@@ -12,8 +12,10 @@ OBJSMM := $(SRCSMM:.cpp=.o)
 
 INCALL := $(INCACC) $(INCSMM)
 
-LIBXSMMROOT ?= $(wildcard ../../../../libxsmm)
-LIBXSMMROOT ?= $(wildcard $(HOME)/libxsmm)
+LIBXSMMROOT := $(wildcard ../../../../libxsmm)
+ifeq (,$(LIBXSMMROOT))
+  LIBXSMMROOT := $(wildcard $(HOME)/libxsmm)
+endif
 NVCC ?= $(shell which nvcc 2>/dev/null)
 CUDA_PATH ?= $(if $(NVCC),$(abspath $(dir $(NVCC))/..))
 UNAME := $(shell uname)
@@ -124,11 +126,11 @@ endif
 LDFLAGS += -lcudart -lcublas -lnvrtc -lcuda
 CFLAGS += -Wno-variadic-macros -Wno-long-long
 
-.PHONY: all
-all: ../dbcsr_acc.a ../dbcsr_acc_smm.a bench test
-
 .PHONY: bench
 bench: ../acc_bench_smm ../acc_bench_trans
+
+.PHONY: all
+all: ../dbcsr_acc.a ../dbcsr_acc_smm.a bench test
 
 .PHONY: test
 test: ../dbcsr_acc_test

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -9,8 +9,10 @@ KERNEL := $(wildcard smm/kernels/*.cl)
 
 INCALL := $(INCACC) $(INCSMM)
 
-LIBXSMMROOT ?= $(wildcard ../../../../libxsmm)
-LIBXSMMROOT ?= $(wildcard $(HOME)/libxsmm)
+LIBXSMMROOT := $(wildcard ../../../../libxsmm)
+ifeq (,$(LIBXSMMROOT))
+  LIBXSMMROOT := $(wildcard $(HOME)/libxsmm)
+endif
 UNAME := $(shell uname)
 INTEL ?= 0
 DEV ?= 0
@@ -121,11 +123,11 @@ else
   LDFLAGS += -lOpenCL
 endif
 
-.PHONY: all
-all: ../dbcsr_acc.a ../dbcsr_acc_smm.a bench test
-
 .PHONY: bench
 bench: ../acc_bench_smm ../acc_bench_trans
+
+.PHONY: all
+all: ../dbcsr_acc.a ../dbcsr_acc_smm.a bench test
 
 .PHONY: test
 test: ../dbcsr_acc_test

--- a/src/acc/opencl/acc_getenv.sh
+++ b/src/acc/opencl/acc_getenv.sh
@@ -24,7 +24,8 @@ EXT="c"
 if [ "${FIND}" ] && [ "${SORT}" ] && [ "${SED}" ] && [ -d ${SRC} ]; then
   export LC_ALL=C
   ENVARS="$(${FIND} ${SRC} -type f -name "*.${EXT}" -exec \
-    ${SED} -n "s/.*getenv[[:space:]]*([[:space:]]*\"\(.[^\"]*\)..*/\1/p" {} \; | \
+    ${SED} "s/getenv[[:space:]]*([[:space:]]*\".[^\"]*/\n&/g" {} \; | \
+    ${SED} -n "s/.*getenv[[:space:]]*([[:space:]]*\"\(.[^\"]*\)..*/\1/p" | \
     ${SORT} -u)"
   OTHERS=$(echo "${ENVARS}" | ${SED} "/ACC_OPENCL_/d;/OPENCL_LIBSMM_/d")
   if [ "${OTHERS}" ]; then

--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -313,7 +313,7 @@ int c_dbcsr_acc_init(void)
               int level_major = 0;
               c_dbcsr_acc_opencl_config.svm_interop = (NULL == env || 0 != atoi(env)) &&
                 (EXIT_SUCCESS == c_dbcsr_acc_opencl_device_level(active_device,
-                  &level_major, NULL/*level_minor*/) && 2 <= level_major);
+                  &level_major, NULL/*level_minor*/, NULL/*cl_std*/) && 2 <= level_major);
             }
 #else
             c_dbcsr_acc_opencl_config.svm_interop = CL_FALSE;
@@ -474,11 +474,12 @@ int c_dbcsr_acc_opencl_device_name(cl_device_id device, const char* name)
 }
 
 
-int c_dbcsr_acc_opencl_device_level(cl_device_id device, int* level_major, int* level_minor)
+int c_dbcsr_acc_opencl_device_level(cl_device_id device,
+  int* level_major, int* level_minor, char cl_std[16])
 {
   char buffer[ACC_OPENCL_BUFFERSIZE];
   int result = EXIT_SUCCESS;
-  assert(NULL != device && (NULL != level_major || NULL != level_minor));
+  assert(NULL != device && (NULL != level_major || NULL != level_minor || NULL != cl_std));
   ACC_OPENCL_CHECK(clGetDeviceInfo(device, CL_DEVICE_VERSION,
     ACC_OPENCL_BUFFERSIZE, buffer, NULL),
     "retrieve device level", result);
@@ -488,6 +489,14 @@ int c_dbcsr_acc_opencl_device_level(cl_device_id device, int* level_major, int* 
     if (2 == sscanf(buffer, "%*s %u.%u", level, level+1)) {
       if (NULL != level_major) *level_major = (int)level[0];
       if (NULL != level_minor) *level_minor = (int)level[1];
+      if (NULL != cl_std) {
+        if (1 < level[0]) {
+          const int nchar = ACC_OPENCL_SNPRINTF(cl_std, 16,
+            "-cl-std=CL%u.%u", level[0], level[1]);
+          if (0 >= nchar || 16 <= nchar) result = EXIT_FAILURE;
+        }
+        else *cl_std = '\0';
+      }
     }
     else {
       result = EXIT_SUCCESS;
@@ -662,16 +671,16 @@ int c_dbcsr_acc_opencl_wgsize(cl_device_id device, cl_kernel kernel,
 
 int c_dbcsr_acc_opencl_dump(const char* basename, cl_program program)
 {
-  cl_int result = EXIT_SUCCESS;
+  cl_int result;
+  unsigned char* binary = NULL;
   size_t size;
   assert(NULL != basename && NULL != program);
-  ACC_OPENCL_CHECK(clGetProgramInfo(program,
-    CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &size, NULL),
-    "query program binary size", result);
-  if (0 < size && size <= ACC_OPENCL_BINARYSIZE) {
-    unsigned char binary[ACC_OPENCL_BINARYSIZE], *binaries = binary;
+  binary = (unsigned char*)(CL_SUCCESS == clGetProgramInfo(program,
+      CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &size, NULL)
+    ? malloc(size) : NULL);
+  if (NULL != binary) {
     result = clGetProgramInfo(program, CL_PROGRAM_BINARIES,
-      sizeof(unsigned char*), &binaries, NULL);
+      sizeof(unsigned char*), &binary, NULL);
     if (CL_SUCCESS == result) {
       char buffer[ACC_OPENCL_BUFFERSIZE];
       const int nchar = ACC_OPENCL_SNPRINTF(buffer, sizeof(buffer),
@@ -688,6 +697,7 @@ int c_dbcsr_acc_opencl_dump(const char* basename, cl_program program)
     else {
       ACC_OPENCL_ERROR("query program binary", result);
     }
+    free(binary);
   }
   else result = EXIT_FAILURE;
   ACC_OPENCL_RETURN(result);

--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -46,11 +46,15 @@
 #if !defined(ACC_OPENCL_BUFFERSIZE)
 # define ACC_OPENCL_BUFFERSIZE (8 << 10/*8KB*/)
 #endif
-#if !defined(ACC_OPENCL_BINARYSIZE)
-# define ACC_OPENCL_BINARYSIZE (8 * ACC_OPENCL_BUFFERSIZE)
-#endif
 #if !defined(ACC_OPENCL_DEVICES_MAXCOUNT)
 # define ACC_OPENCL_DEVICES_MAXCOUNT 256
+#endif
+#if !defined(ACC_OPENCL_OVERMALLOC)
+# if defined(__DBCSR_ACC)
+#   define ACC_OPENCL_OVERMALLOC 0
+# else
+#   define ACC_OPENCL_OVERMALLOC 8192
+# endif
 #endif
 
 /* can depend on OpenCL implementation */
@@ -75,7 +79,7 @@
 # define ACC_OPENCL_EVENT(A) ((cl_event*)(A))
 #endif
 
-#if !defined(ACC_OPENCL_THREADLOCAL_CONTEXT) && /*WORKAROUND*/!defined(__DBCSR_ACC) && 0
+#if !defined(ACC_OPENCL_THREADLOCAL_CONTEXT) && 0
 # define ACC_OPENCL_THREADLOCAL_CONTEXT
 #endif
 #if !defined(ACC_OPENCL_STREAM_PRIORITIES) && 1
@@ -223,7 +227,7 @@ int c_dbcsr_acc_opencl_device_vendor(cl_device_id device, const char* vendor);
 int c_dbcsr_acc_opencl_device_name(cl_device_id device, const char* name);
 /** Return the OpenCL support level for the given device. */
 int c_dbcsr_acc_opencl_device_level(cl_device_id device,
-  int* level_major, int* level_minor);
+  int* level_major, int* level_minor, char cl_std[16]);
 /** Check if given device supports the extensions. */
 int c_dbcsr_acc_opencl_device_ext(cl_device_id device,
   const char *const extnames[], int num_exts);

--- a/src/acc/opencl/smm/kernels/multiply.cl
+++ b/src/acc/opencl/smm/kernels/multiply.cl
@@ -20,16 +20,19 @@
 /* size of workgroup (WG) */
 #define SWG (NBM * NBN)
 
-#if !defined(PRIVATE_A) && (SWG != SN)
+#if !defined(PRIVATE_A) && (SWG != SN) && 1
 # define PRIVATE_A
 #endif
-#if !defined(PRIVATE_B) && 0
+#if !defined(PRIVATE_B) && defined(INTEL) && 1
 # define PRIVATE_B
 #endif
-#if !defined(SHARED_A) && !defined(PRIVATE_A)
-# define SHARED_A
+#if !defined(SHARED_A) && !defined(PRIVATE_A) && 1
+# define SHARED_A ((SK % 16) ? 1 : 2)
 #endif
-#if !defined(TRACK_B) && 0
+#if !defined(SHARED_B) && !defined(PRIVATE_B) && 1
+# define SHARED_B ((SN % 16) ? 1 : 2)
+#endif
+#if !defined(TRACK_B) && defined(PRIVATE_B) && 0
 # define TRACK_B
 #endif
 #if !defined(TRACK_C) && 1
@@ -109,7 +112,18 @@ kernel void FN(global T *restrict cdata,
   global T *restrict c = cdata + c0;
 
 #if defined(SHARED_A)
-  local T awg[SM][SK+BC];
+# if (1 < SHARED_A)
+  local T amk[SM][SK+1];
+# else
+  local T amk[SM][SK];
+# endif
+#endif
+#if defined(SHARED_B)
+# if (1 < SHARED_B)
+  local T bkn[SK][SN+1];
+# else
+  local T bkn[SK][SN];
+# endif
 #endif
 #if (SWG != SN)
 # if defined(PRIVATE_A)
@@ -148,8 +162,8 @@ kernel void FN(global T *restrict cdata,
 #else
   {
 #endif
-    /* transpose A-matrix into local/shared buffer */
 #if defined(SHARED_A)
+    /* transpose A-matrix into local/shared buffer */
 # if (SM != SN || SWG != SN)
     UNROLL(BMN)
     for (int m = m0; m < m1; ++m) {
@@ -157,11 +171,25 @@ kernel void FN(global T *restrict cdata,
     { const int m = idx;
 # endif
       UNROLL(SK)
-      for (int k = 0; k < SK; ++k) awg[m][k] = a[SM*k+m];
+      for (int k = 0; k < SK; ++k) amk[m][k] = a[SM*k+m];
     }
 #endif
 
-#if defined(PRIVATE_B)
+#if defined(SHARED_B)
+    UNROLL(SK)
+    for (int k = 0; k < SK; ++k) {
+# if (SM != SN || SWG != SN)
+#   if defined(__NV_CL_C_VERSION)
+      UNROLL(BN)
+#   endif
+      for (int n = n0; n < n1; ++n) {
+# else
+      { const int n = idx;
+# endif
+        bkn[k][n] = b[SN*k+n];
+      }
+    }
+#elif defined(PRIVATE_B)
 # if defined(TRACK_B) && (1 < BS)
     if (b0 != b1) {
       b1 = b0;
@@ -182,8 +210,8 @@ kernel void FN(global T *restrict cdata,
     }
 #endif
 
-#if defined(SHARED_A) && (1 < SWG)
-    /* finish copy-transpose */
+#if (defined(SHARED_A) || defined(SHARED_B)) && (1 < SWG)
+    /* finish transpose/copy */
     barrier(CLK_LOCAL_MEM_FENCE);
 #endif
 
@@ -199,19 +227,22 @@ kernel void FN(global T *restrict cdata,
       for (int n = n0; n < n1; ++n) {
         T r = 0;
         UNROLL(SK)
-# if defined(PRIVATE_B)
-#   if defined(PRIVATE_A)
-        for (int k = 0; k < SK; ++k) r = FMA(amk[k], bkn[k][n-n0], r);
-#   else
-        for (int k = 0; k < SK; ++k) r = FMA(awg[m][k], bkn[k][n-n0], r);
-#   endif
+        for (int k = 0; k < SK; ++k) r = FMA(
+# if defined(SHARED_A)
+          amk[m][k],
+# elif defined(PRIVATE_A)
+          amk[k],
 # else
-#   if defined(PRIVATE_A)
-        for (int k = 0; k < SK; ++k) r = FMA(amk[k], b[SN*k+n], r);
-#   else
-        for (int k = 0; k < SK; ++k) r = FMA(awg[m][k], b[SN*k+n], r);
-#   endif
+          a[SM*k+m],
 # endif
+# if defined(SHARED_B)
+          bkn[k][n],
+# elif defined(PRIVATE_B)
+          bkn[k][n-n0],
+# else
+          b[SN*k+n],
+# endif
+          r);
 # if (1 < BS)
         cmn[m-m0][n-n0] += r;
 # else
@@ -228,19 +259,20 @@ kernel void FN(global T *restrict cdata,
       T r = 0;
 # endif
       UNROLL(SK)
-# if defined(PRIVATE_B)
-#   if defined(PRIVATE_A) || !defined(SHARED_A)
-      for (int k = 0; k < SK; ++k) r = FMA(a[SM*k+m], bkn[k], r);
-#   else
-      for (int k = 0; k < SK; ++k) r = FMA(awg[m][k], bkn[k], r);
-#   endif
+      for (int k = 0; k < SK; ++k) r = FMA(
+# if defined(SHARED_A)
+        amk[m][k],
 # else
-#   if defined(PRIVATE_A) || !defined(SHARED_A)
-      for (int k = 0; k < SK; ++k) r = FMA(a[SM*k+m], b[SN*k+idx], r);
-#   else
-      for (int k = 0; k < SK; ++k) r = FMA(awg[m][k], b[SN*k+idx], r);
-#   endif
+        a[SM*k+m],
 # endif
+# if defined(SHARED_B)
+        bkn[k][idx],
+# elif defined(PRIVATE_B)
+        bkn[k],
+# else
+        b[SN*k+idx],
+# endif
+        r);
 # if (1 < BS)
       cmn[m] = r;
 # else

--- a/src/acc/opencl/smm/kernels/multiply.cl
+++ b/src/acc/opencl/smm/kernels/multiply.cl
@@ -6,6 +6,11 @@
  * For further information please visit https://dbcsr.cp2k.org                                    *
  * SPDX-License-Identifier: GPL-2.0+                                                              *
  *------------------------------------------------------------------------------------------------*/
+#if (200/*CL_VERSION_2_0*/ <= __OPENCL_VERSION__)
+# define UNROLL(N) __attribute__((opencl_unroll_hint(N)))
+#else
+# define UNROLL(N)
+#endif
 
 #define BMN ((SM + SN - 1) / SN)
 /* number of M-blocks */
@@ -15,24 +20,19 @@
 /* size of workgroup (WG) */
 #define SWG (NBM * NBN)
 
-#if (200/*CL_VERSION_2_0*/ <= __OPENCL_VERSION__)
-# define UNROLL(N) __attribute__((opencl_unroll_hint(N)))
-#else
-# define UNROLL(N)
-#endif
-#if (SWG != SN)
+#if !defined(PRIVATE_A) && (SWG != SN)
 # define PRIVATE_A
 #endif
-#if 0
+#if !defined(PRIVATE_B) && 0
 # define PRIVATE_B
 #endif
-#if !defined(PRIVATE_A)
+#if !defined(SHARED_A) && !defined(PRIVATE_A)
 # define SHARED_A
 #endif
-#if 0
+#if !defined(TRACK_B) && 0
 # define TRACK_B
 #endif
-#if 1
+#if !defined(TRACK_C) && 1
 # define TRACK_C
 #endif
 
@@ -109,7 +109,7 @@ kernel void FN(global T *restrict cdata,
   global T *restrict c = cdata + c0;
 
 #if defined(SHARED_A)
-  local T awg[SM][SK];
+  local T awg[SM][SK+BC];
 #endif
 #if (SWG != SN)
 # if defined(PRIVATE_A)

--- a/src/acc/opencl/smm/kernels/multiply.cl
+++ b/src/acc/opencl/smm/kernels/multiply.cl
@@ -88,6 +88,7 @@ inline void atomic_add_global_xchg(global volatile T* dst, T inc)
 __attribute__((reqd_work_group_size(SWG, 1, 1)))
 kernel void FN(global T *restrict cdata,
   GLOBAL const T *restrict adata, GLOBAL const T *restrict bdata,
+  /* indexes given by param_stack are one-based (Fortran) */
 #if (1 < BS)
   GLOBAL const int *restrict param_stack, int stack_size)
 #else
@@ -95,7 +96,6 @@ kernel void FN(global T *restrict cdata,
 #endif
 {
   const int gid = get_group_id(0), idx = get_local_id(0);
-  /* indexes given by param_stack are one-based */
   GLOBAL const int *restrict params = param_stack + gid * (3 * BS);
 #if (1 < BS)
 # if defined(TRACK_B)

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -78,7 +78,7 @@ typedef struct opencl_libsmm_smm_t {
   cl_kernel kernel; /* must be the 1st data member */
   size_t wgsize;
   /* parameters (either pretuned or determined) */
-  int bs, bm, bn, bc;
+  int bs, bm, bn, aa, ab;
   /* ACC_OPENCL_VERBOSE: perf. counters */
   double gflops_sumlog, gflops_comp;
   size_t nexec;

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -78,7 +78,7 @@ typedef struct opencl_libsmm_smm_t {
   cl_kernel kernel; /* must be the 1st data member */
   size_t wgsize;
   /* parameters (either pretuned or determined) */
-  int bs, bm, bn;
+  int bs, bm, bn, bc;
   /* ACC_OPENCL_VERBOSE: perf. counters */
   double gflops_sumlog, gflops_comp;
   size_t nexec;

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -68,7 +68,9 @@ class SmmTuner(MeasurementInterface):
             self.bs = int(params.group(1)) if params and params.group(1) else None
             self.bm = int(params.group(2)) if params and params.group(2) else None
             self.bn = int(params.group(3)) if params and params.group(3) else None
-            self.bc = 0 != int(params.group(4)) if params and params.group(4) else None
+            self.bc = (
+                (0 != int(params.group(4))) if params and params.group(4) else None
+            )
         else:
             self.typename = self.typeid = None
         if self.typename and self.typeid:
@@ -118,7 +120,7 @@ class SmmTuner(MeasurementInterface):
     def launch(self, envs, nrep=None, size=None):
         """Launch executable supplying environment and arguments"""
         return self.call_program(
-            "OMP_PROC_BIND=TRUE {} {} {}".format(
+            "OMP_PROC_BIND=TRUE {} {} {} {}".format(
                 " ".join(map(str, envs)),  # environment variables
                 "{}/{}".format(self.exepath, self.exename),
                 # executable's arguments
@@ -132,10 +134,10 @@ class SmmTuner(MeasurementInterface):
     def seed_configurations(self):
         return [
             {
-                "BS": self.bs if None != self.bs else self.args.bs,
-                "BM": self.bm if None != self.bm else self.args.bm,
-                "BN": self.bn if None != self.bn else self.args.bn,
-                "BC": self.bc if None != self.bc else self.args.bc,
+                "BS": self.bs if self.bs is not None else self.args.bs,
+                "BM": self.bm if self.bm is not None else self.args.bm,
+                "BN": self.bn if self.bn is not None else self.args.bn,
+                "BC": self.bc if self.bc is not None else self.args.bc,
             }
         ]
 


### PR DESCRIPTION
* Auto-tune parameters based on pretuned values/state (parse verbose output of acc_bench_smm).
* Introduced OPENCL_LIBSMM_SMM_BANK_C/OPENCL_LIBSMM_SMM_BC tunable boolean parameter.
* Some preparation for padded problem sizes (ACC_OPENCL_OVERMALLOC, etc.).
* Fixed dumping IR (replaced ACC_OPENCL_BINARYSIZE with arbitrary size).
* Build OpenCL kernels with latest OpenCL standard (-cl-std=CLx.y).

Other:
* Handle multiple getenv per line (acc_getenv.sh).
* Revised verbose output (more regular, etc.).
* Made clEnqueueWriteBuffer non-blocking.
* Validate final auto-tuned result.