### PR TITLE
ocl: DBCSR perflog (JIT timing) for OpenCL based LIBSMM

### DIFF
--- a/docs/guide/2-user-guide/4-gpu/index.md
+++ b/docs/guide/2-user-guide/4-gpu/index.md
@@ -29,20 +29,20 @@ cd ${HOME}/dbcsr/src/acc/opencl/smm
 ./tune_multiply.py 23 23 23
 ```
 
-The above process would also terminate at some point (based on OpenTuner's default) but can be constrained also by the number of steps (experiments), time to be spent, or a combination of both. Details can be found in the [Developer Guide](../../3-developer-guide/3-programming/2-accelerator-backend/4-opencl-libsmm.html).
+Beside of interactive termination, above process would also terminate based on OpenTuner's default or can be constrained by the number of steps (experiments), time to be spent, or a combination of both. Details can be found in the [Developer Guide](../../3-developer-guide/3-programming/2-accelerator-backend/4-opencl-libsmm.html).
 
-Finally, suppose the 23x23x23-kernel was tuned for some time (e.g., 5-10 minutes), the found parameters can be incorporated into the backend. The aggregated parameters (`tune_multiply.csv`) are automatically embedded when rebuilding the library and driver.
+Suppose the 23x23x23-kernel was tuned for some time (e.g., 5-10 minutes), tuned parameters can be incorporated into the backend. The aggregated parameters (`tune_multiply.csv`) are automatically embedded when rebuilding the library and driver.
 
 ```bash
 cd ${HOME}/dbcsr/src/acc/opencl
 make
 ```
 
-Important kernels can be tuned further (beside of spending more time for tuning the kernel) by widening the set of tuned parameters (`--tuning-level` or `-a` with "0" denoting an unrestricted set of tunables).
+Important kernels can be further tuned (in addition to spending more time for the process) by widening the set of tuned parameters (`--tuning-level` or `-a` with "0" denoting an unrestricted set of tunables).
 
 ```bash
 cd ${HOME}/dbcsr/src/acc/opencl/smm
 ./tune_multiply.py 23 23 23 -a 0
 ```
 
-Please note, to tune *further*, the previously found parameters should be embedded (rebuilding the driver) or specified at runtime (`OPENCL_LIBSMM_SMM_PARAMS=/path/to/tune_multiply.csv`).
+To "continue" tuning beyond the default level, the previously found parameters must be embedded (rebuilding the driver) or can be specified at runtime (`OPENCL_LIBSMM_SMM_PARAMS=/path/to/tune_multiply.csv`).

--- a/docs/guide/3-developer-guide/4-performance/2-just-in-time-compilation.md
+++ b/docs/guide/3-developer-guide/4-performance/2-just-in-time-compilation.md
@@ -1,11 +1,11 @@
-title: Just-In-Time Compilation
+title: JIT
 
 # Just-In-Time (JIT) Compilation
 
-DBCSR's GPU backends rely on templated kernels for batched matrix multiplication and matrix transpose. If DBCSR were to compile kernels for all possible `m, n, k`s (or, in the case of the transpose, for all possible `m, n`s) ahead-of-time (AOT), it would bloat the library and the compilation time would require to account for a large but still limited set of kernels.
+DBCSR's GPU backends rely on templated kernels for batched matrix multiplication and matrix transpose (CUDA/HIP as well as OpenCL backend). If DBCSR were to compile kernels for all possible triplets or MxNxKs (in the case of transposes, for all possible MxNs) ahead-of-time (AOT), it would not only bloat the size of the library but also take a long time to compile the code. Reducing the number of triplets to a "practical set" would either sacrifice performance or limit potential acceleration to certain workloads.
 
-Instead, kernels are JIT-ed on the fly, at runtime, as they are requested by the application and workload. For `libsmm_acc`, the JIT infrastructure is based on the CUDA library [NVRTC](https://docs.nvidia.com/cuda/nvrtc/), a runtime compilation library for CUDA C++. For OpenCL based LIBSMM, the JIT compilation relies on the OpenCL runtime library.
+Instead, kernels are generated Just-In-Time (JIT) or "on the fly", i.e., at runtime, as they are requested by the application and workload. For LIBXSMM_ACC, the JIT infrastructure is based on [CUDA NVRTC](https://docs.nvidia.com/cuda/nvrtc/), a runtime compilation library for CUDA C++. The OpenCL based LIBSMM relies on the OpenCL runtime library to perform JIT compilation.
 
-No matter which runtime is used and whether JIT compilation is in the order of ~500ms per kernel or longer, the compilation time becomes significant during the process of auto-tuning a set of kernels. Therefore extra documentation is provided in either case on how to collect tuned parameters and eventually submit them for reuse.
+No matter which runtime is used and whether JIT compilation is in the order of ~500ms per kernel or not, the compilation time becomes significant during the process of auto-tuning a set of kernels. Therefore extra documentation is provided in either case (CUDA/HIP or OpenCL) on how to collect tuned parameters or to eventually submit a set of tuned parameters for the benefit of others.
 
-For performance debugging of the CUDA/HIP based GPU-support (and in order to check how much time a program spends doing JIT), look at `jit_kernel_multiply` and `jit_kernel_transpose` of the [timings report](1-insights.html) at the end of the output file. For the OpenCL based GPU-support, the [Runtime Settings](../../3-developer-guide/3-programming/2-accelerator-backend/3-opencl-backend.html) (`ACC_OPENCL_VERBOSE`) can be used to collect the time needed for JIT compilation.
+To check how much time a program spends for JIT compilation, GPU-backends contribute `jit_kernel_multiply` and `jit_kernel_transpose` entries to the [timings report](1-insights.html). This report appears when the application terminates (final output). The OpenCL backend supports additional [Runtime Settings](../../3-developer-guide/3-programming/2-accelerator-backend/3-opencl-backend.html), e.g., to report compilation time on a per-kernel basis (`ACC_OPENCL_VERBOSE=2`).

--- a/src/acc/opencl/acc_opencl.sh
+++ b/src/acc/opencl/acc_opencl.sh
@@ -80,7 +80,7 @@ if [ "${BASENAME}" ] && [ "${SED}" ] && [ "${RM}" ]; then
               -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/  "/' -e 's/$/\\n" \\/' \
               >>"${OFILE}"
             echo "  \"\"" >>"${OFILE}"
-            echo "const char ${VNAME}[] = ${SNAME};" >>"${OFILE}"
+            echo "static const char ${VNAME}[] = ${SNAME};" >>"${OFILE}"
             NFILES_OCL=$((NFILES_OCL+1))
           else
             >&2 echo "ERROR: ${IFILE} does not exist!"
@@ -121,7 +121,7 @@ if [ "${BASENAME}" ] && [ "${SED}" ] && [ "${RM}" ]; then
               ${SED} "1d;s/^/  \"/;s/[\r]*$/\\\n\" \\\/" "${IFILE}" >>"${OFILE}"
             fi
             echo "  \"\"" >>"${OFILE}"
-            echo "const char ${VNAME}[] = ${SNAME};" >>"${OFILE}"
+            echo "static const char ${VNAME}[] = ${SNAME};" >>"${OFILE}"
             NFILES_CSV=$((NFILES_CSV+1))
           fi
         else


### PR DESCRIPTION
* Doc: account for timing report now supported by the OpenCL backend.
* Doc: improved spelling and inline-format of certain terms.

Other:
* Allow to potentially include opencl_kernels.h multiple times.