### PR TITLE
ocl: implemented thread-local context and device

### DIFF
--- a/src/acc/opencl/acc_opencl_event.c
+++ b/src/acc/opencl/acc_opencl_event.c
@@ -19,7 +19,8 @@ extern "C" {
 int c_dbcsr_acc_event_create(void** event_p)
 {
   cl_int result = EXIT_SUCCESS;
-  const cl_event event = clCreateUserEvent(c_dbcsr_acc_opencl_context, &result);
+  const cl_context context = c_dbcsr_acc_opencl_context(NULL);
+  const cl_event event = clCreateUserEvent(context, &result);
   assert(NULL != event_p);
   if (NULL != event) {
     cl_int status = CL_COMPLETE;


### PR DESCRIPTION
* Migrated global c_dbcsr_acc_opencl_streams and c_dbcsr_acc_opencl_nstreams into c_dbcsr_acc_opencl_config.
* Migrated global c_dbcsr_acc_opencl_ndevices into c_dbcsr_acc_opencl_config (ndevices).
* Redefined ACC_OPENCL_STREAMS_MAXCOUNT to count on a per-thread basis.
* Encapsulated thread-local context into c_dbcsr_acc_opencl_context().