### PR TITLE
ocl: introduced tunables and other kernel adjustments

### DIFF
--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -78,7 +78,7 @@ typedef struct opencl_libsmm_smm_t {
   cl_kernel kernel; /* must be the 1st data member */
   size_t wgsize;
   /* parameters (either pretuned or determined) */
-  int bs, bm, bn, wg, lu, nz, ap, aa, ab, ac;
+  int bs, bm, bn, bk, wg, lu, nz, al, ap, aa, ab, ac;
   /* ACC_OPENCL_VERBOSE: perf. counters */
   double gflops_sumlog, gflops_comp;
   size_t nexec;

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -37,11 +37,12 @@ class SmmTuner(MeasurementInterface):
         self.args.bs = max(min(self.args.bs, self.args.mb), 1)
         self.args.bm = [max(self.args.bm, 1), self.args.m][0 == self.args.bm]
         self.args.bn = [max(self.args.bn, 1), 1][0 == self.args.bn]
-        self.bs = self.bm = self.bn = self.wg = self.nz = self.lu = None
-        self.ap = self.aa = self.ab = self.ac = None
+        self.args.bk = [max(self.args.bk, 1), self.args.k][0 == self.args.bk]
+        self.bs = self.bm = self.bn = self.bk = self.wg = self.lu = self.nz = None
+        self.al = self.ap = self.aa = self.ab = self.ac = None
         self.gfbase = self.gflops = 0
         self.config = None
-        self.exepath = "../.."
+        self.exepath = os.path.join(os.path.dirname(sys.argv[0]), "..", "..")
         self.exename = "acc_bench_smm"
         run_result = (  # verbosity to capture device name and tuned parameters
             self.launch(["ACC_OPENCL_VERBOSE=2", "CHECK=0"], nrep=1, size=1)
@@ -49,7 +50,7 @@ class SmmTuner(MeasurementInterface):
             and (self.args.update is None or "" == self.args.update)
             else None
         )
-        if run_result and 0 == run_result["returncode"]:
+        if run_result:
             typename = re.search(
                 "typename \\(id=([0-9]+)\\):\\s+(\\w+)", str(run_result["stdout"])
             )
@@ -62,12 +63,17 @@ class SmmTuner(MeasurementInterface):
                 str(run_result["stderr"]),
             )
             self.device = device.group(1) if device and device.group(1) else ""
+        elif self.args.update is not None and "" != self.args.update:
+            self.device = self.args.update
+        else:
+            self.typename = self.typeid = self.device = None
+        if run_result and 0 == run_result["returncode"]:
             seedpat = "INFO ACC/OpenCL:\\s+{}\\s+{}SMM-kernel{}{}{}{}".format(
                 "{}x{}x{}".format(self.args.m, self.args.n, self.args.k),
                 {"float": "S", "double": "D"}.get(self.typename, ""),
-                "\\s+bs=([0-9]+)\\s+bm=([0-9]+)\\s+bn=([0-9]+)",
-                "\\s+wg=([0-9]+)\\s+lu=(-*[0-9]+)\\s+nz=([0-9]+)",
-                "\\s+ap=([0-9]+)\\s+aa=([0-9]+)\\s+ab=([0-9]+)",
+                "\\s+bs=([0-9]+)\\s+bm=([0-9]+)\\s+bn=([0-9]+)\\s+bk=([0-9]+)",
+                "\\s+wg=([0-9]+)\\s+lu=(-*[0-9]+)\\s+nz=([0-9]+)",  # lu can be neg.
+                "\\s+al=([0-9]+)\\s+ap=([0-9]+)\\s+aa=([0-9]+)\\s+ab=([0-9]+)",
                 "\\s+ac=([0-9]+)\\s+gen=",
             )
             seed = re.search(seedpat, str(run_result["stderr"]))
@@ -88,40 +94,50 @@ class SmmTuner(MeasurementInterface):
             else:
                 self.bn = int(seed.group(3)) if seed and seed.group(3) else None
                 paramt.append(IntegerParameter("BN", 1, self.args.n))
+            if os.getenv("OPENCL_LIBSMM_SMM_BK"):
+                params.append(IntegerParameter("BK", self.args.bk, self.args.bk))
+            else:
+                self.bk = int(seed.group(4)) if seed and seed.group(4) else None
+                paramt.append(IntegerParameter("BK", 1, self.args.m))
             if os.getenv("OPENCL_LIBSMM_SMM_WG"):
                 params.append(IntegerParameter("WG", self.args.wg, self.args.wg))
             else:
-                self.wg = int(seed.group(4)) if seed and seed.group(4) else None
+                self.wg = int(seed.group(5)) if seed and seed.group(5) else None
                 paramt.append(IntegerParameter("WG", 0, 2))
             if os.getenv("OPENCL_LIBSMM_SMM_LU"):
                 params.append(IntegerParameter("LU", self.args.lu, self.args.lu))
             else:
-                self.lu = int(seed.group(5)) if seed and seed.group(5) else None
+                self.lu = int(seed.group(6)) if seed and seed.group(6) else None
                 paramt.append(IntegerParameter("LU", -1, 2))
             if os.getenv("OPENCL_LIBSMM_SMM_NZ"):
                 params.append(IntegerParameter("NZ", self.args.nz, self.args.nz))
             else:
-                self.nz = int(seed.group(6)) if seed and seed.group(6) else None
+                self.nz = int(seed.group(7)) if seed and seed.group(7) else None
                 paramt.append(IntegerParameter("NZ", 0, 1))
+            if os.getenv("OPENCL_LIBSMM_SMM_AL"):
+                params.append(IntegerParameter("AL", self.args.al, self.args.al))
+            else:
+                self.al = int(seed.group(8)) if seed and seed.group(8) else None
+                paramt.append(IntegerParameter("AL", 0, 1))
             if os.getenv("OPENCL_LIBSMM_SMM_AP"):
                 params.append(IntegerParameter("AP", self.args.ap, self.args.ap))
             else:
-                self.ap = int(seed.group(7)) if seed and seed.group(7) else None
+                self.ap = int(seed.group(9)) if seed and seed.group(9) else None
                 paramt.append(IntegerParameter("AP", 0, 1))
             if os.getenv("OPENCL_LIBSMM_SMM_AA"):
                 params.append(IntegerParameter("AA", self.args.aa, self.args.aa))
             else:
-                self.aa = int(seed.group(8)) if seed and seed.group(8) else None
+                self.aa = int(seed.group(10)) if seed and seed.group(10) else None
                 paramt.append(IntegerParameter("AA", 0, 3))
             if os.getenv("OPENCL_LIBSMM_SMM_AB"):
                 params.append(IntegerParameter("AB", self.args.ab, self.args.ab))
             else:
-                self.ab = int(seed.group(9)) if seed and seed.group(9) else None
+                self.ab = int(seed.group(11)) if seed and seed.group(11) else None
                 paramt.append(IntegerParameter("AB", 0, 3))
             if os.getenv("OPENCL_LIBSMM_SMM_AC"):
                 params.append(IntegerParameter("AC", self.args.ac, self.args.ac))
             else:
-                self.ac = int(seed.group(10)) if seed and seed.group(10) else None
+                self.ac = int(seed.group(12)) if seed and seed.group(12) else None
                 paramt.append(IntegerParameter("AC", 0, 2))
             if not paramt:
                 sys.tracebacklimit = 0
@@ -130,13 +146,11 @@ class SmmTuner(MeasurementInterface):
                 )
             for param in params + paramt:
                 manipulator.add_parameter(param)
-        elif self.args.update is not None and "" != self.args.update:
-            self.device = self.args.update
-        else:
-            self.typename = self.typeid = self.device = None
         # consider to update and/or merge JSONS (update first)
         if self.args.merge or self.args.update is None or "" != self.args.update:
-            filenames = glob.glob("*.json")
+            filenames = glob.glob(
+                os.path.normpath(os.path.join(self.args.jsondir, "*.json"))
+            )
             if self.args.update is None or "" != self.args.update:
                 self.update_jsons(filenames)
             if self.args.merge:
@@ -153,7 +167,7 @@ class SmmTuner(MeasurementInterface):
         else:
             sys.tracebacklimit = 0
             raise RuntimeError(
-                "Setup failed for {}/{}!".format(self.exepath, self.exename)
+                "Setup failed for {}!".format(os.path.join(self.exepath, self.exename))
             )
         # register signal handler (CTRL-C)
         signal(SIGINT, self.handle_sigint)
@@ -167,7 +181,7 @@ class SmmTuner(MeasurementInterface):
         return self.call_program(
             "OMP_PROC_BIND=TRUE {} {} {} {}".format(
                 envstrs,  # environment variables
-                "{}/{}".format(self.exepath, self.exename),
+                "{}".format(os.path.join(self.exepath, self.exename)),
                 # executable's arguments
                 "{} {}".format(
                     self.args.r if nrep is None else nrep,
@@ -183,9 +197,11 @@ class SmmTuner(MeasurementInterface):
                 "BS": self.bs if self.bs is not None else self.args.bs,
                 "BM": self.bm if self.bm is not None else self.args.bm,
                 "BN": self.bn if self.bn is not None else self.args.bn,
+                "BK": self.bk if self.bk is not None else self.args.bk,
                 "WG": self.wg if self.wg is not None else self.args.wg,
                 "NZ": self.nz if self.nz is not None else self.args.nz,
                 "LU": self.lu if self.lu is not None else self.args.lu,
+                "AL": self.al if self.al is not None else self.args.al,
                 "AP": self.ap if self.ap is not None else self.args.ap,
                 "AA": self.aa if self.aa is not None else self.args.aa,
                 "AB": self.ab if self.ab is not None else self.args.ab,
@@ -204,9 +220,11 @@ class SmmTuner(MeasurementInterface):
             "OPENCL_LIBSMM_SMM_BS={}".format(config["BS"]),
             "OPENCL_LIBSMM_SMM_BM={}".format(config["BM"]),
             "OPENCL_LIBSMM_SMM_BN={}".format(config["BN"]),
+            "OPENCL_LIBSMM_SMM_BK={}".format(config["BK"]),
             "OPENCL_LIBSMM_SMM_WG={}".format(config["WG"]),
             "OPENCL_LIBSMM_SMM_LU={}".format(config["LU"]),
             "OPENCL_LIBSMM_SMM_NZ={}".format(config["NZ"]),
+            "OPENCL_LIBSMM_SMM_AL={}".format(config["AL"]),
             "OPENCL_LIBSMM_SMM_AP={}".format(config["AP"]),
             "OPENCL_LIBSMM_SMM_AA={}".format(config["AA"]),
             "OPENCL_LIBSMM_SMM_AB={}".format(config["AB"]),
@@ -281,9 +299,11 @@ class SmmTuner(MeasurementInterface):
                     device = data["DEVICE"] if "DEVICE" in data else self.device
                     key = (device, data["TYPEID"], data["M"], data["N"], data["K"])
                     value = (data["GFLOPS"], data["BS"], data["BM"], data["BN"]) + (
+                        data["BK"] if "BK" in data else 0,
                         data["WG"] if "WG" in data else 0,
                         data["LU"] if "LU" in data else 0,
                         data["NZ"] if "NZ" in data else 0,
+                        data["AL"] if "AL" in data else 0,
                         data["AP"] if "AP" in data else 0,
                         data["AA"] if "AA" in data else 0,
                         data["AB"] if "AB" in data else 0,
@@ -310,10 +330,10 @@ class SmmTuner(MeasurementInterface):
                         "{}{}{}{}{}\n".format(  # key-part
                             self.args.csvsep.join(["DEVICE", "TYPEID", "M", "N", "K"]),
                             self.args.csvsep,  # separator for value-part
-                            self.args.csvsep.join(["GFLOPS", "BS", "BM", "BN"]),
+                            self.args.csvsep.join(["GFLOPS", "BS", "BM", "BN", "BK"]),
                             self.args.csvsep,
                             self.args.csvsep.join(
-                                ["WG", "LU", "NZ", "AP", "AA", "AB", "AC"]
+                                ["WG", "LU", "NZ", "AL", "AP", "AA", "AB", "AC"]
                             ),
                         )
                     )
@@ -346,8 +366,17 @@ class SmmTuner(MeasurementInterface):
     def save_final_config(self, configuration):
         """Called at termination"""
         if 0 < self.gflops and configuration:
-            filename = "tune_multiply-{}-{}x{}x{}-{}gflops.json".format(
-                self.typename, self.args.m, self.args.n, self.args.k, round(self.gflops)
+            filename = os.path.normpath(
+                os.path.join(
+                    self.args.jsondir,
+                    "tune_multiply-{}-{}x{}x{}-{}gflops.json".format(
+                        self.typename,
+                        self.args.m,
+                        self.args.n,
+                        self.args.k,
+                        round(self.gflops),
+                    ),
+                )
             )
             # extend result for easier reuse later
             config = configuration.data
@@ -357,7 +386,9 @@ class SmmTuner(MeasurementInterface):
             config["M"] = self.args.m
             config["N"] = self.args.n
             config["K"] = self.args.k
-            filenames = glob.glob("*.json")
+            filenames = glob.glob(
+                os.path.normpath(os.path.join(self.args.jsondir, "*.json"))
+            )
             if not filenames and glob.glob(self.args.csvfile):
                 print(
                     "WARNING: no JSON file found but (unrelated?) {}".format(
@@ -445,8 +476,17 @@ if __name__ == "__main__":
         help="Merge JSONs into CSV, and terminate",
     )
     argparser.add_argument(
+        "-p",
+        "--jsons-dir",
+        type=str,
+        default=".",
+        nargs="?",
+        dest="jsondir",
+        help="Directory to read/write JSONs",
+    )
+    argparser.add_argument(
         "-u",
-        "--update-jsons",
+        "--jsons-update",
         type=str,
         default="",
         nargs="?",
@@ -498,6 +538,15 @@ if __name__ == "__main__":
         help="Block/tile size (BN)",
     )
     argparser.add_argument(
+        "-bk",
+        "--initial-bk",
+        type=int,
+        default=int(os.getenv("OPENCL_LIBSMM_SMM_BK", "0")),
+        nargs="?",
+        dest="bk",
+        help="Block size (BK)",
+    )
+    argparser.add_argument(
         "-wg",
         "--initial-wg",
         type=int,
@@ -520,6 +569,14 @@ if __name__ == "__main__":
         default=int(os.getenv("OPENCL_LIBSMM_SMM_NZ", "0")),
         dest="nz",
         help="Check atomic increment to be non-zero (1)",
+    )
+    argparser.add_argument(
+        "-al",
+        "--initial-al",
+        type=int,
+        default=int(os.getenv("OPENCL_LIBSMM_SMM_AL", "0")),
+        dest="al",
+        help="Access: transposed (0), linear (1)",
     )
     argparser.add_argument(
         "-ap",
@@ -557,7 +614,7 @@ if __name__ == "__main__":
         "-bs",
         "--initial-bs",
         type=int,
-        default=int(os.getenv("OPENCL_LIBSMM_SMM_BS", "16")),
+        default=int(os.getenv("OPENCL_LIBSMM_SMM_BS", "8")),
         nargs="?",
         dest="bs",
         help="Minibatch size (BS)",
@@ -585,12 +642,13 @@ if __name__ == "__main__":
     if 1 <= args.tlevel or 0 > args.tlevel:
         os.environ["OPENCL_LIBSMM_SMM_BM"] = "{}".format(args.bm)
         os.environ["OPENCL_LIBSMM_SMM_BN"] = "{}".format(args.bn)
-    if 2 <= args.tlevel:
-        os.environ["OPENCL_LIBSMM_SMM_AP"] = "{}".format(args.ap)
-        os.environ["OPENCL_LIBSMM_SMM_NZ"] = "{}".format(args.nz)
-    if 3 <= args.tlevel:
-        os.environ["OPENCL_LIBSMM_SMM_AC"] = "{}".format(args.ac)
         os.environ["OPENCL_LIBSMM_SMM_WG"] = "{}".format(args.wg)
+    if 2 <= args.tlevel:
+        os.environ["OPENCL_LIBSMM_SMM_BK"] = "{}".format(args.bk)
+        os.environ["OPENCL_LIBSMM_SMM_NZ"] = "{}".format(args.nz)
+        os.environ["OPENCL_LIBSMM_SMM_AC"] = "{}".format(args.ac)
+    if 3 <= args.tlevel:
+        os.environ["OPENCL_LIBSMM_SMM_AP"] = "{}".format(args.ap)
     if 0 == args.mb:
         args.mb = 64
     # additional/depending arguments


### PR DESCRIPTION
* Adjusted default of intra-kernel batchsize (OPENCL_LIBSMM_SMM_BS).
* Partially (fast/column-path) implemented BK-parameter (kernel).
* Fixed decision about fallback-atomics (ATOMIC32_ADD64).
* Thin abstraction (macros) of matrix-access (indexing).
* OPENCL_LIBSMM_SMM_KERNEL env.var. load kernel source.
* Introduced (tunable) k-blocks (peeled from m-loop).
* Introduced (tunable) AT-parameter.

Other:
* Comdline arg for dir to read/write JSONs (tune_multiply.py).
* Use os.path instead of string ops (tune_multiply.py).
* Adjusted tuning-levels (tune_multiply.py).