### PR TITLE
ocl: revised auto-tuning script

### DIFF
--- a/docs/guide/2-user-guide/4-gpu/index.md
+++ b/docs/guide/2-user-guide/4-gpu/index.md
@@ -26,7 +26,7 @@ Tuning the 23x23x23-kernel for example is the default case. However, to better i
 
 ```bash
 cd ${HOME}/dbcsr/src/acc/opencl/smm
-./tune_multiply.py 23 23 23
+./tune_multiply.py 23x23x23
 ```
 
 Beside of interactive termination, above process would also terminate based on OpenTuner's default or can be constrained by the number of steps (experiments), time to be spent, or a combination of both. Details can be found in the [Developer Guide](../../3-developer-guide/3-programming/2-accelerator-backend/4-opencl-libsmm.html).
@@ -42,7 +42,7 @@ Important kernels can be further tuned (in addition to spending more time for th
 
 ```bash
 cd ${HOME}/dbcsr/src/acc/opencl/smm
-./tune_multiply.py 23 23 23 -a 0
+./tune_multiply.py 23x23x23 -a 0
 ```
 
 To "continue" tuning beyond the default level, the previously found parameters must be embedded (by rebuilding the library and driver program) or can be alternatively specified at runtime (`OPENCL_LIBSMM_SMM_PARAMS=/path/to/tune_multiply.csv`).

--- a/src/acc/opencl/smm/README.md
+++ b/src/acc/opencl/smm/README.md
@@ -86,7 +86,7 @@ pip install -r requirements.txt
 The OpenTuner script supports several command line arguments (`tune_multiply.py --help`). For example, `--stop-after=300` can be of interest to finish in five minutes (without limit, OpenTuner decides when the auto-tuning process is finished). A single kernel can be selected by M, N, and K parameters (GEMM), e.g., `M=15`, `N=5`, and `K=7`:
 
 ```bash
-./tune_multiply.py 13 5 7
+./tune_multiply.py 13x5x7
 ```
 
 **NOTE**: If multiple different kernels are tuned using `tune_multiply.py`, it is advisable to delete the `opentuner.db` directory prior to tuning a different kernel since otherwise auto-tuning is potentially (mis-)guided by information which was collected for a different kernel (`tune_multiply.sh` does this automatically).

--- a/src/acc/opencl/smm/opencl_libsmm.c
+++ b/src/acc/opencl/smm/opencl_libsmm.c
@@ -931,17 +931,17 @@ c_dbcsr_acc_bool_t libsmm_acc_process_suitable(
 #endif
     default: assert(0 == result);
   }
-#if defined(OPENCL_LIBSMM_SUITABLE)
   if ((0 == result) &&
       (2 <= c_dbcsr_acc_opencl_config.verbosity || 0 > c_dbcsr_acc_opencl_config.verbosity))
   {
     fprintf(stderr, "INFO ACC/OpenCL: %ix%ix%i %sSMM-kernel ss=%i", m_max, n_max, k_max,
       dbcsr_type_real_8 == datatype ? "D" : (dbcsr_type_real_4 == datatype ? "S" : ""),
       stack_size);
+#if defined(OPENCL_LIBSMM_SUITABLE)
     if (0 < hst && 0 < acc) fprintf(stderr, " hst=%.1f acc=%.1f GFLOPS/s", hst, acc);
+#endif
     fprintf(stderr, " not suitable%s", 0 != def_mnk ? "\n" : " (inhomogeneous)\n");
   }
-#endif
   return result;
 }
 

--- a/src/acc/opencl/smm/tune_multiply.sh
+++ b/src/acc/opencl/smm/tune_multiply.sh
@@ -157,12 +157,11 @@ if [ "${SORT}" ] && [ "${SED}" ] && [ "${LS}" ] && [ "${RM}" ] && [ "${WC}" ]; t
   N=0
   for MNK in ${MNKS}; do
     if [ "0" != "$((PARTOFFS<=N))" ]; then
-      TRIPLET=$(echo "${MNK}" | ${SED} "s/x/ /g")
       echo
       echo "Started auto-tuning ${MNK}-kernel..."
       # avoid mixing database of previous results into new session
       ${RM} -rf "${HERE}/opentuner.db"
-      eval "${HERE}/tune_multiply.py ${TRIPLET} -p ${JSONDIR} -a ${TLEVEL} ${MAXTIME}"
+      eval "${HERE}/tune_multiply.py ${MNK} -p ${JSONDIR} -a ${TLEVEL} ${MAXTIME}"
       RESULT=$?
       # environment var. CONTINUE allows to proceed with next kernel
       # even if tune_multiply.py returned non-zero exit code
@@ -177,6 +176,9 @@ if [ "${SORT}" ] && [ "${SED}" ] && [ "${LS}" ] && [ "${RM}" ] && [ "${WC}" ]; t
     fi
     N=$((N+1))
   done
+  if [ "${RESULT}" ]; then
+    ${RM} -rf "${HERE}/opentuner.db"
+  fi
 else
   >&2 echo "ERROR: missing prerequisites!"
   exit 1


### PR DESCRIPTION
* Parse MxNxK rather than "M N K" (tune_multiply.py).
* Updated documentation accordingly.
* Print failing configurations.

Other:
* Revised c_dbcsr_acc_event_query for clarity.
* Adjusted precondition of suitability-info.