### PR TITLE
ocl: improved auto-tuning script to keep collection of tuned results up-to-date

### DIFF
--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -506,11 +506,9 @@ int c_dbcsr_acc_opencl_device_level(cl_device_id device,
   int* level_major, int* level_minor, char cl_std[16])
 {
   char buffer[ACC_OPENCL_BUFFERSIZE], skip[ACC_OPENCL_BUFFERSIZE];
-#if 0
-  cl_int result = clGetDeviceInfo(device, CL_DEVICE_VERSION, ACC_OPENCL_BUFFERSIZE, buffer, NULL);
-#else
-  cl_int result = clGetDeviceInfo(device, CL_DEVICE_OPENCL_C_VERSION, ACC_OPENCL_BUFFERSIZE, buffer, NULL);
-#endif
+  cl_int result = (EXIT_SUCCESS != c_dbcsr_acc_opencl_device_vendor(device, "nvidia")
+    ? clGetDeviceInfo(device, CL_DEVICE_VERSION, ACC_OPENCL_BUFFERSIZE, buffer, NULL)
+    : clGetDeviceInfo(device, CL_DEVICE_OPENCL_C_VERSION, ACC_OPENCL_BUFFERSIZE, buffer, NULL));
   assert(NULL != device && (NULL != level_major || NULL != level_minor || NULL != cl_std));
   if (CL_SUCCESS == result) {
     unsigned int level[2];

--- a/src/acc/opencl/smm/kernels/multiply.cl
+++ b/src/acc/opencl/smm/kernels/multiply.cl
@@ -7,12 +7,15 @@
  * SPDX-License-Identifier: GPL-2.0+                                                              *
  *------------------------------------------------------------------------------------------------*/
 #if (200/*CL_VERSION_2_0*/ <= __OPENCL_VERSION__) || defined(__NV_CL_C_VERSION)
-# define UNROLL(N) __attribute__((opencl_unroll_hint(N)))
+# define UNROLL_FORCE(N) __attribute__((opencl_unroll_hint(N)))
 #else
+# define UNROLL_FORCE(N)
+#endif
+#if !defined(UNROLL)
 # define UNROLL(N)
 #endif
 #if !defined(UNROLL_SM)
-# define UNROLL_SM UNROLL(SM)
+# define UNROLL_SM UNROLL_FORCE(SM)
 #endif
 
 #if (1 == TN)

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -78,7 +78,7 @@ typedef struct opencl_libsmm_smm_t {
   cl_kernel kernel; /* must be the 1st data member */
   size_t wgsize;
   /* parameters (either pretuned or determined) */
-  int bs, bm, bn, wg, nz, lu, ap, aa, ab, ac;
+  int bs, bm, bn, wg, lu, nz, ap, aa, ab, ac;
   /* ACC_OPENCL_VERBOSE: perf. counters */
   double gflops_sumlog, gflops_comp;
   size_t nexec;

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -486,10 +486,9 @@ if __name__ == "__main__":
         os.environ["OPENCL_LIBSMM_SMM_BN"] = "0"
         default_mb = 64
     if 2 <= args.tlevel:
-        os.environ["OPENCL_LIBSMM_SMM_LU"] = "0" if 24 >= m else "1"
+        os.environ["OPENCL_LIBSMM_SMM_AP"] = "0" if 24 >= m else "1"
         os.environ["OPENCL_LIBSMM_SMM_NZ"] = "0"
     if 3 <= args.tlevel:
-        os.environ["OPENCL_LIBSMM_SMM_AP"] = "0" if 24 >= m else "1"
         os.environ["OPENCL_LIBSMM_SMM_AC"] = "0"
         os.environ["OPENCL_LIBSMM_SMM_WG"] = "1"
     # additional/depending arguments

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -193,7 +193,7 @@ class SmmTuner(MeasurementInterface):
         ]
 
     def objective(self):
-        if not self.args.primary:
+        if 0 == args.tlevel:
             return opentuner.search.objective.MaximizeAccuracyMinimizeSize()
         else:
             return opentuner.search.objective.MaximizeAccuracy()
@@ -466,14 +466,6 @@ if __name__ == "__main__":
         default=False,
         dest="verbose",
         help="Verbose output",
-    )
-    argparser.add_argument(
-        "-p",
-        "--primary-objective",
-        action="store_true",
-        default=False,
-        dest="primary",
-        help="Primary objective only",
     )
     argparser.add_argument(
         "-a",

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -291,9 +291,10 @@ class SmmTuner(MeasurementInterface):
                     )
                     if key not in merged:
                         merged[key] = value
-                    elif merged[key][0] < value[0]:
+                    else:
+                        if merged[key][0] < value[0]:
+                            merged[key] = value
                         filename2 = merged[key][-1]
-                        merged[key] = value
                         if key in worse:
                             worse[key].append(filename2)
                         else:


### PR DESCRIPTION
* tune_multiply.py: introduced "retain" and "delete" category (suitable for "rm" command).
* Extended LU-parameter (previously "LimitUnroll", now "LoopUnroll").
* Adjusted c_dbcsr_acc_opencl_device_level.