### PR TITLE
introduced __DBCSR_DISABLE_WORKSHARE

### DIFF
--- a/src/data/dbcsr_ptr_util.F
+++ b/src/data/dbcsr_ptr_util.F
@@ -302,9 +302,13 @@ CONTAINS
         !! destination memory
       ${type1}$, DIMENSION(1:n), INTENT(IN) :: src
         !! source memory
+#if !defined(__DBCSR_DISABLE_WORKSHARE)
 !$OMP     PARALLEL WORKSHARE DEFAULT(none) SHARED(dst,src)
+#endif
       dst(:) = src(:)
+#if !defined(__DBCSR_DISABLE_WORKSHARE)
 !$OMP     END PARALLEL WORKSHARE
+#endif
    END SUBROUTINE mem_copy_${nametype1}$
 
    SUBROUTINE mem_zero_${nametype1}$ (dst, n)
@@ -314,9 +318,13 @@ CONTAINS
         !! length of elements to zero
       ${type1}$, DIMENSION(1:n), INTENT(OUT) :: dst
         !! destination memory
+#if !defined(__DBCSR_DISABLE_WORKSHARE)
 !$OMP     PARALLEL WORKSHARE DEFAULT(none) SHARED(dst)
+#endif
       dst(:) = ${zero1}$
+#if !defined(__DBCSR_DISABLE_WORKSHARE)
 !$OMP     END PARALLEL WORKSHARE
+#endif
    END SUBROUTINE mem_zero_${nametype1}$
 
    SUBROUTINE mem_alloc_${nametype1}$ (mem, n, mem_type)

--- a/src/mpi/dbcsr_mpiwrap.F
+++ b/src/mpi/dbcsr_mpiwrap.F
@@ -5111,9 +5111,13 @@ CONTAINS
             IF (myproc .EQ. source) do_local_copy = .TRUE.
          ENDIF
          IF (do_local_copy) THEN
+#if !defined(__DBCSR_DISABLE_WORKSHARE)
 !$OMP           PARALLEL WORKSHARE DEFAULT(none) SHARED(base,win_data,disp_aint,len)
+#endif
             base(:) = win_data(disp_aint + 1:disp_aint + len)
+#if !defined(__DBCSR_DISABLE_WORKSHARE)
 !$OMP           END PARALLEL WORKSHARE
+#endif
             request = mp_request_null
             ierr = 0
          ELSE

--- a/src/ops/dbcsr_operations.F
+++ b/src/ops/dbcsr_operations.F
@@ -314,8 +314,17 @@ CONTAINS
       INTEGER                                            :: handle
 
       CALL timeset(routineN, handle)
-
       SELECT CASE (dbcsr_get_data_type(matrix_a))
+#if defined(__DBCSR_DISABLE_WORKSHARE)
+      CASE (dbcsr_type_complex_4)
+         matrix_a%data_area%d%c_sp = (0.0, 0.0)
+      CASE (dbcsr_type_complex_8)
+         matrix_a%data_area%d%c_dp = (0.0_dp, 0.0_dp)
+      CASE (dbcsr_type_real_4)
+         matrix_a%data_area%d%r_sp = 0.0
+      CASE (dbcsr_type_real_8)
+         matrix_a%data_area%d%r_dp = 0.0_dp
+#else
       CASE (dbcsr_type_complex_4)
 !$OMP       PARALLEL WORKSHARE DEFAULT(NONE), SHARED(matrix_a)
          matrix_a%data_area%d%c_sp = (0.0, 0.0)
@@ -332,10 +341,9 @@ CONTAINS
 !$OMP       PARALLEL WORKSHARE DEFAULT(NONE), SHARED(matrix_a)
          matrix_a%data_area%d%r_dp = 0.0_dp
 !$OMP       END PARALLEL WORKSHARE
+#endif
       END SELECT
-
       CALL timestop(handle)
-
    END SUBROUTINE dbcsr_zero
 
    SUBROUTINE dbcsr_scale_anytype(matrix_a, alpha_scalar, limits)


### PR DESCRIPTION
* If __DBCSR_DISABLE_WORKSHARE defined, the parallel WORKSHARE construct is avoided.