### PR TITLE
ocl: fixes and code cleanup

### DIFF
--- a/src/acc/acc_bench.h
+++ b/src/acc/acc_bench.h
@@ -43,15 +43,15 @@ static INLINE void init_stack(int* stack, int stack_size,
   int mn, int mk, int kn, int nc, int na, int nb)
 {
   /* navg matrix products are accumulated into a C-matrix */
-  int navg = stack_size / nc;
-  int nimb = MAX(1, navg - 4); /* imbalance */
+  const int navg = stack_size / nc;
+  const int nimb = MAX(1, navg - 4); /* imbalance */
   int i = 0, c = 0, ntop = 0;
   assert(0 < nc && nc <= stack_size);
   while (i < stack_size) {
     const int next = c + 1;
     ntop += navg + (rand() % (2 * nimb) - nimb);
     if (stack_size < ntop) ntop = stack_size;
-    for (;i < ntop; ++i) { /* setup one-based indexes */
+    for (; i < ntop; ++i) { /* setup one-based indexes */
       const int a = rand() % na, b = rand() % nb;
       *stack++ = a * mk + 1; /* A-index */
       *stack++ = b * kn + 1; /* B-index */

--- a/src/acc/cuda/Makefile
+++ b/src/acc/cuda/Makefile
@@ -10,10 +10,11 @@ OBJACC := $(SRCACC:.cpp=.o)
 
 GPUSMM := $(wildcard $(MAKDIR)/../libsmm_acc/kernels/*.h*)
 INCSMM := $(wildcard $(MAKDIR)/../libsmm_acc/*.h*) \
-  $(MAKDIR)/../libsmm_acc/smm_acc_kernels.h \
-  $(MAKDIR)/../libsmm_acc/parameters.h \
-  $(MAKDIR)/../acc_libsmm.h \
-  $(NULL)
+                     $(MAKDIR)/../libsmm_acc/smm_acc_kernels.h \
+                     $(MAKDIR)/../libsmm_acc/parameters.h \
+                     $(MAKDIR)/../acc_libsmm.h \
+                     $(MAKDIR)/../acc_bench.h \
+                     $(NULL)
 SRCSMM := $(wildcard $(MAKDIR)/../libsmm_acc/*.cpp)
 OBJSMM := $(SRCSMM:.cpp=.o)
 

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -6,6 +6,7 @@ OBJACC := $(SRCACC:.c=.o)
 INCSMM := $(wildcard $(MAKDIR)/smm/*.h*) \
                      $(MAKDIR)/smm/opencl_kernels.h \
                      $(MAKDIR)/../acc_libsmm.h \
+                     $(MAKDIR)/../acc_bench.h \
                      $(NULL)
 SRCSMM := $(wildcard $(MAKDIR)/smm/*.c)
 OBJSMM := $(SRCSMM:.c=.o)

--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -250,7 +250,7 @@ int c_dbcsr_acc_opencl_device_name(cl_device_id device, const char match[]);
 int c_dbcsr_acc_opencl_device_id(cl_device_id device, const char format[], int* id);
 /** Return the OpenCL support level for the given device. */
 int c_dbcsr_acc_opencl_device_level(cl_device_id device,
-  int* level_major, int* level_minor, char cl_std[16]);
+  int* level_major, int* level_minor, char cl_std[16], cl_device_type* type);
 /** Check if given device supports the extensions. */
 int c_dbcsr_acc_opencl_device_ext(cl_device_id device,
   const char *const extnames[], int num_exts);

--- a/src/acc/opencl/smm/kernels/multiply.cl
+++ b/src/acc/opencl/smm/kernels/multiply.cl
@@ -55,15 +55,6 @@
 # define ZERO 0
 #endif
 
-#if !defined(TRACK_B) && (1 < BS)
-# if defined(REG_B) && !defined(SLM_B)
-#   define TRACK_B
-# endif
-#endif
-#if !defined(TRACK_C) && (1 < BS)
-# define TRACK_C
-#endif
-
 #if defined(SLM_P) && (1 < BS)
 # define IDXBASE 0
 #else
@@ -208,7 +199,7 @@ kernel void FN(global T *restrict cdata,
   T cnm[SM] = { ZERO };
 # endif
 #endif
-#if defined(TRACK_B)
+#if defined(TRACK_B) && (1 < BS) && defined(REG_B) && !defined(SLM_B)
   int b1 = -1;
 #endif
 
@@ -530,9 +521,8 @@ kernel void FN(global T *restrict cdata,
 # endif
 # if (BM < SM || 1 != BN)
     { /* atomically commit C-tile to global memory */
-      int bn = 0;
       UNROLL(BN)
-      for (; bn < BN; ++bn) {
+      for (int bn = 0; bn < BN; ++bn) {
         const int n = bn + n0;
 #   if (SN % BN)
         if (n < SN)
@@ -543,9 +533,8 @@ kernel void FN(global T *restrict cdata,
 #   else
           T *restrict r = &cnm[bn][0];
 #   endif
-          int bm = 0;
           UNROLL_FORCE(BM)
-          for (; bm < BM; ++bm) {
+          for (int bm = 0; bm < BM; ++bm) {
             const int m = bm + m0;
 #   if (SM % BM)
             if (m < SM)

--- a/src/acc/opencl/smm/kernels/transpose.cl
+++ b/src/acc/opencl/smm/kernels/transpose.cl
@@ -14,14 +14,14 @@ kernel void FN(GLOBAL const int *restrict trs_stack, int trs_offset, global T *r
   const int offset = trs_stack[trs_offset+get_group_id(0)];
   /* matrix according to the index (transpose-stack) */
   global T *const restrict mat = matrix + offset;
-  const int index = get_local_id(0);
+  const int idx = get_local_id(0);
 #if (SM != SN) || (0 == INPLACE)
   /* local memory buffer */
   local T buf[SM][SN];
 #endif
 
 #if (SWG == SM)
-  const int m = index;
+  const int m = idx;
 # if (SM != SN) || (0 == INPLACE)
   /* copy matrix elements into local buffer */
   for (int n = 0; n < SN; ++n) buf[m][n] = mat[SM*n+m];

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -78,7 +78,7 @@ typedef struct opencl_libsmm_smm_t {
   cl_kernel kernel; /* must be the 1st data member */
   size_t wgsize;
   /* parameters (either pretuned or determined) */
-  int bs, bm, bn, bk, wg, lu, nz, al, tb, tc, ap, aa, ab, ac;
+  int bs, bm, bn, bk, ws, wg, lu, nz, al, tb, tc, ap, aa, ab, ac;
   /* ACC_OPENCL_VERBOSE: perf. counters */
   double gflops_sumlog, gflops_comp;
   size_t nexec;


### PR DESCRIPTION
* Introduced (optionally) querying device-type (c_dbcsr_acc_opencl_device_level).
* Recalculate block size to ensure minimum requested WG-size (WS).
* Fixed variable name in certain code-path (transpose kernel).
* Adjusted help messages and tuning level (tune_multiply.py).
* Kernel: fixed taking TB and TC into account.
* Kernel: code cleanup.
* Makefile dependency.