### PR TITLE
ocl: fixes, tests and common utilities

### DIFF
--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -25,7 +25,7 @@ if [ ! -d "${HOME}/libxsmm" ]; then
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout 55802eda6277d9706de4451ec9322b10210bf4e2
+git checkout 2a373509dadfda2d13f90ae1be920f03d8fb3415
 make -j
 cd ..
 

--- a/.cp2k/Makefile
+++ b/.cp2k/Makefile
@@ -30,9 +30,9 @@
 # FCFLAGS  => Fortran compilation flags
 # LDFLAGS  => Linker flags
 # LIBS     => Libraries
-# ACC      => ACC can be nvcc (CUDA), mpicc or g++ (HIP), or non-empty string (OpenCL)
+# ACC      => ACC can be nvcc (CUDA), mpicxx/mpicc or gcc/g++ (HIP), or mpicc/gcc (OpenCL)
 # ACCFLAGS => ACC flags
-# USE_ACCEL => hip, cuda or non-empty string (OpenCL)
+# USE_ACCEL => hip, cuda, or opencl
 # GPUVER   =>
 #          - for CUDA, possible values correspond to NVIDIA GPUs:
 #            possible values are K20X, K40, K80, P100, V100
@@ -149,8 +149,7 @@ override ACCFLAGS += -D__HIP
 FCFLAGS += -D__HIP
 CXXFLAGS += -D__HIP
 # OpenCL backend
-else
-# OBJ_SRC_FILES already includes all *.c files (OpenCL backend is C based)
+else ifeq (opencl,$(USE_ACCEL))
 CFLAGS += -D__OPENCL
 LIBXSMMROOT := $(if $(LIBXSMMROOT),$(LIBXSMMROOT),$(wildcard ../../../libxsmm))
 LIBXSMMROOT := $(if $(LIBXSMMROOT),$(LIBXSMMROOT),$(wildcard $(HOME)/libxsmm))
@@ -180,24 +179,22 @@ LIBSMM_ACC_ABS_DIR := $(shell find $(SRCDIR) -type d -name "libsmm_acc")
 
 ALL_PKG_FILES := $(shell find $(SRCDIR) -name "PACKAGE")
 OBJ_SRC_FILES  = $(shell cd $(SRCDIR); find . ! -name "dbcsr_api_c.F" ! -name "dbcsr_tensor_api_c.F" -name "*.F")
-OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . -path ../src/acc/opencl -prune -type f -name "*.c")
+OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . -type f -name "*.c")
 
 # if compiling with GPU acceleration
 ifneq ($(ACC),)
-ifeq (cuda,$(USE_ACCEL))
-# All *.cpp files belong to the accelerator backend common between CUDA/HIP
-OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . -type f ! -name "acc_cuda.cpp" ! -name "acc_hip.cpp" -name "*.cpp")
-OBJ_SRC_FILES += $(LIBSMM_ACC_DIR)/../cuda/acc_cuda.cpp
-# Exclude autotuning files
-OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . -type f ! -name "tune_*_exe*_part*.cu" ! -name "tune_*_exe*_main*.cu"  -name "*.cu")
-else ifeq (hip,$(USE_ACCEL))
-# All *.cpp files belong to the accelerator backend common between CUDA/HIP
-OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . -type f ! -name "acc_cuda.cpp" ! -name "acc_hip.cpp" -name "*.cpp")
-OBJ_SRC_FILES += $(LIBSMM_ACC_DIR)/../hip/acc_hip.cpp
-else
-# OpenCL backend: include *.c files in OBJ_SRC_FILES 
-OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . -path ../src/acc/opencl -name "*.c")
-endif
+  ifeq (cuda,$(USE_ACCEL))
+    # All *.cpp files belong to the accelerator backend common between CUDA/HIP
+    OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . -type f ! -name "acc_cuda.cpp" ! -name "acc_hip.cpp" -name "*.cpp")
+    OBJ_SRC_FILES += $(LIBSMM_ACC_DIR)/../cuda/acc_cuda.cpp
+    # Exclude autotuning files
+    OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . -type f ! -name "tune_*_exe*_part*.cu" ! -name "tune_*_exe*_main*.cu"  -name "*.cu")
+  else ifeq (hip,$(USE_ACCEL))
+    # All *.cpp files belong to the accelerator backend common between CUDA/HIP
+    OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . -type f ! -name "acc_cuda.cpp" ! -name "acc_hip.cpp" -name "*.cpp")
+    OBJ_SRC_FILES += $(LIBSMM_ACC_DIR)/../hip/acc_hip.cpp
+  # OpenCL backend: OBJ_SRC_FILES already includes all *.c files
+  endif
 endif
 
 # Include also source files which won't compile into an object file
@@ -321,7 +318,7 @@ else ifeq (hip,$(USE_ACCEL))
 acc_hip.o: acc_hip.cpp acc_hip.h
 	$(ACC) -c $(ACCFLAGS) -I'$(SRCDIR)' $<
 # if compiling OpenCL backend
-else
+else ifeq (opencl,$(USE_ACCEL))
 OPENCL_KERNELS := $(wildcard $(LIBSMM_ACC_ABS_DIR)/../opencl/smm/kernels/*.cl)
 OPENCL_KRNLGEN := $(LIBSMM_ACC_ABS_DIR)/../opencl/acc_opencl.sh
 $(LIBSMM_ACC_ABS_DIR)/../opencl/smm/opencl_kernels.h: $(OPENCL_KRNLGEN) $(OPENCL_KERNELS)

--- a/src/acc/acc_bench_smm.c
+++ b/src/acc/acc_bench_smm.c
@@ -42,54 +42,111 @@
 #endif
 
 #define ACC_BENCH_SMM_EPSILON(T) DBCSR_CONCATENATE(ACC_BENCH_SMM_EPSILON_, T)
-#define ACC_BENCH_SMM_EPSILON_double 5E-6
-#define ACC_BENCH_SMM_EPSILON_float 5E-6
+#define ACC_BENCH_SMM_EPSILON_double 5E-4
+#define ACC_BENCH_SMM_EPSILON_float 5E-4
 
 #define ROUNDUP2(N, NPOT) ((((unsigned long long)N) + ((NPOT) - 1)) & ~((NPOT) - 1))
 #define CHECK(EXPR, RPTR) if ((NULL != ((const void*)(RPTR)) && EXIT_SUCCESS != *((const int*)(RPTR))) || \
   EXIT_SUCCESS != (NULL != ((const void*)(RPTR)) ? (*((int*)(RPTR)) = (EXPR)) : (EXPR))) assert(0)
 
 
-#if defined(_DEBUG) && defined(USE_LIBXSMM) && defined(VALIDATE) && (0 != VALIDATE)
-static void print(FILE* ostream, const char* label, const ELEM_TYPE* mat, int m, int n);
-#endif
-
-
-static int parse_params(int argc, char* argv[], FILE** file,
+static void parse_params(int argc, char* argv[], FILE** file,
   int* inr, int* iss, int* ism, int* isn, int* isk, int* inc, int* ina, int* inb)
 {
-  int result = EXIT_SUCCESS;
+  char buffer[1024], *args[8];
+  int i;
   assert(file && inr && iss && ism && isn && isk && inc && ina && inb);
-  if (NULL == *file) *file = (1 < argc ? fopen(argv[1], "r") : NULL);
-  if (NULL == *file) {
-    *inr = (1 < argc ? atoi(argv[1]) : 0);
-    *iss = (2 < argc ? atoi(argv[2]) : 0);
-    *ism = (3 < argc ? atoi(argv[3]) : 0);
-    *isn = (4 < argc ? atoi(argv[4]) : 0);
-    *isk = (5 < argc ? atoi(argv[5]) : 0);
-    *inc = (6 < argc ? atoi(argv[6]) : 0);
-    *ina = (7 < argc ? atoi(argv[7]) : 0);
-    *inb = (8 < argc ? atoi(argv[8]) : 0);
-  }
+  --argc;
+  if (NULL == *file) *file = (1 <= argc ? fopen(argv[1], "r") : NULL);
+  if (NULL == *file) for (i = 0; i < argc; ++i) args[i] = argv[i+1];
   else {
-    char buffer[1024];
-    *inr = *iss = *ism = *isn = *isk = *inc = *ina = *inb = 0;
-    result = ((NULL != fgets(buffer, sizeof(buffer), *file) &&
-        0 <= sscanf(buffer, "%i %i %i %i %i %i %i %i",
-          inr, iss, ism, isn, isk, inc, ina, inb))
-      ? EXIT_SUCCESS : EXIT_FAILURE);
+    argc = 0;
+    if (NULL != fgets(buffer, sizeof(buffer), *file)) {
+      char* arg = strtok(buffer, " \t;,:");
+      for (; NULL != arg; arg = strtok(NULL, " \t;,:")) {
+        if (argc * sizeof(*args) < sizeof(args)) {
+          args[argc++] = arg;
+        }
+        else { /* malformed command-line */
+          fclose(*file);
+          *file = NULL;
+          break;
+        }
+      }
+    }
+    else {
+      fclose(*file);
+      *file = NULL;
+    }
   }
-  return result;
+  i = 0;
+  if (i < argc) {
+    const char* x1 = strchr(args[i], 'x');
+    const char* x2 = (NULL == x1 ? NULL : strchr(x1 + 1, 'x'));
+    if (NULL == x1 || NULL == x2) { /* accept "M N K"*/
+      *inr = atoi(args[i++]);
+      *iss = (i < argc ? atoi(args[i++]) : 0);
+      if (i < argc) {
+        x1 = strchr(args[i], 'x');
+        x2 = (NULL == x1 ? NULL : strchr(x1 + 1, 'x'));
+        *ism = atoi(args[i++]);
+        if (NULL == x1 || NULL == x2) { /* accept "M N K"*/
+          *isn = (i < argc ? atoi(args[i++]) : 0);
+          *isk = (i < argc ? atoi(args[i++]) : 0);
+        }
+        else { /* accept "MxNxK" */
+          *isn = atoi(x1 + 1);
+          *isk = atoi(x2 + 1);
+        }
+      }
+    }
+    else { /* accept "MxNxK" */
+      *ism = atoi(args[i++]);
+      *isn = atoi(x1 + 1);
+      *isk = atoi(x2 + 1);
+    }
+  }
+  *inc = (i < argc ? atoi(args[i++]) : 0);
+  *ina = (i < argc ? atoi(args[i++]) : 0);
+  *inb = (i < argc ? atoi(args[i++]) : 0);
 }
 
 
 int main(int argc, char* argv[])
 {
+#if defined(USE_LIBXSMM) && defined(VALIDATE) && (0 != VALIDATE)
+  double maxerror = 0;
+#endif
+#if defined(WARMUP) && (0 < WARMUP) && !defined(_DEBUG)
+  const int warmup = MAX(WARMUP, 2) / 2 * 2;
+#else
+  const int warmup = 0;
+#endif
+  int result = c_dbcsr_acc_init();
   FILE* file = NULL;
-  int result = EXIT_SUCCESS;
-  do {
-    int inr = 0, iss = 0, ism = 0, isn = 0, isk = 0, inc = 0, ina = 0, inb = 0;
-    int result = parse_params(argc, argv, &file, &inr, &iss, &ism, &isn, &isk, &inc, &ina, &inb);
+  int nok = 0, inr = 0, iss = 0, ism = 0, isn = 0, isk = 0, inc = 0, ina = 0, inb = 0;
+  parse_params(argc, argv, &file, &inr, &iss, &ism, &isn, &isk, &inc, &ina, &inb);
+  CHECK(libsmm_acc_init(), &result); /* note: libsmm_acc_init() may imply acc_init() */
+  if (EXIT_SUCCESS == result) {
+    const char *const env_device = getenv("DEVICE");
+    const int device = ((NULL == env_device || '\0' == *env_device) ? 0 : atoi(env_device));
+    int ndevices = 0;
+    result = c_dbcsr_acc_get_ndevices(&ndevices);
+    if (0 < ndevices && (0 == device || EXIT_SUCCESS == c_dbcsr_acc_set_active_device(device))) {
+#if defined(_DEBUG)
+      fprintf(stderr, "Activated device %i of %i.\n", device, ndevices);
+#endif
+    }
+    else {
+      if (0 >= ndevices) fprintf(stderr, "No ACC-device found!\n");
+      else fprintf(stderr, "Failed to activate device %i of %i!\n", device, ndevices);
+      result = EXIT_FAILURE;
+    }
+  }
+  else {
+    fprintf(stderr, "ACC initialization failed!\n");
+  }
+  while (EXIT_SUCCESS == result) {
     const int nrepeat = (0 < inr ? inr : 3);
     const int stack_size = (0 < iss ? iss : 30000);
     const int m = (0 < ism ? ism : 23);
@@ -108,17 +165,9 @@ int main(int argc, char* argv[])
 #else
     const int mn = m * n, mk = m * k, kn = k * n;
 #endif
-#if defined(WARMUP) && (0 < WARMUP) && !defined(_DEBUG)
-    const int warmup = MAX(WARMUP, 2) / 2 * 2;
-#else
-    const int warmup = 0;
-#endif
-    const char *const env_device = getenv("DEVICE");
-    const int device = ((NULL == env_device || '\0' == *env_device) ? 0 : atoi(env_device));
     int *stack_hst = NULL, *stack_dev = NULL, *trans_hst = NULL, *trans_dev = NULL;
     ELEM_TYPE *amat_hst = NULL, *bmat_hst = NULL, *cmat_hst = NULL;
     ELEM_TYPE *amat_dev = NULL, *bmat_dev = NULL, *cmat_dev = NULL;
-    int ndevices = 0, r, i;
     void *stream = NULL;
 #if defined(USE_LIBXSMM)
 # if defined(VALIDATE) && (0 != VALIDATE)
@@ -132,41 +181,16 @@ int main(int argc, char* argv[])
 # endif
     double duration;
 #endif
-    assert(m <= (mn / n) && 0 == (mn % n) && k <= (mk / k) && 0 == (mk % k) && n <= (kn / n) && 0 == (kn % n));
-    CHECK(c_dbcsr_acc_init(), &result);
-    /* note: libsmm_acc_init() may imply acc_init() */
-    CHECK(libsmm_acc_init(), &result);
-    if (EXIT_SUCCESS == result) {
-      result = c_dbcsr_acc_get_ndevices(&ndevices);
-      if (0 < ndevices && (0 == device || EXIT_SUCCESS == c_dbcsr_acc_set_active_device(device))) {
-#if defined(_DEBUG)
-        fprintf(stderr, "Activated device %i of %i.\n", device, ndevices);
-#endif
-      }
-      else {
-        if (0 >= ndevices) fprintf(stderr, "No ACC-device found!\n");
-        else fprintf(stderr, "Failed to activate device %i of %i!\n", device, ndevices);
-#if !defined(__CUDA)
-        CHECK(libsmm_acc_finalize(), NULL);
-#endif
-        CHECK(c_dbcsr_acc_finalize(), NULL);
-        return result;
-      }
-    }
-    else ndevices = 0;
-    if (EXIT_SUCCESS == result) {
-      printf("%s%s%i %i %i %i %i %i %i %i\n", 0 < argc ? argv[0] : "", 0 < argc ? " " : "",
-        nrepeat, stack_size, m, n, k, nc, na, nb);
-      printf("typename (id=%i): %s\n", DBCSR_TYPE(ELEM_TYPE), DBCSR_STRINGIFY(ELEM_TYPE));
-    }
-    else if (0 < ndevices) break; /* end of input/argument-file reached */
-    else {
-      fprintf(stderr, "ACC initialization failed!\n");
-#if !defined(__CUDA)
-      CHECK(libsmm_acc_finalize(), NULL);
-#endif
-      CHECK(c_dbcsr_acc_finalize(), NULL);
-      return result;
+    int r, i;
+    assert(m <= (mn / n) && 0 == (mn % n));
+    assert(m <= (mk / k) && 0 == (mk % k));
+    assert(k <= (kn / n) && 0 == (kn % n));
+    printf("%s%s%i %i %i %i %i %i %i %i\n", 0 < argc ? argv[0] : "", 0 < argc ? " " : "",
+      nrepeat, stack_size, m, n, k, nc, na, nb);
+    printf("typename (id=%i): %s\n", DBCSR_TYPE(ELEM_TYPE), DBCSR_STRINGIFY(ELEM_TYPE));
+    if (MAX_KERNEL_DIM < m || MAX_KERNEL_DIM < n || MAX_KERNEL_DIM < k) {
+      fprintf(stderr, "Matrix shape exceeds MAX_KERNEL_DIM!\n");
+      result = EXIT_FAILURE;
     }
     CHECK(c_dbcsr_acc_stream_create(&stream, "stream", -1/*default priority*/), &result);
     CHECK(c_dbcsr_acc_host_mem_allocate((void**)&amat_hst, sizeof(ELEM_TYPE) * mk * na, stream), &result);
@@ -175,24 +199,25 @@ int main(int argc, char* argv[])
     CHECK(c_dbcsr_acc_host_mem_allocate((void**)&stack_hst, sizeof(int) * 3 * stack_size, stream), &result);
     CHECK(c_dbcsr_acc_host_mem_allocate((void**)&trans_hst, sizeof(int) * nb, stream), &result);
     CHECK(c_dbcsr_acc_stream_sync(stream), &result); /* ensure host-data is allocated */
-    /* initialize matrices */
+    if (NULL != amat_hst && NULL != bmat_hst && NULL != trans_hst && NULL != stack_hst) {
 #if defined(_OPENMP)
-#   pragma omp parallel
+#     pragma omp parallel
 #endif
-    {
+      {
 #if defined(_OPENMP)
-#     pragma omp for
+#       pragma omp for
 #endif
-      for (i = 0; i < na; ++i) INIT_MAT(ELEM_TYPE, i/*seed*/ + 42, &amat_hst[i*mk], m, k, 1.0 / (nr * na));
+        for (i = 0; i < na; ++i) INIT_MAT(ELEM_TYPE, i/*seed*/ + 42, &amat_hst[i*mk], m, k, 1.0 / (nr * na));
 #if defined(_OPENMP)
-#     pragma omp for
+#       pragma omp for
 #endif
-      for (i = 0; i < nb; ++i) {
-        INIT_MAT(ELEM_TYPE, i/*seed*/ + 24, &bmat_hst[i*kn], k, n, 1.0 / (nr * nb));
-        trans_hst[i] = i * kn;
+        for (i = 0; i < nb; ++i) {
+          INIT_MAT(ELEM_TYPE, i/*seed*/ + 24, &bmat_hst[i*kn], k, n, 1.0 / (nr * nb));
+          trans_hst[i] = i * kn;
+        }
       }
+      init_stack(stack_hst, stack_size, mn, mk, kn, nc, na, nb);
     }
-    init_stack(stack_hst, stack_size, mn, mk, kn, nc, na, nb);
     CHECK(c_dbcsr_acc_dev_mem_allocate((void**)&amat_dev, sizeof(ELEM_TYPE) * mk * na), &result);
     CHECK(c_dbcsr_acc_dev_mem_allocate((void**)&bmat_dev, sizeof(ELEM_TYPE) * kn * nb), &result);
     CHECK(c_dbcsr_acc_dev_mem_allocate((void**)&cmat_dev, sizeof(ELEM_TYPE) * mn * nc), &result);
@@ -209,10 +234,12 @@ int main(int argc, char* argv[])
     CHECK(c_dbcsr_acc_memcpy_h2d(stack_hst, stack_dev, sizeof(int) * 3 * stack_size, stream), &result);
 #if defined(USE_LIBXSMM)
     CHECK(c_dbcsr_acc_stream_sync(stream), &result);
-    duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
-    printf("copy-in: %.1f ms %.1f GB/s\n", 1000.0 * duration,
-      (sizeof(ELEM_TYPE) * (mk + kn) + sizeof(int) * 3)
-        * stack_size / (duration * (1ULL << 30)));
+    if (NULL != amat_hst && NULL != bmat_hst && NULL != stack_hst) {
+      duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
+      printf("copy-in: %.1f ms %.1f GB/s\n", 1000.0 * duration,
+        (sizeof(ELEM_TYPE) * (mk + kn) + sizeof(int) * 3)
+          * stack_size / (duration * (1ULL << 30)));
+    }
 #endif
 #if defined(TRANSPOSE) && (0 != TRANSPOSE) && defined(VALIDATE) && (0 != VALIDATE)
     /* warmup execution and prebuild transpose-kernel */
@@ -262,7 +289,7 @@ int main(int argc, char* argv[])
     }
 # if defined(VALIDATE) && (0 != VALIDATE)
     /* determine host's performance independent of current result code/status */
-    if (NULL != gold_hst) {
+    if (NULL != gold_hst && NULL != amat_hst && NULL != bmat_hst && NULL != stack_hst) {
       const ELEM_TYPE alpha = 1, beta = 1;
       const char transa = 'N';
 #   if defined(TRANSPOSE) && (0 != TRANSPOSE)
@@ -297,36 +324,33 @@ int main(int argc, char* argv[])
         CHECK(c_dbcsr_acc_memcpy_d2h(cmat_dev, cmat_hst, sizeof(ELEM_TYPE) * mn * nc, stream), &result);
         CHECK(c_dbcsr_acc_stream_sync(stream), &result);
         if (EXIT_SUCCESS == result) {
-          double abserror = 0, relerror = 0, a = 0, b = 0;
+          libxsmm_matdiff_info diff;
+#   if (1 < VALIDATE)
+          libxsmm_matdiff_info di;
+          libxsmm_matdiff_clear(&diff);
           for (i = 0; i < nc; ++i) {
             const ELEM_TYPE *const gold = gold_hst + mn * i;
             const ELEM_TYPE *const test = cmat_hst + mn * i;
-            double diff = 0, ai = 0, bi = 0;
-            for (r = 0; r < (m * n); ++r) {
-              const double ar = (double)gold[r];
-              const double br = (double)test[r];
-              const double d = fabs(ar - br);
-              if (diff < d) {
-                diff = d; ai = ar; bi = br;
-              }
-            }
-            if (0 < diff) {
-              const double rd = fabs(0 != ai ? (diff / ai) : (diff / bi));
-#   if defined(_DEBUG)
-              print(stderr, "gold = ", gold, m, n);
-              print(stderr, "test = ", test, m, n);
-              fprintf(stderr, "rel = %g (%g != %g)\n", rd, ai, bi);
-#   endif
-              if (abserror < diff) {
-                abserror = diff;
-                relerror = rd;
-                a = ai; b = bi;
-              }
-            }
+            result = libxsmm_matdiff(&di, LIBXSMM_DATATYPE(ELEM_TYPE), m, n, gold, test, &m, &m);
+            if (EXIT_SUCCESS == result) libxsmm_matdiff_reduce(&diff, &di);
+            else break;
           }
-          printf("max.error: %g", relerror / nr);
-          if (0 < abserror) printf(" (%g != %g)\n", a, b); else printf("\n");
-          if (0 < check && (nr * check) < relerror) result = EXIT_FAILURE;
+#   else
+          /* validate result buffers at once (including excess area/padded space) */
+          result = libxsmm_matdiff(&diff, LIBXSMM_DATATYPE(ELEM_TYPE),
+            mn, nc, gold_hst, cmat_hst, &mn, &mn);
+#   endif
+          if (EXIT_SUCCESS == result) {
+            const double relerror = 1.0 - diff.rsq;
+            printf("rel.error: %g", relerror);
+            if (maxerror < relerror && NULL != file) maxerror = relerror;
+            if (0 < relerror) {
+              if (LIBXSMM_NOTNAN(diff.v_tst)) printf(" (%g != %g)\n", diff.v_ref, diff.v_tst);
+              else printf(" (%g)\n", diff.v_tst);
+            }
+            else printf("\n");
+            if (0 < check && check < relerror) result = EXIT_FAILURE;
+          }
         }
       }
       libxsmm_free(gold_hst);
@@ -344,31 +368,23 @@ int main(int argc, char* argv[])
     CHECK(c_dbcsr_acc_dev_mem_deallocate(bmat_dev), NULL);
     CHECK(c_dbcsr_acc_dev_mem_deallocate(cmat_dev), NULL);
     CHECK(c_dbcsr_acc_stream_destroy(stream), NULL);
-#if !defined(__CUDA)
-    CHECK(libsmm_acc_finalize(), NULL);
-#endif
-    CHECK(c_dbcsr_acc_finalize(), NULL);
-    if (EXIT_SUCCESS != result) {
-      fprintf(stderr, "FAILED\n");
+    if (EXIT_SUCCESS == result) {
+      ++nok; parse_params(argc, argv, &file, &inr, &iss, &ism, &isn, &isk, &inc, &ina, &inb);
+      if (NULL != file) printf("\n"); else break;
     }
-  } while (NULL != file);
-  if (NULL != file) fclose(file);
+  }
+  if (EXIT_SUCCESS == result) {
+#if defined(USE_LIBXSMM) && defined(VALIDATE) && (0 != VALIDATE)
+    if (1 < nok) printf("\nmax.error: %g\n", maxerror);
+#endif
+  }
+  else {
+    if (NULL != file) fclose(file);
+    fprintf(stderr, "FAILED\n");
+  }
+#if !defined(__CUDA)
+  CHECK(libsmm_acc_finalize(), NULL);
+#endif
+  CHECK(c_dbcsr_acc_finalize(), NULL);
   return result;
 }
-
-
-#if defined(_DEBUG) && defined(USE_LIBXSMM) && defined(VALIDATE) && (0 != VALIDATE)
-static void print(FILE* ostream, const char* label, const ELEM_TYPE* mat, int m, int n)
-{
-  int i, j;
-  const char *const s = (NULL != label ? label : "");
-  const int len = (int)strlen(s);
-  for (i = 0; i < n; ++i) {
-    if (0 < i) fprintf(ostream, "%*s", len, " "); else fprintf(ostream, "%s", s);
-    for (j = 0; j < m; ++j) {
-      fprintf(ostream, "%.2f ", mat[i*m+j]);
-    }
-    fprintf(ostream, "\n");
-  }
-}
-#endif

--- a/src/acc/acc_triplets.sh
+++ b/src/acc/acc_triplets.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+####################################################################################################
+# Copyright (C) by the DBCSR developers group - All rights reserved                                #
+# This file is part of the DBCSR library.                                                          #
+#                                                                                                  #
+# For information on the license, see the LICENSE file.                                            #
+# For further information please visit https://dbcsr.cp2k.org                                      #
+# SPDX-License-Identifier: GPL-2.0+                                                                #
+####################################################################################################
+XARGS=$(command -v xargs)
+SORT=$(command -v sort)
+HEAD=$(command -v head)
+SED=$(command -v gsed)
+CUT=$(command -v cut)
+
+# GNU sed is desired (macOS)
+if [ "" = "${SED}" ]; then
+  SED=$(command -v sed)
+fi
+
+if [ "${XARGS}" ] &&  [ "${SORT}" ] && [ "${HEAD}" ] && [ "${SED}" ] && [ "${CUT}" ]; then
+  LINES=0
+  while test $# -gt 0; do
+    case "$1" in
+    -h|--help)
+      shift $#;;
+    -l|--lines)
+      LINES=1
+      shift;;
+    -m|--limit)
+      LIMIT=$2
+      shift 2;;
+    -n|--size)
+      SIZE=$2
+      shift 2;;
+    -a|--amat)
+      CUTSEL=-f1,3
+      shift;;
+    -b|--bmat)
+      CUTSEL=-f3,2
+      shift;;
+    -c|--cmat)
+      CUTSEL=-f1,2
+      shift;;
+    -s|--specid)
+      case "$2" in
+      0) TRIPLETS="23, 6, 14 16 29, 5 16 13 24 26, 9 16 22, 32, 64, 78, 16 29 55";;
+      1) TRIPLETS="23, 6, 14 16 29, 5 32 13 24 26, 9 32 22, 32, 64, 78, 16 29 55";;
+      2) TRIPLETS="23, 6, 14 16 29, 5 32 13 24 26, 9 32 22, 32, 64, 78, 16 29 55, 12";;
+      3) TRIPLETS="23, 6, 14 16 29, 14 32 29, 5 32 13 24 26, 9 32 22, 32, 64, 78, 16 29 55, 32 29 55, 12";;
+      4) TRIPLETS="23, 6, 14 16 29, 14 32 29, 5 32 13 24 26, 9 32 22, 32, 64, 78, 16 29 55, 32 29 55, 12, 13 26 28 32 45";;
+      5) TRIPLETS="23, 6, 14 16 29, 14 32 29, 5 32 13 24 26, 9 32 22, 32, 64, 78, 16 29 55, 32 29 55, 12, 13 26 28 32 45, 7 13 25 32";;
+      6) TRIPLETS="23, 6, 14 16 29, 14 32 29, 5 32 13 24 26, 9 32 22, 64, 78, 16 29 55, 32 29 55, 12, 4 5 7 9 13 25 26 28 32 45";;
+      7) TRIPLETS="23, 6, 14 16 29, 14 32 29, 5 32 13 24 26, 9 32 22, 64, 78, 16 29 55, 32 29 55, 12, 4 5 7 9 13 25 26 28 32 45, 4 10";;
+      8) TRIPLETS="23, 6, 14 16 29, 14 32 29, 5 32 13 24 26, 9 32 22, 64, 78, 16 29 55, 32 29 55, 12, 4 5 7 9 13 25 26 28 32 45, 4 10 15";;
+      9) TRIPLETS="23, 6, 14 16 29, 14 32 29, 5 32 13 24 26, 9 32 22, 64, 78, 16 29 55, 32 29 55, 12, 4 5 7 9 13 25 26 28 32 45, 4 10 15, 6 7 8";;
+      *) TRIPLETS=" \
+          4 5 7 9 13 25 26 28 32 45, \
+          13 14 25 26 32, \
+          5 32 13 24 26, \
+          14 16 29, \
+          14 32 29, \
+          16 29 55, \
+          32 29 55, \
+          9 32 22, \
+          4 10 15, \
+          6 7 8, \
+          23, \
+          64, \
+          78, \
+          12, \
+          6";;
+      esac
+      shift 2;;
+    *)
+      if [ "" = "$(echo "$*" | ${SED} -n "s/[0-9]*[[:space:]]*,*//gp")" ]; then
+        TRIPLETS="$*"
+      else
+        >&2 echo "ERROR: invalid triplet specification!"
+      fi
+      break;;
+    esac
+  done
+  if [ "${TRIPLETS}" ]; then
+    for SPECS in $(echo "${TRIPLETS}" | ${SED} -e "s/[[:space:]][[:space:]]*/x/g" -e "s/,/ /g"); do
+      SPEC=$(echo "${SPECS}" | ${SED} -e "s/^x//g" -e "s/x$//g" -e "s/x/,/g")
+      if [ "${LIMIT}" ] && [ "0" != "$((0<LIMIT))" ]; then
+        for EXT in $(echo "${SPEC}" | ${SED} "s/,/ /g"); do
+          if [ "0" != "$((LIMIT<EXT))" ]; then continue 2; fi
+        done
+      fi
+      MNKS="${MNKS} $(eval printf "%s" "{${SPEC}}x{${SPEC}}x{${SPEC}}\" \"" | ${SED} -e "s/{//g" -e "s/}//g")"
+    done
+    if [ "${MNKS}" ]; then
+      if [ "${CUTSEL}" ]; then
+        MNK=$(echo "${MNKS}" | ${XARGS} -n1 | ${CUT} -dx ${CUTSEL} | ${SORT} -u -n -tx -k1 -k2 -k3 | \
+          if [ "0" != "$((0<SIZE))" ]; then ${HEAD} -n${SIZE}; else cat; fi)
+      else
+        MNK=$(echo "${MNKS}" | ${XARGS} -n1 | ${SORT} -u -n -tx -k1 -k2 -k3 | \
+          if [ "0" != "$((0<SIZE))" ]; then ${HEAD} -n${SIZE}; else cat; fi)
+      fi
+      if [ "0" = "${LINES}" ]; then
+        echo "${MNK}" | ${XARGS}
+      else
+        echo "${MNK}"
+      fi
+    fi
+  else
+    echo "Usage: $0 [options] [<triplet-spec>]"
+    echo "       Options must precede triplet specification"
+    echo "       -l|--lines: lines instead of list of words"
+    echo "       -m|--limit N: limit shape extents to N"
+    echo "       -n|--size  N: limit number of elements"
+    echo "       -a|--amat: select MxK instead of MxNxK"
+    echo "       -b|--bmat: select KxN instead of MxNxK"
+    echo "       -c|--cmat: select MxN instead of MxNxK"
+    echo "       -s|--specid N: predefined triplets"
+    echo "        0-10: older to newer (larger), e.g.,"
+    echo "       -s  0:  201 kernels"
+    echo "       -s 10: 1266 kernels"
+    echo "       <triplet-spec>, e.g., 134 kernels"
+    echo "         23, 5 32 13 24 26, 4 9"
+    echo
+  fi
+else
+  >&2 echo "ERROR: missing prerequisites!"
+  exit 1
+fi

--- a/src/acc/cuda/Makefile
+++ b/src/acc/cuda/Makefile
@@ -1,32 +1,50 @@
-INCACC := $(wildcard *.h*) ../acc.h
-SRCACC := $(wildcard *.cpp)
+MAKDIR := $(subst //,,$(dir $(firstword $(MAKEFILE_LIST)))/)
+INCACC := $(wildcard $(MAKDIR)/*.h*) $(MAKDIR)/../acc.h
+SRCACC := $(wildcard $(MAKDIR)/*.cpp)
 OBJACC := $(SRCACC:.cpp=.o)
 
-GPUSMM := $(wildcard ../libsmm_acc/kernels/*.h*)
-INCSMM := $(wildcard ../libsmm_acc/*.h*) ../acc_libsmm.h \
-  ../libsmm_acc/smm_acc_kernels.h \
-  ../libsmm_acc/parameters.h \
+GPUSMM := $(wildcard $(MAKDIR)/../libsmm_acc/kernels/*.h*)
+INCSMM := $(wildcard $(MAKDIR)/../libsmm_acc/*.h*) \
+  $(MAKDIR)/../libsmm_acc/smm_acc_kernels.h \
+  $(MAKDIR)/../libsmm_acc/parameters.h \
+  $(MAKDIR)/../acc_libsmm.h \
   $(NULL)
-SRCSMM := $(wildcard ../libsmm_acc/*.cpp)
+SRCSMM := $(wildcard $(MAKDIR)/../libsmm_acc/*.cpp)
 OBJSMM := $(SRCSMM:.cpp=.o)
 
 INCALL := $(INCACC) $(INCSMM)
 
-LIBXSMMROOT := $(wildcard ../../../../libxsmm)
+LIBXSMMROOT := $(wildcard $(MAKDIR)/../../../../libxsmm)
 ifeq (,$(LIBXSMMROOT))
   LIBXSMMROOT := $(wildcard $(HOME)/libxsmm)
 endif
-NVCC ?= $(shell which nvcc 2>/dev/null)
-CUDA_PATH ?= $(if $(NVCC),$(abspath $(dir $(NVCC))/..))
 UNAME := $(shell uname)
 WITH_GPU ?= P100
 INTEL ?= 0
 DEV ?= 0
 
-PYTHON := $(shell which python3 2>/dev/null)
-ifeq (,$(PYTHON))
-  PYTHON := $(shell which python 2>/dev/null)
+# select from set of predefined triplet specifications
+SPECID ?= 0
+# limit shape in tests (zero or negative for unlimited)
+MAXEXT ?= 48
+# number of tests (zero or negative for unlimited)
+NTRANS ?= 10
+NSMMS ?= 10
+
+COMMAND := $(shell which command 2>/dev/null)
+ifneq (,$(COMMAND))
+  which = $(shell $(COMMAND) -v $1)
+else
+  which = $(shell which $(firstword $1) 2>/dev/null)
 endif
+
+PYTHON := $(call which,python3)
+ifeq (,$(PYTHON))
+  PYTHON := $(call which,python)
+endif
+
+NVCC ?= $(call which,nvcc)
+CUDA_PATH ?= $(if $(NVCC),$(abspath $(dir $(NVCC))/..))
 
 ifeq ($(WITH_GPU),K20X)
   ARCH_NUMBER = 35
@@ -48,6 +66,8 @@ endif
 
 CFLAGS := -fPIC \
   -Wall -Wextra -pedantic \
+  -Wno-variadic-macros \
+  -Wno-long-long \
   -DARCH_NUMBER=$(ARCH_NUMBER) \
   -DNO_DBCSR_TIMESET \
   -D__CUDA \
@@ -75,6 +95,13 @@ else
   endif
 endif
 
+ifeq (0,$(DEV))
+  CFLAGS += \
+    -Wno-unused-parameter \
+    -Wno-format \
+    $(NULL)
+endif
+
 ifneq (0,$(DBG))
   ifeq (,$(DBG))
     CFLAGS += -O2
@@ -93,85 +120,145 @@ ifneq (0,$(SYM))
 endif
 
 ifneq (0,$(OMP))
-ifneq (0,$(INTEL))
-  CFLAGS += -qopenmp
-  LDFLAGS += -qopenmp
-else ifneq (Darwin,$(UNAME))
-  CFLAGS += -fopenmp
-  LDFLAGS += -fopenmp
-else # macOS
-  CFLAGS += -Xpreprocessor -fopenmp
-  LDFLAGS += -lomp
+  ifneq (0,$(INTEL))
+    CFLAGS += -qopenmp
+    LDFLAGS += -qopenmp
+  else ifneq (Darwin,$(UNAME))
+    CFLAGS += -fopenmp
+    LDFLAGS += -fopenmp
+  else # macOS
+    CFLAGS += -Xpreprocessor -fopenmp
+    LDFLAGS += -lomp
+  endif
+  ifneq (,$(LIBXSMMROOT))
+    LDFLAGS += -lxsmmext -lxsmm -lxsmmnoblas -ldl -lm
+  endif
+else
+  ifneq (,$(LIBXSMMROOT))
+    LDFLAGS += -lxsmm -lxsmmnoblas -ldl -lm
+  endif
 endif
-endif
-
 ifneq (,$(LIBXSMMROOT))
-  LDFLAGS := -pthread $(LDFLAGS) -L$(LIBXSMMROOT)/lib -lxsmmext -lxsmm -lxsmmnoblas -ldl -lm
-  CFLAGS += -pthread -D__LIBXSMM -I$(LIBXSMMROOT)/include
+  CFLAGS_XSMM += -pthread -D__LIBXSMM -I$(LIBXSMMROOT)/include
+  LDFLAGS := -pthread $(LDFLAGS)
+  LDFLAGS += -L$(LIBXSMMROOT)/lib
+  ifneq (Darwin,$(UNAME))
+    LDFLAGS += -Wl,-rpath=$(LIBXSMMROOT)/lib $(LDFLAGS)
+  endif
 endif
 
 ifneq (,$(CUDA_PATH))
+  LDFLAGS += -L$(CUDA_PATH)/lib64/stubs -Wl,-rpath=$(CUDA_PATH)/lib64/stubs
+  LDFLAGS += -L$(CUDA_PATH)/lib64 -Wl,-rpath=$(CUDA_PATH)/lib64
   CFLAGS += -I$(CUDA_PATH)/include
-  LDFLAGS += -L$(CUDA_PATH)/lib64/stubs
-  LDFLAGS += -L$(CUDA_PATH)/lib64
 endif
 
-ifneq (0,$(DEV))
-  CXXFLAGS := -std=c++11 $(CFLAGS)
-  CFLAGS := -std=c89 $(CFLAGS)
-else
-  CXXFLAGS := $(CFLAGS)
+CXXLIBDIR := $(dir $(call which,$(CXX)))/../lib64
+ifneq (,$(wildcard $(CXXLIBDIR)))
+  LDFLAGS += -Wl,-rpath=$(abspath $(CXXLIBDIR))
 endif
 
 LDFLAGS += -lcudart -lcublas -lnvrtc -lcuda
-CFLAGS += -Wno-variadic-macros -Wno-long-long
+CXXFLAGS += -std=c++11 $(CFLAGS)
 
 .PHONY: bench
-bench: ../acc_bench_smm ../acc_bench_trans
+bench: $(MAKDIR)/../acc_bench_smm $(MAKDIR)/../acc_bench_trans
 
 .PHONY: all
-all: ../dbcsr_acc.a ../dbcsr_acc_smm.a bench test
+all: $(MAKDIR)/../dbcsr_acc.a $(MAKDIR)/../dbcsr_acc_smm.a bench test
 
 .PHONY: test
-test: ../dbcsr_acc_test
+test: test-interface test-trans test-smm
 
-../libsmm_acc/parameters.h: Makefile ../libsmm_acc/generate_parameters.py ../libsmm_acc/parameters/parameters_$(WITH_GPU).json
-	@cd ../libsmm_acc && $(PYTHON) ../libsmm_acc/generate_parameters.py --gpu_version=$(WITH_GPU) --base_dir=../libsmm_acc/parameters
+.PHONY: test-interface
+test-interface: $(MAKDIR)/../dbcsr_acc_test
+	@echo "--- DBCSR Backend Interface"
+	$(MAKDIR)/../dbcsr_acc_test
 
-../libsmm_acc/smm_acc_kernels.h: $(GPUSMM) Makefile ../libsmm_acc/generate_kernels.py ../libsmm_acc/parameters/parameters_$(WITH_GPU).json
-	@cd ../libsmm_acc && $(PYTHON) ../libsmm_acc/generate_kernels.py ../libsmm_acc/kernels
+.PHONY: test-trans
+test-trans: bench
+	$(eval SHAPES = $(shell $(MAKDIR)/../acc_triplets.sh -l -s $(SPECID) -m $(MAXEXT) -n $(NTRANS) -a))
+	@echo "--- DBCSR OpenCL Transposes ($(words $(SHAPES)))"
+	@echo "runtime libraries:"
+	@ldd $(MAKDIR)/../acc_bench_trans
+	@echo "hostname: $$(hostname)"
+	@echo
+	@for SHAPE in $(SHAPES); do \
+		$(MAKDIR)/../acc_bench_trans $${SHAPE} || exit 1; \
+		echo; \
+	done
 
-../dbcsr_acc.a: $(OBJACC) ../libsmm_acc/libsmm_acc_init.o
+$(MAKDIR)/test-smm.log: bench
+	@echo "--- DBCSR OpenCL SMMs"
+	@echo "runtime libraries:"
+	@ldd $(MAKDIR)/../acc_bench_smm
+	@echo "hostname: $$(hostname)"
+	@echo
+	@$(MAKDIR)/../acc_triplets.sh -l -s $(SPECID) -m $(MAXEXT) -n $(NSMMS) | \
+		(CHECK=1 stdbuf --output=L $(MAKDIR)/../acc_bench_smm /dev/stdin \
+			2>$(MAKDIR)/test-smm.err && rm $(MAKDIR)/test-smm.err) | tee $@
+	@if [ -s $(MAKDIR)/test-smm.err ]; then cat $(MAKDIR)/test-smm.err && exit 1; fi
+
+.PHONY: test-smm
+test-smm: $(MAKDIR)/test-smm.log
+ifneq (,$(call which,datamash))
+ifeq (,$(shell datamash geomean 2>&1 | grep invalid))
+	@echo "geomean: $$(sed -n "/device:/p" $< | datamash -W -R 1 geomean 4) GFLOPS/s"
+endif
+	@echo "median: $$(sed -n "/device:/p" $< | datamash -W -R 1 median 4) GFLOPS/s"
+	@echo "mean: $$(sed -n "/device:/p" $< | datamash -W -R 1 mean 4) GFLOPS/s"
+endif
+
+$(MAKDIR)/../libsmm_acc/parameters.h: $(MAKDIR)/Makefile $(MAKDIR)/../libsmm_acc/generate_parameters.py $(MAKDIR)/../libsmm_acc/parameters/parameters_$(WITH_GPU).json
+	@cd $(MAKDIR)/../libsmm_acc && $(PYTHON) ../libsmm_acc/generate_parameters.py --gpu_version=$(WITH_GPU) --base_dir=../libsmm_acc/parameters
+
+$(MAKDIR)/../libsmm_acc/smm_acc_kernels.h: $(GPUSMM) $(MAKDIR)/Makefile $(MAKDIR)/../libsmm_acc/generate_kernels.py $(MAKDIR)/../libsmm_acc/parameters/parameters_$(WITH_GPU).json
+	@cd $(MAKDIR)/../libsmm_acc && $(PYTHON) ../libsmm_acc/generate_kernels.py ../libsmm_acc/kernels
+
+$(MAKDIR)/../dbcsr_acc.a: $(OBJACC) $(MAKDIR)/../libsmm_acc/libsmm_acc_init.o
 	$(AR) -rs $@ $^
 
-../dbcsr_acc_smm.a: $(OBJSMM)
+$(MAKDIR)/../dbcsr_acc_smm.a: $(OBJSMM)
 	$(AR) -rs $@ $^
 
-%.o: %.cpp $(INCALL) Makefile
-	$(CXX) $(CXXFLAGS) -c $< -o $@
+%.o: %.cpp $(INCALL) $(MAKDIR)/Makefile
+	$(CXX) $(CXXFLAGS) $(CFLAGS_XSMM) -c $< -o $@
 
-acc_bench_smm.o: ../acc_bench_smm.c Makefile
+$(MAKDIR)/acc_bench_smm.o: $(MAKDIR)/../acc_bench_smm.c $(MAKDIR)/Makefile
+ifneq (0,$(LIBXSMM))
+	$(CC) $(CFLAGS) $(CFLAGS_XSMM) -c $< -o $@
+else
 	$(CC) $(CFLAGS) -c $< -o $@
-../acc_bench_smm: acc_bench_smm.o ../dbcsr_acc_smm.a ../dbcsr_acc.a
+endif
+$(MAKDIR)/../acc_bench_smm: $(MAKDIR)/acc_bench_smm.o $(MAKDIR)/../dbcsr_acc_smm.a $(MAKDIR)/../dbcsr_acc.a
 	$(CXX) $^ $(LDFLAGS) -o $@
 
-acc_bench_trans.o: ../acc_bench_trans.c Makefile
+$(MAKDIR)/acc_bench_trans.o: $(MAKDIR)/../acc_bench_trans.c $(MAKDIR)/Makefile
+ifneq (0,$(LIBXSMM))
+	$(CC) $(CFLAGS) $(CFLAGS_XSMM) -c $< -o $@
+else
 	$(CC) $(CFLAGS) -c $< -o $@
-../acc_bench_trans: acc_bench_trans.o ../dbcsr_acc_smm.a ../dbcsr_acc.a
+endif
+$(MAKDIR)/../acc_bench_trans: $(MAKDIR)/acc_bench_trans.o $(MAKDIR)/../dbcsr_acc_smm.a $(MAKDIR)/../dbcsr_acc.a
 	$(CXX) $^ $(LDFLAGS) -o $@
 
-dbcsr_acc_test.o: ../../../tests/dbcsr_acc_test.c Makefile
-	$(CC) $(CFLAGS) -I../.. -c $< -o $@
-../dbcsr_acc_test: dbcsr_acc_test.o ../dbcsr_acc_smm.a ../dbcsr_acc.a
+$(MAKDIR)/dbcsr_acc_test.o: $(MAKDIR)/../../../tests/dbcsr_acc_test.c $(MAKDIR)/Makefile
+	$(CC) $(CFLAGS) -I$(MAKDIR)/../.. -c $< -o $@
+$(MAKDIR)/../dbcsr_acc_test: $(MAKDIR)/dbcsr_acc_test.o $(MAKDIR)/../dbcsr_acc.a
 	$(CXX) $^ $(LDFLAGS) -o $@
 
 .PHONY: clean
 clean:
 	@rm -f $(OBJACC) $(OBJSMM)
-	@rm -f acc_bench_smm.o acc_bench_trans.o dbcsr_acc_test.o
+	@rm -f $(MAKDIR)/dbcsr_acc_test.o
+	@rm -f $(MAKDIR)/acc_bench_trans.o
+	@rm -f $(MAKDIR)/acc_bench_smm.o
+	@rm -f $(MAKDIR)/../libsmm_acc/parameters.h
+	@rm -f $(MAKDIR)/test-smm.err
 
 .PHONY: realclean
 realclean: clean
-	@rm -f ../dbcsr_acc.a ../dbcsr_acc_smm.a
-	@rm -f ../acc_bench_smm ../acc_bench_trans
-	@rm -f ../dbcsr_acc_test
+	@rm -f $(MAKDIR)/../dbcsr_acc.a $(MAKDIR)/../dbcsr_acc_smm.a
+	@rm -f $(MAKDIR)/../acc_bench_smm $(MAKDIR)/../acc_bench_trans
+	@rm -f $(MAKDIR)/../dbcsr_acc_test
+	@rm -f $(MAKDIR)/test-smm.log

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -1,15 +1,19 @@
-INCACC := $(wildcard *.h*) ../acc.h
-SRCACC := $(wildcard *.c)
+MAKDIR := $(subst //,,$(dir $(firstword $(MAKEFILE_LIST)))/)
+INCACC := $(wildcard $(MAKDIR)/*.h*) $(MAKDIR)/../acc.h
+SRCACC := $(wildcard $(MAKDIR)/*.c)
 OBJACC := $(SRCACC:.c=.o)
 
-INCSMM := $(wildcard smm/*.h*) smm/opencl_kernels.h ../acc_libsmm.h
-SRCSMM := $(wildcard smm/*.c)
+INCSMM := $(wildcard $(MAKDIR)/smm/*.h*) \
+                     $(MAKDIR)/smm/opencl_kernels.h \
+                     $(MAKDIR)/../acc_libsmm.h \
+                     $(NULL)
+SRCSMM := $(wildcard $(MAKDIR)/smm/*.c)
 OBJSMM := $(SRCSMM:.c=.o)
-KERNEL := $(wildcard smm/kernels/*.cl)
+KERNEL := $(wildcard $(MAKDIR)/smm/kernels/*.cl)
 
 INCALL := $(INCACC) $(INCSMM)
 
-LIBXSMMROOT := $(wildcard ../../../../libxsmm)
+LIBXSMMROOT := $(wildcard $(MAKDIR)/../../../../libxsmm)
 ifeq (,$(LIBXSMMROOT))
   LIBXSMMROOT := $(wildcard $(HOME)/libxsmm)
 endif
@@ -17,8 +21,23 @@ UNAME := $(shell uname)
 INTEL ?= 0
 DEV ?= 0
 
-PARAMS_WITHGPU := smm/params/tune_multiply_$(WITH_GPU).csv
-PARAMS_DEFAULT := smm/tune_multiply.csv
+# select from set of predefined triplet specifications
+SPECID ?= 0
+# limit shape in tests (zero or negative for unlimited)
+MAXEXT ?= 48
+# number of tests (zero or negative for unlimited)
+NTRANS ?= 10
+NSMMS ?= 10
+
+COMMAND := $(shell which command 2>/dev/null)
+ifneq (,$(COMMAND))
+  which = $(shell $(COMMAND) -v $1)
+else
+  which = $(shell which $(firstword $1) 2>/dev/null)
+endif
+
+PARAMS_WITHGPU := $(MAKDIR)/smm/params/tune_multiply_$(WITH_GPU).csv
+PARAMS_DEFAULT := $(MAKDIR)/smm/tune_multiply.csv
 PARAMS := $(if $(wildcard $(PARAMS_WITHGPU)),$(PARAMS_WITHGPU),$(PARAMS_DEFAULT))
 
 CFLAGS := -fPIC \
@@ -68,7 +87,7 @@ else
 endif
 
 ifneq (0,$(DBG))
-  CPPFLAGS += -CC
+  CPP_OPENCL_FLAGS += -C
   ifeq (,$(DBG))
     CFLAGS += -O2
   else
@@ -97,13 +116,19 @@ ifneq (0,$(OMP))
     LDFLAGS += -lomp
   endif
   ifneq (,$(LIBXSMMROOT))
-    LDFLAGS := -pthread $(LDFLAGS) -L$(LIBXSMMROOT)/lib -lxsmmext -lxsmm -lxsmmnoblas -ldl -lm
-    CFLAGS += -pthread -D__LIBXSMM -I$(LIBXSMMROOT)/include
+    LDFLAGS += -lxsmmext -lxsmm -lxsmmnoblas -ldl -lm
   endif
 else
   ifneq (,$(LIBXSMMROOT))
-    LDFLAGS := -pthread $(LDFLAGS) -L$(LIBXSMMROOT)/lib -lxsmm -lxsmmnoblas -ldl -lm
-    CFLAGS += -pthread -D__LIBXSMM -I$(LIBXSMMROOT)/include
+    LDFLAGS += -lxsmm -lxsmmnoblas -ldl -lm
+  endif
+endif
+ifneq (,$(LIBXSMMROOT))
+  CFLAGS_XSMM += -pthread -D__LIBXSMM -I$(LIBXSMMROOT)/include
+  LDFLAGS := -pthread $(LDFLAGS)
+  LDFLAGS += -L$(LIBXSMMROOT)/lib
+  ifneq (Darwin,$(UNAME))
+    LDFLAGS += -Wl,-rpath=$(LIBXSMMROOT)/lib $(LDFLAGS)
   endif
 endif
 
@@ -114,64 +139,125 @@ else
     CUDATOOLKIT_HOME := $(NVSDKCOMPUTE_ROOT)
   endif
   ifeq (,$(CUDATOOLKIT_HOME))
-    NVCC := $(shell which nvcc 2>/dev/null)
+    NVCC := $(call which,nvcc)
     CUDATOOLKIT_HOME := $(if $(NVCC),$(abspath $(dir $(NVCC))/..))
   endif
   ifneq (,$(CUDATOOLKIT_HOME))
     CFLAGS += -I$(CUDATOOLKIT_HOME)/include
-    LDFLAGS += -L$(CUDATOOLKIT_HOME)/lib64
+    ifeq (,$(wildcard $(LIBOPENCL)))
+      LDFLAGS += -L$(CUDATOOLKIT_HOME)/lib64
+      LDFLAGS += -Wl,-rpath=$(CUDATOOLKIT_HOME)/lib64
+    endif
   endif
-  ifneq (,$(wildcard $(LIBOPENCL)))
-    LDFLAGS += $(LIBOPENCL)
-  else
+  ifeq (,$(wildcard $(LIBOPENCL)))
     LDFLAGS += -lOpenCL
+  else
+    LDFLAGS += $(LIBOPENCL)
   endif
 endif
 
+CXXLIBDIR := $(dir $(call which,$(CXX)))/../lib64
+ifneq (,$(wildcard $(CXXLIBDIR)))
+  LDFLAGS += -Wl,-rpath=$(abspath $(CXXLIBDIR))
+endif
+
 .PHONY: bench
-bench: ../acc_bench_smm ../acc_bench_trans
+bench: $(MAKDIR)/../acc_bench_smm $(MAKDIR)/../acc_bench_trans
 
 .PHONY: all
-all: ../dbcsr_acc.a ../dbcsr_acc_smm.a bench test
+all: $(MAKDIR)/../dbcsr_acc.a $(MAKDIR)/../dbcsr_acc_smm.a bench test
 
 .PHONY: test
-test: ../dbcsr_acc_test
+test: test-interface test-trans test-smm
 
-smm/opencl_kernels.h: acc_opencl.sh $(KERNEL)
-	CPPFLAGS=$(CPPFLAGS) ./acc_opencl.sh $(KERNEL) $(PARAMS) $@
+.PHONY: test-interface
+test-interface: $(MAKDIR)/../dbcsr_acc_test
+	@echo "--- DBCSR Backend Interface"
+	$(MAKDIR)/../dbcsr_acc_test
 
-../dbcsr_acc.a: $(OBJACC)
+.PHONY: test-trans
+test-trans: bench
+	$(eval SHAPES = $(shell $(MAKDIR)/../acc_triplets.sh -l -s $(SPECID) -m $(MAXEXT) -n $(NTRANS) -a))
+	@echo "--- DBCSR OpenCL Transposes ($(words $(SHAPES)))"
+	@ACC_OPENCL_VERBOSE=1 CHECK=0 $(MAKDIR)/../acc_bench_trans 2>&1 >/dev/null
+	@echo "runtime libraries:"
+	@ldd $(MAKDIR)/../acc_bench_trans
+	@echo "hostname: $$(hostname)"
+	@echo
+	@for SHAPE in $(SHAPES); do \
+		$(MAKDIR)/../acc_bench_trans $${SHAPE} || exit 1; \
+		echo; \
+	done
+
+$(MAKDIR)/test-smm.log: bench
+	@echo "--- DBCSR OpenCL SMMs"
+	@ACC_OPENCL_VERBOSE=1 CHECK=0 $(MAKDIR)/../acc_bench_smm 2>&1 >/dev/null
+	@echo "runtime libraries:"
+	@ldd $(MAKDIR)/../acc_bench_smm
+	@echo "hostname: $$(hostname)"
+	@echo
+	@$(MAKDIR)/../acc_triplets.sh -l -s $(SPECID) -m $(MAXEXT) -n $(NSMMS) | \
+		(CHECK=1 stdbuf --output=L $(MAKDIR)/../acc_bench_smm /dev/stdin \
+			2>$(MAKDIR)/test-smm.err && rm $(MAKDIR)/test-smm.err) | tee $@
+	@if [ -s $(MAKDIR)/test-smm.err ]; then cat $(MAKDIR)/test-smm.err && exit 1; fi
+
+.PHONY: test-smm
+test-smm: $(MAKDIR)/test-smm.log
+ifneq (,$(call which,datamash))
+ifeq (,$(shell datamash geomean 2>&1 | grep invalid))
+	@echo "geomean: $$(sed -n "/device:/p" $< | datamash -W -R 1 geomean 4) GFLOPS/s"
+endif
+	@echo "median: $$(sed -n "/device:/p" $< | datamash -W -R 1 median 4) GFLOPS/s"
+	@echo "mean: $$(sed -n "/device:/p" $< | datamash -W -R 1 mean 4) GFLOPS/s"
+endif
+
+$(MAKDIR)/smm/opencl_kernels.h: $(MAKDIR)/acc_opencl.sh $(KERNEL)
+	@CPPFLAGS=$(CPP_OPENCL_FLAGS) $(MAKDIR)/acc_opencl.sh $(KERNEL) $(PARAMS) $@
+
+$(MAKDIR)/../dbcsr_acc.a: $(OBJACC)
 	$(AR) -rs $@ $^
 
-../dbcsr_acc_smm.a: $(OBJSMM)
+$(MAKDIR)/../dbcsr_acc_smm.a: $(OBJSMM)
 	$(AR) -rs $@ $^
 
-%.o: %.c $(INCALL) Makefile
-	$(CC) $(CFLAGS) -c $< -o $@
+%.o: %.c $(INCALL) $(MAKDIR)/Makefile
+	$(CC) $(CFLAGS) $(CFLAGS_XSMM) -c $< -o $@
 
-acc_bench_smm.o: ../acc_bench_smm.c Makefile
+$(MAKDIR)/acc_bench_smm.o: $(MAKDIR)/../acc_bench_smm.c $(MAKDIR)/Makefile
+ifneq (0,$(LIBXSMM))
+	$(CC) $(CFLAGS) $(CFLAGS_XSMM) -c $< -o $@
+else
 	$(CC) $(CFLAGS) -c $< -o $@
-../acc_bench_smm: acc_bench_smm.o ../dbcsr_acc_smm.a ../dbcsr_acc.a
+endif
+$(MAKDIR)/../acc_bench_smm: $(MAKDIR)/acc_bench_smm.o $(MAKDIR)/../dbcsr_acc_smm.a $(MAKDIR)/../dbcsr_acc.a
 	$(CC) $^ $(LDFLAGS) -o $@
 
-acc_bench_trans.o: ../acc_bench_trans.c Makefile
+$(MAKDIR)/acc_bench_trans.o: $(MAKDIR)/../acc_bench_trans.c $(MAKDIR)/Makefile
+ifneq (0,$(LIBXSMM))
+	$(CC) $(CFLAGS) $(CFLAGS_XSMM) -c $< -o $@
+else
 	$(CC) $(CFLAGS) -c $< -o $@
-../acc_bench_trans: acc_bench_trans.o ../dbcsr_acc_smm.a ../dbcsr_acc.a
+endif
+$(MAKDIR)/../acc_bench_trans: $(MAKDIR)/acc_bench_trans.o $(MAKDIR)/../dbcsr_acc_smm.a $(MAKDIR)/../dbcsr_acc.a
 	$(CC) $^ $(LDFLAGS) -o $@
 
-dbcsr_acc_test.o: ../../../tests/dbcsr_acc_test.c Makefile
-	$(CC) $(CFLAGS) -I../.. -c $< -o $@
-../dbcsr_acc_test: dbcsr_acc_test.o ../dbcsr_acc.a
+$(MAKDIR)/dbcsr_acc_test.o: $(MAKDIR)/../../../tests/dbcsr_acc_test.c $(MAKDIR)/Makefile
+	$(CC) $(CFLAGS) -I$(MAKDIR)/../.. -c $< -o $@
+$(MAKDIR)/../dbcsr_acc_test: $(MAKDIR)/dbcsr_acc_test.o $(MAKDIR)/../dbcsr_acc.a
 	$(CC) $^ $(LDFLAGS) -o $@
 
 .PHONY: clean
 clean:
 	@rm -f $(OBJACC) $(OBJSMM)
-	@rm -f acc_bench_smm.o acc_bench_trans.o dbcsr_acc_test.o
-	@rm -f smm/opencl_kernels.h
+	@rm -f $(MAKDIR)/dbcsr_acc_test.o
+	@rm -f $(MAKDIR)/acc_bench_trans.o
+	@rm -f $(MAKDIR)/acc_bench_smm.o
+	@rm -f $(MAKDIR)/smm/opencl_kernels.h
+	@rm -f $(MAKDIR)/test-smm.err
 
 .PHONY: realclean
 realclean: clean
-	@rm -f ../dbcsr_acc.a ../dbcsr_acc_smm.a
-	@rm -f ../acc_bench_smm ../acc_bench_trans
-	@rm -f ../dbcsr_acc_test
+	@rm -f $(MAKDIR)/../dbcsr_acc.a $(MAKDIR)/../dbcsr_acc_smm.a
+	@rm -f $(MAKDIR)/../acc_bench_smm $(MAKDIR)/../acc_bench_trans
+	@rm -f $(MAKDIR)/../dbcsr_acc_test
+	@rm -f $(MAKDIR)/test-smm.log

--- a/src/acc/opencl/acc_opencl.sh
+++ b/src/acc/opencl/acc_opencl.sh
@@ -32,7 +32,7 @@ if [ "${BASENAME}" ] && [ "${SED}" ] && [ "${RM}" ]; then
     -h|--help)
       shift $#;;
     -c|-d|--debug|--comments)
-      CPPFLAGS+=" -CC"
+      CPPFLAGS+=" -C"
       shift;;
     *) break;;
     esac
@@ -145,6 +145,7 @@ if [ "${BASENAME}" ] && [ "${SED}" ] && [ "${RM}" ]; then
     echo "       At least one OpenCL file must be supplied."
     echo "       Parameters per CSV file are optional."
     echo "       The CSV file can be at any position."
+    echo "       -c|-d|--debug|--comments: keep comments"
   fi
 else
   >&2 echo "ERROR: missing prerequisites!"

--- a/src/acc/opencl/acc_opencl_mem.c
+++ b/src/acc/opencl/acc_opencl_mem.c
@@ -83,6 +83,7 @@ int c_dbcsr_acc_host_mem_allocate(void** host_mem, size_t nbytes, void* stream)
       clSVMAlloc(c_dbcsr_acc_opencl_context, CL_MEM_READ_WRITE, size, sizeof(void*)/*minimal alignment*/), &result) :
 #endif
     clCreateBuffer(c_dbcsr_acc_opencl_context, CL_MEM_ALLOC_HOST_PTR, size, NULL/*host_ptr*/, &result));
+  assert(CL_SUCCESS == result || NULL == buffer);
   assert(NULL != host_mem && NULL != stream);
   if (NULL != buffer) {
     const cl_command_queue queue = *ACC_OPENCL_STREAM(stream);

--- a/src/acc/opencl/smm/opencl_libsmm.c
+++ b/src/acc/opencl/smm/opencl_libsmm.c
@@ -988,7 +988,7 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
             const int ab = ((NULL == env_ab || '\0' == *env_ab || '0' == *env_ab)
               ? (NULL == config ? 0/*default*/ : config->ab) : LIBXSMM_CLMP(atoi(env_ab), 0, 3));
             const int ac = ((NULL == env_ac || '\0' == *env_ac || '0' == *env_ac)
-              ? (NULL == config ? 0/*default*/ : config->ac) : LIBXSMM_CLMP(atoi(env_ac), 0, 3));
+              ? (NULL == config ? 0/*default*/ : config->ac) : LIBXSMM_CLMP(atoi(env_ac), 0, 2));
             int wgsize_max, wgsize_prf, wgsize, bs, bm, bn, nbm, nbn;
             result = c_dbcsr_acc_opencl_info_devmem(active_device, NULL, NULL, NULL, &unified);
             if (EXIT_SUCCESS == result) {
@@ -1188,7 +1188,7 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
           && 0 <= config->ap && 1 >= config->ap
           && 0 <= config->aa && 3 >= config->aa
           && 0 <= config->ab && 3 >= config->ab
-          && 0 <= config->ac && 3 >= config->ac));
+          && 0 <= config->ac && 2 >= config->ac));
       if (EXIT_SUCCESS == result) {
         cl_event event, *const perf_event = ((0 <= c_dbcsr_acc_opencl_config.verbosity
           && 3 > c_dbcsr_acc_opencl_config.verbosity) ? NULL : &event);

--- a/src/acc/opencl/smm/opencl_libsmm.c
+++ b/src/acc/opencl/smm/opencl_libsmm.c
@@ -967,18 +967,20 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
           if (NULL != tname) {
             int cl_intel_id = 0, unified = 0;
             const char *const env_wg = getenv("OPENCL_LIBSMM_SMM_WG"), *const env_nz = getenv("OPENCL_LIBSMM_SMM_NZ");
-            const char *const env_lu = getenv("OPENCL_LIBSMM_SMM_LU"), *const env_ap = getenv("OPENCL_LIBSMM_SMM_AP");
-            const char *const env_aa = getenv("OPENCL_LIBSMM_SMM_AA"), *const env_ab = getenv("OPENCL_LIBSMM_SMM_AB");
-            const char *const env_ac = getenv("OPENCL_LIBSMM_SMM_AC");
-            const int cl_intel = (EXIT_SUCCESS == c_dbcsr_acc_opencl_device_vendor(active_device, "intel")
-                               && EXIT_SUCCESS == c_dbcsr_acc_opencl_device_id(active_device, "%[^[][0x%xi]", &cl_intel_id));
-            const int cl_nonv = (cl_intel || EXIT_SUCCESS != c_dbcsr_acc_opencl_device_vendor(active_device, "nvidia"));
+            const char *const env_lu = getenv("OPENCL_LIBSMM_SMM_LU"), *const env_bc = getenv("OPENCL_LIBSMM_SMM_BC");
+            const char *const env_ap = getenv("OPENCL_LIBSMM_SMM_AP"), *const env_aa = getenv("OPENCL_LIBSMM_SMM_AA");
+            const char *const env_ab = getenv("OPENCL_LIBSMM_SMM_AB"), *const env_ac = getenv("OPENCL_LIBSMM_SMM_AC");
+            const int cl_nonv = ((EXIT_SUCCESS == c_dbcsr_acc_opencl_device_vendor(active_device, "intel")
+                               && EXIT_SUCCESS == c_dbcsr_acc_opencl_device_id(active_device, "%[^[][0x%xi]", &cl_intel_id))
+                               || EXIT_SUCCESS != c_dbcsr_acc_opencl_device_vendor(active_device, "nvidia"));
             const int wg = ((NULL == env_wg || '\0' == *env_wg || '0' == *env_wg)
               ? (NULL == config ? 0/*default*/ : config->wg) : LIBXSMM_CLMP(atoi(env_wg), 0, 2));
             const int nz = ((NULL == env_nz || '\0' == *env_nz || '0' == *env_nz)
               ? (NULL == config ? 0/*default*/ : config->nz) : LIBXSMM_CLMP(atoi(env_nz), 0, 1));
             const int lu = ((NULL == env_lu || '\0' == *env_lu || '0' == *env_lu)
               ? (NULL == config ? 0/*default*/ : config->lu) : LIBXSMM_CLMP(atoi(env_lu), 0, 1));
+            const int bc = ((NULL == env_bc || '\0' == *env_bc || '0' == *env_bc)
+              ? 0/*default*/ : LIBXSMM_CLMP(atoi(env_bc), 0, 2));
             const int ap = ((NULL == env_ap || '\0' == *env_ap || '0' == *env_ap)
               ? (NULL == config ? 0/*default*/ : config->ap) : LIBXSMM_CLMP(atoi(env_ap), 0, 1));
             const int aa = ((NULL == env_aa || '\0' == *env_aa || '0' == *env_aa)
@@ -1040,7 +1042,7 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
               if (wgsize <= wgsize_max) { /* SMMs can be potentially handled by device */
                 const char *const cmem = (EXIT_SUCCESS != opencl_libsmm_use_cmem(active_device) ? "global" : "constant");
 # if !defined(NDEBUG)
-                const char *const cl_debug = cl_intel ? "-gline-tables-only" : "";
+                const char *const cl_debug = (0 != cl_intel_id ? "-gline-tables-only" : "");
 # else
                 const char *const cl_debug = "";
 # endif
@@ -1050,51 +1052,51 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
                 if (NULL == env_atomics || '0' != *env_atomics) {
                   const char* extension[] = { "cl_khr_int64_base_atomics" };
                   if (NULL == env_atomics || '\0' == *env_atomics) { /* no request made */
-                    if (cl_intel && 0x4905 != cl_intel_id && 0 == unified && dbcsr_type_real_4 == datatype) {
+                    if (0 != cl_intel_id && 0x4905 != cl_intel_id && 0 == unified && dbcsr_type_real_4 == datatype) {
                       atomic_ops = "-Dcl_intel_global_float_atomics";
-                      atomic_expr = "atomic_add(A,B)";
+                      atomic_expr = "atomic_add(A, B)";
                     }
                     else if (cl_nonv) {
-                      if (1 < bs && 2 <= m_max && n_max == wgsize && dbcsr_type_real_4 == datatype
-                        && 0 == (n_max & 1) /* remainder handling produces wrong result */
+                      if (1 < bs && dbcsr_type_real_4 == datatype && 1 == bn && bm >= m_max
+                        && (0 == (m_max & 1) || (0 == cl_intel_id /*&& cl_nonv*/)) /* TODO */
                         && EXIT_SUCCESS == c_dbcsr_acc_opencl_device_ext(active_device, extension, 1))
                       {
-                        atomic_expr2 = "-D\"ATOMIC_ADD2_GLOBAL(A,B)=atomic_add_global_cmpxchg2(A,B)\"";
+                        atomic_expr2 = "-D\"ATOMIC_ADD2_GLOBAL(A,B)=atomic_add_global_cmpxchg2(A, B)\"";
                       }
-                      atomic_expr = "atomic_add_global_cmpxchg(A,B)";
+                      atomic_expr = "atomic_add_global_cmpxchg(A, B)";
                     }
                     else {
-                      atomic_expr = "atomic_add_global_xchg(A,B)";
+                      atomic_expr = "atomic_add_global_xchg(A, B)";
                       atomic_ops = "";
                     }
                   }
                   else if (NULL != c_dbcsr_acc_opencl_stristr(env_atomics, "cmpxchg")) {
-                    if (1 < bs && 2 <= m_max && n_max == wgsize && dbcsr_type_real_4 == datatype
-                      && 0 == (n_max & 1) /* remainder handling produces wrong result */
+                    if (1 < bs && dbcsr_type_real_4 == datatype && 1 == bn && bm >= m_max
+                      && (0 == (m_max & 1) || (0 == cl_intel_id && cl_nonv)) /* TODO */
                       && '2' == env_atomics[strlen(env_atomics)-1]
                       && EXIT_SUCCESS == c_dbcsr_acc_opencl_device_ext(active_device, extension, 1))
                     {
-                      atomic_expr2 = "-D\"ATOMIC_ADD2_GLOBAL(A,B)=atomic_add_global_cmpxchg2(A,B)\"";
+                      atomic_expr2 = "-D\"ATOMIC_ADD2_GLOBAL(A,B)=atomic_add_global_cmpxchg2(A, B)\"";
                     }
-                    atomic_expr = "atomic_add_global_cmpxchg(A,B)";
+                    atomic_expr = "atomic_add_global_cmpxchg(A, B)";
                   }
-                  else atomic_expr = "atomic_add_global_xchg(A,B)";
+                  else atomic_expr = "atomic_add_global_xchg(A, B)";
                 }
                 else {
-                  atomic_expr = "*(A)+=(B)";
+                  atomic_expr = "*(A) += (B)";
                 }
                 assert(NULL != atomic_expr);
                 /* compose build parameters and flags */
                 nchar = ACC_OPENCL_SNPRINTF(build_params, sizeof(build_params),
-                  "-DFMA=fma -DGLOBAL=%s -DINTEL=%i -DSWG=%i -DFN=%s "
+                  "-DFMA=fma -DINTEL=%i -DGLOBAL=%s -DBC=%i -DSWG=%i -DFN=%s "
                   "-DSM=%i -DSN=%i -DSK=%i -DBS=%i -DBM=%i -DBN=%i -DT=%s -DTN=%i "
-                  "%s %s %s %s %s %s %s -D\"ATOMIC_ADD_GLOBAL(A,B)=%s\" %s",
-                  cmem, cl_intel_id, wgsize, fname, m_max, n_max, k_max, bs, bm, bn, tname, datatype,
+                  "%s %s %s %s %s %s %s %s -D\"ATOMIC_ADD_GLOBAL(A,B)=%s\" %s",
+                  cl_intel_id, cmem, bc, wgsize, fname, m_max, n_max, k_max, bs, bm, bn, tname, datatype,
                   0 == aa ? "" : (1 == aa ? "-DSHARED_A=1" : (2 == aa ? "-DSHARED_A=2" : "-DPRIVATE_A")),
                   0 == ab ? "" : (1 == ab ? "-DSHARED_B=1" : (2 == ab ? "-DSHARED_B=2" : "-DPRIVATE_B")),
                   0 == ac ? "" : (1 == ac ? "-DSHARED_C=1" : (2 == ac ? "-DSHARED_C=2" : "-DPRIVATE_C")),
                   0 == ap ? "" : "-DSHARED_S", 0 == nz ? "" : "-DATOMIC_INC_NZ",
-                  0 == lu ? "" : "-D\"UNROLL_SM=UNROLL(1)\"",
+                  0 == lu ? "" : "-D\"UNROLL_SM=UNROLL(1)\"", NULL == config ? "-DCONFIG" : "",
                   atomic_ops, atomic_expr, atomic_expr2);
                 if (0 < nchar && (int)sizeof(build_params) > nchar) {
                   nchar = ACC_OPENCL_SNPRINTF(build_options, sizeof(build_options),

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -147,7 +147,7 @@ class SmmTuner(MeasurementInterface):
         if os.getenv("OPENCL_LIBSMM_SMM_AC"):
             params.append(IntegerParameter("AC", self.args.ac, self.args.ac))
         else:
-            paramt.append(IntegerParameter("AC", 0, 3))
+            paramt.append(IntegerParameter("AC", 0, 2))
         if not paramt:
             sys.tracebacklimit = 0
             raise RuntimeError(
@@ -462,7 +462,7 @@ if __name__ == "__main__":
         type=int,
         default=int(os.getenv("OPENCL_LIBSMM_SMM_AC", "0")),
         dest="ac",
-        help="Matrix C: auto (0), shared (1), shared-bc (2), private (3)",
+        help="Matrix C: private (0), shared (1), shared-bc (2)",
     )
     argparser.add_argument(
         "-bs",

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -106,34 +106,54 @@ class SmmTuner(MeasurementInterface):
             raise RuntimeError(
                 "Setup failed for {}/{}!".format(self.exepath, self.exename)
             )
-        # setup tunable parameters
-        manipulator, params = ConfigurationManipulator(), []
-        if not os.getenv("OPENCL_LIBSMM_SMM_BS"):
-            params.append(IntegerParameter("BS", 1, self.args.mb))
-        if not os.getenv("OPENCL_LIBSMM_SMM_BM"):
-            params.append(IntegerParameter("BM", 1, self.args.m))
-        if not os.getenv("OPENCL_LIBSMM_SMM_BN"):
-            params.append(IntegerParameter("BN", 1, self.args.n))
-        if not os.getenv("OPENCL_LIBSMM_SMM_WG"):
-            params.append(IntegerParameter("WG", 0, 2))
-        if not os.getenv("OPENCL_LIBSMM_SMM_NZ"):
-            params.append(IntegerParameter("NZ", 0, 1))
-        if not os.getenv("OPENCL_LIBSMM_SMM_LU"):
-            params.append(IntegerParameter("LU", 0, 1))
-        if not os.getenv("OPENCL_LIBSMM_SMM_AP"):
-            params.append(IntegerParameter("AP", 0, 1))
-        if not os.getenv("OPENCL_LIBSMM_SMM_AA"):
-            params.append(IntegerParameter("AA", 0, 3))
-        if not os.getenv("OPENCL_LIBSMM_SMM_AB"):
-            params.append(IntegerParameter("AB", 0, 3))
-        if not os.getenv("OPENCL_LIBSMM_SMM_AC"):
-            params.append(IntegerParameter("AC", 0, 3))
-        if not params:
+        # setup fixed and tunable parameters
+        manipulator, params, paramt = ConfigurationManipulator(), [], []
+        if os.getenv("OPENCL_LIBSMM_SMM_BS"):
+            params.append(IntegerParameter("BS", self.args.bs, self.args.bs))
+        else:
+            paramt.append(IntegerParameter("BS", 1, self.args.mb))
+        if os.getenv("OPENCL_LIBSMM_SMM_BM"):
+            params.append(IntegerParameter("BM", self.args.bm, self.args.bm))
+        else:
+            paramt.append(IntegerParameter("BM", 1, self.args.m))
+        if os.getenv("OPENCL_LIBSMM_SMM_BN"):
+            params.append(IntegerParameter("BN", self.args.bn, self.args.bn))
+        else:
+            paramt.append(IntegerParameter("BN", 1, self.args.n))
+        if os.getenv("OPENCL_LIBSMM_SMM_WG"):
+            params.append(IntegerParameter("WG", self.args.wg, self.args.wg))
+        else:
+            paramt.append(IntegerParameter("WG", 0, 2))
+        if os.getenv("OPENCL_LIBSMM_SMM_NZ"):
+            params.append(IntegerParameter("NZ", self.args.nz, self.args.nz))
+        else:
+            paramt.append(IntegerParameter("NZ", 0, 1))
+        if os.getenv("OPENCL_LIBSMM_SMM_LU"):
+            params.append(IntegerParameter("LU", self.args.lu, self.args.lu))
+        else:
+            paramt.append(IntegerParameter("LU", 0, 1))
+        if os.getenv("OPENCL_LIBSMM_SMM_AP"):
+            params.append(IntegerParameter("AP", self.args.ap, self.args.ap))
+        else:
+            paramt.append(IntegerParameter("AP", 0, 1))
+        if os.getenv("OPENCL_LIBSMM_SMM_AA"):
+            params.append(IntegerParameter("AA", self.args.aa, self.args.aa))
+        else:
+            paramt.append(IntegerParameter("AA", 0, 3))
+        if os.getenv("OPENCL_LIBSMM_SMM_AB"):
+            params.append(IntegerParameter("AB", self.args.ab, self.args.ab))
+        else:
+            paramt.append(IntegerParameter("AB", 0, 3))
+        if os.getenv("OPENCL_LIBSMM_SMM_AC"):
+            params.append(IntegerParameter("AC", self.args.ac, self.args.ac))
+        else:
+            paramt.append(IntegerParameter("AC", 0, 3))
+        if not paramt:
             sys.tracebacklimit = 0
             raise RuntimeError(
                 "All tunable parameters are fixed with environment variables!"
             )
-        for param in params:
+        for param in params + paramt:
             manipulator.add_parameter(param)
         # register signal handler (CTRL-C)
         self.default_sigint = signal(SIGINT, self.handle_sigint)

--- a/src/acc/opencl/smm/tune_multiply.sh
+++ b/src/acc/opencl/smm/tune_multiply.sh
@@ -36,26 +36,6 @@ if [ "$1" ]; then
 else
   PART=1
 fi
-if [ "$1" ]; then
-  TRIPLETS="$*"
-else
-  TRIPLETS=" \
-    4 5 7 9 13 25 26 28 32 45, \
-    13 14 25 26 32, \
-    5 32 13 24 26, \
-    14 16 29, \
-    14 32 29, \
-    16 29 55, \
-    32 29 55, \
-    9 32 22, \
-    4 10 15, \
-    6 7 8, \
-    23, \
-    64, \
-    78, \
-    12, \
-    6"
-fi
 
 if [ "0" != "$((NPARTS<PART))" ]; then
   >&2 echo "ERROR: part-number ${PART} is larger than the requested ${NPARTS} parts!"
@@ -63,18 +43,19 @@ if [ "0" != "$((NPARTS<PART))" ]; then
 fi
 
 if [ "${SED}" ] && [ "${LS}" ] && [ "${RM}" ] && [ "${WC}" ]; then
-  echo "Usage: $0 [seconds-per-kernel [num-parts [part [triplet-spec]]]]"
+  echo "Usage: $0 [seconds-per-kernel [num-parts [part [<triplet-spec>]]]]"
   echo "       num-parts and part (one-based), e.g., 12 3"
   echo "         for this session being the 3rd of 12 sessions"
-  echo "       triplet-spec, e.g.,"
+  echo "       <triplet-spec>, e.g., 134 kernels"
   echo "         23, 5 32 13 24 26, 4 9"
   echo
-  for SPECS in $(echo "${TRIPLETS}" | ${SED} -e "s/[[:space:]][[:space:]]*/x/g" -e "s/,/ /g"); do
-    SPEC=$(echo "${SPECS}" | ${SED} -e "s/^x//g" -e "s/x$//g" -e "s/x/,/g")
-    MNKS="${MNKS} $(eval printf "%s" "{${SPEC}}x{${SPEC}}x{${SPEC}}\" \"" | ${SED} -e "s/{//g" -e "s/}//g")"
-  done
-  if [ "$(command -v sort)" ] && [ "$(command -v xargs)" ]; then
-    MNKS=$(echo "${MNKS}" | xargs -n1 | sort -u | xargs)
+  if [ "$1" ]; then
+    MNKS=$("${HERE}/../../acc_triplets.sh" "$@")
+  else
+    if [ "" != "${MAXEXT}" ]; then MAXEXT="-m ${MAXEXT}"; fi
+    if [ "" != "${MAXNUM}" ]; then MAXNUM="-n ${MAXNUM}"; fi
+    if [ "" == "${SPECID}" ]; then SPECID=10; fi
+    MNKS=$("${HERE}/../acc_triplets.sh" -s ${SPECID} "${LIMIT}" "${MAXNUM}")
   fi
   NTRIPLETS=$(echo "${MNKS}" | wc -w)
   PARTSIZE=$(((NTRIPLETS+NPARTS-1)/NPARTS))


### PR DESCRIPTION
* Validate result buffers at once (including excess area/padded space).
* Adjusted error margin according to revised measure (libxsmm_matdiff).
* Always print maximum error if multiple runs were performed.
* Tests: runtime and environment information (test log).
* Tests: use datamash to produce summary statistics.
* Fixed condition for double-update (atomic).
* Improved ACC_OPENCL_DUMP=1.

Auto-tuning
* Only auto-configure kernel if no external configuration is supplied.
  This allows to discover the full space of tunables.
* Corrected handling fixed parameters (tune_multiply.py).
* Introduced acc_triplets.sh.

Other:
* Avoid init/finalize within loop (growing memory consumption depending on OpenCL impl).
  Note: within loop was meant to exercise tear-down, etc. (but not feasible).
* benchmark: runtime message about excessive matrix-shape (MAX_KERNEL_DIM).
* benchmark: accept x-triplet form at the first position (CLI).
* Makefile/CUDA: introduced test infra similar to OpenCL.
* Removed unused code in benchmark (debug/print).
* benchmarks: more sophisticated (rpath-)linkage.
* Fixed issues pointed out by Shellcheck.
* Updated LIBXSMM (Daint-CI).
* Absolute paths (Makefile).