### PR TITLE
ocl: various minor improvements and additional kernel code-path

### DIFF
--- a/src/acc/acc_bench_smm.c
+++ b/src/acc/acc_bench_smm.c
@@ -43,7 +43,7 @@
 
 #define ACC_BENCH_SMM_EPSILON(T) DBCSR_CONCATENATE(ACC_BENCH_SMM_EPSILON_, T)
 #define ACC_BENCH_SMM_EPSILON_double 1E-3
-#define ACC_BENCH_SMM_EPSILON_float 1E-3
+#define ACC_BENCH_SMM_EPSILON_float 3E-3
 
 #define ROUNDUP2(N, NPOT) ((((unsigned long long)N) + ((NPOT) - 1)) & ~((NPOT) - 1))
 #define CHECK(EXPR, RPTR) if ((NULL != ((const void*)(RPTR)) && EXIT_SUCCESS != *((const int*)(RPTR))) || \

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -134,7 +134,7 @@ class SmmTuner(MeasurementInterface):
                 params.append(IntegerParameter("WG", self.args.wg, self.args.wg))
             else:
                 self.wg = int(seed.group(6)) if seed and seed.group(6) else None
-                paramt.append(IntegerParameter("WG", -1, 1))  # avoid WG=2
+                paramt.append(IntegerParameter("WG", -2, 1))  # avoid WG=2
             if env_isfixed("OPENCL_LIBSMM_SMM_LU"):
                 params.append(IntegerParameter("LU", self.args.lu, self.args.lu))
             else:
@@ -355,9 +355,9 @@ class SmmTuner(MeasurementInterface):
                         data["AL"] if "AL" in data else 0,
                         data["TB"] if "TB" in data else 0,
                         data["TC"] if "TC" in data else 1,
-                        data["AP"] if "AP" in data else 0,
-                        data["AA"] if "AA" in data else 0,
-                        data["AB"] if "AB" in data else 0,
+                        data["AP"] if "AP" in data else 1,
+                        data["AA"] if "AA" in data else 1,
+                        data["AB"] if "AB" in data else 3,
                         data["AC"] if "AC" in data else 0,
                         filename,
                     )

--- a/src/acc/opencl/smm/tune_multiply.sh
+++ b/src/acc/opencl/smm/tune_multiply.sh
@@ -107,15 +107,19 @@ if [ "${SORT}" ] && [ "${SED}" ] && [ "${LS}" ] && [ "${RM}" ] && [ "${WC}" ]; t
   if [ "${SPECID}" ] && [ "$1" ]; then
     >&2 echo "ERROR: --specid and <triplet-spec> are mutual exclusive!"
     exit 1
-  elif [ "${UPDATE}" ] && [ "0" != "${UPDATE}" ]; then
-    if [ ! "${TLEVEL}" ] || [ "0" != "$((0>TLEVEL))" ]; then TLEVEL=0; fi
-    if [ ! "${MAXTIME}" ]; then MAXTIME=320; fi
-    MNKS=$(echo "${JSONS}" | ${SED} -n "s/.*tune_multiply-..*-\(..*x..*x..*\)-[0-9][0-9]*gflops.json/\1/p" \
-       | ${SORT} -u -n -tx -k1 -k2 -k3)
-  elif [ "${SPECID}" ]; then
-    MNKS=$(eval "${HERE}/../../acc_triplets.sh -r ${BOUNDL} ${BOUNDU} -m ${MAXEXT} -n ${MAXNUM} -s ${SPECID} 2>/dev/null")
+  elif [ ! "${HELP}" ] || [ "0" = "${HELP}" ]; then
+    if [ "${UPDATE}" ] && [ "0" != "${UPDATE}" ]; then
+      if [ ! "${TLEVEL}" ] || [ "0" != "$((0>TLEVEL))" ]; then TLEVEL=0; fi
+      if [ ! "${MAXTIME}" ]; then MAXTIME=320; fi
+      MNKS=$(echo "${JSONS}" | ${SED} -n "s/.*tune_multiply-..*-\(..*x..*x..*\)-[0-9][0-9]*gflops.json/\1/p" \
+         | ${SORT} -u -n -tx -k1 -k2 -k3)
+    elif [ "${SPECID}" ]; then
+      MNKS=$(eval "${HERE}/../../acc_triplets.sh -r ${BOUNDL} ${BOUNDU} -m ${MAXEXT} -n ${MAXNUM} -s ${SPECID} 2>/dev/null")
+    else
+      MNKS=$(eval "${HERE}/../../acc_triplets.sh -r ${BOUNDL} ${BOUNDU} -m ${MAXEXT} -n ${MAXNUM} $* 2>/dev/null")
+    fi
   else
-    MNKS=$(eval "${HERE}/../../acc_triplets.sh -r ${BOUNDL} ${BOUNDU} -m ${MAXEXT} -n ${MAXNUM} $* 2>/dev/null")
+    exit 0
   fi
   NTRIPLETS=$(echo "${MNKS}" | wc -w)
   if [ "0" != "$((0==NTRIPLETS))" ]; then


### PR DESCRIPTION
* Correctly reproduce default values (if not present in JSON).
* Outer k-loop for code-path using general tiles.
* Fixed issues pointed out by static analysis.
* Decoupled WG=-1 and BK=1 (introduced WG=-2).
* Improved BOUNDL/BOUNDU (acc_triplets.sh).
* Adjusted range of WG-parameter.
* Omit barriers if possible.
* Improved handling errors.
* Adjusted code-format.
* Adjusted tolerance.