### PR TITLE
ocl: improved handling loaded vs embedded parameters

### DIFF
--- a/src/acc/acc_bench_smm.c
+++ b/src/acc/acc_bench_smm.c
@@ -47,7 +47,7 @@
 
 #define ROUNDUP2(N, NPOT) ((((unsigned long long)N) + ((NPOT) - 1)) & ~((NPOT) - 1))
 #define CHECK(EXPR, RPTR) if ((NULL != ((const void*)(RPTR)) && EXIT_SUCCESS != *((const int*)(RPTR))) || \
-  EXIT_SUCCESS != (NULL != ((const void*)(RPTR)) ? (*((int*)(RPTR)) = (EXPR)) : (EXPR))) assert(0)
+  EXIT_SUCCESS != (NULL != ((const void*)(RPTR)) ? (*((int*)(RPTR)) = (EXPR)) : (EXPR))) assert(-1 == *((int*)(RPTR)))
 
 
 static void parse_params(int argc, char* argv[], FILE** file,
@@ -373,6 +373,10 @@ int main(int argc, char* argv[])
       if (NULL != file) printf("\n"); else break;
     }
   }
+#if !defined(__CUDA)
+  CHECK(libsmm_acc_finalize(), NULL);
+#endif
+  CHECK(c_dbcsr_acc_finalize(), NULL);
   if (EXIT_SUCCESS == result) {
 #if defined(USE_LIBXSMM) && defined(VALIDATE) && (0 != VALIDATE)
     if (1 < nok) printf("\nmax.error: %g\n", maxerror);
@@ -380,11 +384,13 @@ int main(int argc, char* argv[])
   }
   else {
     if (NULL != file) fclose(file);
-    fprintf(stderr, "FAILED\n");
+    if (-1 != result) {
+      fprintf(stderr, "FAILED\n");
+    }
+    else {
+      fprintf(stderr, "Kernel not suitable!\n");
+      result = EXIT_SUCCESS;
+    }
   }
-#if !defined(__CUDA)
-  CHECK(libsmm_acc_finalize(), NULL);
-#endif
-  CHECK(c_dbcsr_acc_finalize(), NULL);
   return result;
 }

--- a/src/acc/cuda/Makefile
+++ b/src/acc/cuda/Makefile
@@ -177,8 +177,8 @@ test-interface: $(MAKDIR)/../dbcsr_acc_test
 
 .PHONY: test-trans
 test-trans: bench
-	$(eval SHAPES = $(shell $(MAKDIR)/../acc_triplets.sh -l -s $(SPECID) -m $(MAXEXT) -n $(NTRANS) -a))
-	@echo "--- DBCSR OpenCL Transposes ($(words $(SHAPES)))"
+	$(eval SHAPES = $(shell $(MAKDIR)/../acc_triplets.sh -s $(SPECID) -m $(MAXEXT) -n $(NTRANS) -a))
+	@echo "--- DBCSR CUDA Transposes ($(words $(SHAPES)))"
 	@echo "runtime libraries:"
 	@ldd $(MAKDIR)/../acc_bench_trans
 	@echo "hostname: $$(hostname)"
@@ -189,12 +189,13 @@ test-trans: bench
 	done
 
 $(MAKDIR)/test-smm.log: bench
-	@echo "--- DBCSR OpenCL SMMs"
+	$(eval SHAPES = $(shell $(MAKDIR)/../acc_triplets.sh -s $(SPECID) -m $(MAXEXT) -n $(NSMMS)))
+	@echo "--- DBCSR CUDA SMMs ($(words $(SHAPES)))"
 	@echo "runtime libraries:"
 	@ldd $(MAKDIR)/../acc_bench_smm
 	@echo "hostname: $$(hostname)"
 	@echo
-	@$(MAKDIR)/../acc_triplets.sh -l -s $(SPECID) -m $(MAXEXT) -n $(NSMMS) | \
+	@echo "$(SHAPES)" | xargs -n1 | \
 		(CHECK=1 stdbuf --output=L $(MAKDIR)/../acc_bench_smm /dev/stdin \
 			2>$(MAKDIR)/test-smm.err && rm $(MAKDIR)/test-smm.err) | tee $@
 	@if [ -s $(MAKDIR)/test-smm.err ]; then cat $(MAKDIR)/test-smm.err && exit 1; fi

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -40,6 +40,13 @@ PARAMS_WITHGPU := $(MAKDIR)/smm/params/tune_multiply_$(WITH_GPU).csv
 PARAMS_DEFAULT := $(MAKDIR)/smm/tune_multiply.csv
 PARAMS := $(if $(wildcard $(PARAMS_WITHGPU)),$(PARAMS_WITHGPU),$(wildcard $(PARAMS_DEFAULT)))
 
+#PARAMS_DIR ?= $(MAKDIR)/smm/params
+ifeq (,$(PARAMS))
+ifneq (,$(wildcard $(PARAMS_DIR)))
+  WITH_GPUS := $(shell ls -1 $(PARAMS_DIR)/*.csv | cut -d. -f1 | rev | cut -d_ -f1 | rev)
+endif
+endif
+
 CFLAGS := -fPIC \
   -Wall -Wextra -pedantic \
   -Wno-overlength-strings \
@@ -177,9 +184,10 @@ test-interface: $(MAKDIR)/../dbcsr_acc_test
 
 .PHONY: test-trans
 test-trans: bench
-	$(eval SHAPES = $(shell $(MAKDIR)/../acc_triplets.sh -l -s $(SPECID) -m $(MAXEXT) -n $(NTRANS) -a))
+	$(eval SHAPES = $(shell $(MAKDIR)/../acc_triplets.sh -s $(SPECID) -m $(MAXEXT) -n $(NTRANS) -a))
+	$(eval DEVICE = $(shell ACC_OPENCL_VERBOSE=1 CHECK=0 $(MAKDIR)/../acc_bench_smm 1 1 1 2>&1 >/dev/null))
 	@echo "--- DBCSR OpenCL Transposes ($(words $(SHAPES)))"
-	@ACC_OPENCL_VERBOSE=1 CHECK=0 $(MAKDIR)/../acc_bench_trans 2>&1 >/dev/null
+	@echo "$(DEVICE)"
 	@echo "runtime libraries:"
 	@ldd $(MAKDIR)/../acc_bench_trans
 	@echo "hostname: $$(hostname)"
@@ -190,14 +198,19 @@ test-trans: bench
 	done
 
 $(MAKDIR)/test-smm.log: bench
-	@echo "--- DBCSR OpenCL SMMs"
-	@ACC_OPENCL_VERBOSE=1 CHECK=0 $(MAKDIR)/../acc_bench_smm 2>&1 >/dev/null
+	$(eval SHAPES = $(shell $(MAKDIR)/../acc_triplets.sh -s $(SPECID) -m $(MAXEXT) -n $(NSMMS)))
+	$(eval DEVICE = "$(shell LIBXSMM_VERBOSE=0 ACC_OPENCL_VERBOSE=1 CHECK=0 $(MAKDIR)/../acc_bench_smm 1 1 1 2>&1 >/dev/null)")
+	$(eval WITH_GPU = $(firstword $(foreach GPU,$(WITH_GPUS),$(findstring $(GPU),$(DEVICE)))))
+	$(eval PARAMS = $(firstword $(wildcard $(PARAMS_DIR)/tune_multiply_*$(WITH_GPU).csv)))
+	$(eval GPUENV = $(if $(PARAMS),OPENCL_LIBSMM_SMM_PARAMS=$(PARAMS)))
+	@echo "--- DBCSR OpenCL SMMs ($(words $(SHAPES)))"
+	@echo "$(DEVICE)"
 	@echo "runtime libraries:"
 	@ldd $(MAKDIR)/../acc_bench_smm
 	@echo "hostname: $$(hostname)"
 	@echo
-	@$(MAKDIR)/../acc_triplets.sh -l -s $(SPECID) -m $(MAXEXT) -n $(NSMMS) | \
-		(CHECK=1 stdbuf --output=L $(MAKDIR)/../acc_bench_smm /dev/stdin \
+	@echo "$(SHAPES)" | xargs -n1 | \
+		($(GPUENV) CHECK=1 stdbuf --output=L $(MAKDIR)/../acc_bench_smm /dev/stdin \
 			2>$(MAKDIR)/test-smm.err && rm $(MAKDIR)/test-smm.err) | tee $@
 	@if [ -s $(MAKDIR)/test-smm.err ]; then cat $(MAKDIR)/test-smm.err && exit 1; fi
 


### PR DESCRIPTION
* Allow successful libsmm_acc_init if given parameter file cannot be loaded or does not exist (OPENCL_LIBSMM_SMM_PARAMS).
* Introduced OPENCL_LIBSMM_SUITABLE which allows to disable suitability-check even if support/enabled at compile-time.
* If PARAMS_DIR is given, attempt to automatically determine GPU-environment (OPENCL_LIBSMM_SMM_PARAMS).
* Support unsuitable kernel (return code -1) without failing the benchmark/test (acc_bench_*).
* Run (optional/disabled) suitability test even if OPENCL_LIBSMM_SMM_PARAMS is given.
* Load embedded parameters if loading from file failed (soft error).
* Print number of test cases. Fixed title of test cases (Makefile).
* Track and print performance of seed- or initial configuration.
* Removed debug code (acc_bench_trans).