### PR TITLE
Simpler hip backend

### DIFF
--- a/src/acc/cuda_hip/acc_dev.cpp
+++ b/src/acc/cuda_hip/acc_dev.cpp
@@ -28,6 +28,11 @@ extern "C" int c_dbcsr_acc_get_ndevices(int *n_devices){
   return 0;
 }
 
+/****************************************************************************/
+extern "C" void c_dbcsr_acc_device_synchronize(){
+  ACC_API_CALL(DeviceSynchronize, ());
+  return;
+}
 
 /****************************************************************************/
 extern "C" int c_dbcsr_acc_set_active_device(int device_id){

--- a/src/acc/cuda_hip/acc_dev.cpp
+++ b/src/acc/cuda_hip/acc_dev.cpp
@@ -29,9 +29,9 @@ extern "C" int c_dbcsr_acc_get_ndevices(int *n_devices){
 }
 
 /****************************************************************************/
-extern "C" void c_dbcsr_acc_device_synchronize(){
+extern "C" int c_dbcsr_acc_device_synchronize(){
   ACC_API_CALL(DeviceSynchronize, ());
-  return;
+  return 0;
 }
 
 /****************************************************************************/

--- a/src/acc/dbcsr_acc_device.F
+++ b/src/acc/dbcsr_acc_device.F
@@ -40,13 +40,17 @@ MODULE dbcsr_acc_device
 
       END FUNCTION acc_set_active_device_cu
 
+      FUNCTION acc_device_synchronize_cu() RESULT(istat) &
+         BIND(C, name="c_dbcsr_acc_device_synchronize")
+         IMPORT
+         INTEGER(KIND=C_INT)                      :: istat
+
+      END FUNCTION acc_device_synchronize_cu
+
       SUBROUTINE acc_clear_errors_cu() &
          BIND(C, name="c_dbcsr_acc_clear_errors")
       END SUBROUTINE acc_clear_errors_cu
 
-      SUBROUTINE acc_device_synchronize_cu() &
-         BIND(C, name="c_dbcsr_acc_device_synchronize")
-      END SUBROUTINE acc_device_synchronize_cu
    END INTERFACE
 
 #endif
@@ -101,8 +105,13 @@ CONTAINS
    END SUBROUTINE dbcsr_acc_clear_errors
 
    SUBROUTINE acc_device_synchronize()
+      !! Fortran-wrapper for waiting for work on all streams to complete
+
 #if defined (__DBCSR_ACC)
-      CALL acc_device_synchronize_cu()
+      INTEGER                                  :: istat
+      istat = acc_device_synchronize_cu()
+      IF (istat /= 0) &
+         DBCSR_ABORT("acc_device_synchronize failed")
 #else
       DBCSR_ABORT("__DBCSR_ACC not compiled in")
 #endif

--- a/src/acc/dbcsr_acc_device.F
+++ b/src/acc/dbcsr_acc_device.F
@@ -15,7 +15,7 @@ MODULE dbcsr_acc_device
 
    IMPLICIT NONE
 
-   PUBLIC :: dbcsr_acc_get_ndevices, dbcsr_acc_set_active_device, dbcsr_acc_clear_errors 
+   PUBLIC :: dbcsr_acc_get_ndevices, dbcsr_acc_set_active_device, dbcsr_acc_clear_errors
    PUBLIC :: acc_device_synchronize
 
    PRIVATE

--- a/src/acc/dbcsr_acc_device.F
+++ b/src/acc/dbcsr_acc_device.F
@@ -15,7 +15,8 @@ MODULE dbcsr_acc_device
 
    IMPLICIT NONE
 
-   PUBLIC :: dbcsr_acc_get_ndevices, dbcsr_acc_set_active_device, dbcsr_acc_clear_errors
+   PUBLIC :: dbcsr_acc_get_ndevices, dbcsr_acc_set_active_device, dbcsr_acc_clear_errors 
+   PUBLIC :: acc_device_synchronize
 
    PRIVATE
 
@@ -42,6 +43,10 @@ MODULE dbcsr_acc_device
       SUBROUTINE acc_clear_errors_cu() &
          BIND(C, name="c_dbcsr_acc_clear_errors")
       END SUBROUTINE acc_clear_errors_cu
+
+      SUBROUTINE acc_device_synchronize_cu() &
+         BIND(C, name="c_dbcsr_acc_device_synchronize")
+      END SUBROUTINE acc_device_synchronize_cu
    END INTERFACE
 
 #endif
@@ -94,5 +99,13 @@ CONTAINS
       DBCSR_ABORT("__DBCSR_ACC not compiled in")
 #endif
    END SUBROUTINE dbcsr_acc_clear_errors
+
+   SUBROUTINE acc_device_synchronize()
+#if defined (__DBCSR_ACC)
+      CALL acc_device_synchronize_cu()
+#else
+      DBCSR_ABORT("__DBCSR_ACC not compiled in")
+#endif
+   END SUBROUTINE acc_device_synchronize
 
 END MODULE dbcsr_acc_device

--- a/src/acc/libsmm_acc/kernels/smm_acc_common.h
+++ b/src/acc/libsmm_acc/kernels/smm_acc_common.h
@@ -13,7 +13,7 @@
 #define __HIP
 #endif
 #endif
-#if defined(__HIP) && !defined(__HIP_PLATFORM_NVCC__)
+#if defined(__HIP) && !defined(__HIP_PLATFORM_NVCC__) && !defined(__HIPCC_RTC__)
 # include <hip/hip_runtime.h>
 #endif
 

--- a/src/core/dbcsr_config.F
+++ b/src/core/dbcsr_config.F
@@ -201,6 +201,12 @@ CONTAINS
       IF (PRESENT(mm_densification)) dbcsr_cfg%mm_densification = mm_densification
       IF (PRESENT(accdrv_priority_streams)) dbcsr_cfg%accdrv_priority_streams = accdrv_priority_streams
       IF (PRESENT(accdrv_priority_buffers)) dbcsr_cfg%accdrv_priority_buffers = accdrv_priority_buffers
+#if defined(__DBCSR_ACC) && defined(__HIP_PLATFORM_AMD__)
+      nthreads = 1
+!$    nthreads = OMP_GET_MAX_THREADS()
+      dbcsr_cfg%accdrv_priority_streams = nthreads
+      dbcsr_cfg%accdrv_priority_buffers = nthreads*4
+#endif
       IF (PRESENT(accdrv_posterior_streams)) dbcsr_cfg%accdrv_posterior_streams = accdrv_posterior_streams
       IF (PRESENT(accdrv_posterior_buffers)) dbcsr_cfg%accdrv_posterior_buffers = accdrv_posterior_buffers
       IF (PRESENT(accdrv_avoid_after_busy)) dbcsr_cfg%accdrv_avoid_after_busy = accdrv_avoid_after_busy

--- a/src/core/dbcsr_config.F
+++ b/src/core/dbcsr_config.F
@@ -201,7 +201,7 @@ CONTAINS
       IF (PRESENT(mm_densification)) dbcsr_cfg%mm_densification = mm_densification
       IF (PRESENT(accdrv_priority_streams)) dbcsr_cfg%accdrv_priority_streams = accdrv_priority_streams
       IF (PRESENT(accdrv_priority_buffers)) dbcsr_cfg%accdrv_priority_buffers = accdrv_priority_buffers
-#if defined(__DBCSR_ACC) && defined(__HIP_PLATFORM_AMD__)
+#if defined(__DBCSR_ACC) && (defined(__HIP_PLATFORM_AMD__) || defined(__CUDA) || defined(__HIP_PLATFORM_NVCC__))
       nthreads = 1
 !$    nthreads = OMP_GET_MAX_THREADS()
       dbcsr_cfg%accdrv_priority_streams = nthreads

--- a/src/mm/dbcsr_mm_accdrv.F
+++ b/src/mm/dbcsr_mm_accdrv.F
@@ -300,9 +300,9 @@ CONTAINS
                                                             nthreads
 #if !defined(__HIP_PLATFORM_AMD__)
       INTEGER                                            :: my_posterior_buffers
-      INTEGER, SAVE                                      :: curr_posterior_stream = 0
+      INTEGER, SAVE                                      :: curr_posterior_stream = 0, &
+                                                            curr_priority_stream = 0
 #endif
-      INTEGER, SAVE                                      :: curr_priority_stream = 0
       TYPE(thread_private_type), POINTER                 :: thread_privates
 
       nthreads = 1; ithread = 0

--- a/src/mm/dbcsr_mm_accdrv.F
+++ b/src/mm/dbcsr_mm_accdrv.F
@@ -36,15 +36,14 @@ MODULE dbcsr_mm_accdrv
    USE dbcsr_acc_stream, ONLY: acc_stream_associated, &
                                acc_stream_create, &
                                acc_stream_destroy, &
-                               acc_stream_priority_range, &
                                acc_stream_synchronize, &
                                acc_stream_type
    USE dbcsr_block_operations, ONLY: block_add
    USE dbcsr_config, ONLY: dbcsr_cfg, &
                            default_resize_factor
    !accdrv_binning_binsize, accdrv_binning_nbins, accdrv_min_flop_sort, &
-   !accdrv_posterior_buffers, accdrv_posterior_streams, accdrv_priority_buffers, &
-   !accdrv_priority_streams, default_resize_factor, mm_stack_size
+   !accdrv_priority_buffers, !accdrv_priority_streams, &
+   !default_resize_factor, mm_stack_size
    USE dbcsr_data_methods, ONLY: dbcsr_data_dev2host, &
                                  dbcsr_data_ensure_size, &
                                  dbcsr_data_get_size, &
@@ -118,8 +117,6 @@ MODULE dbcsr_mm_accdrv
    END TYPE thread_private_type
 
    TYPE(thread_private_type), SAVE, DIMENSION(:), ALLOCATABLE, TARGET :: all_thread_privates
-   TYPE(acc_stream_type), SAVE                            :: upload_stream
-   TYPE(acc_stream_type), SAVE, DIMENSION(:), POINTER     :: posterior_streams => Null()
    TYPE(acc_stream_type), SAVE, DIMENSION(:), POINTER     :: priority_streams => Null()
    TYPE(acc_event_type), SAVE, DIMENSION(:), POINTER     :: barrier_events => Null()
    INTEGER, SAVE                                          :: barrier_counter = 0
@@ -220,22 +217,10 @@ CONTAINS
    SUBROUTINE setup_streams()
       !! Helper routine used by dbcsr_mm_accdrv_init()
 
-      INTEGER                                            :: greatest_priority, least_priority
 
 !$OMP MASTER
-      CALL acc_stream_priority_range(least_priority, greatest_priority)
-#if defined(__HIP_PLATFORM_AMD__) || defined(__CUDA) || defined(__HIP_PLATFORM_NVCC__)
       CALL stream_array_force_size(priority_streams, "Calc (priority)", &
                                    n=dbcsr_cfg%accdrv_priority_streams)
-#else
-      CALL stream_array_force_size(priority_streams, "Calc (priority)", &
-                                   n=dbcsr_cfg%accdrv_priority_streams, priority=greatest_priority)
-      CALL stream_array_force_size(posterior_streams, "Calc (posterior)", &
-                                   n=dbcsr_cfg%accdrv_posterior_streams, events=barrier_events)
-#endif
-      !create upload stream
-      IF (.NOT. acc_stream_associated(upload_stream)) &
-         CALL acc_stream_create(upload_stream, "Stackbuf h2d")
 !$OMP END MASTER
 ! Other threads have to wait until streams are created
 !$OMP BARRIER
@@ -246,13 +231,7 @@ CONTAINS
       !! Helper routine used by setup_streams() and dbcsr_mm_accdrv_lib_finalize()
 
 !$OMP MASTER
-      IF (acc_stream_associated(upload_stream)) &
-         CALL acc_stream_destroy(upload_stream)
-
       CALL stream_array_force_size(priority_streams, "Calc (priority)", n=0)
-#if !defined(__HIP_PLATFORM_AMD__) && !defined(__CUDA) && !defined(__HIP_PLATFORM_NVCC__)
-      CALL stream_array_force_size(posterior_streams, "Calc (posterior)", n=0, events=barrier_events)
-#endif
 !$OMP END MASTER
 
    END SUBROUTINE deallocate_streams
@@ -298,11 +277,6 @@ CONTAINS
       INTEGER                                            :: i, ithread, &
                                                             my_priority_buffers, my_total_buffers, &
                                                             nthreads
-#if !defined(__HIP_PLATFORM_AMD__) && !defined(__CUDA) && !defined(__HIP_PLATFORM_NVCC__)
-      INTEGER                                            :: my_posterior_buffers
-      INTEGER, SAVE                                      :: curr_posterior_stream = 0, &
-                                                            curr_priority_stream = 0
-#endif
       TYPE(thread_private_type), POINTER                 :: thread_privates
 
       nthreads = 1; ithread = 0
@@ -312,16 +286,9 @@ CONTAINS
       ! distribute total number of buffers approx. evenly among threads
       ! my_* variables hold number of buffers for current thread.
       my_priority_buffers = CEILING(REAL(dbcsr_cfg%accdrv_priority_buffers)/REAL(nthreads), int_4)
-#if !defined(__HIP_PLATFORM_AMD__) && !defined(__CUDA) && !defined(__HIP_PLATFORM_NVCC__)
-      my_posterior_buffers = CEILING(REAL(dbcsr_cfg%accdrv_posterior_buffers)/REAL(nthreads), int_4)
-#endif
 
       this%nbuffers_phaseout = my_priority_buffers
-#if defined(__HIP_PLATFORM_AMD__) || defined(__CUDA) || defined(__HIP_PLATFORM_NVCC__)
       my_total_buffers = my_priority_buffers
-#else
-      my_total_buffers = my_posterior_buffers + my_priority_buffers
-#endif
 
       IF (ASSOCIATED(thread_privates%stack_buffers)) THEN
          IF (SIZE(thread_privates%stack_buffers) /= my_total_buffers) &
@@ -330,22 +297,12 @@ CONTAINS
 
       IF (.NOT. ASSOCIATED(thread_privates%stack_buffers)) THEN
          ALLOCATE (thread_privates%stack_buffers(my_total_buffers))
-         !Done with OMP CRITICAL because curr_*_stream are shared.
+         !OMP CRITICAL may not be needed anymore
 !$OMP        CRITICAL(crit_setup_stackbuffers)
          DO i = 1, my_total_buffers
             CALL acc_devmem_allocate_bytes(thread_privates%stack_buffers(i)%devmem, &
                                            int_4_size*dbcsr_ps_acc_width*dbcsr_cfg%mm_stack_size)
-#if !defined(__HIP_PLATFORM_AMD__) && !defined(__CUDA) && !defined(__HIP_PLATFORM_NVCC__)
-            IF (i <= my_priority_buffers) THEN
-               curr_priority_stream = MOD(curr_priority_stream, SIZE(priority_streams)) + 1
-               thread_privates%stack_buffers(i)%stream = priority_streams(curr_priority_stream)
-            ELSE
-               curr_posterior_stream = MOD(curr_posterior_stream, SIZE(posterior_streams)) + 1
-               thread_privates%stack_buffers(i)%stream = posterior_streams(curr_posterior_stream)
-            ENDIF
-#else
             thread_privates%stack_buffers(i)%stream = priority_streams(ithread + 1)
-#endif
             CALL acc_hostmem_allocate(thread_privates%stack_buffers(i)%hostmem, &
                                       dbcsr_ps_acc_width, dbcsr_cfg%mm_stack_size, thread_privates%stack_buffers(i)%stream)
             CALL acc_event_create(thread_privates%stack_buffers(i)%ready)
@@ -474,31 +431,11 @@ CONTAINS
    END SUBROUTINE dbcsr_mm_accdrv_phaseout
 
    SUBROUTINE dbcsr_mm_accdrv_barrier()
-#if !defined(__HIP_PLATFORM_AMD__) && !defined(__CUDA) && !defined(__HIP_PLATFORM_NVCC__)
-      !! After being called by ALL threads, it installs a special barrier that
-      !! forces the priority-streams to wait for the normal-streams.
-
-      INTEGER                                            :: i, j, nthreads
-      nthreads = 1
-!$    nthreads = OMP_GET_NUM_THREADS()
-!$OMP     CRITICAL
-      barrier_counter = MOD(barrier_counter + 1, nthreads)
-      IF (barrier_counter == 0) THEN
-         DO i = 1, SIZE(posterior_streams)
-            CALL acc_event_record(barrier_events(i), stream=posterior_streams(i))
-            DO j = 1, SIZE(priority_streams)
-               CALL acc_stream_wait_event(priority_streams(j), barrier_events(i))
-            ENDDO
-         ENDDO
-      ENDIF
-!$OMP     END CRITICAL
-#else
       INTEGER                                            :: ithread
 
       ithread = 0
 !$    ithread = OMP_GET_THREAD_NUM()
       CALL acc_stream_synchronize(priority_streams(ithread + 1))
-#endif
    END SUBROUTINE dbcsr_mm_accdrv_barrier
 
    SUBROUTINE dbcsr_mm_accdrv_process(this, left, right, params, stack_size, &
@@ -528,9 +465,7 @@ CONTAINS
 !$    ithread = OMP_GET_THREAD_NUM()
       stack_buffers => all_thread_privates(ithread)%stack_buffers
 
-#if defined(__HIP_PLATFORM_AMD__) || defined(__CUDA) || defined(__HIP_PLATFORM_NVCC__)
       DO WHILE (.NOT. ASSOCIATED(stackbuf))
-#endif
          DO i = 1, SIZE(stack_buffers)
             IF (this%phase_out .AND. i > this%nbuffers_phaseout) EXIT
             IF (acc_event_query(stack_buffers(i)%calculated)) THEN
@@ -538,9 +473,7 @@ CONTAINS
                EXIT
             ENDIF
          ENDDO
-#if defined(__HIP_PLATFORM_AMD__) || defined(__CUDA) || defined(__HIP_PLATFORM_NVCC__)
       ENDDO
-#endif
 
       IF (.NOT. ASSOCIATED(stackbuf)) THEN
          success = .FALSE.
@@ -587,22 +520,10 @@ CONTAINS
       IF (.NOT. acc_devmem_allocated(c_area%acc_devmem)) &
          DBCSR_ABORT("dbcsr_mm_accdrv_process: c_area%acc_devmem not allocated")
 
-      ! start uploading stacks only after a, b, and c are ready
-#if !defined (__HIP_PLATFORM_AMD__) && !defined(__CUDA) && !defined(__HIP_PLATFORM_NVCC__)
-      CALL acc_stream_wait_event(upload_stream, a_area%acc_ready)
-      CALL acc_stream_wait_event(upload_stream, b_area%acc_ready)
-      CALL acc_stream_wait_event(upload_stream, c_area%acc_ready)
-#endif
-
+      ! start uploading stacks; a, b, and c are ready by now
       stackbuf_hostmem_cropped => stackbuf%hostmem(:, 1:stack_size)
-#if defined (__HIP_PLATFORM_AMD__) || defined(__CUDA) || defined(__HIP_PLATFORM_NVCC__)
       CALL acc_devmem_host2dev(stackbuf%devmem, hostmem=stackbuf_hostmem_cropped, stream=stackbuf%stream)
       CALL acc_event_record(stackbuf%ready, stream=stackbuf%stream)
-#else
-      CALL acc_devmem_host2dev(stackbuf%devmem, hostmem=stackbuf_hostmem_cropped, stream=upload_stream)
-      CALL acc_event_record(stackbuf%ready, stream=upload_stream)
-      CALL acc_stream_wait_event(stackbuf%stream, stackbuf%ready)
-#endif
 
       ! We have to sync for the C area for the cuBLAS dgemm, used for large kernels
       CALL acc_stream_wait_event(c_area%memory_type%acc_stream, stackbuf%ready)
@@ -621,11 +542,6 @@ CONTAINS
 
       IF (success) THEN
          CALL acc_event_record(stackbuf%calculated, stream=stackbuf%stream)
-#if !defined(__HIP_PLATFORM_AMD__) && !defined(__CUDA) && !defined(__HIP_PLATFORM_NVCC__)
-         CALL acc_stream_wait_event(a_area%memory_type%acc_stream, stackbuf%calculated)
-         CALL acc_stream_wait_event(b_area%memory_type%acc_stream, stackbuf%calculated)
-         CALL acc_stream_wait_event(c_area%memory_type%acc_stream, stackbuf%calculated)
-#endif
       ENDIF
 
       CALL timestop(error_handle)

--- a/src/mm/dbcsr_mm_accdrv.F
+++ b/src/mm/dbcsr_mm_accdrv.F
@@ -583,15 +583,22 @@ CONTAINS
          DBCSR_ABORT("dbcsr_mm_accdrv_process: c_area%acc_devmem not allocated")
 
       ! start uploading stacks only after a, b, and c are ready
+#if !defined (__HIP_PLATFORM_AMD__) 
       CALL acc_stream_wait_event(upload_stream, a_area%acc_ready)
       CALL acc_stream_wait_event(upload_stream, b_area%acc_ready)
       CALL acc_stream_wait_event(upload_stream, c_area%acc_ready)
+#endif
 
       stackbuf_hostmem_cropped => stackbuf%hostmem(:, 1:stack_size)
+#if defined (__HIP_PLATFORM_AMD__)
+      CALL acc_devmem_host2dev(stackbuf%devmem, hostmem=stackbuf_hostmem_cropped, stream=stackbuf%stream)
+      CALL acc_event_record(stackbuf%ready, stream=stackbuf%stream)
+#else
       CALL acc_devmem_host2dev(stackbuf%devmem, hostmem=stackbuf_hostmem_cropped, stream=upload_stream)
       CALL acc_event_record(stackbuf%ready, stream=upload_stream)
-
       CALL acc_stream_wait_event(stackbuf%stream, stackbuf%ready)
+#endif
+
       ! We have to sync for the C area for the cuBLAS dgemm, used for large kernels
       CALL acc_stream_wait_event(c_area%memory_type%acc_stream, stackbuf%ready)
 
@@ -609,9 +616,11 @@ CONTAINS
 
       IF (success) THEN
          CALL acc_event_record(stackbuf%calculated, stream=stackbuf%stream)
+#if !defined(__HIP_PLATFORM_AMD__)
          CALL acc_stream_wait_event(a_area%memory_type%acc_stream, stackbuf%calculated)
          CALL acc_stream_wait_event(b_area%memory_type%acc_stream, stackbuf%calculated)
          CALL acc_stream_wait_event(c_area%memory_type%acc_stream, stackbuf%calculated)
+#endif
       ENDIF
 
       CALL timestop(error_handle)

--- a/src/mm/dbcsr_mm_accdrv.F
+++ b/src/mm/dbcsr_mm_accdrv.F
@@ -224,7 +224,7 @@ CONTAINS
 
 !$OMP MASTER
       CALL acc_stream_priority_range(least_priority, greatest_priority)
-#if defined(__HIP_PLATFORM_AMD__)
+#if defined(__HIP_PLATFORM_AMD__) || defined(__CUDA) || defined(__HIP_PLATFORM_NVCC__)
       CALL stream_array_force_size(priority_streams, "Calc (priority)", &
                                    n=dbcsr_cfg%accdrv_priority_streams)
 #else
@@ -250,7 +250,7 @@ CONTAINS
          CALL acc_stream_destroy(upload_stream)
 
       CALL stream_array_force_size(priority_streams, "Calc (priority)", n=0)
-#if !defined(__HIP_PLATFORM_AMD__)
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__CUDA) && !defined(__HIP_PLATFORM_NVCC__)
       CALL stream_array_force_size(posterior_streams, "Calc (posterior)", n=0, events=barrier_events)
 #endif
 !$OMP END MASTER
@@ -298,7 +298,7 @@ CONTAINS
       INTEGER                                            :: i, ithread, &
                                                             my_priority_buffers, my_total_buffers, &
                                                             nthreads
-#if !defined(__HIP_PLATFORM_AMD__)
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__CUDA) && !defined(__HIP_PLATFORM_NVCC__)
       INTEGER                                            :: my_posterior_buffers
       INTEGER, SAVE                                      :: curr_posterior_stream = 0, &
                                                             curr_priority_stream = 0
@@ -312,12 +312,12 @@ CONTAINS
       ! distribute total number of buffers approx. evenly among threads
       ! my_* variables hold number of buffers for current thread.
       my_priority_buffers = CEILING(REAL(dbcsr_cfg%accdrv_priority_buffers)/REAL(nthreads), int_4)
-#if !defined(__HIP_PLATFORM_AMD__)
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__CUDA) && !defined(__HIP_PLATFORM_NVCC__)
       my_posterior_buffers = CEILING(REAL(dbcsr_cfg%accdrv_posterior_buffers)/REAL(nthreads), int_4)
 #endif
 
       this%nbuffers_phaseout = my_priority_buffers
-#if defined(__HIP_PLATFORM_AMD__)
+#if defined(__HIP_PLATFORM_AMD__) || defined(__CUDA) || defined(__HIP_PLATFORM_NVCC__)
       my_total_buffers = my_priority_buffers
 #else
       my_total_buffers = my_posterior_buffers + my_priority_buffers
@@ -335,7 +335,7 @@ CONTAINS
          DO i = 1, my_total_buffers
             CALL acc_devmem_allocate_bytes(thread_privates%stack_buffers(i)%devmem, &
                                            int_4_size*dbcsr_ps_acc_width*dbcsr_cfg%mm_stack_size)
-#if !defined(__HIP_PLATFORM_AMD__)
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__CUDA) && !defined(__HIP_PLATFORM_NVCC__)
             IF (i <= my_priority_buffers) THEN
                curr_priority_stream = MOD(curr_priority_stream, SIZE(priority_streams)) + 1
                thread_privates%stack_buffers(i)%stream = priority_streams(curr_priority_stream)
@@ -474,7 +474,7 @@ CONTAINS
    END SUBROUTINE dbcsr_mm_accdrv_phaseout
 
    SUBROUTINE dbcsr_mm_accdrv_barrier()
-#if !defined(__HIP_PLATFORM_AMD__)
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__CUDA) && !defined(__HIP_PLATFORM_NVCC__)
       !! After being called by ALL threads, it installs a special barrier that
       !! forces the priority-streams to wait for the normal-streams.
 
@@ -528,7 +528,7 @@ CONTAINS
 !$    ithread = OMP_GET_THREAD_NUM()
       stack_buffers => all_thread_privates(ithread)%stack_buffers
 
-#if defined(__HIP_PLATFORM_AMD__)
+#if defined(__HIP_PLATFORM_AMD__) || defined(__CUDA) || defined(__HIP_PLATFORM_NVCC__)
       DO WHILE (.NOT. ASSOCIATED(stackbuf))
 #endif
          DO i = 1, SIZE(stack_buffers)
@@ -538,7 +538,7 @@ CONTAINS
                EXIT
             ENDIF
          ENDDO
-#if defined(__HIP_PLATFORM_AMD__)
+#if defined(__HIP_PLATFORM_AMD__) || defined(__CUDA) || defined(__HIP_PLATFORM_NVCC__)
       ENDDO
 #endif
 
@@ -588,14 +588,14 @@ CONTAINS
          DBCSR_ABORT("dbcsr_mm_accdrv_process: c_area%acc_devmem not allocated")
 
       ! start uploading stacks only after a, b, and c are ready
-#if !defined (__HIP_PLATFORM_AMD__)
+#if !defined (__HIP_PLATFORM_AMD__) && !defined(__CUDA) && !defined(__HIP_PLATFORM_NVCC__)
       CALL acc_stream_wait_event(upload_stream, a_area%acc_ready)
       CALL acc_stream_wait_event(upload_stream, b_area%acc_ready)
       CALL acc_stream_wait_event(upload_stream, c_area%acc_ready)
 #endif
 
       stackbuf_hostmem_cropped => stackbuf%hostmem(:, 1:stack_size)
-#if defined (__HIP_PLATFORM_AMD__)
+#if defined (__HIP_PLATFORM_AMD__) || defined(__CUDA) || defined(__HIP_PLATFORM_NVCC__)
       CALL acc_devmem_host2dev(stackbuf%devmem, hostmem=stackbuf_hostmem_cropped, stream=stackbuf%stream)
       CALL acc_event_record(stackbuf%ready, stream=stackbuf%stream)
 #else
@@ -621,7 +621,7 @@ CONTAINS
 
       IF (success) THEN
          CALL acc_event_record(stackbuf%calculated, stream=stackbuf%stream)
-#if !defined(__HIP_PLATFORM_AMD__)
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__CUDA) && !defined(__HIP_PLATFORM_NVCC__)
          CALL acc_stream_wait_event(a_area%memory_type%acc_stream, stackbuf%calculated)
          CALL acc_stream_wait_event(b_area%memory_type%acc_stream, stackbuf%calculated)
          CALL acc_stream_wait_event(c_area%memory_type%acc_stream, stackbuf%calculated)

--- a/src/mm/dbcsr_mm_accdrv.F
+++ b/src/mm/dbcsr_mm_accdrv.F
@@ -480,7 +480,7 @@ CONTAINS
 !$    nthreads = OMP_GET_NUM_THREADS()
 !$    ithread = OMP_GET_THREAD_NUM()
 #if defined(__HIP_PLATFORM_AMD__)
-      CALL acc_stream_synchronize (priority_streams(ithread + 1))
+      CALL acc_stream_synchronize(priority_streams(ithread + 1))
 #else
 !$OMP     CRITICAL
       barrier_counter = MOD(barrier_counter + 1, nthreads)

--- a/src/mm/dbcsr_mm_accdrv.F
+++ b/src/mm/dbcsr_mm_accdrv.F
@@ -224,11 +224,15 @@ CONTAINS
 
 !$OMP MASTER
       CALL acc_stream_priority_range(least_priority, greatest_priority)
+#if defined(__HIP_PLATFORM_AMD__)
+      CALL stream_array_force_size(priority_streams, "Calc (priority)", &
+                                   n=dbcsr_cfg%accdrv_priority_streams)
+#else
       CALL stream_array_force_size(priority_streams, "Calc (priority)", &
                                    n=dbcsr_cfg%accdrv_priority_streams, priority=greatest_priority)
       CALL stream_array_force_size(posterior_streams, "Calc (posterior)", &
                                    n=dbcsr_cfg%accdrv_posterior_streams, events=barrier_events)
-
+#endif
       !create upload stream
       IF (.NOT. acc_stream_associated(upload_stream)) &
          CALL acc_stream_create(upload_stream, "Stackbuf h2d")
@@ -246,7 +250,9 @@ CONTAINS
          CALL acc_stream_destroy(upload_stream)
 
       CALL stream_array_force_size(priority_streams, "Calc (priority)", n=0)
+#if !defined(__HIP_PLATFORM_AMD__)
       CALL stream_array_force_size(posterior_streams, "Calc (posterior)", n=0, events=barrier_events)
+#endif
 !$OMP END MASTER
 
    END SUBROUTINE deallocate_streams
@@ -303,10 +309,16 @@ CONTAINS
       ! distribute total number of buffers approx. evenly among threads
       ! my_* variables hold number of buffers for current thread.
       my_priority_buffers = CEILING(REAL(dbcsr_cfg%accdrv_priority_buffers)/REAL(nthreads), int_4)
+#if !defined(__HIP_PLATFORM_AMD__)
       my_posterior_buffers = CEILING(REAL(dbcsr_cfg%accdrv_posterior_buffers)/REAL(nthreads), int_4)
+#endif
 
       this%nbuffers_phaseout = my_priority_buffers
+#if defined(__HIP_PLATFORM_AMD__)
+      my_total_buffers = my_priority_buffers
+#else
       my_total_buffers = my_posterior_buffers + my_priority_buffers
+#endif
 
       IF (ASSOCIATED(thread_privates%stack_buffers)) THEN
          IF (SIZE(thread_privates%stack_buffers) /= my_total_buffers) &
@@ -320,6 +332,7 @@ CONTAINS
          DO i = 1, my_total_buffers
             CALL acc_devmem_allocate_bytes(thread_privates%stack_buffers(i)%devmem, &
                                            int_4_size*dbcsr_ps_acc_width*dbcsr_cfg%mm_stack_size)
+#if !defined(__HIP_PLATFORM_AMD__)
             IF (i <= my_priority_buffers) THEN
                curr_priority_stream = MOD(curr_priority_stream, SIZE(priority_streams)) + 1
                thread_privates%stack_buffers(i)%stream = priority_streams(curr_priority_stream)
@@ -327,6 +340,9 @@ CONTAINS
                curr_posterior_stream = MOD(curr_posterior_stream, SIZE(posterior_streams)) + 1
                thread_privates%stack_buffers(i)%stream = posterior_streams(curr_posterior_stream)
             ENDIF
+#else
+            thread_privates%stack_buffers(i)%stream = priority_streams(ithread+1)
+#endif
             CALL acc_hostmem_allocate(thread_privates%stack_buffers(i)%hostmem, &
                                       dbcsr_ps_acc_width, dbcsr_cfg%mm_stack_size, thread_privates%stack_buffers(i)%stream)
             CALL acc_event_create(thread_privates%stack_buffers(i)%ready)
@@ -458,11 +474,14 @@ CONTAINS
       !! After being called by ALL threads, it installs a special barrier that
       !! forces the priority-streams to wait for the normal-streams.
 
-      INTEGER                                            :: i, j, nthreads
+      INTEGER                                            :: i, j, nthreads, ithread
 
       nthreads = 1
 !$    nthreads = OMP_GET_NUM_THREADS()
-
+!$    ithread = OMP_GET_THREAD_NUM()
+#if defined(__HIP_PLATFORM_AMD__)
+      call acc_stream_synchronize (priority_streams(ithread+1))
+#else
 !$OMP     CRITICAL
       barrier_counter = MOD(barrier_counter + 1, nthreads)
       IF (barrier_counter == 0) THEN
@@ -474,6 +493,7 @@ CONTAINS
          ENDDO
       ENDIF
 !$OMP     END CRITICAL
+#endif
    END SUBROUTINE dbcsr_mm_accdrv_barrier
 
    SUBROUTINE dbcsr_mm_accdrv_process(this, left, right, params, stack_size, &
@@ -503,6 +523,9 @@ CONTAINS
 !$    ithread = OMP_GET_THREAD_NUM()
       stack_buffers => all_thread_privates(ithread)%stack_buffers
 
+#if defined(__HIP_PLATFORM_AMD__)
+      DO WHILE (.NOT. ASSOCIATED(stackbuf))
+#endif
       DO i = 1, SIZE(stack_buffers)
          IF (this%phase_out .AND. i > this%nbuffers_phaseout) EXIT
          IF (acc_event_query(stack_buffers(i)%calculated)) THEN
@@ -510,6 +533,9 @@ CONTAINS
             EXIT
          ENDIF
       ENDDO
+#if defined(__HIP_PLATFORM_AMD__)
+      ENDDO
+#endif
 
       IF (.NOT. ASSOCIATED(stackbuf)) THEN
          success = .FALSE.

--- a/src/mm/dbcsr_mm_accdrv.F
+++ b/src/mm/dbcsr_mm_accdrv.F
@@ -341,7 +341,7 @@ CONTAINS
                thread_privates%stack_buffers(i)%stream = posterior_streams(curr_posterior_stream)
             ENDIF
 #else
-            thread_privates%stack_buffers(i)%stream = priority_streams(ithread+1)
+            thread_privates%stack_buffers(i)%stream = priority_streams(ithread + 1)
 #endif
             CALL acc_hostmem_allocate(thread_privates%stack_buffers(i)%hostmem, &
                                       dbcsr_ps_acc_width, dbcsr_cfg%mm_stack_size, thread_privates%stack_buffers(i)%stream)
@@ -480,7 +480,7 @@ CONTAINS
 !$    nthreads = OMP_GET_NUM_THREADS()
 !$    ithread = OMP_GET_THREAD_NUM()
 #if defined(__HIP_PLATFORM_AMD__)
-      call acc_stream_synchronize (priority_streams(ithread+1))
+      CALL acc_stream_synchronize (priority_streams(ithread + 1))
 #else
 !$OMP     CRITICAL
       barrier_counter = MOD(barrier_counter + 1, nthreads)
@@ -526,13 +526,13 @@ CONTAINS
 #if defined(__HIP_PLATFORM_AMD__)
       DO WHILE (.NOT. ASSOCIATED(stackbuf))
 #endif
-      DO i = 1, SIZE(stack_buffers)
-         IF (this%phase_out .AND. i > this%nbuffers_phaseout) EXIT
-         IF (acc_event_query(stack_buffers(i)%calculated)) THEN
-            stackbuf => stack_buffers(i)
-            EXIT
-         ENDIF
-      ENDDO
+         DO i = 1, SIZE(stack_buffers)
+            IF (this%phase_out .AND. i > this%nbuffers_phaseout) EXIT
+            IF (acc_event_query(stack_buffers(i)%calculated)) THEN
+               stackbuf => stack_buffers(i)
+               EXIT
+            ENDIF
+         ENDDO
 #if defined(__HIP_PLATFORM_AMD__)
       ENDDO
 #endif
@@ -583,7 +583,7 @@ CONTAINS
          DBCSR_ABORT("dbcsr_mm_accdrv_process: c_area%acc_devmem not allocated")
 
       ! start uploading stacks only after a, b, and c are ready
-#if !defined (__HIP_PLATFORM_AMD__) 
+#if !defined (__HIP_PLATFORM_AMD__)
       CALL acc_stream_wait_event(upload_stream, a_area%acc_ready)
       CALL acc_stream_wait_event(upload_stream, b_area%acc_ready)
       CALL acc_stream_wait_event(upload_stream, c_area%acc_ready)

--- a/src/mm/dbcsr_mm_accdrv.F
+++ b/src/mm/dbcsr_mm_accdrv.F
@@ -118,8 +118,6 @@ MODULE dbcsr_mm_accdrv
 
    TYPE(thread_private_type), SAVE, DIMENSION(:), ALLOCATABLE, TARGET :: all_thread_privates
    TYPE(acc_stream_type), SAVE, DIMENSION(:), POINTER     :: priority_streams => Null()
-   TYPE(acc_event_type), SAVE, DIMENSION(:), POINTER     :: barrier_events => Null()
-   INTEGER, SAVE                                          :: barrier_counter = 0
 
 CONTAINS
 
@@ -216,7 +214,6 @@ CONTAINS
 
    SUBROUTINE setup_streams()
       !! Helper routine used by dbcsr_mm_accdrv_init()
-
 
 !$OMP MASTER
       CALL stream_array_force_size(priority_streams, "Calc (priority)", &

--- a/src/mm/dbcsr_mm_accdrv.F
+++ b/src/mm/dbcsr_mm_accdrv.F
@@ -295,11 +295,14 @@ CONTAINS
       !! Helper routine used by dbcsr_mm_accdrv_init()
       TYPE(dbcsr_mm_accdrv_type), INTENT(INOUT)          :: this
 
-      INTEGER                                            :: i, ithread, my_posterior_buffers, &
+      INTEGER                                            :: i, ithread, &
                                                             my_priority_buffers, my_total_buffers, &
                                                             nthreads
-      INTEGER, SAVE                                      :: curr_posterior_stream = 0, &
-                                                            curr_priority_stream = 0
+#if !defined(__HIP_PLATFORM_AMD__)
+      INTEGER                                            :: my_posterior_buffers
+      INTEGER, SAVE                                      :: curr_posterior_stream = 0
+#endif
+      INTEGER, SAVE                                      :: curr_priority_stream = 0
       TYPE(thread_private_type), POINTER                 :: thread_privates
 
       nthreads = 1; ithread = 0
@@ -471,20 +474,13 @@ CONTAINS
    END SUBROUTINE dbcsr_mm_accdrv_phaseout
 
    SUBROUTINE dbcsr_mm_accdrv_barrier()
+#if !defined(__HIP_PLATFORM_AMD__)
       !! After being called by ALL threads, it installs a special barrier that
       !! forces the priority-streams to wait for the normal-streams.
 
       INTEGER                                            :: i, j, nthreads
-#if defined(__HIP_PLATFORM_AMD__)
-      INTEGER                                            :: ithread
-#endif
-
       nthreads = 1
 !$    nthreads = OMP_GET_NUM_THREADS()
-#if defined(__HIP_PLATFORM_AMD__)
-!$    ithread = OMP_GET_THREAD_NUM()
-      CALL acc_stream_synchronize(priority_streams(ithread + 1))
-#else
 !$OMP     CRITICAL
       barrier_counter = MOD(barrier_counter + 1, nthreads)
       IF (barrier_counter == 0) THEN
@@ -496,6 +492,11 @@ CONTAINS
          ENDDO
       ENDIF
 !$OMP     END CRITICAL
+#else
+      INTEGER                                            :: ithread
+
+!$    ithread = OMP_GET_THREAD_NUM()
+      CALL acc_stream_synchronize(priority_streams(ithread + 1))
 #endif
    END SUBROUTINE dbcsr_mm_accdrv_barrier
 

--- a/src/mm/dbcsr_mm_accdrv.F
+++ b/src/mm/dbcsr_mm_accdrv.F
@@ -495,6 +495,7 @@ CONTAINS
 #else
       INTEGER                                            :: ithread
 
+      ithread = 0
 !$    ithread = OMP_GET_THREAD_NUM()
       CALL acc_stream_synchronize(priority_streams(ithread + 1))
 #endif

--- a/src/mm/dbcsr_mm_accdrv.F
+++ b/src/mm/dbcsr_mm_accdrv.F
@@ -474,12 +474,15 @@ CONTAINS
       !! After being called by ALL threads, it installs a special barrier that
       !! forces the priority-streams to wait for the normal-streams.
 
-      INTEGER                                            :: i, j, nthreads, ithread
+      INTEGER                                            :: i, j, nthreads
+#if defined(__HIP_PLATFORM_AMD__)
+      INTEGER                                            :: ithread
+#endif
 
       nthreads = 1
 !$    nthreads = OMP_GET_NUM_THREADS()
-!$    ithread = OMP_GET_THREAD_NUM()
 #if defined(__HIP_PLATFORM_AMD__)
+!$    ithread = OMP_GET_THREAD_NUM()
       CALL acc_stream_synchronize(priority_streams(ithread + 1))
 #else
 !$OMP     CRITICAL

--- a/src/mm/dbcsr_mm_cannon.F
+++ b/src/mm/dbcsr_mm_cannon.F
@@ -17,6 +17,7 @@ MODULE dbcsr_mm_cannon
    !! - 2013-01    reorganized code (Ole Schuett)
 
    USE dbcsr_acc_event, ONLY: acc_event_synchronize
+   USE dbcsr_acc_device, ONLY: acc_device_synchronize
    USE dbcsr_array_types, ONLY: array_data, &
                                 array_exists, &
                                 array_i1d_obj, &
@@ -1600,12 +1601,12 @@ CONTAINS
                            k_sizes)
          !
          IF (has_acc) THEN
-            CALL dbcsr_data_host2dev(left_buffer_calc%mats(1, v_ki_left)%data_area)
             CALL dbcsr_data_host2dev(right_buffer_calc%mats(v_ki_right, 1)%data_area)
             CALL acc_transpose_blocks(right_buffer_calc%mats(v_ki_right, 1), trs_stackbuf_calc, &
                                       k_sizes, n_sizes, &
                                       row_blk_sizes2enum, enum2row_blk_sizes, &
                                       col_blk_sizes2enum, enum2col_blk_sizes)
+            CALL dbcsr_data_host2dev(left_buffer_calc%mats(1, v_ki_left)%data_area)
          END IF
 
          ! Sets the local right-matrix columns
@@ -1617,6 +1618,13 @@ CONTAINS
             CALL calculate_norms(left_buffer_calc%mats(1, v_ki_left), &
                                  left_norms, m_sizes, k_sizes)
          ENDIF
+
+#if defined (__HIP_PLATFORM_AMD__)
+         ! Wait for left and right buffers transfer to device before proceeding
+         IF (has_acc) THEN
+             CALL acc_device_synchronize()
+         END IF
+#endif
          !
          flop_single = 0
          threads_finished = 0

--- a/src/mm/dbcsr_mm_cannon.F
+++ b/src/mm/dbcsr_mm_cannon.F
@@ -1619,7 +1619,7 @@ CONTAINS
                                  left_norms, m_sizes, k_sizes)
          ENDIF
 
-#if defined (__HIP_PLATFORM_AMD__)
+#if defined(__HIP_PLATFORM_AMD__) || defined(__CUDA) || defined(__HIP_PLATFORM_NVCC__)
          ! Wait for left and right buffers transfer to device before proceeding
          IF (has_acc) THEN
             CALL acc_device_synchronize()

--- a/src/mm/dbcsr_mm_cannon.F
+++ b/src/mm/dbcsr_mm_cannon.F
@@ -1622,7 +1622,7 @@ CONTAINS
 #if defined (__HIP_PLATFORM_AMD__)
          ! Wait for left and right buffers transfer to device before proceeding
          IF (has_acc) THEN
-             CALL acc_device_synchronize()
+            CALL acc_device_synchronize()
          END IF
 #endif
          !

--- a/src/mm/dbcsr_mm_cannon.F
+++ b/src/mm/dbcsr_mm_cannon.F
@@ -1619,12 +1619,10 @@ CONTAINS
                                  left_norms, m_sizes, k_sizes)
          ENDIF
 
-#if defined(__HIP_PLATFORM_AMD__) || defined(__CUDA) || defined(__HIP_PLATFORM_NVCC__)
          ! Wait for left and right buffers transfer to device before proceeding
          IF (has_acc) THEN
             CALL acc_device_synchronize()
          END IF
-#endif
          !
          flop_single = 0
          threads_finished = 0


### PR DESCRIPTION
This PR attempts to simplify the DBCSR HIP backend with the following changes (not ready to merge yet, but I am creating the PR to get them tested more thoroughly):

- Remove the use of posterior streams, use only one type of stream. In the current form, we only have priority streams but they are actually low priority, blocking streams. In my tests, higher priority, non-blocking streams seemed unnecessary.
- There is a unique stream assigned per CPU thread for a given process. This removes race conditions seen when running the HIP backend with the original code.
- A device synchronize after the copy of left and right matrices and before the start of the multiply parallel region removes the need for repeatedly checking for event completions in the beginning of every iteration of the loop.
- Copy of stack indices are now done on the same stream as the kernel launches (for kernels that don't use rocBLAS) as they have to be done in order anyway.
- A stream synchronize (by each CPU thread) at the end of the multiply parallel region (i.e., in accdrv_finalize) ensures that the data (C host buffer)  is ready before it is transferred over MPI. This also removes the need for three additional wait on event calls after the kernel completes.

I intend to run the same path with the CUDA backend also and if there is no performance hit, we can unify the code paths. I would prefer not to use #if defined macros before merging if possible.