### PR TITLE
ocl: revised backend to improve c_dbcsr_acc_device_synchronize

### DIFF
--- a/src/acc/opencl/README.md
+++ b/src/acc/opencl/README.md
@@ -30,10 +30,3 @@ Runtime settings are made by the means of environment variables. The OpenCL back
     * `ACC_OPENCL_DUMP=2`: dump compiled OpenCL kernels (depends on OpenCL implementation), e.g., PTX code on Nvidia.
 
 The OpenCL backend enumerates and orders devices by device-kind, i.e., GPU, CPU, and "other" (primary criterion) and by memory capacity (secondary criterion). Device IDs are zero-based as defined by the ACC interface (and less than what is permitted/returned by `acc_get_ndevices`).
-
-Other runtime settings include:
-
-* `ACC_OPENCL_ASYNC_MEMOPS`: Boolean value (zero or non-zero integer) for asynchronous data movements.
-* `ACC_OPENCL_SVM`: Boolean value (zero or non-zero integer) for Shared Virtual Memory (SVM).
-
-**Note**: some of the above runtime settings depend on compile-time settings to take effect.

--- a/src/acc/opencl/acc_opencl_stream.c
+++ b/src/acc/opencl/acc_opencl_stream.c
@@ -11,6 +11,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#if defined(_OPENMP)
+# include <omp.h>
+#endif
 
 #if defined(CL_VERSION_2_0)
 # define ACC_OPENCL_CREATE_COMMAND_QUEUE(CTX, DEV, PROPS, RESULT) \
@@ -35,87 +38,78 @@ extern "C" {
 int c_dbcsr_acc_opencl_stream_create(cl_command_queue* stream_p, const char* name,
   const ACC_OPENCL_COMMAND_QUEUE_PROPERTIES* properties)
 {
-  const cl_context context = c_dbcsr_acc_opencl_context(NULL);
-  cl_int result = EXIT_SUCCESS;
+  int tid, i;
+  const cl_context context = c_dbcsr_acc_opencl_context(&tid);
+  cl_int result = (NULL != context ? EXIT_SUCCESS : EXIT_FAILURE);
   assert(NULL != stream_p);
-  if (NULL != context) {
-    cl_device_id device_id = NULL;
-    result = c_dbcsr_acc_opencl_device(NULL/*stream*/, &device_id);
-    if (EXIT_SUCCESS == result) {
-      *stream_p = ACC_OPENCL_CREATE_COMMAND_QUEUE(context,
-        device_id, properties, &result);
-#if defined(ACC_OPENCL_STREAMS_MAXCOUNT)
-      if (EXIT_SUCCESS == result) {
-        int i;
-# if defined(_OPENMP)
-#   if (201107/*v3.1*/ <= _OPENMP)
-#       pragma omp atomic capture
-#   else
-#       pragma omp critical(c_dbcsr_acc_opencl_nstreams)
-#   endif
-# endif
-        i = c_dbcsr_acc_opencl_config.nstreams++;
-        assert(i < (ACC_OPENCL_STREAMS_MAXCOUNT * c_dbcsr_acc_opencl_config.nthreads)
-          && NULL != *stream_p);
-        c_dbcsr_acc_opencl_config.streams[i] = *stream_p;
+  if (EXIT_SUCCESS == result) {
+    cl_command_queue *const streams = c_dbcsr_acc_opencl_config.streams
+      + ACC_OPENCL_STREAMS_MAXCOUNT * tid;
+    for (i = 0; i < ACC_OPENCL_STREAMS_MAXCOUNT; ++i) if (NULL == streams[i]) break;
+    if (i < ACC_OPENCL_STREAMS_MAXCOUNT) { /* register stream */
+      cl_device_id device = NULL;
+      result = clGetContextInfo(context, CL_CONTEXT_DEVICES,
+        sizeof(cl_device_id), &device, NULL);
+      if (CL_SUCCESS == result) {
+        streams[i] = ACC_OPENCL_CREATE_COMMAND_QUEUE(context, device, properties, &result);
+        assert(CL_SUCCESS == result || NULL == streams[i]);
       }
-#endif
+      *stream_p = streams[i];
     }
     else {
-      ACC_OPENCL_ERROR("create command queue", result);
+      result = EXIT_FAILURE;
+      *stream_p = NULL;
     }
   }
+  else *stream_p = NULL;
   ACC_OPENCL_RETURN_CAUSE(result, name);
 }
 
 
 int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int priority)
 {
-  cl_int result = EXIT_SUCCESS;
-  const cl_context context = c_dbcsr_acc_opencl_context(NULL);
-  if (NULL != context) {
-    ACC_OPENCL_COMMAND_QUEUE_PROPERTIES properties[8] = {
-      CL_QUEUE_PROPERTIES, 0/*placeholder*/,
-      0 /* terminator */
-    };
-    cl_command_queue queue = NULL;
+  cl_int result;
+  ACC_OPENCL_COMMAND_QUEUE_PROPERTIES properties[8] = {
+    CL_QUEUE_PROPERTIES, 0/*placeholder*/,
+    0 /* terminator */
+  };
+  cl_command_queue queue = NULL;
 #if !defined(ACC_OPENCL_STREAM_PRIORITIES) || !defined(CL_QUEUE_PRIORITY_KHR)
-    ACC_OPENCL_UNUSED(priority);
+  ACC_OPENCL_UNUSED(priority);
 #else
-    if (0 <= priority) {
-      properties[2] = CL_QUEUE_PRIORITY_KHR;
-      properties[3] = ((  CL_QUEUE_PRIORITY_HIGH_KHR <= priority
-                        && CL_QUEUE_PRIORITY_LOW_KHR >= priority)
-        ? priority : CL_QUEUE_PRIORITY_MED_KHR);
-      properties[4] = 0; /* terminator */
-    }
+  if (0 <= priority) {
+    properties[2] = CL_QUEUE_PRIORITY_KHR;
+    properties[3] = ((  CL_QUEUE_PRIORITY_HIGH_KHR <= priority
+                      && CL_QUEUE_PRIORITY_LOW_KHR >= priority)
+      ? priority : CL_QUEUE_PRIORITY_MED_KHR);
+    properties[4] = 0; /* terminator */
+  }
 #endif
-    if (3 <= c_dbcsr_acc_opencl_config.verbosity
-      || 0 > c_dbcsr_acc_opencl_config.verbosity)
-    {
-      properties[1] = CL_QUEUE_PROFILING_ENABLE;
-    }
-    result = c_dbcsr_acc_opencl_stream_create(&queue, name, properties);
-    assert(NULL != stream_p);
-    if (EXIT_SUCCESS == result) {
-      assert(NULL != queue);
+  if (3 <= c_dbcsr_acc_opencl_config.verbosity
+    || 0 > c_dbcsr_acc_opencl_config.verbosity)
+  {
+    properties[1] = CL_QUEUE_PROFILING_ENABLE;
+  }
+  result = c_dbcsr_acc_opencl_stream_create(&queue, name, properties);
+  assert(NULL != stream_p);
+  if (EXIT_SUCCESS == result) {
+    assert(NULL != queue);
 #if defined(ACC_OPENCL_STREAM_NOALLOC)
-      assert(sizeof(void*) >= sizeof(cl_command_queue));
-      *stream_p = (void*)queue;
+    assert(sizeof(void*) >= sizeof(cl_command_queue));
+    *stream_p = (void*)queue;
 #else
-      *stream_p = malloc(sizeof(cl_command_queue));
-      if (NULL != *stream_p) {
-        *(cl_command_queue*)*stream_p = queue;
-      }
-      else {
-        clReleaseCommandQueue(queue);
-        result = EXIT_FAILURE;
-      }
-#endif
+    *stream_p = malloc(sizeof(cl_command_queue));
+    if (NULL != *stream_p) {
+      *(cl_command_queue*)*stream_p = queue;
     }
     else {
-      *stream_p = NULL;
+      clReleaseCommandQueue(queue);
+      result = EXIT_FAILURE;
     }
+#endif
+  }
+  else {
+    *stream_p = NULL;
   }
   ACC_OPENCL_RETURN_CAUSE(result, name);
 }
@@ -126,36 +120,34 @@ int c_dbcsr_acc_stream_destroy(void* stream)
   int result = EXIT_SUCCESS;
   if (NULL != stream) {
     const cl_command_queue queue = *ACC_OPENCL_STREAM(stream);
-    ACC_OPENCL_CHECK(clReleaseCommandQueue(queue),
-      "release command queue", result);
+    int tid = 0, i = ACC_OPENCL_STREAMS_MAXCOUNT;
+    cl_command_queue* streams = NULL;
+    for (; tid < c_dbcsr_acc_opencl_config.nthreads; ++tid) { /* unregister */
+      streams = c_dbcsr_acc_opencl_config.streams + ACC_OPENCL_STREAMS_MAXCOUNT * tid;
+      for (i = 0; i < ACC_OPENCL_STREAMS_MAXCOUNT; ++i) if (queue == streams[i]) {
+        tid = c_dbcsr_acc_opencl_config.nthreads; /* break outer loop */
+        break;
+      }
+    }
+    if (i < ACC_OPENCL_STREAMS_MAXCOUNT) {
+      const int j = i + 1;
+      result = clReleaseCommandQueue(queue);
+      assert(NULL != streams);
+      streams[i] = NULL;
+      /* compacting streams is not thread-safe */
+      if (j < ACC_OPENCL_STREAMS_MAXCOUNT && NULL != streams[j]) {
+        memmove(streams + i, streams + j,
+          sizeof(cl_command_queue) * (ACC_OPENCL_STREAMS_MAXCOUNT - j));
+      }
+    }
+    else {
+      ACC_OPENCL_EXPECT(CL_SUCCESS, clReleaseCommandQueue(queue));
+      result = EXIT_FAILURE;
+    }
 #if defined(ACC_OPENCL_STREAM_NOALLOC)
     assert(sizeof(void*) >= sizeof(cl_command_queue));
 #else
     free(stream);
-#endif
-#if defined(ACC_OPENCL_STREAMS_MAXCOUNT)
-    { /* collect garbage */
-      int i = 0, nstreams;
-# if defined(_OPENMP)
-#   if (201107/*v3.1*/ <= _OPENMP)
-#     pragma omp atomic capture
-#   else
-#     pragma omp critical(c_dbcsr_acc_opencl_nstreams)
-#   endif
-# endif
-      nstreams = c_dbcsr_acc_opencl_config.nstreams--;
-      assert(0 <= nstreams);
-      for (; i < nstreams; ++i) if (queue == c_dbcsr_acc_opencl_config.streams[i]) {
-        c_dbcsr_acc_opencl_config.streams[i] = NULL; break;
-      }
-# if defined(_OPENMP)
-#     pragma omp master
-# endif
-      if (NULL == c_dbcsr_acc_opencl_config.streams[i] && (i + 1) < nstreams) {
-        memmove(c_dbcsr_acc_opencl_config.streams + i, c_dbcsr_acc_opencl_config.streams + (i + 1),
-          sizeof(cl_command_queue) * (nstreams - (i + 1)));
-      }
-    }
 #endif
   }
   ACC_OPENCL_RETURN(result);
@@ -165,58 +157,62 @@ int c_dbcsr_acc_stream_destroy(void* stream)
 int c_dbcsr_acc_stream_priority_range(int* least, int* greatest)
 {
   int result = ((NULL != least || NULL != greatest) ? EXIT_SUCCESS : EXIT_FAILURE);
-  const cl_context context = c_dbcsr_acc_opencl_context(NULL);
-  if (NULL != context) {
 #if defined(ACC_OPENCL_STREAM_PRIORITIES) && defined(CL_QUEUE_PRIORITY_KHR)
-    char buffer[ACC_OPENCL_BUFFERSIZE];
-    cl_platform_id platform = NULL;
-    cl_device_id active_id = NULL;
-    assert(0 < c_dbcsr_acc_opencl_config.ndevices);
-    if (EXIT_SUCCESS == result) {
-      result = c_dbcsr_acc_opencl_device(NULL/*stream*/, &active_id);
-    }
-    ACC_OPENCL_CHECK(clGetDeviceInfo(active_id, CL_DEVICE_PLATFORM,
-      sizeof(cl_platform_id), &platform, NULL),
-      "retrieve platform associated with active device", result);
-    ACC_OPENCL_CHECK(clGetPlatformInfo(platform, CL_PLATFORM_EXTENSIONS,
-      ACC_OPENCL_BUFFERSIZE, buffer, NULL),
-      "retrieve platform extensions", result);
-    if (EXIT_SUCCESS == result) {
-      if (NULL != strstr(buffer, "cl_khr_priority_hints")) {
-        if (NULL != least) *least = CL_QUEUE_PRIORITY_LOW_KHR;
-        if (NULL != greatest) *greatest = CL_QUEUE_PRIORITY_HIGH_KHR;
-      }
-      else
+  char buffer[ACC_OPENCL_BUFFERSIZE];
+  cl_platform_id platform = NULL;
+  cl_device_id active_id = NULL;
+  assert(0 < c_dbcsr_acc_opencl_config.ndevices);
+  if (EXIT_SUCCESS == result) {
+#if defined(_OPENMP)
+    const int tid = omp_get_thread_num() % c_dbcsr_acc_opencl_config.nthreads;
+#else
+    const int tid = 0; /*master*/
 #endif
-      {
-        if (NULL != least) *least = -1;
-        if (NULL != greatest) *greatest = -1;
-      }
+    result = c_dbcsr_acc_opencl_device(tid, &active_id);
+  }
+  ACC_OPENCL_CHECK(clGetDeviceInfo(active_id, CL_DEVICE_PLATFORM,
+    sizeof(cl_platform_id), &platform, NULL),
+    "retrieve platform associated with active device", result);
+  ACC_OPENCL_CHECK(clGetPlatformInfo(platform, CL_PLATFORM_EXTENSIONS,
+    ACC_OPENCL_BUFFERSIZE, buffer, NULL),
+    "retrieve platform extensions", result);
+  if (EXIT_SUCCESS == result) {
+    if (NULL != strstr(buffer, "cl_khr_priority_hints")) {
+      if (NULL != least) *least = CL_QUEUE_PRIORITY_LOW_KHR;
+      if (NULL != greatest) *greatest = CL_QUEUE_PRIORITY_HIGH_KHR;
+    }
+    else
+#endif
+    {
+      if (NULL != least) *least = -1;
+      if (NULL != greatest) *greatest = -1;
+    }
 #if defined(ACC_OPENCL_STREAM_PRIORITIES) && defined(CL_QUEUE_PRIORITY_KHR)
-    }
+  }
 #endif
-  }
-  else {
-    if (NULL != least) *least = -1;
-    if (NULL != greatest) *greatest = -1;
-  }
   assert(least != greatest); /* no alias */
   ACC_OPENCL_RETURN(result);
 }
 
 
 int c_dbcsr_acc_stream_sync(void* stream)
-{ /* Blocks the host-thread. */
+{
   int result = EXIT_SUCCESS;
   assert(NULL != stream);
-  ACC_OPENCL_CHECK(clFinish(*ACC_OPENCL_STREAM(stream)),
-    "synchronize stream", result);
+  if (0 == (4 & c_dbcsr_acc_opencl_config.flush)) {
+    ACC_OPENCL_CHECK(clFinish(*ACC_OPENCL_STREAM(stream)),
+      "synchronize stream", result);
+  }
+  else {
+    ACC_OPENCL_CHECK(clFlush(*ACC_OPENCL_STREAM(stream)),
+      "synchronize stream", result);
+  }
   ACC_OPENCL_RETURN(result);
 }
 
 
 int c_dbcsr_acc_stream_wait_event(void* stream, void* event)
-{ /* Wait for an event (device-side). */
+{ /* wait for an event (device-side) */
   int result = EXIT_SUCCESS;
   assert(NULL != stream && NULL != event);
   ACC_OPENCL_CHECK(ACC_OPENCL_WAIT_EVENT(*ACC_OPENCL_STREAM(stream),

--- a/src/acc/opencl/smm/opencl_libsmm.c
+++ b/src/acc/opencl/smm/opencl_libsmm.c
@@ -249,9 +249,11 @@ int opencl_libsmm_read_params(char* parambuf,
 
 int opencl_libsmm_device(void* stream, cl_device_id* device, const char** config)
 {
-  int result = c_dbcsr_acc_opencl_device(stream, device), empty = 0, i = 0;
-  assert(NULL != config);
-  if (EXIT_SUCCESS == result) {
+  int result, empty = 0, i = 0;
+  assert(NULL != stream && NULL != device && NULL != config);
+  result = clGetCommandQueueInfo(*ACC_OPENCL_STREAM(stream),
+    CL_QUEUE_DEVICE, sizeof(cl_device_id), device, NULL);
+  if (CL_SUCCESS == result) {
     char buffer[ACC_OPENCL_BUFFERSIZE];
     result = clGetDeviceInfo(*device, CL_DEVICE_NAME,
       ACC_OPENCL_BUFFERSIZE, buffer, NULL);
@@ -642,8 +644,10 @@ int libsmm_acc_transpose(const int* dev_trs_stack, int offset, int stack_size,
 # endif
       if (0 < nchar && (int)sizeof(fname) > nchar) {
         cl_device_id active_device;
-        result = c_dbcsr_acc_opencl_device(stream, &active_device);
-        if (EXIT_SUCCESS == result) {
+        assert(NULL != stream);
+        result = clGetCommandQueueInfo(*ACC_OPENCL_STREAM(stream),
+          CL_QUEUE_DEVICE, sizeof(cl_device_id), &active_device, NULL);
+        if (CL_SUCCESS == result) {
           const char *const param_format = "-DGLOBAL=%s -DINPLACE=%i -DFN=%s -DSM=%i -DSN=%i -DSWG=%i -DT=%s";
           const char *const cmem = (EXIT_SUCCESS != opencl_libsmm_use_cmem(active_device) ? "global" : "constant");
           const char *const env_options = getenv("OPENCL_LIBSMM_TRANS_BUILDOPTS"), *tname = "";


### PR DESCRIPTION
* Account for c_dbcsr_acc_device_synchronize called outside of parallel region.
* Cleaned experimental runtime settings. Updated documentation accordingly.
* Removed ACC_OPENCL_THREADLOCAL_CONTEXT and ACC_OPENCL_STREAMS_MAXCOUNT.
* Removed testing races between stream create/destroy (dbcsr_acc_test).
* Attempt to share contexts more aggressively.
* Code cleanup