### PR TITLE
ocl: match production source and dumped source

### DIFF
--- a/src/acc/opencl/smm/kernels/multiply.cl
+++ b/src/acc/opencl/smm/kernels/multiply.cl
@@ -6,7 +6,7 @@
  * For further information please visit https://dbcsr.cp2k.org                                    *
  * SPDX-License-Identifier: GPL-2.0+                                                              *
  *------------------------------------------------------------------------------------------------*/
-#if (200/*CL_VERSION_2_0*/ <= __OPENCL_VERSION__)
+#if (200/*CL_VERSION_2_0*/ <= __OPENCL_VERSION__) || defined(__NV_CL_C_VERSION)
 # define UNROLL(N) __attribute__((opencl_unroll_hint(N)))
 #else
 # define UNROLL(N)


### PR DESCRIPTION
* Automatically apply CL-standard compile-flag (c_dbcsr_acc_opencl_kernel).
* Apply vendor definition (c_dbcsr_acc_opencl_kernel).
* Fixed __OPENCL_VERSION__ based on real version.