### PR TITLE
ocl: fixed/improved initialization, finalization and handling errors

### DIFF
--- a/src/acc/opencl/acc_opencl_event.c
+++ b/src/acc/opencl/acc_opencl_event.c
@@ -26,9 +26,9 @@ int c_dbcsr_acc_event_create(void** event_p)
   cl_event event;
   assert(NULL != event_p && NULL != context);
   event  = clCreateUserEvent(context, &result);
-  if (NULL != event) {
+  if (CL_SUCCESS == result) {
     cl_int status = CL_COMPLETE;
-    assert(CL_SUCCESS == result);
+    assert(NULL != event);
     /* an empty event (unrecorded) has no work to wait for; hence it is
      * considered occurred and c_dbcsr_acc_event_synchronize must not block
      */
@@ -129,7 +129,7 @@ int c_dbcsr_acc_event_query(void* event, c_dbcsr_acc_bool_t* has_occurred)
     *has_occurred = ((CL_COMPLETE == status || CL_SUCCESS != result) ? 1 : 0);
     if (!*has_occurred) {
 #if defined(_OPENMP)
-      const int tid = omp_get_thread_num() % c_dbcsr_acc_opencl_config.nthreads;
+      const int tid = omp_get_thread_num();
 #else
       const int tid = 0; /* master */
 #endif

--- a/src/acc/opencl/acc_opencl_stream.c
+++ b/src/acc/opencl/acc_opencl_stream.c
@@ -97,6 +97,7 @@ int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int priority)
 #if defined(_OPENMP)
   if (1 < omp_get_num_threads()) {
     int c, tid;
+    assert(0 < c_dbcsr_acc_opencl_config.nthreads);
 # if (201107/*v3.1*/ <= _OPENMP)
 #   pragma omp atomic capture
 # else
@@ -194,7 +195,7 @@ int c_dbcsr_acc_stream_priority_range(int* least, int* greatest)
   assert(0 < c_dbcsr_acc_opencl_config.ndevices);
   if (EXIT_SUCCESS == result) {
 #if defined(_OPENMP)
-    const int tid = omp_get_thread_num() % c_dbcsr_acc_opencl_config.nthreads;
+    const int tid = omp_get_thread_num();
 #else
     const int tid = 0; /*master*/
 #endif


### PR DESCRIPTION
* Fixed ACC_OPENCL_DUMP in case of multiple threads dumping the same kernel.
* Do not test if no device was found (dbcsr_acc_test).