### PR TITLE
Prototype c_dbcsr_timeset and c_dbcsr_timestop in acc_libsmm.h

### DIFF
--- a/examples/dbcsr_example_3.cpp
+++ b/examples/dbcsr_example_3.cpp
@@ -27,7 +27,7 @@ std::vector<int> random_dist(int dist_size, int nbins)
 
     std::vector<int> dist(dist_size);
 
-    for(int i=0; i < dist_size; i++)
+    for (int i=0; i < dist_size; i++)
         dist[i] = i % nbins;
 
     return dist;
@@ -139,7 +139,7 @@ int main(int argc, char* argv[])
                     double* blk = nullptr;
                     c_dbcsr_iterator_next_2d_block_d(iter, &i, &j, &blk, &tr, &nblk, &rsize, &csize, nullptr, nullptr);
 
-                    std::generate(blk, blk + rsize*csize, [&](){ return static_cast<double>(std::rand())/RAND_MAX; });
+                    std::generate(blk, blk + rsize*csize, [&]() { return static_cast<double>(std::rand())/RAND_MAX; });
 
         }
 

--- a/examples/dbcsr_tensor_example_2.cpp
+++ b/examples/dbcsr_tensor_example_2.cpp
@@ -29,7 +29,7 @@ std::vector<int> random_dist(int dist_size, int nbins)
 
     std::vector<int> dist(dist_size);
 
-    for(int i=0; i < dist_size; i++)
+    for (int i=0; i < dist_size; i++)
         dist[i] = i % nbins;
 
     return dist;

--- a/src/acc/acc_libsmm.h
+++ b/src/acc/acc_libsmm.h
@@ -15,6 +15,16 @@
 #define DBCSR_TYPE_double dbcsr_type_real_8
 #define DBCSR_TYPE_float dbcsr_type_real_4
 
+#if defined(__DBCSR_ACC)
+# define LIBSMM_ACC_TRANSPOSE_ROUTINE_NAME_STRPTR ((const char**)&libsmm_acc_transpose_routine_name_ptr)
+# define LIBSMM_ACC_TRANSPOSE_ROUTINE_NAME_LENPTR (&libsmm_acc_transpose_routine_name_len)
+# define LIBSMM_ACC_TRANSPOSE_ROUTINE_NAME_STR (libsmm_acc_transpose_routine_name_str)
+
+# define LIBSMM_ACC_PROCESS_ROUTINE_NAME_STRPTR ((const char**)&libsmm_acc_process_routine_name_ptr)
+# define LIBSMM_ACC_PROCESS_ROUTINE_NAME_LENPTR (&libsmm_acc_process_routine_name_len)
+# define LIBSMM_ACC_PROCESS_ROUTINE_NAME_STR (libsmm_acc_process_routine_name_str)
+#endif
+
 
 #if defined(__cplusplus)
 extern "C" {
@@ -37,6 +47,19 @@ int libsmm_acc_transpose(const int* dev_trs_stack, int offset, int stack_size,
 int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, int stack_size,
   int nparams, libsmm_acc_data_t datatype, const void* dev_a_data, const void* dev_b_data, void* dev_c_data,
   int m_max, int n_max, int k_max, int max_kernel_dim, c_dbcsr_acc_bool_t def_mnk, void* stack_stream, void* c_stream);
+
+#if defined(__DBCSR_ACC)
+static const char        libsmm_acc_transpose_routine_name_str[] = "jit_kernel_transpose";
+static const char *const libsmm_acc_transpose_routine_name_ptr = libsmm_acc_transpose_routine_name_str;
+static const int         libsmm_acc_transpose_routine_name_len = (int)sizeof(libsmm_acc_transpose_routine_name_str) - 1;
+
+static const char        libsmm_acc_process_routine_name_str[] = "jit_kernel_multiply";
+static const char *const libsmm_acc_process_routine_name_ptr = libsmm_acc_process_routine_name_str;
+static const int         libsmm_acc_process_routine_name_len = (int)sizeof(libsmm_acc_process_routine_name_str) - 1;
+
+void c_dbcsr_timeset(const char** routineN, const int* routineN_len, int* handle);
+void c_dbcsr_timestop(const int* handle);
+#endif
 
 #if defined(__cplusplus)
 }

--- a/src/acc/cuda/Makefile
+++ b/src/acc/cuda/Makefile
@@ -75,7 +75,6 @@ CFLAGS := -fPIC \
   -Wno-variadic-macros \
   -Wno-long-long \
   -DARCH_NUMBER=$(ARCH_NUMBER) \
-  -DNO_DBCSR_TIMESET \
   -D__CUDA \
   $(NULL)
 

--- a/src/acc/cuda/acc_cuda.cpp
+++ b/src/acc/cuda/acc_cuda.cpp
@@ -9,15 +9,15 @@
 
 #include "acc_cuda.h"
 
-nvrtcResult nvrtcGetLowLevelCode(nvrtcProgram prog, char* code){
+nvrtcResult nvrtcGetLowLevelCode(nvrtcProgram prog, char* code) {
   return nvrtcGetPTX(prog, code);
 }
 
-nvrtcResult nvrtcGetLowLevelCodeSize(nvrtcProgram prog, size_t* codeSizeRet){
+nvrtcResult nvrtcGetLowLevelCodeSize(nvrtcProgram prog, size_t* codeSizeRet) {
   return nvrtcGetPTXSize(prog, codeSizeRet);
 }
 
-CUresult cuLaunchJITKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY, unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY, unsigned int blockDimZ, unsigned int sharedMemBytes, CUstream stream, void **kernelParams, void **extra){
+CUresult cuLaunchJITKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY, unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY, unsigned int blockDimZ, unsigned int sharedMemBytes, CUstream stream, void **kernelParams, void **extra) {
   return cuLaunchKernel(f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ, sharedMemBytes, stream, kernelParams, extra);
 }
 

--- a/src/acc/cuda/acc_cuda.h
+++ b/src/acc/cuda/acc_cuda.h
@@ -66,19 +66,19 @@
     cublasStatus_t result = ACC_BLAS(func) args;                  \
     if (result != CUBLAS_STATUS_SUCCESS) {                        \
       const char* error_name = "CUBLAS_ERRROR";                   \
-      if (result == CUBLAS_STATUS_NOT_INITIALIZED){               \
+      if (result == CUBLAS_STATUS_NOT_INITIALIZED) {               \
         error_name = "CUBLAS_STATUS_NOT_INITIALIZED";             \
-      } else if (result == CUBLAS_STATUS_ALLOC_FAILED){           \
+      } else if (result == CUBLAS_STATUS_ALLOC_FAILED) {           \
         error_name = "CUBLAS_STATUS_ALLOC_FAILED";                \
-      } else if (result == CUBLAS_STATUS_INVALID_VALUE){          \
+      } else if (result == CUBLAS_STATUS_INVALID_VALUE) {          \
         error_name = "CUBLAS_STATUS_INVALID_VALUE";               \
-      } else if (result == CUBLAS_STATUS_ARCH_MISMATCH){          \
+      } else if (result == CUBLAS_STATUS_ARCH_MISMATCH) {          \
         error_name = "CUBLAS_STATUS_ARCH_MISMATCH";               \
-      } else if (result == CUBLAS_STATUS_MAPPING_ERROR){          \
+      } else if (result == CUBLAS_STATUS_MAPPING_ERROR) {          \
         error_name = "CUBLAS_STATUS_MAPPING_ERROR";               \
-      } else if (result == CUBLAS_STATUS_EXECUTION_FAILED){       \
+      } else if (result == CUBLAS_STATUS_EXECUTION_FAILED) {       \
         error_name = "CUBLAS_STATUS_EXECUTION_FAILED";            \
-      } else if (result == CUBLAS_STATUS_INTERNAL_ERROR){         \
+      } else if (result == CUBLAS_STATUS_INTERNAL_ERROR) {         \
         error_name = "CUBLAS_STATUS_INTERNAL_ERROR";              \
       }                                                           \
       printf("\nCUBLAS ERROR: %s failed with error %s\n",         \

--- a/src/acc/cuda/dbcsr_cuda_nvtx_cu.cpp
+++ b/src/acc/cuda/dbcsr_cuda_nvtx_cu.cpp
@@ -61,7 +61,7 @@ extern "C" int cuda_nvtx_range_pop_cu() {
 }
 
 //==============================================================================
-extern "C" void cuda_nvtx_name_osthread_cu(char* name){
+extern "C" void cuda_nvtx_name_osthread_cu(char* name) {
     nvtxNameOsThread(pthread_self(), name);
 }
 

--- a/src/acc/cuda_hip/acc_dev.cpp
+++ b/src/acc/cuda_hip/acc_dev.cpp
@@ -23,14 +23,14 @@
 static const int verbose_print = 1;
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_get_ndevices(int *n_devices){
+extern "C" int c_dbcsr_acc_get_ndevices(int *n_devices) {
   ACC_API_CALL(GetDeviceCount, (n_devices));
   return 0;
 }
 
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_set_active_device(int device_id){
+extern "C" int c_dbcsr_acc_set_active_device(int device_id) {
   int myDevice, runtimeVersion;
 
   ACC_API_CALL(RuntimeGetVersion, (&runtimeVersion));
@@ -44,7 +44,7 @@ extern "C" int c_dbcsr_acc_set_active_device(int device_id){
   ACC_API_CALL(Free, (0));
 
 #if defined(__HIP_PLATFORM_NVCC__)
-  if (verbose_print){
+  if (verbose_print) {
     ACC_API_CALL(DeviceSetLimit, (ACC(LimitPrintfFifoSize), (size_t) 1000000000));
   }
 #endif

--- a/src/acc/cuda_hip/acc_error.cpp
+++ b/src/acc/cuda_hip/acc_error.cpp
@@ -19,14 +19,14 @@
 #include <math.h>
 
 /****************************************************************************/
-int acc_error_check (ACC(Error_t) error){
-  if (error != ACC(Success)){
-      printf (BACKEND" error: %s\n", ACC(GetErrorString)(error));
-      return -1;
+int acc_error_check(ACC(Error_t) error) {
+    if (error != ACC(Success)) {
+        printf (BACKEND" error: %s\n", ACC(GetErrorString)(error));
+        return -1;
     }
-  return 0;
+    return 0;
 }
 
-extern "C" void c_dbcsr_acc_clear_errors () {
-  ACC(GetLastError)();
+extern "C" void c_dbcsr_acc_clear_errors() {
+    ACC(GetLastError)();
 }

--- a/src/acc/cuda_hip/acc_error.h
+++ b/src/acc/cuda_hip/acc_error.h
@@ -16,6 +16,6 @@
 # include "../hip/acc_hip.h"
 #endif
 
-int acc_error_check (ACC(Error_t) acc_error);
+int acc_error_check(ACC(Error_t) acc_error);
 
 #endif /* LIBSMM_ACC_H */

--- a/src/acc/cuda_hip/acc_event.cpp
+++ b/src/acc/cuda_hip/acc_event.cpp
@@ -22,12 +22,12 @@
 static const int verbose_print = 0;
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_event_create(void** event_p){
+extern "C" int c_dbcsr_acc_event_create(void** event_p) {
   *event_p = malloc(sizeof(ACC(Event_t)));
-  ACC(Event_t)* acc_event = (ACC(Event_t)*) *event_p;
+  ACC(Event_t)* acc_event =(ACC(Event_t)*) *event_p;
 
   ACC(Error_t) cErr = ACC(EventCreate)(acc_event);
-  if(verbose_print) printf("EventCreate) :  %p -> %ld\n", *event_p, (long int)*acc_event);
+  if (verbose_print) printf("EventCreate) :  %p -> %ld\n", *event_p, (long int)*acc_event);
   if (acc_error_check(cErr)) return -1;
   if (acc_error_check(ACC(GetLastError)())) return -1;
   return 0;
@@ -35,10 +35,10 @@ extern "C" int c_dbcsr_acc_event_create(void** event_p){
 
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_event_destroy(void* event){
-    ACC(Event_t)* acc_event = (ACC(Event_t*)) event;
+extern "C" int c_dbcsr_acc_event_destroy(void* event) {
+    ACC(Event_t)* acc_event =(ACC(Event_t*)) event;
 
-    if(verbose_print) printf("EventDestroy, called\n");
+    if (verbose_print) printf("EventDestroy, called\n");
     if (event == NULL) return 0; /* not an error */
     ACC(Error_t) cErr = ACC(EventDestroy)(*acc_event);
     free(acc_event);
@@ -49,28 +49,28 @@ extern "C" int c_dbcsr_acc_event_destroy(void* event){
 
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_event_record(void* event, void* stream){
-    ACC(Event_t)* acc_event = (ACC(Event_t)*) event;
-    ACC(Stream_t)* acc_stream = (ACC(Stream_t)*) stream;
+extern "C" int c_dbcsr_acc_event_record(void* event, void* stream) {
+    ACC(Event_t)* acc_event =(ACC(Event_t)*) event;
+    ACC(Stream_t)* acc_stream =(ACC(Stream_t)*) stream;
 
-    if(verbose_print) printf("EventRecord): %p -> %ld,  %p -> %ld\n", acc_event, (long int)*acc_event, acc_stream, (long int)*acc_stream);
+    if (verbose_print) printf("EventRecord): %p -> %ld,  %p -> %ld\n", acc_event, (long int)*acc_event, acc_stream, (long int)*acc_stream);
     ACC_API_CALL(EventRecord, (*acc_event, *acc_stream));
     return 0;
 }
 
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_event_query(void* event, int* has_occurred){
-    if(verbose_print) printf("dbcsr_acc_event_query called\n");
+extern "C" int c_dbcsr_acc_event_query(void* event, int* has_occurred) {
+    if (verbose_print) printf("dbcsr_acc_event_query called\n");
 
-    ACC(Event_t)* acc_event = (ACC(Event_t)*) event;
+    ACC(Event_t)* acc_event =(ACC(Event_t)*) event;
     ACC(Error_t) cErr = ACC(EventQuery)(*acc_event);
-    if(cErr==ACC(Success)){
+    if (cErr==ACC(Success)) {
          *has_occurred = 1;
          return 0;
     }
 
-    if(cErr==ACC(ErrorNotReady)){
+    if (cErr==ACC(ErrorNotReady)) {
         *has_occurred = 0;
         return 0;
     }
@@ -80,11 +80,11 @@ extern "C" int c_dbcsr_acc_event_query(void* event, int* has_occurred){
 
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_stream_wait_event(void* stream, void* event){
-    if(verbose_print) printf("c_dbcsr_acc_stream_wait_event called\n");
+extern "C" int c_dbcsr_acc_stream_wait_event(void* stream, void* event) {
+    if (verbose_print) printf("c_dbcsr_acc_stream_wait_event called\n");
 
-    ACC(Event_t)* acc_event = (ACC(Event_t)*) event;
-    ACC(Stream_t)* acc_stream = (ACC(Stream_t)*) stream;
+    ACC(Event_t)* acc_event =(ACC(Event_t)*) event;
+    ACC(Stream_t)* acc_stream =(ACC(Stream_t)*) stream;
 
     // flags: Parameters for the operation (must be 0)
     ACC_API_CALL(StreamWaitEvent, (*acc_stream, *acc_event, 0));
@@ -93,9 +93,9 @@ extern "C" int c_dbcsr_acc_stream_wait_event(void* stream, void* event){
 
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_event_synchronize(void* event){
-    if(verbose_print) printf("EventSynchronize called\n");
-    ACC(Event_t)* acc_event = (ACC(Event_t)*) event;
+extern "C" int c_dbcsr_acc_event_synchronize(void* event) {
+    if (verbose_print) printf("EventSynchronize called\n");
+    ACC(Event_t)* acc_event =(ACC(Event_t)*) event;
     ACC_API_CALL(EventSynchronize, (*acc_event));
     return 0;
 }

--- a/src/acc/cuda_hip/acc_init.cpp
+++ b/src/acc/cuda_hip/acc_init.cpp
@@ -23,7 +23,7 @@
 #endif
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_init(){
+extern "C" int c_dbcsr_acc_init() {
   int myDevice;
   // Driver boilerplate
   ACC_DRV_CALL(Init, (0));
@@ -38,7 +38,7 @@ extern "C" int c_dbcsr_acc_init(){
 }
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_finalize(){
+extern "C" int c_dbcsr_acc_finalize() {
   int myDevice;
   // Release driver resources
   ACC_DRV(device) acc_device;

--- a/src/acc/cuda_hip/acc_mem.cpp
+++ b/src/acc/cuda_hip/acc_mem.cpp
@@ -26,7 +26,7 @@ static const int verbose_print = 0;
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_dev_mem_allocate(void **dev_mem, size_t n){
+extern "C" int c_dbcsr_acc_dev_mem_allocate(void **dev_mem, size_t n) {
   ACC_API_CALL(Malloc, ((void **) dev_mem, (size_t) n));
   if (dev_mem == NULL)
     return -2;
@@ -38,7 +38,7 @@ extern "C" int c_dbcsr_acc_dev_mem_allocate(void **dev_mem, size_t n){
 
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_dev_mem_deallocate(void *dev_mem){
+extern "C" int c_dbcsr_acc_dev_mem_deallocate(void *dev_mem) {
   if (verbose_print)
     printf ("Device deallocation address %p\n", dev_mem);
   ACC_API_CALL(Free, ((void *) dev_mem));
@@ -48,7 +48,7 @@ extern "C" int c_dbcsr_acc_dev_mem_deallocate(void *dev_mem){
 
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_host_mem_allocate(void **host_mem, size_t n, void *stream){
+extern "C" int c_dbcsr_acc_host_mem_allocate(void **host_mem, size_t n, void *stream) {
   unsigned int flag = ACC(HostAllocDefault);
 
   ACC_API_CALL(HostAlloc, ((void **) host_mem, (size_t) n, flag));
@@ -62,7 +62,7 @@ extern "C" int c_dbcsr_acc_host_mem_allocate(void **host_mem, size_t n, void *st
 
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_host_mem_deallocate(void *host_mem, void *stream){
+extern "C" int c_dbcsr_acc_host_mem_deallocate(void *host_mem, void *stream) {
   if (verbose_print)
     printf ("Host pinned deallocation address %p\n", host_mem);
   ACC_API_CALL(FreeHost, ((void *) host_mem));
@@ -71,7 +71,7 @@ extern "C" int c_dbcsr_acc_host_mem_deallocate(void *host_mem, void *stream){
 }
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_dev_mem_set_ptr(void **dev_mem, void *other, size_t lb){
+extern "C" int c_dbcsr_acc_dev_mem_set_ptr(void **dev_mem, void *other, size_t lb) {
 
   (*dev_mem) = ((char *) other) + lb;
 
@@ -79,8 +79,8 @@ extern "C" int c_dbcsr_acc_dev_mem_set_ptr(void **dev_mem, void *other, size_t l
 }
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_memcpy_h2d(const void *host_mem, void *dev_mem, size_t count, void* stream){
-  ACC(Stream_t)* acc_stream = (ACC(Stream_t)*) stream;
+extern "C" int c_dbcsr_acc_memcpy_h2d(const void *host_mem, void *dev_mem, size_t count, void* stream) {
+  ACC(Stream_t)* acc_stream =(ACC(Stream_t)*) stream;
   if (verbose_print)
       printf ("Copying %zd bytes from host address %p to device address %p \n", count, host_mem, dev_mem);
 
@@ -91,8 +91,8 @@ extern "C" int c_dbcsr_acc_memcpy_h2d(const void *host_mem, void *dev_mem, size_
 
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_memcpy_d2h(const void *dev_mem, void *host_mem, size_t count, void* stream){
-  ACC(Stream_t)* acc_stream = (ACC(Stream_t)*) stream;
+extern "C" int c_dbcsr_acc_memcpy_d2h(const void *dev_mem, void *host_mem, size_t count, void* stream) {
+  ACC(Stream_t)* acc_stream =(ACC(Stream_t)*) stream;
   if (verbose_print)
       printf ("Copying %zd bytes from device address %p to host address %p\n", count, dev_mem, host_mem);
 
@@ -106,13 +106,13 @@ extern "C" int c_dbcsr_acc_memcpy_d2h(const void *dev_mem, void *host_mem, size_
 
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_memcpy_d2d(const void *devmem_src, void *devmem_dst, size_t count, void* stream){
-  ACC(Stream_t)* acc_stream = (ACC(Stream_t)*) stream;
+extern "C" int c_dbcsr_acc_memcpy_d2d(const void *devmem_src, void *devmem_dst, size_t count, void* stream) {
+  ACC(Stream_t)* acc_stream =(ACC(Stream_t)*) stream;
   if (verbose_print)
       printf ("Copying %zd bytes from device address %p to device address %p \n", count, devmem_src, devmem_dst);
 
 
-  if(stream == NULL){
+  if (stream == NULL) {
       ACC_API_CALL(Memcpy, (devmem_dst, devmem_src, count, ACC(MemcpyDeviceToDevice)));
   } else {
       ACC_API_CALL(MemcpyAsync, (devmem_dst, devmem_src, count, ACC(MemcpyDeviceToDevice), *acc_stream));
@@ -123,10 +123,10 @@ extern "C" int c_dbcsr_acc_memcpy_d2d(const void *devmem_src, void *devmem_dst, 
 
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_memset_zero(void *dev_mem, size_t offset, size_t length, void* stream){
+extern "C" int c_dbcsr_acc_memset_zero(void *dev_mem, size_t offset, size_t length, void* stream) {
   ACC(Error_t) cErr;
-  ACC(Stream_t)* acc_stream = (ACC(Stream_t)*) stream;
-  if(stream == NULL){
+  ACC(Stream_t)* acc_stream =(ACC(Stream_t)*) stream;
+  if (stream == NULL) {
       cErr = ACC(Memset)((void *) (((char *) dev_mem) + offset), (int) 0, length);
   } else {
       cErr = ACC(MemsetAsync)((void *) (((char *) dev_mem) + offset), (int) 0, length, *acc_stream);
@@ -145,7 +145,7 @@ extern "C" int c_dbcsr_acc_memset_zero(void *dev_mem, size_t offset, size_t leng
 
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_dev_mem_info(size_t* free, size_t* avail){
+extern "C" int c_dbcsr_acc_dev_mem_info(size_t* free, size_t* avail) {
   ACC_API_CALL(MemGetInfo, (free, avail));
   return 0;
 }

--- a/src/acc/cuda_hip/acc_stream.cpp
+++ b/src/acc/cuda_hip/acc_stream.cpp
@@ -27,7 +27,7 @@ static const int verbose_print = 0;
 
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_stream_priority_range(int* least, int* greatest){
+extern "C" int c_dbcsr_acc_stream_priority_range(int* least, int* greatest) {
   *least = -1;
   *greatest = -1;
   ACC_API_CALL(DeviceGetStreamPriorityRange, (least, greatest));
@@ -37,13 +37,13 @@ extern "C" int c_dbcsr_acc_stream_priority_range(int* least, int* greatest){
 
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int priority){
+extern "C" int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int priority) {
   ACC(Error_t) cErr;
   *stream_p = malloc(sizeof(ACC(Stream_t)));
 
-  ACC(Stream_t)* acc_stream = (ACC(Stream_t)*) *stream_p;
+  ACC(Stream_t)* acc_stream =(ACC(Stream_t)*) *stream_p;
 
-  if(priority > 0){
+  if (priority > 0) {
       unsigned int flags = ACC(StreamNonBlocking);
       cErr = ACC(StreamCreateWithPriority)(acc_stream, flags, priority);
   } else {
@@ -63,10 +63,10 @@ extern "C" int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int 
 
 
 /****************************************************************************/
-extern "C" int c_dbcsr_acc_stream_destroy(void* stream){
-    ACC(Stream_t)* acc_stream = (ACC(Stream_t)*) stream;
+extern "C" int c_dbcsr_acc_stream_destroy(void* stream) {
+    ACC(Stream_t)* acc_stream =(ACC(Stream_t)*) stream;
 
-    if(verbose_print) printf("StreamDestroy called\n");
+    if (verbose_print) printf("StreamDestroy called\n");
     if (stream == NULL) return 0; /* not an error */
     ACC(Error_t) cErr = ACC(StreamDestroy)(*acc_stream);
     free(acc_stream);
@@ -78,7 +78,7 @@ extern "C" int c_dbcsr_acc_stream_destroy(void* stream){
 /****************************************************************************/
 extern "C" int c_dbcsr_acc_stream_sync(void* stream)
 {
-  ACC(Stream_t)* acc_stream = (ACC(Stream_t)*) stream;
+  ACC(Stream_t)* acc_stream =(ACC(Stream_t)*) stream;
   ACC_API_CALL(StreamSynchronize, (*acc_stream));
   return 0;
 }

--- a/src/acc/hip/acc_hip.cpp
+++ b/src/acc/hip/acc_hip.cpp
@@ -9,33 +9,33 @@
 
 #include "acc_hip.h"
 
-hipError_t hipHostAlloc(void **ptr, size_t size, unsigned int flags){
+hipError_t hipHostAlloc(void **ptr, size_t size, unsigned int flags) {
   return hipHostMalloc(ptr, size, flags);
 }
 
 unsigned int hipHostAllocDefault = hipHostMallocDefault;
 
-hipError_t hipFreeHost(void *ptr){
+hipError_t hipFreeHost(void *ptr) {
   return hipHostFree(ptr);
 }
 
-hiprtcResult hiprtcGetLowLevelCode(hiprtcProgram prog, char* code){
+hiprtcResult hiprtcGetLowLevelCode(hiprtcProgram prog, char* code) {
   return hiprtcGetCode(prog, code);
 }
 
-hiprtcResult hiprtcGetLowLevelCodeSize(hiprtcProgram prog, size_t* codeSizeRet){
+hiprtcResult hiprtcGetLowLevelCodeSize(hiprtcProgram prog, size_t* codeSizeRet) {
   return hiprtcGetCodeSize(prog, codeSizeRet);
 }
 
-hipError_t hipEventCreate(hipEvent_t *event, unsigned flags){
+hipError_t hipEventCreate(hipEvent_t *event, unsigned flags) {
   return hipEventCreateWithFlags(event, flags);
 }
 
-hipError_t hipStreamCreate(hipStream_t *stream, unsigned int flags){
+hipError_t hipStreamCreate(hipStream_t *stream, unsigned int flags) {
   return hipStreamCreateWithFlags(stream, flags);
 }
 
-hipError_t hipLaunchJITKernel(hipFunction_t f, unsigned int gridDimX, unsigned int gridDimY, unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY, unsigned int blockDimZ, unsigned int sharedMemBytes, hipStream_t stream, void **kernelParams, void **extra){
+hipError_t hipLaunchJITKernel(hipFunction_t f, unsigned int gridDimX, unsigned int gridDimY, unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY, unsigned int blockDimZ, unsigned int sharedMemBytes, hipStream_t stream, void **kernelParams, void **extra) {
   return hipModuleLaunchKernel(f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ, sharedMemBytes, stream, kernelParams, extra);
 }
 

--- a/src/acc/hip/acc_hip.h
+++ b/src/acc/hip/acc_hip.h
@@ -55,23 +55,23 @@
     hipblasStatus_t result = ACC_BLAS(func) args;                 \
     if (result != HIPBLAS_STATUS_SUCCESS) {                       \
       const char* error_name = "HIPBLAS_ERRROR";                  \
-      if (result == HIPBLAS_STATUS_NOT_INITIALIZED){              \
+      if (result == HIPBLAS_STATUS_NOT_INITIALIZED) {              \
         error_name = "HIPBLAS_STATUS_NOT_INITIALIZED ";           \
-      } else if (result == HIPBLAS_STATUS_ALLOC_FAILED){          \
+      } else if (result == HIPBLAS_STATUS_ALLOC_FAILED) {          \
         error_name = "HIPBLAS_STATUS_ALLOC_FAILED ";              \
-      } else if (result == HIPBLAS_STATUS_INVALID_VALUE){         \
+      } else if (result == HIPBLAS_STATUS_INVALID_VALUE) {         \
         error_name = "HIPBLAS_STATUS_INVALID_VALUE ";             \
-      } else if (result == HIPBLAS_STATUS_MAPPING_ERROR){         \
+      } else if (result == HIPBLAS_STATUS_MAPPING_ERROR) {         \
         error_name = "HIPBLAS_STATUS_MAPPING_ERROR ";             \
-      } else if (result == HIPBLAS_STATUS_EXECUTION_FAILED){      \
+      } else if (result == HIPBLAS_STATUS_EXECUTION_FAILED) {      \
         error_name = "HIPBLAS_STATUS_EXECUTION_FAILED ";          \
-      } else if (result == HIPBLAS_STATUS_INTERNAL_ERROR){        \
+      } else if (result == HIPBLAS_STATUS_INTERNAL_ERROR) {        \
         error_name = "HIPBLAS_STATUS_INTERNAL_ERROR ";            \
-      } else if (result == HIPBLAS_STATUS_NOT_SUPPORTED){         \
+      } else if (result == HIPBLAS_STATUS_NOT_SUPPORTED) {         \
         error_name = "HIPBLAS_STATUS_NOT_SUPPORTED ";             \
-      } else if (result == HIPBLAS_STATUS_ARCH_MISMATCH){         \
+      } else if (result == HIPBLAS_STATUS_ARCH_MISMATCH) {         \
         error_name = "HIPBLAS_STATUS_ARCH_MISMATCH ";             \
-      } else if (result == HIPBLAS_STATUS_HANDLE_IS_NULLPTR){     \
+      } else if (result == HIPBLAS_STATUS_HANDLE_IS_NULLPTR) {     \
         error_name = "HIPBLAS_STATUS_HANDLE_IS_NULLPTR ";         \
       }                                                           \
       printf("\nHIPBLAS ERROR: %s failed with error %s\n",        \

--- a/src/acc/libsmm_acc/kernels/README.md
+++ b/src/acc/libsmm_acc/kernels/README.md
@@ -1,6 +1,4 @@
-# libsmm_acc/kernels
-
-`libsmm_acc`'s GPU kernels.
+# LIBSMM_ACC Kernels
 
 ## Directory Organization
 

--- a/src/acc/libsmm_acc/kernels/smm_acc_dnt_base.py
+++ b/src/acc/libsmm_acc/kernels/smm_acc_dnt_base.py
@@ -138,7 +138,7 @@ class Kernel:
         else:  # i.e. compiler == "hipcc"
             output += "hipStream_t stream, "
         output += "int m_max, int n_max, int k_max, "
-        output += "const double *a_data, const double *b_data, double *c_data){\n"
+        output += "const double *a_data, const double *b_data, double *c_data) {\n"
         output += indent + "int shared_size = 0;\n"
         output += indent + "//%s\n" % str(self.__dict__)
         output += (

--- a/src/acc/libsmm_acc/kernels/smm_acc_dnt_medium.h
+++ b/src/acc/libsmm_acc/kernels/smm_acc_dnt_medium.h
@@ -55,7 +55,7 @@ template < int m,  int n,  int k, int M, int N, int threads, int grouping, int m
 __global__ void
 __launch_bounds__(threads, minblocks)
 smm_acc_dnt_medium(const int* __restrict__ param_stack, int stack_size,
-     const double* __restrict__ a_data, const double* __restrict__ b_data, double* c_data){
+     const double* __restrict__ a_data, const double* __restrict__ b_data, double* c_data) {
 
   /* Total number of elements in block matrices */
   const int mn = m * n; /* c_block */
@@ -155,7 +155,7 @@ smm_acc_dnt_medium(const int* __restrict__ param_stack, int stack_size,
    * Each triplet indicates the beginning of a submatrix to multiply */
   psp = bidx * npar * grouping;
 #pragma unroll 3
-  for (int i = tidx; i < nrun; i += threads){
+  for (int i = tidx; i < nrun; i += threads) {
     // param_stack is 1-based, convert to 0-based here
     param_stack_s[i * npar    ] = __ldg(&param_stack[psp + i * npar    ]) - 1; /* value = index in a_data */
     param_stack_s[i * npar + 1] = __ldg(&param_stack[psp + i * npar + 1]) - 1; /* value = index in b_data */
@@ -166,14 +166,14 @@ smm_acc_dnt_medium(const int* __restrict__ param_stack, int stack_size,
   if (need_sync) syncthreads ();
 
   /* In each run, we process one stack entry from param_stack_s */
-  for (int run = 0; run < nrun; run++){
+  for (int run = 0; run < nrun; run++) {
 
     /* Index in shared memory buffers to read from */
     psp = run * npar;
 
     int srcA, srcB;
 
-    if (!is_loaded){ /* If a_block, b_block are not loaded into registers yet */
+    if (!is_loaded) { /* If a_block, b_block are not loaded into registers yet */
 
       /* Index in a_data, b_data and c_data arrays
        * indicating where to fetch resp. write back matrix elements for this run
@@ -182,58 +182,58 @@ smm_acc_dnt_medium(const int* __restrict__ param_stack, int stack_size,
       srcB = param_stack_s[psp + 1];
 
     /* Copy a_block, b_block from global memory to registers */
-    if (m == n){
+    if (m == n) {
 #pragma unroll 3
-      for (int i = tidx; i < n_mkloads * (load_unroll_factor_1 * threads); i += load_unroll_factor_1 * threads){
+      for (int i = tidx; i < n_mkloads * (load_unroll_factor_1 * threads); i += load_unroll_factor_1 * threads) {
 #pragma unroll
-        for (int l = 0; l < load_unroll_factor_1; l++){
+        for (int l = 0; l < load_unroll_factor_1; l++) {
           lba_r[l] = __ldg(&a_data[srcA + i + l * threads]);
           lbb_r[l] = __ldg(&b_data[srcB + i + l * threads]);
         }
       }
 
 #pragma unroll 3
-      for (int i = n_mkloads * (load_unroll_factor_1 * threads) + tidx; i < m_loads_to_finish; i += mkloads_remained * threads){
+      for (int i = n_mkloads * (load_unroll_factor_1 * threads) + tidx; i < m_loads_to_finish; i += mkloads_remained * threads) {
 #pragma unroll
-        for (int l = 0; l < mkloads_remained; l++){
+        for (int l = 0; l < mkloads_remained; l++) {
           lba_r[l] = __ldg(&a_data[srcA + i + l * threads]);
           lbb_r[l] = __ldg(&b_data[srcB + i + l * threads]);
         }
       }
 
-      if (left_to_finish_1 < mk){
+      if (left_to_finish_1 < mk) {
         lba_r[load_unroll_factor_1 + mkloads_remained] = __ldg(&a_data[srcA + left_to_finish_1]);
         lbb_r[load_unroll_factor_2 + knloads_remained] = __ldg(&b_data[srcB + left_to_finish_2]);
       }
     } else {
 #pragma unroll 3
-      for (int i = tidx; i < n_mkloads * (load_unroll_factor_1 * threads); i += load_unroll_factor_1 * threads){
+      for (int i = tidx; i < n_mkloads * (load_unroll_factor_1 * threads); i += load_unroll_factor_1 * threads) {
 #pragma unroll
-        for (int l = 0; l < load_unroll_factor_1; l++){
+        for (int l = 0; l < load_unroll_factor_1; l++) {
           lba_r[l] = __ldg(&a_data[srcA + i + l * threads]);
         }
       }
 
 #pragma unroll 3
-      for (int i = tidx; i < n_knloads * (load_unroll_factor_2 * threads); i += load_unroll_factor_2 * threads){
+      for (int i = tidx; i < n_knloads * (load_unroll_factor_2 * threads); i += load_unroll_factor_2 * threads) {
 #pragma unroll
-        for (int l = 0; l < load_unroll_factor_2; l++){
+        for (int l = 0; l < load_unroll_factor_2; l++) {
           lbb_r[l] = __ldg(&b_data[srcB + i + l * threads]);
         }
       }
 
 #pragma unroll 3
-      for (int i = n_mkloads * (load_unroll_factor_1 * threads) + tidx; i < m_loads_to_finish; i += mkloads_remained * threads){
+      for (int i = n_mkloads * (load_unroll_factor_1 * threads) + tidx; i < m_loads_to_finish; i += mkloads_remained * threads) {
 #pragma unroll
-        for (int l = 0; l < mkloads_remained; l++){
+        for (int l = 0; l < mkloads_remained; l++) {
           lba_r[l] = __ldg(&a_data[srcA + i + l * threads]);
         }
       }
 
 #pragma unroll 3
-      for (int i = n_knloads * (load_unroll_factor_2 * threads) + tidx; i < n_loads_to_finish; i += knloads_remained * threads){
+      for (int i = n_knloads * (load_unroll_factor_2 * threads) + tidx; i < n_loads_to_finish; i += knloads_remained * threads) {
 #pragma unroll
-        for (int l = 0; l < knloads_remained; l++){
+        for (int l = 0; l < knloads_remained; l++) {
           lbb_r[l] = __ldg(&b_data[srcB + i + l * threads]);
         }
       }
@@ -249,58 +249,58 @@ smm_acc_dnt_medium(const int* __restrict__ param_stack, int stack_size,
     }
 
     /* Copy a_block, b_block from registers to shared memory */
-    if (m == n){
+    if (m == n) {
 #pragma unroll 3
-      for (int i = n_mkloads * (load_unroll_factor_1 * threads) + tidx; i < m_loads_to_finish; i += mkloads_remained * threads){
+      for (int i = n_mkloads * (load_unroll_factor_1 * threads) + tidx; i < m_loads_to_finish; i += mkloads_remained * threads) {
 #pragma unroll
-        for (int l = 0; l < mkloads_remained; l++){
+        for (int l = 0; l < mkloads_remained; l++) {
           buff[i + l * threads] = lba_r[l];
           buff[i + mk + l * threads] = lbb_r[l];
         }
       }
 
 #pragma unroll 3
-      for (int i = tidx; i < n_mkloads * (load_unroll_factor_1 * threads); i += load_unroll_factor_1 * threads){
+      for (int i = tidx; i < n_mkloads * (load_unroll_factor_1 * threads); i += load_unroll_factor_1 * threads) {
 #pragma unroll
-        for (int l = 0; l < load_unroll_factor_1; l++){
+        for (int l = 0; l < load_unroll_factor_1; l++) {
           buff[i + l * threads] = lba_r[l];
           buff[i + mk + l * threads] = lbb_r[l];
         }
       }
 
-      if (left_to_finish_1 < mk){
+      if (left_to_finish_1 < mk) {
         buff[left_to_finish_1] = lba_r[load_unroll_factor_1 + mkloads_remained];
         buff[mk + left_to_finish_2] = lbb_r[load_unroll_factor_2 + knloads_remained];
       }
     } else {
 #pragma unroll 3
-      for (int i = n_mkloads * (load_unroll_factor_1 * threads) + tidx; i < m_loads_to_finish; i += mkloads_remained * threads){
+      for (int i = n_mkloads * (load_unroll_factor_1 * threads) + tidx; i < m_loads_to_finish; i += mkloads_remained * threads) {
 #pragma unroll
-        for (int l = 0; l < mkloads_remained; l++){
+        for (int l = 0; l < mkloads_remained; l++) {
           buff[i + l * threads] = lba_r[l];
         }
       }
 
 #pragma unroll 3
-      for (int i = n_knloads * (load_unroll_factor_2 * threads) + tidx; i < n_loads_to_finish; i += knloads_remained * threads){
+      for (int i = n_knloads * (load_unroll_factor_2 * threads) + tidx; i < n_loads_to_finish; i += knloads_remained * threads) {
 #pragma unroll
-        for (int l = 0; l < knloads_remained; l++){
+        for (int l = 0; l < knloads_remained; l++) {
           buff[i + mk + l * threads] = lbb_r[l];
         }
       }
 
 #pragma unroll 3
-      for (int i = tidx; i < n_mkloads * (load_unroll_factor_1 * threads); i += load_unroll_factor_1 * threads){
+      for (int i = tidx; i < n_mkloads * (load_unroll_factor_1 * threads); i += load_unroll_factor_1 * threads) {
 #pragma unroll
-        for (int l = 0; l < load_unroll_factor_1; l++){
+        for (int l = 0; l < load_unroll_factor_1; l++) {
           buff[i + l * threads] = lba_r[l];
         }
       }
 
 #pragma unroll 3
-      for (int i = tidx; i < n_knloads * (load_unroll_factor_2 * threads); i += load_unroll_factor_2 * threads){
+      for (int i = tidx; i < n_knloads * (load_unroll_factor_2 * threads); i += load_unroll_factor_2 * threads) {
 #pragma unroll
-        for (int l = 0; l < load_unroll_factor_2; l++){
+        for (int l = 0; l < load_unroll_factor_2; l++) {
           buff[i + mk + l * threads] = lbb_r[l];
         }
       }
@@ -316,7 +316,7 @@ smm_acc_dnt_medium(const int* __restrict__ param_stack, int stack_size,
     int next_run = run + 1;
     if (next_run >= nrun) is_loaded = true;
 
-    if (!is_loaded || (run == 0 && nrun > 1)){
+    if (!is_loaded || (run == 0 && nrun > 1)) {
       /* Next parameter stack position */
       int next_psp = next_run * npar;
 
@@ -327,58 +327,58 @@ smm_acc_dnt_medium(const int* __restrict__ param_stack, int stack_size,
       srcB = param_stack_s[next_psp + 1];
 
       /* Buffering: copy the input data for the next run from global memory to registers */
-      if (m == n){
+      if (m == n) {
 #pragma unroll 3
-        for (int i = tidx; i < n_mkloads * (load_unroll_factor_1 * threads); i += load_unroll_factor_1 * threads){
+        for (int i = tidx; i < n_mkloads * (load_unroll_factor_1 * threads); i += load_unroll_factor_1 * threads) {
 #pragma unroll
-          for (int l = 0; l < load_unroll_factor_1; l++){
+          for (int l = 0; l < load_unroll_factor_1; l++) {
             lba_r[l] = __ldg(&a_data[srcA + i + l * threads]);
             lbb_r[l] = __ldg(&b_data[srcB + i + l * threads]);
           }
         }
 
 #pragma unroll 3
-        for (int i = n_mkloads * (load_unroll_factor_1 * threads) + tidx; i < m_loads_to_finish; i += mkloads_remained * threads){
+        for (int i = n_mkloads * (load_unroll_factor_1 * threads) + tidx; i < m_loads_to_finish; i += mkloads_remained * threads) {
 #pragma unroll
-          for (int l = 0; l < mkloads_remained; l++){
+          for (int l = 0; l < mkloads_remained; l++) {
             lba_r[l] = __ldg(&a_data[srcA + i + l * threads]);
             lbb_r[l] = __ldg(&b_data[srcB + i +l * threads]);
           }
         }
 
-        if (left_to_finish_1 < mk){
+        if (left_to_finish_1 < mk) {
           lba_r[load_unroll_factor_1 + mkloads_remained] = __ldg(&a_data[srcA + left_to_finish_1]);
           lbb_r[load_unroll_factor_2 + knloads_remained] = __ldg(&b_data[srcB + left_to_finish_2]);
         }
       } else {
 #pragma unroll 3
-        for (int i = tidx; i < n_mkloads * (load_unroll_factor_1 * threads); i += load_unroll_factor_1 * threads){
+        for (int i = tidx; i < n_mkloads * (load_unroll_factor_1 * threads); i += load_unroll_factor_1 * threads) {
 #pragma unroll
-          for (int l = 0; l < load_unroll_factor_1; l++){
+          for (int l = 0; l < load_unroll_factor_1; l++) {
             lba_r[l] = __ldg(&a_data[srcA + i + l * threads]);
           }
         }
 
 #pragma unroll 3
-        for (int i = tidx; i < n_knloads * (load_unroll_factor_2 * threads); i += load_unroll_factor_2 * threads){
+        for (int i = tidx; i < n_knloads * (load_unroll_factor_2 * threads); i += load_unroll_factor_2 * threads) {
 #pragma unroll
-          for (int l = 0; l < load_unroll_factor_2; l++){
+          for (int l = 0; l < load_unroll_factor_2; l++) {
             lbb_r[l] = __ldg(&b_data[srcB + i + l * threads]);
           }
         }
 
 #pragma unroll 3
-        for (int i = n_mkloads * (load_unroll_factor_1 * threads) + tidx; i < m_loads_to_finish; i += mkloads_remained * threads){
+        for (int i = n_mkloads * (load_unroll_factor_1 * threads) + tidx; i < m_loads_to_finish; i += mkloads_remained * threads) {
 #pragma unroll
-          for (int l = 0; l < mkloads_remained; l++){
+          for (int l = 0; l < mkloads_remained; l++) {
             lba_r[l] = __ldg(&a_data[srcA + i + l * threads]);
           }
         }
 
 #pragma unroll 3
-        for (int i = n_knloads * (load_unroll_factor_2 * threads) + tidx; i < n_loads_to_finish; i += knloads_remained * threads){
+        for (int i = n_knloads * (load_unroll_factor_2 * threads) + tidx; i < n_loads_to_finish; i += knloads_remained * threads) {
 #pragma unroll
-          for (int l = 0; l < knloads_remained; l++){
+          for (int l = 0; l < knloads_remained; l++) {
             lbb_r[l] = __ldg(&b_data[srcB + i + l * threads]);
           }
         }
@@ -391,11 +391,11 @@ smm_acc_dnt_medium(const int* __restrict__ param_stack, int stack_size,
     }
 
     /* Do actual multiplication. */
-    if (c < cmax  && r < rmax){
-      for (int l = 0; l < k; l++){
+    if (c < cmax  && r < rmax) {
+      for (int l = 0; l < k; l++) {
         /* Loop over all elements c_ij of tile T */
-        for (int i = 0; i < M; i++){
-          for (int j = 0; j < N; j++){
+        for (int i = 0; i < M; i++) {
+          for (int j = 0; j < N; j++) {
             /* Compute c_ij = sum_k (a_ik * b_kj) in shared memory */
             myc[N * i + j] += buff_l[l * m + M * r + i] * buff_r[l * n + N * c + j];
           }
@@ -404,18 +404,18 @@ smm_acc_dnt_medium(const int* __restrict__ param_stack, int stack_size,
     }
 
 
-    if (run == nrun - 1 || param_stack_s[psp + 2] != param_stack_s[psp + 2 + npar]){
+    if (run == nrun - 1 || param_stack_s[psp + 2] != param_stack_s[psp + 2 + npar]) {
 
       /* Index in c_data indicating where to write back matrix elements for this run */
       int srcC = param_stack_s[psp + 2];
 
-      if (M > 1 || N > 1){
+      if (M > 1 || N > 1) {
         if (need_sync) syncthreads();
         /* Decompress results to buffer and set tile elements back to 0 */
-        if (c < cmax  && r < rmax){
-          for (int i = 0; i < M; i++){
-            for (int j = 0; j < N; j++){
-              if (M * r + i < m && N * c + j < n){
+        if (c < cmax  && r < rmax) {
+          for (int i = 0; i < M; i++) {
+            for (int j = 0; j < N; j++) {
+              if (M * r + i < m && N * c + j < n) {
                 buff[(N * c + j) * m + M * r + i] = myc[N * i + j];
                 myc[N * i + j] = 0.0;
               }
@@ -426,13 +426,13 @@ smm_acc_dnt_medium(const int* __restrict__ param_stack, int stack_size,
 
         /* Add results from shared memory buffer to global C block. */
 #pragma unroll
-        for (int i = tidx; i < mn; i += threads){
+        for (int i = tidx; i < mn; i += threads) {
           atomicAdd (&c_data[srcC + i], buff[i]);
         }
       } else {
         /* Add results from registers to global C block. */
 #pragma unroll
-        for (int i = tidx; i < mn; i += threads){
+        for (int i = tidx; i < mn; i += threads) {
           atomicAdd (&c_data[srcC + i], myc[0]);
         }
         myc[0] = 0.0;

--- a/src/acc/libsmm_acc/kernels/smm_acc_dnt_tiny.h
+++ b/src/acc/libsmm_acc/kernels/smm_acc_dnt_tiny.h
@@ -55,7 +55,7 @@ template <int m, int n, int k, int threads, int grouping, int minblocks>
 __global__ void
 __launch_bounds__(threads, minblocks)
 smm_acc_dnt_tiny(const int* __restrict__ param_stack, int stack_size,
-     const double* __restrict__ a_data, const double* __restrict__ b_data, double* c_data){
+     const double* __restrict__ a_data, const double* __restrict__ b_data, double* c_data) {
 
   /* Total number of elements in block matrices */
   const int mn = m * n; /* c_block */
@@ -111,7 +111,7 @@ smm_acc_dnt_tiny(const int* __restrict__ param_stack, int stack_size,
    * Each triplet indicates the beginning of a submatrix to multiply */
   psp = bidx * npar * grouping;
 #pragma unroll
-  for (int i = tidx; i < nrun; i += threads){
+  for (int i = tidx; i < nrun; i += threads) {
     // param_stack is 1-based, convert to 0-based here
     param_stack_s[i * npar    ] = __ldg(&param_stack[psp + i * npar    ]) - 1; /* value = index in a_data */
     param_stack_s[i * npar + 1] = __ldg(&param_stack[psp + i * npar + 1]) - 1; /* value = index in b_data */
@@ -139,17 +139,17 @@ smm_acc_dnt_tiny(const int* __restrict__ param_stack, int stack_size,
      * once an element s loaded into shared memory, it is available for all threads of the thread block to use */
     if (m == n) {
 #pragma unroll
-      for (int i = tidx; i < mk; i += threads){
+      for (int i = tidx; i < mk; i += threads) {
         buff_a[i] = __ldg(&a_data[srcA + i]);
         buff_b[i] = __ldg(&b_data[srcB + i]);
       }
     } else {
 #pragma unroll
-      for (int i = tidx; i < mk; i += threads){
+      for (int i = tidx; i < mk; i += threads) {
         buff_a[i] = __ldg(&a_data[srcA + i]);
       }
 #pragma unroll
-      for (int i = tidx; i < kn; i += threads){
+      for (int i = tidx; i < kn; i += threads) {
         buff_b[i] = __ldg(&b_data[srcB + i]);
       }
     }

--- a/src/acc/libsmm_acc/kernels/smm_acc_transpose.h
+++ b/src/acc/libsmm_acc/kernels/smm_acc_transpose.h
@@ -39,21 +39,21 @@
  */
 
 template <int m, int n>
-__global__ void transpose_d(int *trs_stack, double* mat){
+__global__ void transpose_d(int *trs_stack, double* mat) {
  __shared__ double buf[m*n];
 
  /* Get the offset in the transpose-stack that this block ID should handle */
  int offset = trs_stack[blockIdx.x];
 
  /* Loop over m*n matrix elements */
- for(int i=threadIdx.x; i < m*n; i+=blockDim.x){
+ for (int i=threadIdx.x; i < m*n; i+=blockDim.x) {
      /* Load matrix elements into a temporary buffer */
      buf[i] = mat[offset + i];
  }
  syncthreads();
 
  /* Loop over elements of the matrix to be overwritten */
- for(int i=threadIdx.x; i < m*n; i+=blockDim.x){
+ for (int i=threadIdx.x; i < m*n; i+=blockDim.x) {
      /* Compute old row and column index of matrix element */
      int r_out = i % n;
      int c_out = i / n;

--- a/src/acc/libsmm_acc/libsmm_acc_benchmark.cpp
+++ b/src/acc/libsmm_acc/libsmm_acc_benchmark.cpp
@@ -19,7 +19,7 @@
 //===========================================================================
 // Allocate memory and accelerator events
 void libsmm_acc_benchmark_init(libsmm_acc_benchmark_t** handle, benchmark_mode mode,
-                               int max_m, int max_n, int max_k){
+                               int max_m, int max_n, int max_k) {
 
     libsmm_acc_benchmark_t* h = (libsmm_acc_benchmark_t*) malloc(sizeof(libsmm_acc_benchmark_t));
     *handle = h;
@@ -70,10 +70,9 @@ void libsmm_acc_benchmark_init(libsmm_acc_benchmark_t** handle, benchmark_mode m
 
 }
 
-
 //===========================================================================
 // Free memory and accelerator events
-void libsmm_acc_benchmark_finalize(libsmm_acc_benchmark_t* handle){
+void libsmm_acc_benchmark_finalize(libsmm_acc_benchmark_t* handle) {
     ACC_DRV_CALL(EventDestroy, (handle->t_start));
     ACC_DRV_CALL(EventDestroy, (handle->t_stop));
     ACC_API_CALL(Free, (handle->d_stack_trs_b));
@@ -93,54 +92,50 @@ void libsmm_acc_benchmark_finalize(libsmm_acc_benchmark_t* handle){
     free(handle);
 }
 
-
 //===========================================================================
 // initialize matrix
-void matInit(double* mat, int mat_n, int x, int y, int seed){
+void matInit(double* mat, int mat_n, int x, int y, int seed) {
 
  double *m = mat;
 
- for(int n=0; n<mat_n; n++)
-   for(int j=0; j<y; j++)
-     for(int i=0; i<x; i++, m++)
+ for (int n=0; n<mat_n; n++)
+   for (int j=0; j<y; j++)
+     for (int i=0; i<x; i++, m++)
        *m = (double) j*x + i + n + seed;
 
 }
-
 
 //===========================================================================
 // initialize the task list ("stack" in DBCSR lingo)
 // for each of the result matrices we have a random number
 void stackInit(int *stack, int n_stack, int n_c, int n_a, int n_b,
-               int mat_m, int mat_n, int mat_k){
+               int mat_m, int mat_n, int mat_k) {
 
   init_stack(stack, n_stack, mat_m * mat_n, mat_m * mat_k, mat_k * mat_n, n_c, n_a, n_b);
 }
 
-
 //===========================================================================
 // initialize the task list ("stack" in DBCSR lingo)
-void stackInitTransp(int *stack, int n_stack, int mat_m, int mat_n){
+void stackInitTransp(int *stack, int n_stack, int mat_m, int mat_n) {
 
   int* s = stack;
-  for(int p=0; p<n_stack; p++)
+  for (int p=0; p<n_stack; p++)
      *s++ =  p * mat_m * mat_n;
 }
 
-
 //===========================================================================
 void stackCalc(int* stack, int n_stack, double* mat_c, double *mat_a, double* mat_b,
-               int mat_m, int mat_n, int mat_k){
+               int mat_m, int mat_n, int mat_k) {
 
-  for(int s=0; s<n_stack; s++){
+  for (int s=0; s<n_stack; s++) {
      int a_base = stack[3 * s    ] - 1;
      int b_base = stack[3 * s + 1] - 1;
      int c_base = stack[3 * s + 2] - 1;
 
-     for(int n=0; n<mat_n; n++){
-       for(int m=0; m<mat_m; m++){
+     for (int n=0; n<mat_n; n++) {
+       for (int m=0; m<mat_m; m++) {
          double res = 0.;
-         for(int k=0; k<mat_k; k++){
+         for (int k=0; k<mat_k; k++) {
           int a_ind = k * mat_m + m;
           int b_ind = k * mat_n + n;
           res += mat_a[a_base + a_ind] * mat_b[b_base + b_ind];
@@ -153,14 +148,13 @@ void stackCalc(int* stack, int n_stack, double* mat_c, double *mat_a, double* ma
 
 }
 
-
 //===========================================================================
 void stackTransp(int* stack, int n_stack, double *mat, double* mat_trs,
-                 int mat_m, int mat_n){
-    for(int s=0; s < n_stack; s++){
+                 int mat_m, int mat_n) {
+    for (int s=0; s < n_stack; s++) {
         int offset = stack[s];
-        for(int m=0; m < mat_m; m++){
-            for(int n=0; n < mat_n; n++){
+        for (int m=0; m < mat_m; m++) {
+            for (int n=0; n < mat_n; n++) {
                 int i = n * mat_m + m;
                 int r_out = i % mat_n;
                 int c_out = i / mat_n;
@@ -171,19 +165,17 @@ void stackTransp(int* stack, int n_stack, double *mat, double* mat_trs,
     }
 }
 
-
 //===========================================================================
-double checkSum(double* mat_c, int n_c, int mat_m, int mat_n){
+double checkSum(double* mat_c, int n_c, int mat_m, int mat_n) {
    double res = 0;
-   for(int i=0; i<n_c * mat_m * mat_n; i++){
+   for (int i=0; i<n_c * mat_m * mat_n; i++) {
      res += mat_c[i];
    }
    return res;
 }
 
-
 //===========================================================================
-double checkSumTransp(double* mat, int n_stack, int mat_m, int mat_n){
+double checkSumTransp(double* mat, int n_stack, int mat_m, int mat_n) {
     // for transposition, a regular checkSum does not inform about the
     // transpose's correctness. Instead, we perform a checkSum on a
     // sample of elements.
@@ -192,40 +184,38 @@ double checkSumTransp(double* mat, int n_stack, int mat_m, int mat_n){
     int n_samples = size / 3;
     int step = size;
 
-    if(n_samples > 0){
+    if (n_samples > 0) {
         step = size / n_samples;
     }
 
-    for(int s=0; s < n_stack; s++){
+    for (int s=0; s < n_stack; s++) {
         int offset = s * size;
-        for(int idx=s%step; idx < size; idx+=step)
+        for (int idx=s%step; idx < size; idx+=step)
             res += mat[offset + idx];
     }
     return res;
 }
 
-
 //===========================================================================
 //Removes special symbols so that the output is useful for awk and gnuplot.
-static void clean_string(char* str_in, char* str_out){
-    for(int i=0; i<1000 ; i++){
-        if(str_in[i] == '=' || str_in[i] == ',' || str_in[i] == '(' || str_in[i] == ')'){
+static void clean_string(char* str_in, char* str_out) {
+    for (int i=0; i<1000 ; i++) {
+        if (str_in[i] == '=' || str_in[i] == ',' || str_in[i] == '(' || str_in[i] == ')') {
             str_out[i] = ' ';
          }else{
              str_out[i] = str_in[i];
          }
-         if(str_in[i] == 0)
+         if (str_in[i] == 0)
              break;
     }
 }
 
-
 //===========================================================================
 int libsmm_acc_benchmark(libsmm_acc_benchmark_t* h,
                          int mat_m, int mat_n, int mat_k,
-                         int nkernels, KernelLauncher* launchers, char ** kernel_descr){
+                         int nkernels, KernelLauncher* launchers, char ** kernel_descr) {
 
- if(mat_m > h->max_m || mat_n > h->max_n || mat_k > h->max_k){
+ if (mat_m > h->max_m || mat_n > h->max_n || mat_k > h->max_k) {
      printf("libsmm_acc_benchmark: got handle with too few resources\n");
      exit(1);
  }
@@ -233,14 +223,14 @@ int libsmm_acc_benchmark(libsmm_acc_benchmark_t* h,
  std::vector<Triplet> blocksizes;
  get_libsmm_acc_triplets(blocksizes, ht);
  auto it = std::find(std::begin(blocksizes), std::end(blocksizes), Triplet({ mat_m, mat_n, mat_k }));
- if(it == std::end(blocksizes) && h->mode != tune){
+ if (it == std::end(blocksizes) && h->mode != tune) {
      printf("Triplet %i x %i x %i is not defined in libsmm_acc\n", mat_m, mat_n, mat_k);
      exit(1);
  }
 
 
  int n_iter{0}, n_warm{0};
- switch(h->mode){
+ switch(h->mode) {
    case tune:
    case timing: // for larger matrices few iteration give enough statistics
      n_iter = std::max(3, 12500/(mat_m * mat_n * mat_k));
@@ -266,14 +256,14 @@ int libsmm_acc_benchmark(libsmm_acc_benchmark_t* h,
  matInit(h->mat_a, h->n_a, mat_m, mat_k, 42);
  matInit(h->mat_b, h->n_b, mat_k, mat_n, 24);
 
- if(h->mode == tune)
+ if (h->mode == tune)
      printf("Initializing ...\n");
  stackInit(h->stack, h->n_stack, h->n_c, h->n_a, h->n_b, mat_m, mat_n, mat_k);
 
  // Actually, we would have to calculate the stack n_iter times.
  // We cheat by simply scaling the results of a single stack calculation.
  stackCalc(h->stack, h->n_stack, h->mat_c, h->mat_a, h->mat_b, mat_m, mat_n, mat_k);
- for(int i=0 ; i < h->n_c*mat_m*mat_n ; i++)
+ for (int i=0 ; i < h->n_c*mat_m*mat_n ; i++)
      h->mat_c[i] *= n_iter;
 
  sumCPU =  checkSum(h->mat_c, h->n_c, mat_m, mat_n);
@@ -283,16 +273,16 @@ int libsmm_acc_benchmark(libsmm_acc_benchmark_t* h,
  ACC_API_CALL(Memcpy, (h->d_stack, h->stack, h->n_stack * 3 * sizeof(int), ACC(MemcpyHostToDevice)));
  // d_mat_c gets zeroed after warmup run
 
- for(int ikern=0; ikern < nkernels; ikern++){
+ for (int ikern=0; ikern < nkernels; ikern++) {
 
     // Warmup run (more often if n_iter is small)
-    for(int i=0; i<n_warm; i++)
+    for (int i=0; i<n_warm; i++)
         launchers[ikern](h->d_stack, h->n_stack, stream, mat_m, mat_n, mat_k, h->d_mat_a, h->d_mat_b, h->d_mat_c);
     ACC_API_CALL(Memset, (h->d_mat_c, 0, h->n_c * mat_m * mat_n * sizeof(double)));
 
     ACC_DRV_CALL(EventRecord, (h->t_start, stream));
 
-    for(int i=0; i<n_iter; i++)
+    for (int i=0; i<n_iter; i++)
         launchers[ikern](h->d_stack, h->n_stack, stream, mat_m, mat_n, mat_k, h->d_mat_a, h->d_mat_b, h->d_mat_c);
 
     ACC_DRV_CALL(EventRecord, (h->t_stop, stream));
@@ -303,20 +293,20 @@ int libsmm_acc_benchmark(libsmm_acc_benchmark_t* h,
 
     clean_string(kernel_descr[ikern], descr);
 
-    if(h->mode == tune)
+    if (h->mode == tune)
         sprintf(msg_prefix, "params %d / %d\n",ikern+1, nkernels);
 
     sumGPU =  checkSum(h->mat_c, h->n_c, mat_m, mat_n);
-    if(sumGPU != sumCPU){
+    if (sumGPU != sumCPU) {
         printf("%sERROR %s checksum_diff: %g\n",msg_prefix, descr, sumGPU-sumCPU);
         error_counter++;
         continue;
     }
 
-    if(h->mode == tune || h->mode == timing){
+    if (h->mode == tune || h->mode == timing) {
        double gflops = ((double) n_iter * h->n_stack * mat_m * mat_n * mat_k * 2 / (1e9))/(t_duration * 1e-3);
        printf("%sOK %s GFlop/s %g\n", msg_prefix, descr, gflops);
-       if(best_gflops < gflops){
+       if (best_gflops < gflops) {
            best_gflops = gflops;
            best_kernel = ikern;
        }
@@ -328,9 +318,9 @@ int libsmm_acc_benchmark(libsmm_acc_benchmark_t* h,
 #endif
  }
 
- if(h->mode == tune){
+ if (h->mode == tune) {
     printf("\n\n");
-    if(best_kernel > -1){
+    if (best_kernel > -1) {
         printf("WINNER: %d %s , # %g GFlop/s \n", best_kernel+1, kernel_descr[best_kernel], best_gflops);
     }else{
        printf("WINNER: None\n");
@@ -341,14 +331,13 @@ int libsmm_acc_benchmark(libsmm_acc_benchmark_t* h,
  return(error_counter);
 }
 
-
 //===========================================================================
 int libsmm_acc_benchmark_transpose_(int n_stack, int* stack, int* d_stack,
                                     double* mat, double* mat_trs, double* d_mat,
                                     int n, int mat_m, int mat_n,
                                     ACC_DRV(event) start, ACC_DRV(event) stop, char** kernel_descr,
-                                    TransposeLauncher* launcher){
- if(mat_m > MAX_BLOCK_DIM || mat_n > MAX_BLOCK_DIM){
+                                    TransposeLauncher* launcher) {
+ if (mat_m > MAX_BLOCK_DIM || mat_n > MAX_BLOCK_DIM) {
      printf("Cannot transpose matrices with dimensions above %i, got (%i x %i)\n",
             MAX_BLOCK_DIM, mat_m, mat_n);
      exit(1);
@@ -379,13 +368,13 @@ int libsmm_acc_benchmark_transpose_(int n_stack, int* stack, int* d_stack,
  ACC_API_CALL(Memcpy, (d_stack, stack, n_stack * sizeof(int), ACC(MemcpyHostToDevice)));
 
  // Warmup run
- for(int i=0; i<n_warm; i++)
+ for (int i=0; i<n_warm; i++)
    launcher[0](d_stack, offset, n_stack, d_mat, mat_m, mat_n, stream);
 
  // Real runs
  ACC_DRV_CALL(EventRecord, (start, stream));
 
- for(int i=0; i<n_iter; i++)
+ for (int i=0; i<n_iter; i++)
    launcher[0](d_stack, offset, n_stack, d_mat, mat_m, mat_n, stream);
 
  ACC_DRV_CALL(EventRecord, (stop, stream));
@@ -397,7 +386,7 @@ int libsmm_acc_benchmark_transpose_(int n_stack, int* stack, int* d_stack,
  clean_string(kernel_descr[0], descr);
 
  sumGPU = checkSumTransp(mat_trs, n_stack, mat_m, mat_n);
- if(sumGPU != sumCPU){
+ if (sumGPU != sumCPU) {
      printf("%sERROR %s checksum_diff: %g\n", msg_prefix, descr, sumGPU-sumCPU);
      error_counter++;
  }
@@ -410,17 +399,16 @@ int libsmm_acc_benchmark_transpose_(int n_stack, int* stack, int* d_stack,
 
 }
 
-
 //===========================================================================
 int libsmm_acc_benchmark_transpose(libsmm_acc_benchmark_t* handle,
                                    int mat_m, int mat_n,
-                                   TransposeLauncher* launcher, char** kernel_descr){
+                                   TransposeLauncher* launcher, char** kernel_descr) {
 
- if(mat_m > handle->max_m || mat_n > handle->max_n){
+ if (mat_m > handle->max_m || mat_n > handle->max_n) {
      printf("libsmm_acc_benchmark_transpose: got handle with too few resources\n");
      exit(1);
  }
- if(handle->mode == tune){
+ if (handle->mode == tune) {
      printf("Tune mode not supported for benchmarking of transpose");
      exit(1);
  }

--- a/src/acc/libsmm_acc/libsmm_acc_init.cpp
+++ b/src/acc/libsmm_acc/libsmm_acc_init.cpp
@@ -8,6 +8,7 @@
  *------------------------------------------------------------------------------------------------*/
 
 #include "libsmm_acc_init.h"
+#include "../acc_libsmm.h"
 
 #if defined(_OPENMP)
 #include <omp.h>
@@ -17,21 +18,21 @@
 std::vector<ACC_BLAS(Handle_t)*> acc_blashandles;
 
 
-#if !defined(NO_DBCSR_TIMESET)
+#if defined(__DBCSR_ACC)
 //===========================================================================
-void timeset(const std::string& routine_name, int& handle){
+void timeset(const std::string& routine_name, int& handle) {
     const char* routine_name_ = routine_name.c_str();
     int routine_name_length  = routine_name.length();
     c_dbcsr_timeset(&routine_name_, &routine_name_length, &handle);
 }
 
-void timestop(int handle){
+void timestop(int handle) {
     c_dbcsr_timestop(&handle);
 }
 #endif
 
 //===========================================================================
-int libsmm_acc_gpu_blas_init(){
+int libsmm_acc_gpu_blas_init() {
     // allocate memory for acc_blas handles
 #if defined _OPENMP
     int nthreads = omp_get_num_threads();
@@ -42,7 +43,7 @@ int libsmm_acc_gpu_blas_init(){
 
     // initialize acc_blas and store acc_blas handles
     // one handle per thread!
-    for(int i = 0; i < nthreads; i++){
+    for (int i = 0; i < nthreads; i++) {
         ACC_BLAS(Handle_t)* c_handle;
         acc_blas_create(&c_handle);
         acc_blashandles[i] = c_handle;
@@ -51,10 +52,9 @@ int libsmm_acc_gpu_blas_init(){
     return 0;
 }
 
-
 //===========================================================================
 extern "C" int libsmm_acc_init() {
-#if !defined(NO_DBCSR_TIMESET)
+#if defined(__DBCSR_ACC)
     std::string routineN = "libsmm_acc_init";
     int handle;
     timeset(routineN, handle);
@@ -62,16 +62,15 @@ extern "C" int libsmm_acc_init() {
     // check warp size consistency
     libsmm_acc_check_gpu_warp_size_consistency();
     libsmm_acc_gpu_blas_init();
-#if !defined(NO_DBCSR_TIMESET)
+#if defined(__DBCSR_ACC)
     timestop(handle);
 #endif
     return 0;
 }
 
-
 //===========================================================================
 extern "C" int libsmm_acc_finalize() {
-#if !defined(NO_DBCSR_TIMESET)
+#if defined(__DBCSR_ACC)
     std::string routineN = "libsmm_acc_finalize";
     int handle;
     timeset(routineN, handle);
@@ -85,21 +84,20 @@ extern "C" int libsmm_acc_finalize() {
 
     // free acc_blas handle resources
     // one handle per thread!
-    for(int i = 0; i < nthreads; i++){
+    for (int i = 0; i < nthreads; i++) {
         acc_blas_destroy(acc_blashandles[i]);
     }
-#if !defined(NO_DBCSR_TIMESET)
+#if defined(__DBCSR_ACC)
     timestop(handle);
 #endif
     return 0;
 }
 
-
 //===========================================================================
 int libsmm_acc_check_gpu_warp_size_consistency() {
     int acc_warp_size = acc_get_gpu_warp_size();
     extern const int warp_size;
-    if (warp_size != acc_warp_size){
+    if (warp_size != acc_warp_size) {
         printf("Inconsistency in warp sizes: Cuda/Hip indicates warp size = %d, while the gpu_properties files indicates warp_size = %d.\nPlease check whether src/acc/libsmm_acc/kernels/gpu_properties.json contains the correct data about the GPU you are using.", warp_size, acc_warp_size);
     }
     return 0;

--- a/src/acc/libsmm_acc/libsmm_acc_init.h
+++ b/src/acc/libsmm_acc/libsmm_acc_init.h
@@ -15,11 +15,8 @@
 #include <vector>
 #include <string>
 
-#if !defined(NO_DBCSR_TIMESET)
-extern "C" void c_dbcsr_timeset(const char** routineN, int* routineN_len, int* handle);
+#if defined(__DBCSR_ACC)
 void timeset(const std::string& routine_name, int& handle);
-
-extern "C" void c_dbcsr_timestop(int* handle);
 void timestop(int handle);
 #endif
 

--- a/src/acc/libsmm_acc/parameters_utils.h
+++ b/src/acc/libsmm_acc/parameters_utils.h
@@ -36,7 +36,7 @@ namespace std
 
 inline void get_libsmm_acc_triplets(std::vector<Triplet>& v, std::unordered_map<Triplet, KernelParameters> const& ht)
 {
-    for(auto it = ht.begin(); it != ht.end(); ++it)
+    for (auto it = ht.begin(); it != ht.end(); ++it)
         v.push_back(it->first);
 }
 

--- a/src/acc/libsmm_acc/tune/tune_setup.py
+++ b/src/acc/libsmm_acc/tune/tune_setup.py
@@ -214,7 +214,7 @@ def gen_benchmark(outdir, gpu_properties, autotuning_properties, compiler, m, n,
             )
 
         output += "\n"
-        output += "int main(int argc, char** argv){\n"
+        output += "int main(int argc, char** argv) {\n"
         if compiler == "nvcc":
             output += (
                 indent

--- a/tests/dbcsr_tensor_test.cpp
+++ b/tests/dbcsr_tensor_test.cpp
@@ -42,7 +42,7 @@ std::vector<int> random_dist(int dist_size, int nbins)
 
     std::vector<int> dist(dist_size);
 
-    for(int i=0; i < dist_size; i++)
+    for (int i=0; i < dist_size; i++)
         dist[i] = i % nbins;
 
     return dist;

--- a/tests/dbcsr_test.cpp
+++ b/tests/dbcsr_test.cpp
@@ -27,7 +27,7 @@ std::vector<int> random_dist(int dist_size, int nbins)
 
     std::vector<int> dist(dist_size);
 
-    for(int i=0; i < dist_size; i++)
+    for (int i=0; i < dist_size; i++)
         dist[i] = i % nbins;
 
     return dist;
@@ -139,7 +139,7 @@ int main(int argc, char* argv[])
                     double* blk = nullptr;
                     c_dbcsr_iterator_next_2d_block_d(iter, &i, &j, &blk, &tr, &nblk, &rsize, &csize, &roff, &coff);
 
-                    std::generate(blk, blk + rsize*csize, [&](){ return static_cast<double>(std::rand())/RAND_MAX; });
+                    std::generate(blk, blk + rsize*csize, [&]() { return static_cast<double>(std::rand())/RAND_MAX; });
 
         }
 

--- a/tests/libsmm_acc_timer_multiply.cpp.template
+++ b/tests/libsmm_acc_timer_multiply.cpp.template
@@ -15,13 +15,13 @@
 #include "libsmm_acc_benchmark.h"
 #include "libsmm_acc.h"
 
-std::vector<Triplet> combinations(std::vector<int> to_combine){
+std::vector<Triplet> combinations(std::vector<int> to_combine) {
 
     std::vector<Triplet> v;
     size_t len = to_combine.size();
-    for(size_t i=0; i<len; i++){
-        for(size_t j=0; j<len; j++){
-            for(size_t k=0; k<len; k++){
+    for (size_t i=0; i<len; i++) {
+        for (size_t j=0; j<len; j++) {
+            for (size_t k=0; k<len; k++) {
                 v.push_back({to_combine[i], to_combine[j], to_combine[k]});
             }
         }
@@ -36,9 +36,9 @@ std::vector<Triplet> combinations(std::vector<int> to_combine){
            0 otherwise
   \****************************************************************************/
 
-int main(int argc, char* argv[]){
+int main(int argc, char* argv[]) {
 
-    if(argc < 2){
+    if (argc < 2) {
         printf("Usage: %s <autotuned|predicted>\n", argv[0]);
         return -1;
     }
@@ -46,13 +46,13 @@ int main(int argc, char* argv[]){
     printf("Time kernels: %s\n", argv[1]);
 
     std::vector<Triplet> libsmm_acc_triplets;
-    if(argv[1] == std::string("autotuned")){
+    if (argv[1] == std::string("autotuned")) {
 
         libsmm_acc_triplets = {
             [[AUTOTUNED_KERNELS_HERE]]
         };
 
-    } else if(argv[1] == std::string("predicted")){
+    } else if (argv[1] == std::string("predicted")) {
 
         libsmm_acc_triplets = {
             [[PREDICTED_KERNELS_HERE]]
@@ -76,7 +76,7 @@ int main(int argc, char* argv[]){
     int errors = 0;
     libsmm_acc_benchmark_t* handle;
 
-    for(int i=0; i<n_triplets; i++){
+    for (int i=0; i<n_triplets; i++) {
         printf("\n\n");
         int m = libsmm_acc_triplets[i][0];
         int n = libsmm_acc_triplets[i][1];

--- a/tests/libsmm_acc_unittest_multiply.cpp.template
+++ b/tests/libsmm_acc_unittest_multiply.cpp.template
@@ -19,7 +19,7 @@
  \brief Checks correctness of randomly selected libsmm_acc multiplication kernels
 \****************************************************************************/
 
-int main(int argc, char** argv){
+int main(int argc, char** argv) {
 
     KernelLauncher launcher_mm = libsmm_acc_process_d;
 
@@ -34,7 +34,7 @@ int main(int argc, char** argv){
     printf("# libsmm_acc has %d blocksizes for multiplication\n", n_triplets);
 
     int max_m=0, max_n=0, max_k=0;
-    for(int i=0; i<n_triplets; i++){
+    for (int i=0; i<n_triplets; i++) {
         max_m = std::max(max_n, libsmm_acc_triplets[i][0]);
         max_n = std::max(max_m, libsmm_acc_triplets[i][1]);
         max_k = std::max(max_k, libsmm_acc_triplets[i][2]);
@@ -44,7 +44,7 @@ int main(int argc, char** argv){
     libsmm_acc_benchmark_init(&handle, test, max_m, max_n, max_k);
 
     int errors = 0;
-    for(int i=0; i<n_triplets; i++){
+    for (int i=0; i<n_triplets; i++) {
         int m = libsmm_acc_triplets[i][0];
         int n = libsmm_acc_triplets[i][1];
         int k = libsmm_acc_triplets[i][2];

--- a/tests/libsmm_acc_unittest_transpose.cpp
+++ b/tests/libsmm_acc_unittest_transpose.cpp
@@ -21,7 +21,7 @@
  \brief Checks correctness of all libsmm transpose kernels
 \****************************************************************************/
 
-int main(int argc, char** argv){
+int main(int argc, char** argv) {
 
     TransposeLauncher launcher_tr = libsmm_acc_transpose_d;
 
@@ -35,7 +35,7 @@ int main(int argc, char** argv){
     int n_triplets = libsmm_acc_triplets.size();
 
     int max_m=0, max_n=0, max_k=0;
-    for(int i=0; i<n_triplets; i++){
+    for (int i=0; i<n_triplets; i++) {
         max_m = std::max(max_n, libsmm_acc_triplets[i][0]);
         max_n = std::max(max_m, libsmm_acc_triplets[i][1]);
         max_k = std::max(max_k, libsmm_acc_triplets[i][2]);
@@ -46,7 +46,7 @@ int main(int argc, char** argv){
 
     // Get (m,n) pairs to test transposition
     std::vector<std::pair<int,int> > libsmm_acc_transpose_pairs;
-    for(int i=0; i<n_triplets; i++){
+    for (int i=0; i<n_triplets; i++) {
         int m = libsmm_acc_triplets[i][0];
         int n = libsmm_acc_triplets[i][1];
         int k = libsmm_acc_triplets[i][2];
@@ -64,8 +64,8 @@ int main(int argc, char** argv){
 
     // Sort (m,n) pairs in growing order
     std::sort(libsmm_acc_transpose_pairs.begin(), libsmm_acc_transpose_pairs.end(),
-              [](std::pair<int, int> mn1, std::pair<int, int> mn2){
-                  if(mn1.first != mn2.first){
+              [](std::pair<int, int> mn1, std::pair<int, int> mn2) {
+                  if (mn1.first != mn2.first) {
                       return mn1.first < mn2.first;
                   } else {
                       return mn1.second < mn2.second;
@@ -73,7 +73,7 @@ int main(int argc, char** argv){
               });
 
     int errors = 0;
-    for(int i=0; i<n_pairs; i++){
+    for (int i=0; i<n_pairs; i++) {
         int m = libsmm_acc_transpose_pairs[i].first;
         int n = libsmm_acc_transpose_pairs[i].second;
         sprintf(buffer, "%d x %d", m, n);


### PR DESCRIPTION
* Replaced !defined(NO_DBCSR_TIMESET) with defined(__DBCSR_ACC).
* Ensure l-value (libsmm_acc_transpose_routine_name_ptr).
* Prepared DBCSR perflog in OpenCL based LIBSMM (JIT).
* Const-correct prototype functions (c_dbcsr_time*).

Other:
* Normalized format of C++ code.