### PR TITLE
Documentation: section in User Guide about auto-tuning GPU-kernels

### DIFF
--- a/docs/guide/2-user-guide/1-installation/index.md
+++ b/docs/guide/2-user-guide/1-installation/index.md
@@ -33,7 +33,7 @@ To build DBCSR's GPU backend:
     * Optionally, `clinfo` (can be useful to show available devices)
 
 DBCSR is tested against GNU and Intel compilers on Linux systems, and GNU compiler on MacOS systems.
-See a list of supported compilers [here](./3-supported-compilers.html).
+See a list of supported compilers [here](3-supported-compilers.html).
 
 ## Get DBCSR
 
@@ -87,7 +87,7 @@ export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${HOME}/libxsmm/lib"
 
 ### CMake Build Recipes
 
-For build recipes on different platforms, make sure to also read the [CMake Build Recipes](./1-cmake-build-recipes.html).
+For build recipes on different platforms, make sure to also read the [CMake Build Recipes](1-cmake-build-recipes.html).
 
 ### Building with spack
 

--- a/docs/guide/2-user-guide/4-gpu/index.md
+++ b/docs/guide/2-user-guide/4-gpu/index.md
@@ -1,0 +1,48 @@
+title: GPUs
+
+# CUDA/HIP backend and LIBSMM_ACC
+
+Users interested to tune kernels for the CUDA/HIP backend, can take a look at the [Developer Guide](../../3-developer-guide/3-programming/2-accelerator-backend/2-libsmm_acc/3-tune.html). Following the guide, [tuned parameters](https://github.com/cp2k/dbcsr/tree/develop/src/acc/libsmm_acc/parameters) can be collected for the desired GPU and potentially submitted for the benefit of others.
+
+# OpenCL Backend and OpenCL based LIBSMM
+
+This section shows how to auto-tune a kernel for the OpenCL based LIBSMM library. The process builds a stand-alone driver program which is then driven by an [OpenTuner](https://opentuner.org/) based script guiding the auto-tuning of the desired kernel. The [Developer Guide](../../3-developer-guide/3-programming/2-accelerator-backend/4-opencl-libsmm.html) provides more information, e.g., about constraining execution time or parallelizing the tuning-process as well as how to select and tune an entire set of kernels.
+
+For simplicity, the GNU Compiler is used to build the afore mentioned driver program, both DBCSR and LIBXSMM are Git-cloned into the same common directory, e.g., the user's `HOME` directory, and the driver is built for tuning double-precision kernels (DP).
+
+```bash
+cd ${HOME}
+git clone https://github.com/hfp/libxsmm.git
+cd libxsmm
+make GNU=1 -j
+
+cd ${HOME}
+git clone https://github.com/cp2k/dbcsr.git
+cd dbcsr/src/acc/opencl
+make
+```
+
+Tuning the 23x23x23-kernel for example is the default case. However, to better illustrate the options, M, N, and K are given explicitly. The `tune_multiply.py` script can be used interactively for example, and terminated with CTRL-C which writes a JSON-file with tuned parameters (note a file `.tune_multiply-double-32x32x32.json` is quietly written every time a better set of parameter is found), and then aggregates all JSON-file in the directory into a CSV-file (`tune_multiply.csv`).
+
+```bash
+cd ${HOME}/dbcsr/src/acc/opencl/smm
+./tune_multiply.py 23 23 23
+```
+
+The above process would also terminate at some point (based on OpenTuner's default) but can be constrained also by the number of steps (experiments), time to be spent, or a combination of both. Details can be found in the [Developer Guide](../../3-developer-guide/3-programming/2-accelerator-backend/4-opencl-libsmm.html).
+
+Finally, suppose the 23x23x23-kernel was tuned for some time (e.g., 5-10 minutes), the found parameters can be incorporated into the backend. The aggregated parameters (`tune_multiply.csv`) are automatically embedded when rebuilding the library and driver.
+
+```bash
+cd ${HOME}/dbcsr/src/acc/opencl
+make
+```
+
+Important kernels can be tuned further (beside of spending more time for tuning the kernel) by widening the set of tuned parameters (`--tuning-level` or `-a` with "0" denoting an unrestricted set of tunables).
+
+```bash
+cd ${HOME}/dbcsr/src/acc/opencl/smm
+./tune_multiply.py 23 23 23 -a 0
+```
+
+Please note, to tune *further*, the previously found parameters should be embedded (rebuilding the driver) or specified at runtime (`OPENCL_LIBSMM_SMM_PARAMS=/path/to/tune_multiply.csv`).

--- a/docs/guide/3-developer-guide/3-programming/1-overview/index.md
+++ b/docs/guide/3-developer-guide/3-programming/1-overview/index.md
@@ -2,7 +2,7 @@ title: Overview
 
 # Code Architecture
 
-![DBCSR code architecture](./dbcsr_mm_overview.png)
+![DBCSR code architecture](dbcsr_mm_overview.png)
 
 ```
 dbcsr/
@@ -26,9 +26,9 @@ dbcsr/
 
 Assumed square matrix with 20x20 matrix with 5x5 blocks and a 2x2 processor grid
 
-![DBCSR distribution over processors](./dbcsr_dist.png)
+![DBCSR distribution over processors](dbcsr_dist.png)
 
-![DBCSR block scheme](./dbcsr_blocks.png)
+![DBCSR block scheme](dbcsr_blocks.png)
 
 # List of standard compiler flags
 

--- a/docs/guide/3-developer-guide/4-performance/2-just-in-time-compilation.md
+++ b/docs/guide/3-developer-guide/4-performance/2-just-in-time-compilation.md
@@ -1,14 +1,11 @@
 title: Just-In-Time Compilation
 
-# Just-In-Time (JIT) Compilation in libsmm_acc
+# Just-In-Time (JIT) Compilation
 
-DBCSR's GPU backend, libsmm_acc, uses heavily templated cuda/hip kernels for its batched multiplication and transpose.
+DBCSR's GPU backends rely on templated kernels for batched matrix multiplication and matrix transpose. If DBCSR were to compile kernels for all possible `m, n, k`s (or, in the case of the transpose, for all possible `m, n`s) ahead-of-time (AOT), it would bloat the library and the compilation time would require to account for a large but still limited set of kernels.
 
-If DBCSR were to compile kernels for all possible `m, n, k`s (or, in the case of the transpose, for all possible `m, n`s) ahead-of-time (AOT), this would bloat the library and the compilation time would be much longer.
-Instead, kernels are JIT-ed on the fly, at runtime, as they are requested by the user. `libsmm_acc`'s JIT infrastructure is based on the CUDA library [NVRTC](https://docs.nvidia.com/cuda/nvrtc/), a runtime compilation library for CUDA C++.
+Instead, kernels are JIT-ed on the fly, at runtime, as they are requested by the application and workload. For `libsmm_acc`, the JIT infrastructure is based on the CUDA library [NVRTC](https://docs.nvidia.com/cuda/nvrtc/), a runtime compilation library for CUDA C++. For OpenCL based LIBSMM, the JIT compilation relies on the OpenCL runtime library.
 
-On NVIDIA's P100, the overhead of JIT has been found to be around 400ms for one kernel - a negligible overhead for typical DBCSR (and CP2K) runs.
-On AMD GPUs however, the overhead has been found to be of several seconds, a real hinderance to performance.
+No matter which runtime is used and whether JIT compilation is in the order of ~500ms per kernel or longer, the compilation time becomes significant during the process of auto-tuning a set of kernels. Therefore extra documentation is provided in either case on how to collect tuned parameters and eventually submit them for reuse.
 
-For performance debugging and in order to check how much time a program spends doing JIT, look for the functions `jit_kernel_multiply` and `jit_kernel_transpose` in the [timings report](./1-insights.html) at the end of the output file.
-
+For performance debugging of the CUDA/HIP based GPU-support (and in order to check how much time a program spends doing JIT), look at `jit_kernel_multiply` and `jit_kernel_transpose` of the [timings report](1-insights.html) at the end of the output file. For the OpenCL based GPU-support, the [Runtime Settings](../../3-developer-guide/3-programming/2-accelerator-backend/3-opencl-backend.html) (`ACC_OPENCL_VERBOSE`) can be used to collect the time needed for JIT compilation.


### PR DESCRIPTION
* Revised section about "Just-In-Time Compilation" to be backend-agnostic and more general.
* Subsection about auto-tuning an OpenCL/LIBSMM-kernel (User Guide rather than Developer Guide).
* Subsection about auto-tuning CUDA/HIP-kernels (User Guide rather than Developer Guide).
* Some (minor) cleanup (relative URLs).