### PR TITLE
ocl: completed c_dbcsr_acc_device_synchronize and fixes

### DIFF
--- a/src/acc/cuda/Makefile
+++ b/src/acc/cuda/Makefile
@@ -170,7 +170,7 @@ CXXFLAGS += -std=c++11 $(CFLAGS)
 bench: $(MAKDIR)/../acc_bench_smm $(MAKDIR)/../acc_bench_trans
 
 .PHONY: all
-all: $(MAKDIR)/../dbcsr_acc.a $(MAKDIR)/../dbcsr_acc_smm.a bench
+all: bench $(MAKDIR)/../dbcsr_acc_test
 
 .PHONY: test
 test: test-interface test-trans test-smm

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -175,7 +175,7 @@ endif
 bench: $(MAKDIR)/../acc_bench_smm $(MAKDIR)/../acc_bench_trans
 
 .PHONY: all
-all: $(MAKDIR)/../dbcsr_acc.a $(MAKDIR)/../dbcsr_acc_smm.a bench
+all: bench $(MAKDIR)/../dbcsr_acc_test
 
 .PHONY: test
 test: test-interface test-trans test-smm


### PR DESCRIPTION
* Implemented collecting garbage streams (c_dbcsr_acc_stream_destroy).

Other/fixes:
* c_dbcsr_acc_opencl_kernel (NDEBUG): assume extensions are confirmed upfront.
* Warning about unsupported extension. Revised error/warning messages.
* Introduced separate control for barriers (OPENCL_LIBSMM_SMM_BARRIER).
* Modernized barrier to C11 form (if permitted).
* Use C11 atomics (cl_intel_global_float_atomics).
* Implemented cl_ext_float_atomics (untested).
* Avoid using stateful strtok (nested usage).
* Kernel: fixed syntax error (BS=1 code-path).
* Kernel: some (minor) kernel optimizations.
* Refined "all" target (Makefile).