### PR TITLE
ocl: additional tunable parameter

### DIFF
--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -25,7 +25,7 @@ if [ ! -d "${HOME}/libxsmm" ]; then
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout 5fd40afe1546ba2b6e7f7cc5db9853fe925491fc
+git checkout 55802eda6277d9706de4451ec9322b10210bf4e2
 make -j
 cd ..
 

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -68,6 +68,7 @@ else
 endif
 
 ifneq (0,$(DBG))
+  CPPFLAGS += -CC
   ifeq (,$(DBG))
     CFLAGS += -O2
   else
@@ -120,7 +121,11 @@ else
     CFLAGS += -I$(CUDATOOLKIT_HOME)/include
     LDFLAGS += -L$(CUDATOOLKIT_HOME)/lib64
   endif
-  LDFLAGS += -lOpenCL
+  ifneq (,$(wildcard $(LIBOPENCL)))
+    LDFLAGS += $(LIBOPENCL)
+  else
+    LDFLAGS += -lOpenCL
+  endif
 endif
 
 .PHONY: bench
@@ -133,7 +138,7 @@ all: ../dbcsr_acc.a ../dbcsr_acc_smm.a bench test
 test: ../dbcsr_acc_test
 
 smm/opencl_kernels.h: acc_opencl.sh $(KERNEL)
-	./acc_opencl.sh $(KERNEL) $(PARAMS) $@
+	CPPFLAGS=$(CPPFLAGS) ./acc_opencl.sh $(KERNEL) $(PARAMS) $@
 
 ../dbcsr_acc.a: $(OBJACC)
 	$(AR) -rs $@ $^

--- a/src/acc/opencl/acc_getenv.sh
+++ b/src/acc/opencl/acc_getenv.sh
@@ -21,12 +21,12 @@ HERE="$(cd "$(dirname "$0")" && pwd -P)"
 SRC="${HERE}"
 EXT="c"
 
-if [ "${FIND}" ] && [ "${SORT}" ] && [ "${SED}" ] && [ -d ${SRC} ]; then
+if [ "${FIND}" ] && [ "${SORT}" ] && [ "${SED}" ] && [ -d "${SRC}" ]; then
   export LC_ALL=C
-  ENVARS="$(${FIND} ${SRC} -type f -name "*.${EXT}" -exec \
-    ${SED} "s/getenv[[:space:]]*([[:space:]]*\".[^\"]*/\n&/g" {} \; | \
-    ${SED} -n "s/.*getenv[[:space:]]*([[:space:]]*\"\(.[^\"]*\)..*/\1/p" | \
-    ${SORT} -u)"
+  ENVARS="$(${FIND} "${SRC}" -type f -name "*.${EXT}" -exec \
+    "${SED}" "s/getenv[[:space:]]*([[:space:]]*\".[^\"]*/\n&/g" {} \; | \
+    "${SED}" -n "s/.*getenv[[:space:]]*([[:space:]]*\"\(.[^\"]*\)..*/\1/p" | \
+     ${SORT} -u)"
   OTHERS=$(echo "${ENVARS}" | ${SED} "/ACC_OPENCL_/d;/OPENCL_LIBSMM_/d")
   if [ "${OTHERS}" ]; then
     echo "===================================="

--- a/src/acc/opencl/smm/kernels/multiply.cl
+++ b/src/acc/opencl/smm/kernels/multiply.cl
@@ -71,7 +71,7 @@
 #define NBK (NBM * NBN)
 
 
-#if !defined(cl_intel_global_float_atomics)
+#if !defined(cl_intel_global_float_atomics) || (1 != TN)
 #if defined(CMPXCHG)
 __attribute__((always_inline))
 inline void atomic_add_global_cmpxchg(global volatile T* dst, T inc)

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -78,7 +78,7 @@ typedef struct opencl_libsmm_smm_t {
   cl_kernel kernel; /* must be the 1st data member */
   size_t wgsize;
   /* parameters (either pretuned or determined) */
-  int bs, bm, bn, aa, ab, ac, ap;
+  int bs, bm, bn, wg, nz, lu, ap, aa, ab, ac;
   /* ACC_OPENCL_VERBOSE: perf. counters */
   double gflops_sumlog, gflops_comp;
   size_t nexec;


### PR DESCRIPTION
* Introduced dump-level for external preprocessor (ACC_OPENCL_DUMP=1), dump IR/binary (ACC_OPENCL_DUMP=2).
* Introduced tunable parameter for limited loop-unroll (OPENCL_LIBSMM_SMM_LU=0|1).
* Introduced tunable parameter for handling WG-size (OPENCL_LIBSMM_SMM_WG).
* Introduced ATOMIC_INC_NZ incl. tunable parameter.

General:
* Removed legacy/alternative names of tunable parameters. Updated documentation.
* Support CPPFLAGS and allow flags such as -d, -d, --comments, or --debug (acc_opencl.sh).
* Keep comments when embedding kernel code (acc_opencl.sh -c).
* Fixed splitting device into sub-devices.

tune_multiply.py:
* Implemented verbose output (experiment info when auto-tuning parameters).
* Omit benchmark invocation if update is launched with given device name.
* Uninstall signal handler when calling the handler (tune_multiply.py).
* Fixed command-line arguments (None->0). Revised short options (CLI).
* Avoid launching benchmark if only merging JSONs.