### PR TITLE
ocl: fixed/improved selecting device per ACC_OPENCL_DEVICE

### DIFF
--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -220,8 +220,8 @@ int c_dbcsr_acc_opencl_info_devmem(cl_device_id device,
   int* mem_unified);
 /** Get device associated with thread-ID. */
 int c_dbcsr_acc_opencl_device(int thread_id, cl_device_id* device);
-/** Get device-ID for given device. */
-int c_dbcsr_acc_opencl_device_id(cl_device_id device, int* device_id);
+/** Get device-ID for given device, and optionally global device-ID. */
+int c_dbcsr_acc_opencl_device_id(cl_device_id device, int* device_id, int* global_id);
 /** Confirm the vendor of the given device. */
 int c_dbcsr_acc_opencl_device_vendor(cl_device_id device, const char vendor[]);
 /** Confirm that match is matching the name of the given device. */


### PR DESCRIPTION
* Note: ACC_OPENCL_DEVICE can be used to control/adjust MPI rank-device association.
* Fixed ACC_OPENCL_DEVICE to prune the number of device to only expose the requested ID.
* Extended c_dbcsr_acc_opencl_device_id to determine global device-ID ("true" ID).
* termination message (ACC_OPENCL_VERBOSE=1) shows the true ID.
* Improved termination message to shorter list of streams.