### PR TITLE
cleanup configuration related to #499

### DIFF
--- a/src/core/dbcsr_config.F
+++ b/src/core/dbcsr_config.F
@@ -204,10 +204,10 @@ CONTAINS
       dbcsr_cfg%accdrv_streams = nthreads
       dbcsr_cfg%accdrv_buffers = nthreads*4
       IF (PRESENT(accdrv_priority_streams)) THEN
-        IF (0 < accdrv_priority_streams) dbcsr_cfg%accdrv_streams = accdrv_priority_streams
+         IF (0 < accdrv_priority_streams) dbcsr_cfg%accdrv_streams = accdrv_priority_streams
       ENDIF
       IF (PRESENT(accdrv_priority_buffers)) THEN
-        IF (0 < accdrv_priority_buffers) dbcsr_cfg%accdrv_buffers = accdrv_priority_buffers
+         IF (0 < accdrv_priority_buffers) dbcsr_cfg%accdrv_buffers = accdrv_priority_buffers
       ENDIF
 #else
       MARK_USED(accdrv_priority_streams)

--- a/src/core/dbcsr_config.F
+++ b/src/core/dbcsr_config.F
@@ -97,16 +97,14 @@ MODULE dbcsr_config
       INTEGER  :: num_layers_3D = 1
       LOGICAL  :: use_comm_thread = .TRUE.
       INTEGER  :: comm_thread_load = 100
+      INTEGER  :: multrec_limit = 512
 #if defined (__DBCSR_ACC)
       LOGICAL  :: mm_densification = .FALSE.
 #else
       LOGICAL  :: mm_densification = .TRUE.
 #endif
-      INTEGER  :: multrec_limit = 512
-      INTEGER  :: accdrv_priority_streams = 4
-      INTEGER  :: accdrv_priority_buffers = 40
-      INTEGER  :: accdrv_posterior_streams = 4
-      INTEGER  :: accdrv_posterior_buffers = 80
+      INTEGER  :: accdrv_streams = 0 ! default unknown at compile-time
+      INTEGER  :: accdrv_buffers = 0 ! default unknown at compile-time
       LOGICAL  :: accdrv_avoid_after_busy = .FALSE.
       INTEGER  :: accdrv_min_flop_process = 0
       LOGICAL  :: accdrv_stack_sort = .TRUE.
@@ -191,6 +189,9 @@ CONTAINS
 
       INTEGER                                            :: nthreads
 
+      nthreads = 1
+!$    nthreads = OMP_GET_MAX_THREADS()
+
       IF (PRESENT(use_mpi_allocator)) dbcsr_data_allocation%use_mpi_allocator = use_mpi_allocator
       IF (PRESENT(avg_elements_images)) dbcsr_cfg%avg_elements_images = avg_elements_images
       IF (PRESENT(num_mult_images)) dbcsr_cfg%num_mult_images = num_mult_images
@@ -199,16 +200,21 @@ CONTAINS
       IF (PRESENT(use_comm_thread)) dbcsr_cfg%use_comm_thread = use_comm_thread
       IF (PRESENT(multrec_limit)) dbcsr_cfg%multrec_limit = multrec_limit
       IF (PRESENT(mm_densification)) dbcsr_cfg%mm_densification = mm_densification
-      IF (PRESENT(accdrv_priority_streams)) dbcsr_cfg%accdrv_priority_streams = accdrv_priority_streams
-      IF (PRESENT(accdrv_priority_buffers)) dbcsr_cfg%accdrv_priority_buffers = accdrv_priority_buffers
-#if defined(__DBCSR_ACC) && (defined(__HIP_PLATFORM_AMD__) || defined(__CUDA) || defined(__HIP_PLATFORM_NVCC__))
-      nthreads = 1
-!$    nthreads = OMP_GET_MAX_THREADS()
-      dbcsr_cfg%accdrv_priority_streams = nthreads
-      dbcsr_cfg%accdrv_priority_buffers = nthreads*4
+#if defined(__DBCSR_ACC)
+      dbcsr_cfg%accdrv_streams = nthreads
+      dbcsr_cfg%accdrv_buffers = nthreads*4
+      IF (PRESENT(accdrv_priority_streams)) THEN
+        IF (0 < accdrv_priority_streams) dbcsr_cfg%accdrv_streams = accdrv_priority_streams
+      ENDIF
+      IF (PRESENT(accdrv_priority_buffers)) THEN
+        IF (0 < accdrv_priority_buffers) dbcsr_cfg%accdrv_buffers = accdrv_priority_buffers
+      ENDIF
+#else
+      MARK_USED(accdrv_priority_streams)
+      MARK_USED(accdrv_priority_buffers)
 #endif
-      IF (PRESENT(accdrv_posterior_streams)) dbcsr_cfg%accdrv_posterior_streams = accdrv_posterior_streams
-      IF (PRESENT(accdrv_posterior_buffers)) dbcsr_cfg%accdrv_posterior_buffers = accdrv_posterior_buffers
+      MARK_USED(accdrv_posterior_streams)
+      MARK_USED(accdrv_posterior_buffers)
       IF (PRESENT(accdrv_avoid_after_busy)) dbcsr_cfg%accdrv_avoid_after_busy = accdrv_avoid_after_busy
       IF (PRESENT(accdrv_min_flop_process)) dbcsr_cfg%accdrv_min_flop_process = accdrv_min_flop_process
       IF (PRESENT(accdrv_stack_sort)) dbcsr_cfg%accdrv_stack_sort = accdrv_stack_sort
@@ -225,8 +231,6 @@ CONTAINS
             IF (dbcsr_cfg%use_mpi_rma) THEN
                dbcsr_cfg%comm_thread_load = 100
             ELSE
-               nthreads = 1
-!$             nthreads = OMP_GET_MAX_THREADS()
                dbcsr_cfg%comm_thread_load = MAX(0, 90 - (30*nthreads)/8)
             ENDIF
          ENDIF
@@ -323,10 +327,10 @@ CONTAINS
       IF (PRESENT(comm_thread_load)) comm_thread_load = default_cfg%comm_thread_load
       IF (PRESENT(mm_densification)) mm_densification = default_cfg%mm_densification
       IF (PRESENT(multrec_limit)) multrec_limit = default_cfg%multrec_limit
-      IF (PRESENT(accdrv_priority_streams)) accdrv_priority_streams = default_cfg%accdrv_priority_streams
-      IF (PRESENT(accdrv_priority_buffers)) accdrv_priority_buffers = default_cfg%accdrv_priority_buffers
-      IF (PRESENT(accdrv_posterior_streams)) accdrv_posterior_streams = default_cfg%accdrv_posterior_streams
-      IF (PRESENT(accdrv_posterior_buffers)) accdrv_posterior_buffers = default_cfg%accdrv_posterior_buffers
+      IF (PRESENT(accdrv_priority_streams)) accdrv_priority_streams = default_cfg%accdrv_streams
+      IF (PRESENT(accdrv_priority_buffers)) accdrv_priority_buffers = default_cfg%accdrv_buffers
+      IF (PRESENT(accdrv_posterior_streams)) accdrv_posterior_streams = 0
+      IF (PRESENT(accdrv_posterior_buffers)) accdrv_posterior_buffers = 0
       IF (PRESENT(accdrv_avoid_after_busy)) accdrv_avoid_after_busy = default_cfg%accdrv_avoid_after_busy
       IF (PRESENT(accdrv_min_flop_process)) accdrv_min_flop_process = default_cfg%accdrv_min_flop_process
       IF (PRESENT(accdrv_stack_sort)) accdrv_stack_sort = default_cfg%accdrv_stack_sort
@@ -451,13 +455,9 @@ CONTAINS
          WRITE (UNIT=unit_nr, FMT='(1X,A,T70,I11)') &
             "DBCSR| ACC: Number of devices/node", dbcsr_acc_get_ndevices()
          WRITE (UNIT=unit_nr, FMT='(1X,A,T70,I11)') &
-            "DBCSR| ACC: Number of priority stack-buffers", dbcsr_cfg%accdrv_priority_buffers
+            "DBCSR| ACC: Number of stack-buffers", dbcsr_cfg%accdrv_buffers
          WRITE (UNIT=unit_nr, FMT='(1X,A,T70,I11)') &
-            "DBCSR| ACC: Number of posterior stack-buffers", dbcsr_cfg%accdrv_posterior_buffers
-         WRITE (UNIT=unit_nr, FMT='(1X,A,T70,I11)') &
-            "DBCSR| ACC: Number of priority streams", dbcsr_cfg%accdrv_priority_streams
-         WRITE (UNIT=unit_nr, FMT='(1X,A,T70,I11)') &
-            "DBCSR| ACC: Number of posterior streams", dbcsr_cfg%accdrv_posterior_streams
+            "DBCSR| ACC: Number of streams", dbcsr_cfg%accdrv_streams
          WRITE (UNIT=unit_nr, FMT='(1X,A,T80,L1)') &
             "DBCSR| ACC: Avoid driver after busy ", dbcsr_cfg%accdrv_avoid_after_busy
          WRITE (UNIT=unit_nr, FMT='(1X,A,T80,L1)') &

--- a/src/mm/dbcsr_mm_accdrv.F
+++ b/src/mm/dbcsr_mm_accdrv.F
@@ -42,7 +42,7 @@ MODULE dbcsr_mm_accdrv
    USE dbcsr_config, ONLY: dbcsr_cfg, &
                            default_resize_factor
    !accdrv_binning_binsize, accdrv_binning_nbins, accdrv_min_flop_sort, &
-   !accdrv_priority_buffers, !accdrv_priority_streams, &
+   !accdrv_buffers, !accdrv_streams, &
    !default_resize_factor, mm_stack_size
    USE dbcsr_data_methods, ONLY: dbcsr_data_dev2host, &
                                  dbcsr_data_ensure_size, &
@@ -217,7 +217,7 @@ CONTAINS
 
 !$OMP MASTER
       CALL stream_array_force_size(priority_streams, "Calc (priority)", &
-                                   n=dbcsr_cfg%accdrv_priority_streams)
+                                   n=dbcsr_cfg%accdrv_streams)
 !$OMP END MASTER
 ! Other threads have to wait until streams are created
 !$OMP BARRIER
@@ -272,7 +272,7 @@ CONTAINS
       TYPE(dbcsr_mm_accdrv_type), INTENT(INOUT)          :: this
 
       INTEGER                                            :: i, ithread, &
-                                                            my_priority_buffers, my_total_buffers, &
+                                                            my_buffers, my_total_buffers, &
                                                             nthreads
       TYPE(thread_private_type), POINTER                 :: thread_privates
 
@@ -282,10 +282,10 @@ CONTAINS
 
       ! distribute total number of buffers approx. evenly among threads
       ! my_* variables hold number of buffers for current thread.
-      my_priority_buffers = CEILING(REAL(dbcsr_cfg%accdrv_priority_buffers)/REAL(nthreads), int_4)
+      my_buffers = CEILING(REAL(dbcsr_cfg%accdrv_buffers)/REAL(nthreads), int_4)
 
-      this%nbuffers_phaseout = my_priority_buffers
-      my_total_buffers = my_priority_buffers
+      this%nbuffers_phaseout = my_buffers
+      my_total_buffers = my_buffers
 
       IF (ASSOCIATED(thread_privates%stack_buffers)) THEN
          IF (SIZE(thread_privates%stack_buffers) /= my_total_buffers) &

--- a/src/mm/dbcsr_mm_sched.F
+++ b/src/mm/dbcsr_mm_sched.F
@@ -392,6 +392,7 @@ CONTAINS
 
       this%product_wm_orig_datasize = newsize
    END SUBROUTINE dbcsr_mm_sched_set_orig_datasize
+
    SUBROUTINE stats_add(stats, m, n, k, stacksize_cpu, stacksize_smm, stacksize_acc, &
                         nstacks_cpu, nstacks_smm, nstacks_acc)
       !! Helper-routine used by dbcsr_mm_sched_process to supply statistics.


### PR DESCRIPTION
* Arguments of dbcsr_set_config/dbcsr_get_config remain with terminology "posterior" and priority".
* Integration with CP2K to stay compatible.