### PR TITLE
ocl: added new code-path to SMM-kernel source

### DIFF
--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -50,7 +50,7 @@ endif
 endif
 
 CFLAGS := -fPIC \
-  -Wall -Wextra -pedantic \
+  -Wall -Wextra \
   -Wno-overlength-strings \
   -Wno-variadic-macros \
   -Wno-unused-function \
@@ -82,10 +82,10 @@ endif
 
 ifneq (0,$(DEV))
   ifeq (1,$(DEV))
-    CFLAGS := -std=c89 $(CFLAGS)
+    CFLAGS += -std=c89
     CFLAGS += -Wno-unused-parameter
   else
-    CFLAGS := -Wno-deprecated -Werror $(CFLAGS)
+    CFLAGS += -Wno-deprecated -Werror
     ifneq (,$(findstring clang,$(CC) $(CXX)))
       override CC := clang++ --analyze
     else
@@ -93,8 +93,9 @@ ifneq (0,$(DEV))
     endif
     OMP := 0
   endif
+  CFLAGS += -pedantic
 else
-  CFLAGS := -std=c99 $(CFLAGS)
+  CFLAGS += -std=c99
 endif
 
 ifneq (0,$(DBG))
@@ -135,12 +136,12 @@ else
   endif
 endif
 ifneq (,$(LIBXSMMROOT))
-  CFLAGS_XSMM += -pthread -D__LIBXSMM -I$(LIBXSMMROOT)/include
-  LDFLAGS := -pthread $(LDFLAGS)
-  LDFLAGS += -L$(LIBXSMMROOT)/lib
   ifneq (Darwin,$(UNAME))
-    LDFLAGS += -Wl,-rpath=$(LIBXSMMROOT)/lib $(LDFLAGS)
+    LDFLAGS += -Wl,-rpath=$(LIBXSMMROOT)/lib
   endif
+  CFLAGS_XSMM += -pthread -D__LIBXSMM -I$(LIBXSMMROOT)/include
+  LDFLAGS += -L$(LIBXSMMROOT)/lib
+  LDFLAGS += -pthread
 endif
 
 ifeq (Darwin,$(UNAME))

--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -987,7 +987,7 @@ int c_dbcsr_acc_opencl_kernel(const char source[], const char kernel_name[],
                 " -P -C -nostdinc -D__OPENCL_VERSION__=%u %s %s %s %s > %s.cl", 100 * level_major + 10 * level_minor,
                 EXIT_SUCCESS != c_dbcsr_acc_opencl_device_vendor(active_id, "nvidia") ? "" : "-D__NV_CL_C_VERSION",
                 NULL != build_params ? build_params : "", name_src,
-                NULL != file_sed ? "| " ACC_OPENCL_SEDBIN " '/^[[:space:]]*$/d'" : "",
+                NULL != file_sed ? "| " ACC_OPENCL_SEDBIN " '/^[[:space:]]*\\(\\/\\/.*\\)*$/d'" : "",
                 kernel_name);
               if (0 < nchar && (int)sizeof(buffer) > nchar) {
                 if (EXIT_SUCCESS == system(buffer)) {


### PR DESCRIPTION
* Replaced references/pointers to/into reg-backed arrays (access-macros).
* Strip C++ style comments from kernel's source (ACC_OPENCL_DUMP).
* Reworked unroll-control to be part of the kernel-source.
* Implemented new kernel/code-path (BK=1).
* More detailed error/verbose message.
* Adjusted Makefile.