### PR TITLE
Print error log when JIT compilation of kernels fail

### DIFF
--- a/src/acc/cuda/acc_cuda.cpp
+++ b/src/acc/cuda/acc_cuda.cpp
@@ -29,3 +29,4 @@ CUsharedconfig CUSharedMemBankSizeEightByte = CU_SHARED_MEM_CONFIG_EIGHT_BYTE_BA
 cublasStatus_t ACC_BLAS_STATUS_SUCCESS = CUBLAS_STATUS_SUCCESS;
 cublasOperation_t ACC_BLAS_OP_N = CUBLAS_OP_N;
 cublasOperation_t ACC_BLAS_OP_T = CUBLAS_OP_T;
+nvrtcResult ACC_RTC_SUCCESS = NVRTC_SUCCESS;

--- a/src/acc/cuda/acc_cuda.h
+++ b/src/acc/cuda/acc_cuda.h
@@ -104,4 +104,7 @@ extern cublasStatus_t ACC_BLAS_STATUS_SUCCESS;
 extern cublasOperation_t ACC_BLAS_OP_N;
 extern cublasOperation_t ACC_BLAS_OP_T;
 
+/* NVRTC error status */
+extern nvrtcResult ACC_RTC_SUCCESS;
+
 #endif /*ACC_CUDA_H*/

--- a/src/acc/hip/acc_hip.cpp
+++ b/src/acc/hip/acc_hip.cpp
@@ -42,3 +42,4 @@ hipError_t hipLaunchJITKernel(hipFunction_t f, unsigned int gridDimX, unsigned i
 hipblasStatus_t ACC_BLAS_STATUS_SUCCESS = HIPBLAS_STATUS_SUCCESS;
 hipblasOperation_t ACC_BLAS_OP_N = HIPBLAS_OP_N;
 hipblasOperation_t ACC_BLAS_OP_T = HIPBLAS_OP_T;
+hiprtcResult ACC_RTC_SUCCESS = HIPRTC_SUCCESS;

--- a/src/acc/hip/acc_hip.h
+++ b/src/acc/hip/acc_hip.h
@@ -109,4 +109,8 @@ extern hipblasStatus_t ACC_BLAS_STATUS_SUCCESS;
 extern hipblasOperation_t ACC_BLAS_OP_N;
 extern hipblasOperation_t ACC_BLAS_OP_T;
 
+/* HIPRTC error status */
+extern hiprtcResult ACC_RTC_SUCCESS;
+
+
 #endif /*ACC_HIP_H*/

--- a/src/acc/libsmm_acc/libsmm_acc.cpp
+++ b/src/acc/libsmm_acc/libsmm_acc.cpp
@@ -154,7 +154,25 @@ inline void jit_kernel(ACC_DRV(function)& kern_func, libsmm_acc_algo algo, int t
     const char *compileOptions[] = {"-D__HIP"};
     size_t nOptions = 1;
 #endif
-    ACC_RTC_CALL(CompileProgram, (kernel_program, nOptions, compileOptions));
+    ACC_RTC(Result) compileResult = ACC_RTC(CompileProgram)(kernel_program, nOptions, compileOptions);
+    if (compileResult != ACC_RTC_SUCCESS) {
+       // if compilation fails:
+       // print source, compilation options and compilation log
+       size_t logSize;
+       ACC_RTC_CALL(GetProgramLogSize, (kernel_program, &logSize));
+       char *log = new char[logSize];
+       ACC_RTC_CALL(GetProgramLog, (kernel_program, log));
+       std::cout << "---------------------------------------------------------------------------------" << std::endl
+                 << "Compile source : " << std::endl << kernel_code.c_str() << std::endl
+                 << "---------------------------------------------------------------------------------" << std::endl
+                 << "Compile lowered name : " << kernel_name.c_str() << std::endl
+                 << "---------------------------------------------------------------------------------" << std::endl
+                 << "Compile options : " << *compileOptions << std::endl
+                 << "---------------------------------------------------------------------------------" << std::endl
+                 << "Compile log : " << std::endl << log << '\n';
+       delete[] log;
+       exit(1);
+    }
 
     // Obtain PTX from the program.
     size_t codeSize;
@@ -366,7 +384,25 @@ void jit_transpose_handle(ACC_DRV(function)& kern_func, int m, int n){
     const char *compileOptions[] = {"-D__HIP"};
     size_t nOptions = 1;
 #endif
-    ACC_RTC_CALL(CompileProgram, (kernel_program, nOptions, compileOptions));
+    ACC_RTC(Result) compileResult = ACC_RTC(CompileProgram)(kernel_program, nOptions, compileOptions);
+    if (compileResult != ACC_RTC_SUCCESS) {
+       // if compilation fails:
+       // print source, compilation options and compilation log
+       size_t logSize;
+       ACC_RTC_CALL(GetProgramLogSize, (kernel_program, &logSize));
+       char *log = new char[logSize];
+       ACC_RTC_CALL(GetProgramLog, (kernel_program, log));
+       std::cout << "---------------------------------------------------------------------------------" << std::endl
+                 << "Compile source : " << std::endl << transpose_code.c_str() << std::endl
+                 << "---------------------------------------------------------------------------------" << std::endl
+                 << "Compile lowered name : " << kernel_name.c_str() << std::endl
+                 << "---------------------------------------------------------------------------------" << std::endl
+                 << "Compile options : " << *compileOptions << std::endl
+                 << "---------------------------------------------------------------------------------" << std::endl
+                 << "Compile log : " << std::endl << log << '\n';
+       delete[] log;
+       exit(1);
+    }
 
     // Obtain PTX from the program.
     size_t codeSize;


### PR DESCRIPTION
It is convenient to see the source being compiled and the errors if JIT compilation fails for some reason. 

@hfp, could you please help check if similar changes are necessary for the OpenCL backend?