### PR TITLE
ocl: reworked matching device when loading tunables

### DIFF
--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -25,7 +25,7 @@ if [ ! -d "${HOME}/libxsmm" ]; then
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout d95af1e29cc3e35c38d96e76aff766a33f681fc3
+git checkout 1301d579bf0f13fe11e9b1a276c9e45463b37276
 make -j
 cd ..
 

--- a/src/acc/opencl/acc_opencl_event.c
+++ b/src/acc/opencl/acc_opencl_event.c
@@ -112,8 +112,8 @@ int c_dbcsr_acc_event_record(void* event, void* stream)
 {
   int result = EXIT_SUCCESS;
   assert(NULL != event && NULL != stream);
-  assert(NULL != c_dbcsr_acc_opencl_config.record_event);
-  result = c_dbcsr_acc_opencl_config.record_event(event, stream);
+  assert(NULL != c_dbcsr_acc_opencl_config.devinfo.record_event);
+  result = c_dbcsr_acc_opencl_config.devinfo.record_event(event, stream);
   ACC_OPENCL_RETURN(result);
 }
 

--- a/src/acc/opencl/acc_opencl_stream.c
+++ b/src/acc/opencl/acc_opencl_stream.c
@@ -249,7 +249,7 @@ int c_dbcsr_acc_stream_sync(void* stream)
 {
   int result = EXIT_SUCCESS;
   assert(NULL != stream);
-  if (0 == (2 & c_dbcsr_acc_opencl_config.flush)) {
+  if (0 == (2 & c_dbcsr_acc_opencl_config.devinfo.flush)) {
     ACC_OPENCL_CHECK(clFinish(*ACC_OPENCL_STREAM(stream)),
       "synchronize stream", result);
   }

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -21,9 +21,6 @@
 #if !defined(OPENCL_LIBSMM_SUITABLE) && 0
 # define OPENCL_LIBSMM_SUITABLE
 #endif
-#if !defined(OPENCL_LIBSMM_DEVMATCH) && 0
-# define OPENCL_LIBSMM_DEVMATCH
-#endif
 #if !defined(OPENCL_LIBSMM_DEBUG) && 0
 # define OPENCL_LIBSMM_DEBUG 1
 #endif
@@ -62,7 +59,7 @@ typedef struct opencl_libsmm_smmkey_t {
   libsmm_acc_data_t type; /* must be the 1st data member */
   int m, n, k;
   /* device that matches configuration (parameters) */
-  const char* device; /* must be the last data member */
+  int devuid; /* must be the last data member */
 } opencl_libsmm_smmkey_t;
 
 /** Type for SMM-kernel configuration. */
@@ -88,23 +85,35 @@ typedef struct opencl_libsmm_perfest_t {
 int opencl_libsmm_use_cmem(cl_device_id device);
 
 /**
- * Write tunable parameters into (file-)stream. The environment variable
- * OPENCL_LIBSMM_SMM_PARAMS="<output>" reproduces a configuration.
- * If conig is NULL, parameter names are written. The arguments
+ * TRANS-kernel: write key and tunables into a (file-)stream.
+ * If config=NULL, key/parameter names are written. The arguments
  * delim, begin, and close are optional as well (can be NULL).
+ * With only the key being written the config still controls
+ * if values or names are written.
  * Returns the number of characters written (negative if error).
  */
-int opencl_libsmm_write_params(FILE* stream, const opencl_libsmm_smm_t* config,
+int opencl_libsmm_write_trans_params(FILE* stream, int only_key,
+  const opencl_libsmm_transkey_t* key, const opencl_libsmm_trans_t* config,
+  const char* delim, const char* begin, const char* close);
+
+/**
+ * SMM-kernel: write key and tunables into a (file-)stream.
+ * The environment variable OPENCL_LIBSMM_SMM_PARAMS="<output>"
+ * reproduces a configuration. If config=NULL, key/parameter
+ * names are written. The arguments delim, begin, and close
+ * are optional as well (can be NULL).
+ * With only the key being written the config still controls
+ * if values or names are written.
+ * Returns the number of characters written (negative if error).
+ */
+int opencl_libsmm_write_smm_params(FILE* stream, int only_key,
+  const opencl_libsmm_smmkey_t* key, const opencl_libsmm_smm_t* config,
   const char* delim, const char* begin, const char* close);
 
 /** Tokenize parambuf and initialize key/value pair. */
-int opencl_libsmm_read_params(char* parambuf,
+int opencl_libsmm_read_smm_params(char* parambuf,
   opencl_libsmm_smmkey_t* key, opencl_libsmm_smm_t* value,
-  opencl_libsmm_perfest_t* perfest,
-  char* const* device);
-
-/** Get active device and configuration name. */
-int opencl_libsmm_device(void* stream, cl_device_id* device, const char** config);
+  opencl_libsmm_perfest_t* perfest, char* device);
 
 #if defined(OPENCL_LIBSMM_DEBUG) && defined(_DEBUG)
 void opencl_libsmm_print_matrix(FILE* ostream, const char* label,

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -94,14 +94,17 @@ class SmmTuner(MeasurementInterface):
         else:
             self.typename = self.typeid = self.device = None
         if run_result and 0 == run_result["returncode"]:
-            seedpat = "INFO ACC/OpenCL:\\s+{}\\s+{}SMM-kernel\\s+{}={}\\s+gen=".format(
-                "{}x{}x{}".format(self.mnk[0], self.mnk[1], self.mnk[2]),
-                {"float": "S", "double": "D"}.get(self.typename, ""),
-                "{bs,bm,bn,bk,ws,wg,lu,nz,al,tb,tc,ap,aa,ab,ac}",
-                "{{{},{},{}}}".format(  # "wg", and "lu" can be neg. hence "-*[0-9]+"
-                    "(-*[0-9]+),(-*[0-9]+),(-*[0-9]+),(-*[0-9]+),(-*[0-9]+)",
-                    "(-*[0-9]+),(-*[0-9]+),(-*[0-9]+),(-*[0-9]+),(-*[0-9]+)",
-                    "(-*[0-9]+),(-*[0-9]+),(-*[0-9]+),(-*[0-9]+),(-*[0-9]+)",
+            seedpat = "INFO ACC/OpenCL:\\s+SMM-kernel\\s+{}={}\\s+gen=".format(
+                "{t,m,n,k,bs,bm,bn,bk,ws,wg,lu,nz,al,tb,tc,ap,aa,ab,ac}",
+                "{{{},{}}}".format(  # key and value
+                    "{},{},{},{}".format(  # key
+                        self.typeid, self.mnk[0], self.mnk[1], self.mnk[2]
+                    ),
+                    "{},{},{}".format(  # value: some can be neg. hence "-*[0-9]+"
+                        "(-*[0-9]+),(-*[0-9]+),(-*[0-9]+),(-*[0-9]+),(-*[0-9]+)",
+                        "(-*[0-9]+),(-*[0-9]+),(-*[0-9]+),(-*[0-9]+),(-*[0-9]+)",
+                        "(-*[0-9]+),(-*[0-9]+),(-*[0-9]+),(-*[0-9]+),(-*[0-9]+)",
+                    ),
                 ),
             )
             seed = re.search(seedpat, str(run_result["stderr"]))


### PR DESCRIPTION
* Ensure device-dependent configuration is updated during c_dbcsr_acc_set_active_device.
* Reworked matching kernel-parameters (tunables) against devices (UID).
* Improved order/combining tunables (built-in, file, environment).
* Fixed/implemented matching devices (tunable parameters).
* Allow to build with device-match enabled by default.
* Introduced ACC_OPENCL_DEVMATCH environment variable.
* Reworked/improved opencl_libsmm_read_smm_params.
* Fixed walking OoB (reading set of tunables).
* Revised condition (OPENCL_LIBSMM_SUITABLE).
* Print device's UID (ACC_OPENCL_VERBOSE=2).
* Account for revised interface (LIBXSMM).
* Updated LIBXSMM (Daint-CI).