### PR TITLE
Removed invalid suffixes from literal DP FP-numbers

### DIFF
--- a/examples/dbcsr_example_3.cpp
+++ b/examples/dbcsr_example_3.cpp
@@ -184,7 +184,7 @@ int main(int argc, char* argv[])
     c_dbcsr_finalize(matrix_c);
 
     // Compute C = 3.0 * A * B + 2.0 * C
-    c_dbcsr_multiply_d('N', 'N', 3.0d, matrix_a, matrix_b, 2.0d, matrix_c, nullptr, nullptr,
+    c_dbcsr_multiply_d('N', 'N', 3.0, matrix_a, matrix_b, 2.0, matrix_c, nullptr, nullptr,
                        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 
     c_dbcsr_print(matrix_c);

--- a/tests/dbcsr_test.cpp
+++ b/tests/dbcsr_test.cpp
@@ -191,7 +191,7 @@ int main(int argc, char* argv[])
 
     if (mpi_rank == 0) std::cout << "Multiplying..." << std::endl;
 
-    c_dbcsr_multiply_d('N', 'N', 1.0d, matrix_a, matrix_b, 2.0d, matrix_c, nullptr, nullptr,
+    c_dbcsr_multiply_d('N', 'N', 1.0, matrix_a, matrix_b, 2.0, matrix_c, nullptr, nullptr,
                        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 
     if (mpi_rank == 0) std::cout << "Testing get_info for matrix_c" << std::endl;
@@ -348,7 +348,7 @@ int main(int argc, char* argv[])
     c_dbcsr_print(matrix_d);
 
     double* data = nullptr;
-    double type = 1.0d;
+    double type = 1.0;
     long long int data_size = 0;
     c_dbcsr_get_data_d(matrix_d, &data, &data_size, &type, nullptr, nullptr);
 


### PR DESCRIPTION
Removed invalid suffixes from literal double-precision numbers. Note, 'f' for single-precision exists but 'd' is implied (if a fractional part is given).