### PR TITLE
Issue #535: call acc_init and acc_finalize prior to other ACC routines

### DIFF
--- a/src/core/dbcsr_lib.F
+++ b/src/core/dbcsr_lib.F
@@ -10,11 +10,13 @@
 MODULE dbcsr_lib
 
    !! Routines that affect the DBCSR library as a whole
+   USE dbcsr_acc_init, ONLY: acc_finalize, acc_init
    USE dbcsr_acc_device, ONLY: dbcsr_acc_get_ndevices, dbcsr_acc_set_active_device
    USE dbcsr_config, ONLY: get_accdrv_active_device_id, &
                            set_accdrv_active_device_id, &
                            reset_accdrv_active_device_id, &
-                           dbcsr_set_config
+                           dbcsr_set_config, &
+                           has_acc
    USE dbcsr_kinds, ONLY: int_1_size, &
                           int_2_size, &
                           int_4_size, &
@@ -88,16 +90,15 @@ MODULE dbcsr_lib
          BIND(C, name="libsmm_acc_is_thread_safe")
          IMPORT
          INTEGER(KIND=C_INT)        :: thread_safe
-
       END FUNCTION libsmm_acc_is_thread_safe
    END INTERFACE
+
    INTERFACE
       FUNCTION libsmm_acc_gpu_warp_size() &
          RESULT(warp_size) &
          BIND(C, name="libsmm_acc_gpu_warp_size")
          IMPORT
          INTEGER(KIND=C_INT)        :: warp_size
-
       END FUNCTION libsmm_acc_gpu_warp_size
    END INTERFACE
 #endif
@@ -201,15 +202,19 @@ CONTAINS
       CALL libxsmm_init()
 #endif
 
-      ! Set Acc device
-      IF (dbcsr_acc_get_ndevices() > 0) THEN
-         IF (PRESENT(accdrv_active_device_id)) THEN
-            CALL set_accdrv_active_device_id(accdrv_active_device_id)
-         ELSE
-            ! Use round-robin assignment per rank
-            CALL set_accdrv_active_device_id(MOD(mynode, dbcsr_acc_get_ndevices()))
+      ! Initialize Acc and set active device
+      IF (has_acc) THEN
+         CALL acc_init()
+         IF (dbcsr_acc_get_ndevices() > 0) THEN
+            IF (PRESENT(accdrv_active_device_id)) THEN
+               CALL set_accdrv_active_device_id(accdrv_active_device_id)
+            ELSE
+               ! Use round-robin assignment per rank
+               CALL set_accdrv_active_device_id(MOD(mynode, dbcsr_acc_get_ndevices()))
+            ENDIF
          ENDIF
       ENDIF
+
 #if defined(__DBCSR_ACC)
       CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
 
@@ -227,7 +232,6 @@ CONTAINS
                              "DBCSR compiled w/o threading support while libsmm_acc is compiled w/ threading support.")
          ENDIF
       ENDIF
-
 #endif
    END SUBROUTINE dbcsr_init_lib_pre
 
@@ -301,12 +305,12 @@ CONTAINS
 #endif
       ! Reset Acc ID
       CALL reset_accdrv_active_device_id()
+      IF (has_acc) CALL acc_finalize()
 
       ! Check the number of communicators
       IF (check_comm_count .AND. mp_get_comm_count() .NE. 0) THEN
          DBCSR_ABORT("Number of DBCSR sub-communicators is not zero!")
       ENDIF
-
    END SUBROUTINE dbcsr_finalize_lib
 
    SUBROUTINE dbcsr_print_statistics(print_timers, callgraph_filename)

--- a/src/mm/dbcsr_mm.F
+++ b/src/mm/dbcsr_mm.F
@@ -13,8 +13,6 @@ MODULE dbcsr_mm
    !! - 2016-08    Code organization (Alfio Lazzaro).
 
    USE dbcsr_acc_device, ONLY: dbcsr_acc_clear_errors
-   USE dbcsr_acc_init, ONLY: acc_finalize, &
-                             acc_init
    USE dbcsr_acc_stream, ONLY: acc_stream_associated, &
                                acc_stream_create, &
                                acc_stream_destroy
@@ -108,9 +106,33 @@ MODULE dbcsr_mm
 
 !$ USE OMP_LIB, ONLY: omp_get_thread_num, omp_get_num_threads
 
+#if defined (__DBCSR_ACC)
+   USE ISO_C_BINDING, ONLY: C_INT
+#endif
+
    IMPLICIT NONE
 
    PRIVATE
+
+#if defined (__DBCSR_ACC)
+   INTERFACE
+      FUNCTION libsmm_acc_init_backend() &
+         RESULT(istat) &
+         BIND(C, name="libsmm_acc_init")
+         IMPORT
+         INTEGER(KIND=C_INT) :: istat
+      END FUNCTION libsmm_acc_init_backend
+   END INTERFACE
+
+   INTERFACE
+      FUNCTION libsmm_acc_finalize_backend() &
+         RESULT(istat) &
+         BIND(C, name="libsmm_acc_finalize")
+         IMPORT
+         INTEGER(KIND=C_INT) :: istat
+      END FUNCTION libsmm_acc_finalize_backend
+   END INTERFACE
+#endif
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'dbcsr_mm'
    LOGICAL, PARAMETER :: debug_mod = .FALSE.
@@ -125,16 +147,26 @@ MODULE dbcsr_mm
 
 CONTAINS
 
+   SUBROUTINE libsmm_acc_init()
+#if defined (__DBCSR_ACC)
+      IF (0 /= libsmm_acc_init_backend()) DBCSR_ABORT("libsmm_acc_init: failed")
+#else
+      DBCSR_ABORT("__DBCSR_ACC not compiled in")
+#endif
+   END SUBROUTINE libsmm_acc_init
+
+   SUBROUTINE libsmm_acc_finalize()
+#if defined (__DBCSR_ACC)
+      IF (0 /= libsmm_acc_finalize_backend()) DBCSR_ABORT("libsmm_acc_finalize: failed")
+#else
+      DBCSR_ABORT("__DBCSR_ACC not compiled in")
+#endif
+   END SUBROUTINE libsmm_acc_finalize
+
    SUBROUTINE dbcsr_multiply_lib_init()
       !! Initialize the library
 
       INTEGER                                            :: ithread, nthreads
-
-!$OMP     MASTER
-      IF (has_acc) &
-         CALL acc_init()
-!$OMP     END MASTER
-!$OMP     BARRIER
 
       nthreads = 1; ithread = 0
 !$    nthreads = OMP_GET_NUM_THREADS(); ithread = OMP_GET_THREAD_NUM()
@@ -152,6 +184,7 @@ CONTAINS
       marketing_flops = 0
       max_memory = 0
       ALLOCATE (memtype_product_wm(0:nthreads - 1))
+      IF (has_acc) CALL libsmm_acc_init()
 !$OMP     END MASTER
 !$OMP     BARRIER
 
@@ -175,7 +208,7 @@ CONTAINS
       IF (ASSOCIATED(memtype_product_wm(ithread)%p%pool)) &
          CALL dbcsr_mempool_destruct(memtype_product_wm(ithread)%p%pool)
       DEALLOCATE (memtype_product_wm(ithread)%p)
-
+      IF (has_acc) CALL libsmm_acc_finalize()
 !$OMP      BARRIER
 !$OMP      MASTER
       DEALLOCATE (memtype_product_wm)
@@ -200,8 +233,6 @@ CONTAINS
          CALL acc_stream_destroy(stream_1)
       IF (acc_stream_associated(stream_2)) &
          CALL acc_stream_destroy(stream_2)
-      IF (has_acc) &
-         CALL acc_finalize()
 !$OMP      END MASTER
    END SUBROUTINE dbcsr_multiply_lib_finalize
 


### PR DESCRIPTION
* Call acc_init and acc_finalize in dbcsr_init_lib_pre and dbcsr_finalize_lib respectively.
* Note: libsmm_acc_init/finalize is missing (and up to MM component of DBCSR).
* Call libsmm_acc_init and libsmm_acc_finalize (MM component).
* Code cleanup.