### PR TITLE
fixed potentially inconsistent configuration

### DIFF
--- a/src/core/dbcsr_config.F
+++ b/src/core/dbcsr_config.F
@@ -317,6 +317,10 @@ CONTAINS
       TYPE(dbcsr_config_type)                            :: default_cfg
       TYPE(dbcsr_data_allocation_type)                   :: default_data_allocation
 
+      ! construct defaults which were unknown at compile-time (dbcsr_config_type)
+      ! assume dbcsr_cfg was initialized at runtime; copy dbcsr_cfg to default_cfg
+      default_cfg = dbcsr_cfg
+
       IF (PRESENT(use_mpi_allocator)) use_mpi_allocator = default_data_allocation%use_mpi_allocator
       IF (PRESENT(mm_stack_size)) mm_stack_size = default_cfg%mm_stack_size
       IF (PRESENT(avg_elements_images)) avg_elements_images = default_cfg%avg_elements_images

--- a/src/core/dbcsr_lib.F
+++ b/src/core/dbcsr_lib.F
@@ -13,7 +13,8 @@ MODULE dbcsr_lib
    USE dbcsr_acc_device, ONLY: dbcsr_acc_get_ndevices, dbcsr_acc_set_active_device
    USE dbcsr_config, ONLY: get_accdrv_active_device_id, &
                            set_accdrv_active_device_id, &
-                           reset_accdrv_active_device_id
+                           reset_accdrv_active_device_id, &
+                           dbcsr_set_config
    USE dbcsr_kinds, ONLY: int_1_size, &
                           int_2_size, &
                           int_4_size, &
@@ -176,6 +177,9 @@ CONTAINS
 #if defined(__DBCSR_ACC)
       INTEGER :: dbcsr_thread_safe, libsmm_acc_thread_safe
 #endif
+
+      ! construct defaults which were unknown at compile-time (dbcsr_config_type)
+      CALL dbcsr_set_config()
 
       CALL mp_environ(numnodes, mynode, mp_comm)
 


### PR DESCRIPTION
The type dbcsr_config_type is statically initialized. However, a number of properties are derived at runtime, e.g., accdrv_streams, accdrv_buffers, comm_thread_load, and mm_driver. Even DBCSR's unit tests never call dbcsr_set_config, which is abused to initialize value of aforementioned properties. Further, dbcsr_get_default_config also only relied on static initialization of dbcsr_config_type (rather than at least copying dbcsr_cfg).