### PR TITLE
ocl: revised printing/parsing tunable parameters

### DIFF
--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -111,9 +111,13 @@
 #endif
 
 #if defined(_DEBUG)
-# define ACC_OPENCL_DEBUG_PRINTF(A, ...) printf(A, __VA_ARGS__)
+# define ACC_OPENCL_DEBUG_FPRINTF(STREAM, ...) fprintf(STREAM, __VA_ARGS__)
+# define ACC_OPENCL_DEBUG_IF(CONDITION) if (CONDITION)
+# define ACC_OPENCL_DEBUG_ELSE else
 #else
-# define ACC_OPENCL_DEBUG_PRINTF(A, ...)
+# define ACC_OPENCL_DEBUG_FPRINTF(STREAM, ...)
+# define ACC_OPENCL_DEBUG_IF(CONDITION)
+# define ACC_OPENCL_DEBUG_ELSE
 #endif
 
 #if defined(NDEBUG)

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -16,7 +16,7 @@
 # define OPENCL_LIBSMM_TRANS_INPLACE
 #endif
 #if !defined(OPENCL_LIBSMM_PARAMS_DELIMS)
-# define OPENCL_LIBSMM_PARAMS_DELIMS ";,\t|/"
+# define OPENCL_LIBSMM_PARAMS_DELIMS ",;\t|/"
 #endif
 #if !defined(OPENCL_LIBSMM_SUITABLE) && 0
 # define OPENCL_LIBSMM_SUITABLE
@@ -86,6 +86,16 @@ typedef struct opencl_libsmm_perfest_t {
 
 /** If buffers are hinted for non-concurrent writes aka "OpenCL constant". */
 int opencl_libsmm_use_cmem(cl_device_id device);
+
+/**
+ * Write tunable parameters into (file-)stream. The environment variable
+ * OPENCL_LIBSMM_SMM_PARAMS="<output>" reproduces a configuration.
+ * If conig is NULL, parameter names are written. The arguments
+ * delim, begin, and close are optional as well (can be NULL).
+ * Returns the number of characters written (negative if error).
+ */
+int opencl_libsmm_write_params(FILE* stream, const opencl_libsmm_smm_t* config,
+  const char* delim, const char* begin, const char* close);
 
 /** Tokenize parambuf and initialize key/value pair. */
 int opencl_libsmm_read_params(char* parambuf,

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -94,13 +94,15 @@ class SmmTuner(MeasurementInterface):
         else:
             self.typename = self.typeid = self.device = None
         if run_result and 0 == run_result["returncode"]:
-            seedpat = "INFO ACC/OpenCL:\\s+{}\\s+{}SMM-kernel{}{}{}{}\\s+gen=".format(
+            seedpat = "INFO ACC/OpenCL:\\s+{}\\s+{}SMM-kernel\\s+{}={}\\s+gen=".format(
                 "{}x{}x{}".format(self.mnk[0], self.mnk[1], self.mnk[2]),
                 {"float": "S", "double": "D"}.get(self.typename, ""),
-                "\\s+bs=([0-9]+)\\s+bm=([0-9]+)\\s+bn=([0-9]+)\\s+bk=([0-9]+)\\s+ws=([0-9]+)",
-                "\\s+wg=(-*[0-9]+)\\s+lu=(-*[0-9]+)\\s+nz=([0-9]+)\\s+al=([0-9]+)",  # wg/lu can be neg.
-                "\\s+tb=([0-9]+)\\s+tc=([0-9]+)\\s+ap=([0-9]+)",
-                "\\s+aa=([0-9]+)\\s+ab=([0-9]+)\\s+ac=([0-9]+)",
+                "{bs,bm,bn,bk,ws,wg,lu,nz,al,tb,tc,ap,aa,ab,ac}",
+                "{{{},{},{}}}".format(  # "wg", and "lu" can be neg. hence "-*[0-9]+"
+                    "(-*[0-9]+),(-*[0-9]+),(-*[0-9]+),(-*[0-9]+),(-*[0-9]+)",
+                    "(-*[0-9]+),(-*[0-9]+),(-*[0-9]+),(-*[0-9]+),(-*[0-9]+)",
+                    "(-*[0-9]+),(-*[0-9]+),(-*[0-9]+),(-*[0-9]+),(-*[0-9]+)",
+                ),
             )
             seed = re.search(seedpat, str(run_result["stderr"]))
             # setup fixed and tunable parameters


### PR DESCRIPTION
* Introduced opencl_libsmm_write_params and reworked verbosity/parsing of tunable parameters.
* Improved _DEBUG/trace information and diagnostics.
* Revised c_dbcsr_acc_opencl_set_active_device.
* Revised c_dbcsr_acc_opencl_create_context.
* Revised c_dbcsr_acc_stream_create.
* Fixed __VA_ARGS__ in some macro.
* Lock stdout/stderr stream.