### PR TITLE
ocl: improved scripts for auto/bulk-tuning kernels

### DIFF
--- a/src/acc/opencl/smm/README.md
+++ b/src/acc/opencl/smm/README.md
@@ -150,7 +150,7 @@ This triplet specification expands to 55 kernels using the Cartesian product wit
 
 ```bash
 cd src/acc/opencl/smm
-./tune_multiply.sh 300  8 1  4 10 15, 6 7 8, 23
+./tune_multiply.sh -t 300  -j 8 -i 1  4 10 15, 6 7 8, 23
 ```
 
-The script `tune_multiply.sh` is tuning 1266 kernels by default (`./tune_multiply.sh 300 8 1` taking approximately 13 hours per part). If the process is interrupted earlier (per SIGINT or Ctrl-C), the execution terminates for all requested kernels (triplet specification) unless an environment variable `CONTINUE=1` is set (proceeds to the next kernel).
+The script `tune_multiply.sh` is tuning 1266 kernels by default (`./tune_multiply.sh -t 300 -j 8 -i 1` takes approximately 13 hours per part). If the process is interrupted earlier (per SIGINT or Ctrl-C), the execution terminates for all requested kernels (triplet specification) unless `--continue` is given (or `-c`, or an environment variable `CONTINUE=1`).

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -175,11 +175,9 @@ class SmmTuner(MeasurementInterface):
             exit(0)
         elif self.typename and self.typeid and self.device:
             # construct label used for the database session
-            if not self.args.label:
-                self.args.label = "multiply-{}-{}{}".format(
-                    "{}x{}x{}".format(self.args.m, self.args.n, self.args.k),
-                    self.typename,
-                    " " + self.device if "" != self.device else "",
+            if not self.args.label:  # consider to include self.device
+                self.args.label = "tune_multiply-{}-{}x{}x{}".format(
+                    self.typename, self.args.m, self.args.n, self.args.k
                 )
         else:
             sys.tracebacklimit = 0
@@ -406,12 +404,9 @@ class SmmTuner(MeasurementInterface):
                 if final
                 else None
             )
-            basename = "tune_multiply-{}-{}x{}x{}".format(
-                self.typename, self.args.m, self.args.n, self.args.k
-            )
             # self.manipulator().save_to_file(config, filename)
             with open(
-                os.path.join(self.args.jsondir, ".{}.json".format(basename)), "w"
+                os.path.join(self.args.jsondir, ".{}.json".format(self.args.label)), "w"
             ) as file:
                 json.dump(config, file, sort_keys=True)
                 file.write("\n")  # append newline at EOF
@@ -425,11 +420,11 @@ class SmmTuner(MeasurementInterface):
                 filename = os.path.normpath(
                     os.path.join(
                         self.args.jsondir,
-                        "{}-{}gflops.json".format(basename, round(self.gflops)),
+                        "{}-{}gflops.json".format(self.args.label, round(self.gflops)),
                     )
                 )
                 os.rename(
-                    os.path.join(self.args.jsondir, ".{}.json".format(basename)),
+                    os.path.join(self.args.jsondir, ".{}.json".format(self.args.label)),
                     filename,
                 )
                 if filename not in filenames:

--- a/src/acc/opencl/smm/tune_multiply.sh
+++ b/src/acc/opencl/smm/tune_multiply.sh
@@ -9,6 +9,7 @@
 ####################################################################################################
 
 HERE=$(cd "$(dirname "$0")" && pwd -P)
+SORT=$(command -v sort)
 SED=$(command -v gsed)
 LS=$(command -v ls)
 RM=$(command -v rm)
@@ -16,48 +17,112 @@ WC=$(command -v wc)
 DELAY=12
 
 # GNU sed is desired (macOS)
-if [ "" = "${SED}" ]; then
+if [ ! "${SED}" ]; then
   SED=$(command -v sed)
 fi
 
-if [ "$1" ]; then
-  LIMIT=$1
-  shift
-fi
-if [ "$1" ]; then
-  NPARTS=$1
-  shift
-else
-  NPARTS=1
-fi
-if [ "$1" ]; then
-  PART=$1
-  shift
-else
-  PART=1
-fi
-
-if [ "0" != "$((NPARTS<PART))" ]; then
-  >&2 echo "ERROR: part-number ${PART} is larger than the requested ${NPARTS} parts!"
-  exit 1
-fi
-
-if [ "${SED}" ] && [ "${LS}" ] && [ "${RM}" ] && [ "${WC}" ]; then
-  echo "Usage: $0 [seconds-per-kernel [num-parts [part [<triplet-spec>]]]]"
-  echo "       num-parts and part (one-based), e.g., 12 3"
-  echo "         for this session being the 3rd of 12 sessions"
-  echo "       <triplet-spec>, e.g., 134 kernels"
-  echo "         23, 5 32 13 24 26, 4 9"
-  echo
-  if [ "$1" ]; then
-    MNKS=$(eval "${HERE}/../../acc_triplets.sh $@")
+if [ "${SORT}" ] && [ "${SED}" ] && [ "${LS}" ] && [ "${RM}" ] && [ "${WC}" ]; then
+  while test $# -gt 0; do
+    case "$1" in
+    -h|--help)
+      HELP=1
+      shift $#;;
+    -c|--continue)
+      CONTINUE=1
+      shift 1;;
+    -u|--update)
+      UPDATE=1
+      shift 1;;
+    -a|--tuning-level)
+      TLEVEL=$2
+      shift 2;;
+    -t|--maxtime)
+      MAXTIME=$2
+      shift 2;;
+    -p|--jsondir)
+      JSONDIR=$2
+      shift 2;;
+    -s|--specid)
+      SPECID=$2
+      shift 2;;
+    -m|--limit)
+      MAXEXT=$2
+      shift 2;;
+    -n|--size)
+      MAXNUM=$2
+      shift 2;;
+    -r|--bound)
+      BOUNDL=$2
+      BOUNDU=$3
+      shift 3;;
+    -i|--part)
+      PART=$2
+      shift 2;;
+    -j|--nparts)
+      NPARTS=$2
+      shift 2;;
+    *)
+      break;;
+    esac
+  done
+  if [ ! "${HELP}" ] || [ "0" = "${HELP}" ]; then
+    ECHO=">&2 echo"
   else
-    if [ "" != "${MAXEXT}" ]; then MAXEXT="-m ${MAXEXT}"; fi
-    if [ "" != "${MAXNUM}" ]; then MAXNUM="-n ${MAXNUM}"; fi
-    if [ "" == "${SPECID}" ]; then SPECID=10; fi
-    MNKS=$(eval "${HERE}/../../acc_triplets.sh -s ${SPECID} ${MAXEXT} ${MAXNUM}")
+    ECHO="echo"
+  fi
+  eval "${ECHO} \"Usage: $0 [options] [<triplet-spec>]\""
+  eval "${ECHO} \"       Options must precede triplet specification\""
+  eval "${ECHO} \"       -c|--continue: proceed with plan if tuning is interrupted\""
+  eval "${ECHO} \"       -u|--update: retune all JSONs found in directory (see -p)\""
+  eval "${ECHO} \"       -a|--tuning-level N=0..3: all, most, some, least tunables\""
+  eval "${ECHO} \"       -t|--maxtime N: number of seconds spent per kernel\""
+  eval "${ECHO} \"       -p|--jsondir P: path to JSON-files (tuned params)\""
+  eval "${ECHO} \"       -i|--part N (1-based): Nth session out of nparts\""
+  eval "${ECHO} \"       -j|--nparts N: number of total sessions (see -i)\""
+  eval "${ECHO} \"       -r|--bound L U: limit L**3 < MNK <= U**3\""
+  eval "${ECHO} \"       -m|--limit N: limit shape extents to N\""
+  eval "${ECHO} \"       -n|--size  N: limit number of elements\""
+  eval "${ECHO} \"       -s|--specid N: predefined triplets\""
+  eval "${ECHO} \"        0-10: older to newer (larger), e.g.,\""
+  eval "${ECHO} \"       -s  0:  201 kernels\""
+  eval "${ECHO} \"       -s 10: 1266 kernels\""
+  eval "${ECHO} \"       <triplet-spec>, e.g., 134 kernels\""
+  eval "${ECHO} \"         23, 5 32 13 24 26, 4 9\""
+  eval "${ECHO}"
+  # default settings
+  if [ ! "${JSONDIR}" ]; then JSONDIR=.; fi
+  if [ ! "${TLEVEL}" ]; then TLEVEL=-1; fi
+  if [ ! "${MAXEXT}" ]; then MAXEXT=0; fi
+  if [ ! "${MAXNUM}" ]; then MAXNUM=0; fi
+  if [ ! "${BOUNDL}" ]; then BOUNDL=0; fi
+  if [ ! "${BOUNDU}" ]; then BOUNDU=0; fi
+  if [ ! "${NPARTS}" ]; then NPARTS=1; fi
+  if [ ! "${PART}" ]; then PART=1; fi
+  # sanity checks
+  if [ "0" != "$((NPARTS<PART))" ]; then
+    >&2 echo "ERROR: part-number ${PART} is larger than the requested ${NPARTS} parts!"
+    exit 1
+  fi
+  JSONS=$(${LS} -1 ${JSONDIR}/tune_multiply-*-*x*x*-*gflops.json 2>/dev/null)
+  if [ "${SPECID}" ] && [ "$1" ]; then
+    >&2 echo "ERROR: --specid and <triplet-spec> are mutual exclusive!"
+    exit 1
+  elif [ "${UPDATE}" ] && [ "0" != "${UPDATE}" ]; then
+    if [ ! "${TLEVEL}" ] || [ "0" != "$((0>TLEVEL))" ]; then TLEVEL=0; fi
+    if [ ! "${MAXTIME}" ]; then MAXTIME=320; fi
+    MNKS=$(echo "${JSONS}" | ${SED} -n "s/.*tune_multiply-..*-\(..*x..*x..*\)-[0-9][0-9]*gflops.json/\1/p" \
+       | ${SORT} -u -n -tx -k1 -k2 -k3)
+  elif [ "${SPECID}" ]; then
+    MNKS=$(eval "${HERE}/../../acc_triplets.sh -r ${BOUNDL} ${BOUNDU} -m ${MAXEXT} -n ${MAXNUM} -s ${SPECID} 2>/dev/null")
+  else
+    MNKS=$(eval "${HERE}/../../acc_triplets.sh -r ${BOUNDL} ${BOUNDU} -m ${MAXEXT} -n ${MAXNUM} $* 2>/dev/null")
   fi
   NTRIPLETS=$(echo "${MNKS}" | wc -w)
+  if [ "0" != "$((0==NTRIPLETS))" ]; then
+    if [ "${HELP}" ] || [ "0" = "${HELP}" ]; then exit 0; fi
+    >&2 echo "ERROR: invalid or no <triplet-spec> given!"
+    exit 1
+  fi
   PARTSIZE=$(((NTRIPLETS+NPARTS-1)/NPARTS))
   PARTOFFS=$(((PART-1)*PARTSIZE))
   PARTSIZE=$((PARTSIZE<=(NTRIPLETS-PARTOFFS)?PARTSIZE:(NTRIPLETS-PARTOFFS)))
@@ -66,17 +131,20 @@ if [ "${SED}" ] && [ "${LS}" ] && [ "${RM}" ] && [ "${WC}" ]; then
   else
     echo "Session ${PART} of ${NPARTS} part(s). The problem is over-decomposed!"
   fi
-  if [ "${LIMIT}" ]; then
-    HRS=$((LIMIT*PARTSIZE/3600))
-    MNS=$(((LIMIT*PARTSIZE-HRS*3600+59)/60))
-    echo "Tuning ${PARTSIZE} kernels in this session will take about ${HRS}h${MNS}m."
-    LIMIT="--stop-after=${LIMIT}"
+  if [ "${MAXTIME}" ] && [ "0" != "$((0<MAXTIME))" ]; then
+    HRS=$((MAXTIME*PARTSIZE/3600))
+    MNS=$(((MAXTIME*PARTSIZE-HRS*3600+59)/60))
+    echo "Tuning ${PARTSIZE} kernels in this session will take about" \
+         "${MAXTIME}s per kernel and ${HRS}h${MNS}m in total."
+    MAXTIME="--stop-after=${MAXTIME}"
   else
     echo "Tuning ${PARTSIZE} kernels will take an unknown time (no limit given)."
   fi
-  NJSONS=$(${LS} -1 ./*.json 2>/dev/null | ${WC} -l)
+  NJSONS=$(echo "${JSONS}" | ${WC} -l)
   if [ "0" != "${NJSONS}" ]; then
-    echo "Already found ${NJSONS} (unrelated?) JSON-files."
+    if [ ! "${UPDATE}" ] || [ "0" = "${UPDATE}" ]; then
+      echo "Already found ${NJSONS} (unrelated?) JSON-files."
+    fi
   elif [ -e tune_multiply.csv ]; then
     echo "No JSON file found but (unrelated?) tune_multiply.csv exists."
   fi
@@ -94,7 +162,7 @@ if [ "${SED}" ] && [ "${LS}" ] && [ "${RM}" ] && [ "${WC}" ]; then
       echo "Started auto-tuning ${MNK}-kernel..."
       # avoid mixing database of previous results into new session
       ${RM} -rf "${HERE}/opentuner.db"
-      eval "${HERE}/tune_multiply.py ${TRIPLET} --no-dups ${LIMIT}"
+      eval "${HERE}/tune_multiply.py ${TRIPLET} -p ${JSONDIR} -a ${TLEVEL} ${MAXTIME}"
       RESULT=$?
       # environment var. CONTINUE allows to proceed with next kernel
       # even if tune_multiply.py returned non-zero exit code


### PR DESCRIPTION
tune_multiply.sh
* Introduced command-line flags/options and avoid positional/non-optional arguments.
* Handle if no triplet spec given; improved error/help message.
* Introduced directory arguments for JSON-files.
* Introduced option to set tuning-level.
* Implemented update-mode.

acc_triplets.sh
* Handle if no triplet spec given; improved error/help message.
* Improved checking arguments and compliance with Shellcheck.

Other
* Cleanup (tune_multiply.py).
* Updated documentation.