### PR TITLE
ocl: adjust kernel and default parameters

### DIFF
--- a/src/acc/cuda/Makefile
+++ b/src/acc/cuda/Makefile
@@ -24,7 +24,7 @@ ifeq (,$(LIBXSMMROOT))
   LIBXSMMROOT := $(wildcard $(HOME)/libxsmm)
 endif
 UNAME := $(shell uname)
-WITH_GPU ?= P100
+WITH_GPU := $(if $(WITH_GPU),$(WITH_GPU),$(if $(GPUVER),$(GPUVER),P100))
 INTEL ?= 0
 DEV ?= 0
 
@@ -109,7 +109,7 @@ endif
 
 ifneq (0,$(DBG))
   ifeq (,$(DBG))
-    CFLAGS += -O2
+    CFLAGS += -O2 -DNDEBUG
   else
     ifneq (1,$(DBG))
       CFLAGS += -D_DEBUG
@@ -117,7 +117,7 @@ ifneq (0,$(DBG))
     CFLAGS += -O0
   endif
 else
-  CFLAGS += -O2 -DNDEBUG
+  CFLAGS += -O2 -DNDEBUG -DNDBGDEV
   SYM := 0
 endif
 ifneq (0,$(SYM))

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -36,6 +36,7 @@ else
   which = $(shell which $(firstword $1) 2>/dev/null)
 endif
 
+WITH_GPU := $(if $(WITH_GPU),$(WITH_GPU),$(GPUVER))
 PARAMS_WITHGPU := $(MAKDIR)/smm/params/tune_multiply_$(WITH_GPU).csv
 PARAMS_DEFAULT := $(MAKDIR)/smm/tune_multiply.csv
 PARAMS := $(if $(wildcard $(PARAMS_WITHGPU)),$(PARAMS_WITHGPU),$(wildcard $(PARAMS_DEFAULT)))
@@ -82,12 +83,14 @@ ifneq (0,$(DEV))
   ifeq (1,$(DEV))
     CFLAGS := -std=c89 $(CFLAGS)
     CFLAGS += -Wno-unused-parameter
-  else ifeq (clang,$(CC))
-    #LDFLAGS := --analyze $(LDFLAGS)
-    CFLAGS := --analyze -Wno-deprecated $(CFLAGS)
-    override CC := clang++
   else
-    CC := $(CXX)
+    CFLAGS := -Wno-deprecated -Werror $(CFLAGS)
+    ifneq (,$(findstring clang,$(CC) $(CXX)))
+      override CC := clang++ --analyze
+    else
+      CC := $(CXX)
+    endif
+    OMP := 0
   endif
 else
   CFLAGS := -std=c99 $(CFLAGS)
@@ -96,7 +99,7 @@ endif
 ifneq (0,$(DBG))
   CPP_OPENCL_FLAGS += -C
   ifeq (,$(DBG))
-    CFLAGS += -O2
+    CFLAGS += -O2 -DNDEBUG
   else
     ifneq (1,$(DBG))
       CFLAGS += -D_DEBUG
@@ -104,7 +107,7 @@ ifneq (0,$(DBG))
     CFLAGS += -O0
   endif
 else
-  CFLAGS += -O2 -DNDEBUG
+  CFLAGS += -O2 -DNDEBUG -DNDBGDEV
   SYM := 0
 endif
 ifneq (0,$(SYM))
@@ -242,8 +245,13 @@ ifneq (0,$(LIBXSMM))
 else
 	$(CC) $(CFLAGS) -c $< -o $@
 endif
+
 $(MAKDIR)/../acc_bench_smm: $(MAKDIR)/acc_bench_smm.o $(MAKDIR)/../dbcsr_acc_smm.a $(MAKDIR)/../dbcsr_acc.a
+ifneq (,$(filter 0 1,$(DEV)))
 	$(CC) $^ $(LDFLAGS) -o $@
+else
+.PHONY: $(MAKDIR)/../acc_bench_smm
+endif
 
 $(MAKDIR)/acc_bench_trans.o: $(MAKDIR)/../acc_bench_trans.c $(MAKDIR)/Makefile
 ifneq (0,$(LIBXSMM))
@@ -251,13 +259,23 @@ ifneq (0,$(LIBXSMM))
 else
 	$(CC) $(CFLAGS) -c $< -o $@
 endif
+
 $(MAKDIR)/../acc_bench_trans: $(MAKDIR)/acc_bench_trans.o $(MAKDIR)/../dbcsr_acc_smm.a $(MAKDIR)/../dbcsr_acc.a
+ifneq (,$(filter 0 1,$(DEV)))
 	$(CC) $^ $(LDFLAGS) -o $@
+else
+.PHONY: $(MAKDIR)/../acc_bench_trans
+endif
 
 $(MAKDIR)/dbcsr_acc_test.o: $(MAKDIR)/../../../tests/dbcsr_acc_test.c $(MAKDIR)/Makefile
 	$(CC) $(CFLAGS) -I$(MAKDIR)/../.. -c $< -o $@
+
 $(MAKDIR)/../dbcsr_acc_test: $(MAKDIR)/dbcsr_acc_test.o $(MAKDIR)/../dbcsr_acc.a
+ifneq (,$(filter 0 1,$(DEV)))
 	$(CC) $^ $(LDFLAGS) -o $@
+else
+.PHONY: $(MAKDIR)/../dbcsr_acc_test
+endif
 
 .PHONY: clean
 clean:

--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -251,6 +251,7 @@ int c_dbcsr_acc_opencl_wgsize(cl_device_id device, cl_kernel kernel,
 int c_dbcsr_acc_opencl_kernel(const char source[], const char kernel_name[],
   const char build_params[], const char build_options[],
   const char try_build_options[], int* try_ok,
+  const char *const extnames[], int num_exts,
   cl_kernel* kernel);
 /** Create command queue (stream). */
 int c_dbcsr_acc_opencl_stream_create(cl_command_queue* stream_p, const char name[],

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -99,7 +99,7 @@ class SmmTuner(MeasurementInterface):
                 params.append(IntegerParameter("LU", self.args.lu, self.args.lu))
             else:
                 self.lu = int(seed.group(5)) if seed and seed.group(5) else None
-                paramt.append(IntegerParameter("LU", 0, 2))
+                paramt.append(IntegerParameter("LU", -1, 2))
             if os.getenv("OPENCL_LIBSMM_SMM_NZ"):
                 params.append(IntegerParameter("NZ", self.args.nz, self.args.nz))
             else:
@@ -529,7 +529,7 @@ if __name__ == "__main__":
         type=int,
         default=int(os.getenv("OPENCL_LIBSMM_SMM_LU", "0")),
         dest="lu",
-        help="Loop unroll (0) default, (1) limited, (2) full",
+        help="Loop unroll (-1) no hints, (0) default, (1) limited, (2) full",
     )
     argparser.add_argument(
         "-nz",


### PR DESCRIPTION
* Adjusted enumeration-order: CPUs now appear before "Accelerator"
* Note: CL_DEVICE_TYPE_ACCELERATOR exists in addition to CL_DEVICE_TYPE_GPU.
* Fixed controlling loop-unroll (OPENCL_LIBSMM_SMM_LU).
* Makefile: support GPUVER (in addition to WITH_GPU).
* Introduced extensions to be enabled in source-code.
* Introduced NDBGDEV complementing NDEBUG.
* Forcibly avoid unrolling minibatch-loop.
* Force-unrolling FMA/inner loops.
* Improved pruning kernel-source.
* Support extended atomics.