### PR TITLE
ocl: generate and select kernel for shorter stack-sizes

### DIFF
--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -39,6 +39,11 @@
 # define __LIBXSMM
 #endif
 
+#if !defined(LIBXSMM_VERSION_NUMBER)
+# define LIBXSMM_VERSION_NUMBER LIBXSMM_VERSION4(LIBXSMM_VERSION_MAJOR, \
+    LIBXSMM_VERSION_MINOR, LIBXSMM_VERSION_UPDATE, LIBXSMM_VERSION_PATCH)
+#endif
+
 #include "../acc.h"
 #if !defined(NDEBUG)
 # include <assert.h>
@@ -274,7 +279,7 @@ int c_dbcsr_acc_opencl_create_context(int thread_id, cl_device_id device_id);
 int c_dbcsr_acc_opencl_set_active_device(int thread_id, int device_id);
 /** Get preferred multiple and max. size of workgroup (kernel- or device-specific). */
 int c_dbcsr_acc_opencl_wgsize(cl_device_id device, cl_kernel kernel,
-  int* max_value, int* preferred_multiple);
+  size_t* max_value, size_t* preferred_multiple);
 /**
  * Build kernel from source with given kernel_name, build_params and build_options.
  * The build_params are meant to instantiate the kernel (-D) whereas build_options

--- a/src/acc/opencl/acc_opencl_stream.c
+++ b/src/acc/opencl/acc_opencl_stream.c
@@ -60,7 +60,9 @@ c_dbcsr_acc_opencl_info_stream_t* c_dbcsr_acc_opencl_info_stream(void* stream)
 const int* c_dbcsr_acc_opencl_stream_priority(void* stream)
 {
   const int* result;
-#if defined(ACC_OPENCL_STREAM_PRIORITIES)
+#if !defined(ACC_OPENCL_STREAM_PRIORITIES)
+  LIBXSMM_UNUSED(stream);
+#else
   const c_dbcsr_acc_opencl_info_stream_t *const info =
     c_dbcsr_acc_opencl_info_stream(stream);
   if (NULL != info) result = &info->priority;

--- a/src/acc/opencl/smm/kernels/multiply.cl
+++ b/src/acc/opencl/smm/kernels/multiply.cl
@@ -27,7 +27,7 @@
 #endif
 
 #define MAX(A, B) ((A)<(B)?(B):(A))
-#if !defined(AL) || (SM != SN) || (SN != SK)
+#if !defined(AL) || (SM != SN) || (SN != SK) || (1 == BS)
 # define ADX(M, K) adata[SM*K+M+a0]
 # define BDX(K, N) bdata[SN*K+N+b0]
 # define CDX(M, N) cdata[SM*N+M+c0]

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -58,16 +58,16 @@ typedef struct opencl_libsmm_trans_t {
 typedef struct opencl_libsmm_smmkey_t {
   libsmm_acc_data_t type; /* must be the 1st data member */
   int m, n, k;
-  /* device that matches configuration (parameters) */
-  int devuid; /* must be the last data member */
+  /* device matching configuration (parameters) */
+  int devuid;
 } opencl_libsmm_smmkey_t;
 
 /** Type for SMM-kernel configuration. */
 typedef struct opencl_libsmm_smm_t {
-  cl_kernel kernel; /* must be the 1st data member */
-  size_t wgsize;
-  /* parameters (either pretuned or determined) */
-  int bs, bm, bn, bk, ws, wg, lu, nz, al, tb, tc, ap, aa, ab, ac;
+  cl_kernel kernel[2]; /* must be the 1st data member */
+  size_t wgsize[2];
+  /* (pseudo-)parameters (either pretuned or determined) */
+  int s, bs, bm, bn, bk, ws, wg, lu, nz, al, tb, tc, ap, aa, ab, ac;
   /* ACC_OPENCL_VERBOSE: perf. counters */
   double gflops_sumlog, gflops_comp;
   size_t nexec;

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -357,7 +357,7 @@ class SmmTuner(MeasurementInterface):
             if bool(merged):
                 with open(self.args.csvfile, "w") as file:
                     file.write(  # CSV header line with termination/newline
-                        "{}{}{}{}{}{}{}{}\n".format(  # key-part
+                        "{}{}{}{}{}{}{}{}{}\n".format(  # key-part
                             self.args.csvsep.join(["DEVICE", "TYPEID", "M", "N", "K"]),
                             self.args.csvsep,  # separator for value-part
                             "S",  # pseudo-key component


### PR DESCRIPTION
* acc_bench_smm: SMM_BATCHSIZE to force batch-size (aka stack-size).
* Introduced S-(pseudo-)parameter, and handle kernel-kind (SMMs).
* Fixed OPENCL_LIBSMM_SUITABLE (preparation for LIBXSMM 2.0).
* Use c_dbcsr_acc_opencl_config.ndevices to track initialization.
* Include global/batch-size into tuned result-set (parameters).
* Improved type-checks (opencl_libsmm_read_smm_params).
* tune_multiply.py:: improved JSON-file pattern (CSV-file).
* tune_multiply.py: more compact creation of parameters.
* Revised and fixed LIBXSMM-version specific code-paths.
* Print stream/execution priority (ACC_OPENCL_VERBOSE).
* SMM-kernel: disabled combination of BS=1 and AL=1.
* Better sanitize loaded parameters.
* Adjusted verbose output.
* Code cleanup.