### PR TITLE
ocl: support variety of FP-atomics

### DIFF
--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -25,7 +25,7 @@ if [ ! -d "${HOME}/libxsmm" ]; then
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout 2a373509dadfda2d13f90ae1be920f03d8fb3415
+git checkout d95af1e29cc3e35c38d96e76aff766a33f681fc3
 make -j
 cd ..
 


### PR DESCRIPTION
* Enable FP-atomics in source if __opencl_c_ext_fp64_global_atomic_add is defined.
* More compact expressions expanded from macros and more compact code-format.
* Implemented using FP-atomics without extension/confirmation.
* Disable extensions if confirmation fails.
* Updated LIBXSMM (Daint-CI).