### PR TITLE
ocl: improved determinism for small SMM sequences/batches

### DIFF
--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -25,7 +25,7 @@ if [ ! -d "${HOME}/libxsmm" ]; then
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout f1426110f8cc6982100bed340bddc5612d589a81
+git checkout 011dfb33d01e97274f70aac73f40eb68957f6e32
 make -j
 cd ..
 

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -74,6 +74,11 @@ typedef struct opencl_libsmm_smm_t {
   int size[7];
 } opencl_libsmm_smm_t;
 
+typedef enum opencl_libsmm_timer_t {
+  opencl_libsmm_timer_device,
+  opencl_libsmm_timer_host
+} opencl_libsmm_timer_t;
+
 /** Type to collect statistics about tuned SMM-kernels */
 typedef struct opencl_libsmm_perfest_t {
   double gf_ai_sratio_max, gf_ai_sratio_sumlog, gf_ai_sratio_kahan;

--- a/src/acc/opencl/smm/tune_multiply.sh
+++ b/src/acc/opencl/smm/tune_multiply.sh
@@ -111,7 +111,7 @@ if [ "${SORT}" ] && [ "${SED}" ] && [ "${LS}" ] && [ "${RM}" ] && [ "${WC}" ]; t
     if [ "${UPDATE}" ] && [ "0" != "${UPDATE}" ]; then
       if [ ! "${TLEVEL}" ] || [ "0" != "$((0>TLEVEL))" ]; then TLEVEL=0; fi
       if [ ! "${MAXTIME}" ]; then MAXTIME=320; fi
-      MNKS=$(echo "${JSONS}" | ${SED} -n "s/.*tune_multiply-..*-\(..*x..*x..*\)-..*gflops\.json/\1/p" \
+      MNKS=$(echo "${JSONS}" | ${SED} -n "s/.*tune_multiply-..*-\(..*x..*x.[^-]*\)-..*gflops\.json/\1/p" \
          | ${SORT} -u -n -tx -k1 -k2 -k3)
     elif [ "${SPECID}" ]; then
       MNKS=$(eval "${HERE}/../../acc_triplets.sh -r ${BOUNDL} ${BOUNDU} -m ${MAXEXT} -n ${MAXNUM} -s ${SPECID} 2>/dev/null")


### PR DESCRIPTION
* Implemented cl_cache_dir (see https://github.com/intel/compute-runtime/blob/master/opencl/doc/FAQ.md#feature-cl_cache).
* Introduced opencl_libsmm_timer_t (opencl_libsmm_timer_device, opencl_libsmm_timer_device).
* Introduced environment variable OPENCL_LIBSMM_TIMER (device|host or 0|1).
* Made some code optional (ACC_OPENCL_CPPBIN, ACC_OPENCL_SEDBIN).
* Enable ACC_OPENCL_CACHEDIR in case of __DBCSR_ACC.
* Fixed regex (tune_multiply.sh).
* Adjusted some default values.
* Updated LIBXSMM for Daint-CI.
* Code cleanup.