### PR TITLE
ocl: fixes and prepared glue code to run kernels on CPUs

### DIFF
--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -575,7 +575,7 @@ if __name__ == "__main__":
         "-bs",
         "--initial-bs",
         type=int,
-        default=int(os.getenv("OPENCL_LIBSMM_SMM_BS", "24")),
+        default=int(os.getenv("OPENCL_LIBSMM_SMM_BS", "16")),
         nargs="?",
         dest="bs",
         help="Minibatch size (BS)",


### PR DESCRIPTION
* Fixed correctness issue (e.g., "OPENCL_LIBSMM_SMM_WG=1 OPENCL_LIBSMM_SMM_AA=0 acc_bench_smm 0 0 4 7 4").
* Fixed c_dbcsr_acc_opencl_device_level (assemble command-line flag -cl-std= based on device/lang version).
* Kernel: C11 atomics for atomic_add_global_xchg (atomic_exchange_explicit).
* Kernel: adjusted default size of minibatch (kernel and glue code).
* Kernel: implemented privatized amk-array for fast-path.
* Preparation for fallback code-path (atomics).