### PR TITLE
ocl: Makefile to account for CUDA/HIP common bits

### DIFF
--- a/src/acc/acc_bench_smm.c
+++ b/src/acc/acc_bench_smm.c
@@ -47,7 +47,8 @@
 
 #define ROUNDUP2(N, NPOT) ((((unsigned long long)N) + ((NPOT) - 1)) & ~((NPOT) - 1))
 #define CHECK(EXPR, RPTR) if ((NULL != ((const void*)(RPTR)) && EXIT_SUCCESS != *((const int*)(RPTR))) || \
-  EXIT_SUCCESS != (NULL != ((const void*)(RPTR)) ? (*((int*)(RPTR)) = (EXPR)) : (EXPR))) assert(-1 == *((int*)(RPTR)))
+  EXIT_SUCCESS != (NULL != ((const void*)(RPTR)) ? (*((int*)(RPTR)) = (EXPR)) : (EXPR))) \
+  assert(NULL == (RPTR) || -1 == *((int*)(RPTR)))
 
 
 static void parse_params(int argc, char* argv[], FILE** file,

--- a/src/acc/acc_bench_trans.c
+++ b/src/acc/acc_bench_trans.c
@@ -43,7 +43,8 @@
 #define MAX(A, B) ((B) < (A) ? (A) : (B))
 #define ROUNDUP2(N, NPOT) ((((unsigned long long)N) + ((NPOT) - 1)) & ~((NPOT) - 1))
 #define CHECK(EXPR, RPTR) if ((NULL != ((const void*)(RPTR)) && EXIT_SUCCESS != *((const int*)(RPTR))) || \
-  EXIT_SUCCESS != (NULL != ((const void*)(RPTR)) ? (*((int*)(RPTR)) = (EXPR)) : (EXPR))) assert(-1 == *((int*)(RPTR)))
+  EXIT_SUCCESS != (NULL != ((const void*)(RPTR)) ? (*((int*)(RPTR)) = (EXPR)) : (EXPR))) \
+  assert(NULL == (RPTR) || -1 == *((int*)(RPTR)))
 
 
 static void swap(int* m, int* n) { int tmp = *m; *m = *n; *n = tmp; }

--- a/src/acc/cuda/Makefile
+++ b/src/acc/cuda/Makefile
@@ -3,7 +3,9 @@
 
 MAKDIR := $(subst //,,$(dir $(firstword $(MAKEFILE_LIST)))/)
 INCACC := $(wildcard $(MAKDIR)/*.h*) $(MAKDIR)/../acc.h
-SRCACC := $(wildcard $(MAKDIR)/*.cpp)
+SRCACC := $(wildcard $(MAKDIR)/../cuda_hip/*.cpp) \
+          $(wildcard $(MAKDIR)/*.cpp) \
+          $(NULL)
 OBJACC := $(SRCACC:.cpp=.o)
 
 GPUSMM := $(wildcard $(MAKDIR)/../libsmm_acc/kernels/*.h*)
@@ -168,7 +170,7 @@ CXXFLAGS += -std=c++11 $(CFLAGS)
 bench: $(MAKDIR)/../acc_bench_smm $(MAKDIR)/../acc_bench_trans
 
 .PHONY: all
-all: $(MAKDIR)/../dbcsr_acc.a $(MAKDIR)/../dbcsr_acc_smm.a bench test
+all: $(MAKDIR)/../dbcsr_acc.a $(MAKDIR)/../dbcsr_acc_smm.a bench
 
 .PHONY: test
 test: test-interface test-trans test-smm

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -172,7 +172,7 @@ endif
 bench: $(MAKDIR)/../acc_bench_smm $(MAKDIR)/../acc_bench_trans
 
 .PHONY: all
-all: $(MAKDIR)/../dbcsr_acc.a $(MAKDIR)/../dbcsr_acc_smm.a bench test
+all: $(MAKDIR)/../dbcsr_acc.a $(MAKDIR)/../dbcsr_acc_smm.a bench
 
 .PHONY: test
 test: test-interface test-trans test-smm

--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -248,9 +248,10 @@ int c_dbcsr_acc_opencl_wgsize(cl_device_id device, cl_kernel kernel,
  * The build_params are meant to instantiate the kernel (-D) whereas build_options
  * are are meant to be compiler-flags.
  */
-int c_dbcsr_acc_opencl_kernel(const char source[],
-  const char build_options[], const char build_params[],
-  const char kernel_name[], cl_kernel* kernel);
+int c_dbcsr_acc_opencl_kernel(const char source[], const char kernel_name[],
+  const char build_params[], const char build_options[],
+  const char try_build_options[], int* try_ok,
+  cl_kernel* kernel);
 /** Create command queue (stream). */
 int c_dbcsr_acc_opencl_stream_create(cl_command_queue* stream_p, const char name[],
   const ACC_OPENCL_COMMAND_QUEUE_PROPERTIES* properties);


### PR DESCRIPTION
* Removed test-target from all-target (Makefile/CUDA/OpenCL).
* Introduced try_build_options (c_dbcsr_acc_opencl_kernel).
* Avoid warning with some versions of Clang (acc_bench_*).
* Account for common directory (Makefile/CUDA).
* Adjusted some configuration (OpenCL).