### PR TITLE
ocl: revised wrapper/scripts related to auto-tuning SMMs

### DIFF
--- a/src/acc/acc_triplets.sh
+++ b/src/acc/acc_triplets.sh
@@ -35,8 +35,8 @@ if [ "${XARGS}" ] &&  [ "${SORT}" ] && [ "${HEAD}" ] && [ "${SED}" ] && [ "${CUT
     -m|--limit)
       LIMIT=$2
       shift 2;;
-    -n|--size)
-      SIZE=$2
+    -n|--triplets)
+      MAXNUM=$2
       shift 2;;
     -a|--amat)
       CUTSEL=-f1,3
@@ -47,7 +47,7 @@ if [ "${XARGS}" ] &&  [ "${SORT}" ] && [ "${HEAD}" ] && [ "${SED}" ] && [ "${CUT
     -c|--cmat)
       CUTSEL=-f1,2
       shift;;
-    -s|--specid)
+    -k|--specid)
       case "$2" in
       0) TRIPLETS="23, 6, 14 16 29, 5 16 13 24 26, 9 16 22, 32, 64, 78, 16 29 55";;
       1) TRIPLETS="23, 6, 14 16 29, 5 32 13 24 26, 9 32 22, 32, 64, 78, 16 29 55";;
@@ -113,10 +113,10 @@ if [ "${XARGS}" ] &&  [ "${SORT}" ] && [ "${HEAD}" ] && [ "${SED}" ] && [ "${CUT
       fi
       if [ "${CUTSEL}" ]; then
         MNK=$(echo "${MNKS}" | ${XARGS} -n1 | ${CUT} -dx ${CUTSEL} | ${SORT} -u -n -tx -k1 -k2 -k3 | \
-          if [ "${SIZE}" ] && [ "0" != "$((0<SIZE))" ]; then ${HEAD} -n"${SIZE}"; else cat; fi)
+          if [ "${MAXNUM}" ] && [ "0" != "$((0<MAXNUM))" ]; then ${HEAD} -n"${MAXNUM}"; else cat; fi)
       else
         MNK=$(echo "${MNKS}" | ${XARGS} -n1 | ${SORT} -u -n -tx -k1 -k2 -k3 | \
-          if [ "${SIZE}" ] && [ "0" != "$((0<SIZE))" ]; then ${HEAD} -n"${SIZE}"; else cat; fi)
+          if [ "${MAXNUM}" ] && [ "0" != "$((0<MAXNUM))" ]; then ${HEAD} -n"${MAXNUM}"; else cat; fi)
       fi
       if [ "0" = "${LINES}" ]; then
         echo "${MNK}" | ${XARGS}
@@ -134,12 +134,12 @@ if [ "${XARGS}" ] &&  [ "${SORT}" ] && [ "${HEAD}" ] && [ "${SED}" ] && [ "${CUT
     eval "${ECHO} \"       Options must precede triplet specification\""
     eval "${ECHO} \"       -l|--lines: lines instead of list of words\""
     eval "${ECHO} \"       -r|--bound L U: limit L**3 < MNK <= U**3\""
-    eval "${ECHO} \"       -m|--limit N: limit shape extents to N\""
-    eval "${ECHO} \"       -n|--size  N: limit number of elements\""
+    eval "${ECHO} \"       -m|--limit N: limit any shape extent to N\""
+    eval "${ECHO} \"       -n|--triplets N: limit number of triplet\""
     eval "${ECHO} \"       -a|--amat: select MxK instead of MxNxK\""
     eval "${ECHO} \"       -b|--bmat: select KxN instead of MxNxK\""
     eval "${ECHO} \"       -c|--cmat: select MxN instead of MxNxK\""
-    eval "${ECHO} \"       -s|--specid N: predefined triplets\""
+    eval "${ECHO} \"       -k|--specid N: predefined triplets\""
     eval "${ECHO} \"        0-10: older to newer (larger), e.g.,\""
     eval "${ECHO} \"       -s  0:  201 kernels\""
     eval "${ECHO} \"       -s 10: 1266 kernels\""

--- a/src/acc/cuda/Makefile
+++ b/src/acc/cuda/Makefile
@@ -182,7 +182,7 @@ test-interface: $(MAKDIR)/../dbcsr_acc_test
 
 .PHONY: test-trans
 test-trans: bench
-	$(eval SHAPES = $(shell $(MAKDIR)/../acc_triplets.sh -s $(SPECID) -m $(MAXEXT) -n $(NTRANS) -a))
+	$(eval SHAPES = $(shell $(MAKDIR)/../acc_triplets.sh -k $(SPECID) -m $(MAXEXT) -n $(NTRANS) -a))
 	@echo "--- DBCSR CUDA Transposes ($(words $(SHAPES)))"
 	@echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
 ifneq (,$(LD_PRELOAD))
@@ -200,7 +200,7 @@ endif
 	done
 
 $(MAKDIR)/test-smm.log: bench
-	$(eval SHAPES = $(shell $(MAKDIR)/../acc_triplets.sh -s $(SPECID) -m $(MAXEXT) -n $(NSMMS)))
+	$(eval SHAPES = $(shell $(MAKDIR)/../acc_triplets.sh -k $(SPECID) -m $(MAXEXT) -n $(NSMMS)))
 	@echo "--- DBCSR CUDA SMMs ($(words $(SHAPES)))"
 	@echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
 ifneq (,$(LD_PRELOAD))

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -189,7 +189,7 @@ test-interface: $(MAKDIR)/../dbcsr_acc_test
 
 .PHONY: test-trans
 test-trans: bench
-	$(eval SHAPES = $(shell $(MAKDIR)/../acc_triplets.sh -s $(SPECID) -m $(MAXEXT) -n $(NTRANS) -a))
+	$(eval SHAPES = $(shell $(MAKDIR)/../acc_triplets.sh -k $(SPECID) -m $(MAXEXT) -n $(NTRANS) -a))
 	$(eval DEVICE = $(shell ACC_OPENCL_VERBOSE=1 CHECK=0 $(MAKDIR)/../acc_bench_smm 1 1 1 2>&1 >/dev/null))
 	@echo "--- DBCSR OpenCL Transposes ($(words $(SHAPES)))"
 	@echo "$(DEVICE)"
@@ -208,7 +208,7 @@ endif
 	done
 
 $(MAKDIR)/test-smm.log: bench
-	$(eval SHAPES = $(shell $(MAKDIR)/../acc_triplets.sh -s $(SPECID) -m $(MAXEXT) -n $(NSMMS)))
+	$(eval SHAPES = $(shell $(MAKDIR)/../acc_triplets.sh -k $(SPECID) -m $(MAXEXT) -n $(NSMMS)))
 	$(eval DEVICE = "$(shell LIBXSMM_VERBOSE=0 ACC_OPENCL_VERBOSE=1 CHECK=0 $(MAKDIR)/../acc_bench_smm 1 1 1 2>&1 >/dev/null)")
 	$(eval WITH_GPU = $(firstword $(foreach GPU,$(WITH_GPUS),$(findstring $(GPU),$(DEVICE)))))
 	$(eval PARAMS = $(firstword $(wildcard $(PARAMS_DIR)/tune_multiply_*$(WITH_GPU).csv)))

--- a/src/acc/opencl/smm/opencl_libsmm.c
+++ b/src/acc/opencl/smm/opencl_libsmm.c
@@ -1199,7 +1199,7 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
               new_config.bn = (0 >= blockn ? (0 == kernel_idx ? (NULL == config ? MIN(OPENCL_LIBSMM_DEFAULT_BN, n_max)
                 : LIBXSMM_CLMP(config->bn, 1, n_max)) : MIN(OPENCL_LIBSMM_DEFAULT_BN, n_max)) : MIN(blockn, n_max));
               new_config.bk = (0 >= blockk ? (0 == kernel_idx ? (NULL == config ? /*default*/m_max
-                : LIBXSMM_CLMP(config->bk, 1, m_max)) : /*default*/m_max) : MIN(blockk, m_max));
+                : LIBXSMM_CLMP(config->bk, 1, m_max)) : /*default*/MIN(OPENCL_LIBSMM_VMIN, m_max)) : MIN(blockk, m_max));
               new_config.ws = (0 >= wgmin ? (0 == kernel_idx ? (NULL == config ? /*default*/n_max
                 : LIBXSMM_CLMP(config->ws, 1, n_max * m_max)) : /*default*/n_max) : MIN(wgmin, n_max * m_max));
               new_config.bs = (0 >= blocks ? (0 == kernel_idx ? (NULL == config ? OPENCL_LIBSMM_DEFAULT_BS

--- a/src/acc/opencl/smm/tune_multiply.sh
+++ b/src/acc/opencl/smm/tune_multiply.sh
@@ -42,13 +42,13 @@ if [ "${SORT}" ] && [ "${SED}" ] && [ "${LS}" ] && [ "${RM}" ] && [ "${WC}" ]; t
     -p|--jsondir)
       JSONDIR=$2
       shift 2;;
-    -s|--specid)
+    -k|--specid)
       SPECID=$2
       shift 2;;
     -m|--limit)
       MAXEXT=$2
       shift 2;;
-    -n|--size)
+    -n|--triplets)
       MAXNUM=$2
       shift 2;;
     -r|--bound)
@@ -60,6 +60,9 @@ if [ "${SORT}" ] && [ "${SED}" ] && [ "${LS}" ] && [ "${RM}" ] && [ "${WC}" ]; t
       shift 2;;
     -j|--nparts)
       NPARTS=$2
+      shift 2;;
+    -s|--batchsize)
+      BATCHSIZE=$2
       shift 2;;
     *)
       break;;
@@ -74,15 +77,16 @@ if [ "${SORT}" ] && [ "${SED}" ] && [ "${LS}" ] && [ "${RM}" ] && [ "${WC}" ]; t
   eval "${ECHO} \"       Options must precede triplet specification\""
   eval "${ECHO} \"       -c|--continue: proceed with plan if tuning is interrupted\""
   eval "${ECHO} \"       -u|--update: retune all JSONs found in directory (see -p)\""
+  eval "${ECHO} \"       -s|--batchsize N: Number of batched SMMs (a.k.a. stacksize)\""
   eval "${ECHO} \"       -a|--tuning-level N=0..3: all, most, some, least tunables\""
   eval "${ECHO} \"       -t|--maxtime N: number of seconds spent per kernel\""
   eval "${ECHO} \"       -p|--jsondir P: path to JSON-files (tuned params)\""
   eval "${ECHO} \"       -i|--part N (1-based): Nth session out of nparts\""
   eval "${ECHO} \"       -j|--nparts N: number of total sessions (see -i)\""
   eval "${ECHO} \"       -r|--bound L U: limit L**3 < MNK <= U**3\""
-  eval "${ECHO} \"       -m|--limit N: limit shape extents to N\""
-  eval "${ECHO} \"       -n|--size  N: limit number of elements\""
-  eval "${ECHO} \"       -s|--specid N: predefined triplets\""
+  eval "${ECHO} \"       -m|--limit N: limit any shape extent to N\""
+  eval "${ECHO} \"       -n|--triplets N: limit number of triplet\""
+  eval "${ECHO} \"       -k|--specid N: predefined triplets\""
   eval "${ECHO} \"        0-10: older to newer (larger), e.g.,\""
   eval "${ECHO} \"       -s  0:  201 kernels\""
   eval "${ECHO} \"       -s 10: 1266 kernels\""
@@ -90,6 +94,7 @@ if [ "${SORT}" ] && [ "${SED}" ] && [ "${LS}" ] && [ "${RM}" ] && [ "${WC}" ]; t
   eval "${ECHO} \"         23, 5 32 13 24 26, 4 9\""
   eval "${ECHO}"
   # default settings
+  if [ ! "${BATCHSIZE}" ]; then BATCHSIZE=0; fi
   if [ ! "${JSONDIR}" ]; then JSONDIR=.; fi
   if [ ! "${TLEVEL}" ]; then TLEVEL=-1; fi
   if [ ! "${MAXEXT}" ]; then MAXEXT=0; fi
@@ -110,11 +115,11 @@ if [ "${SORT}" ] && [ "${SED}" ] && [ "${LS}" ] && [ "${RM}" ] && [ "${WC}" ]; t
   elif [ ! "${HELP}" ] || [ "0" = "${HELP}" ]; then
     if [ "${UPDATE}" ] && [ "0" != "${UPDATE}" ]; then
       if [ ! "${TLEVEL}" ] || [ "0" != "$((0>TLEVEL))" ]; then TLEVEL=0; fi
-      if [ ! "${MAXTIME}" ]; then MAXTIME=320; fi
+      if [ ! "${MAXTIME}" ]; then MAXTIME=160; fi
       MNKS=$(echo "${JSONS}" | ${SED} -n "s/.*tune_multiply-..*-\(..*x..*x.[^-]*\)-..*gflops\.json/\1/p" \
          | ${SORT} -u -n -tx -k1 -k2 -k3)
     elif [ "${SPECID}" ]; then
-      MNKS=$(eval "${HERE}/../../acc_triplets.sh -r ${BOUNDL} ${BOUNDU} -m ${MAXEXT} -n ${MAXNUM} -s ${SPECID} 2>/dev/null")
+      MNKS=$(eval "${HERE}/../../acc_triplets.sh -r ${BOUNDL} ${BOUNDU} -m ${MAXEXT} -n ${MAXNUM} -k ${SPECID} 2>/dev/null")
     else
       MNKS=$(eval "${HERE}/../../acc_triplets.sh -r ${BOUNDL} ${BOUNDU} -m ${MAXEXT} -n ${MAXNUM} $* 2>/dev/null")
     fi
@@ -165,7 +170,7 @@ if [ "${SORT}" ] && [ "${SED}" ] && [ "${LS}" ] && [ "${RM}" ] && [ "${WC}" ]; t
       echo "Started auto-tuning ${MNK}-kernel..."
       # avoid mixing database of previous results into new session
       ${RM} -rf "${HERE}/opentuner.db"
-      eval "${HERE}/tune_multiply.py ${MNK} -p ${JSONDIR} -a ${TLEVEL} ${MAXTIME}"
+      eval "${HERE}/tune_multiply.py ${MNK} -p ${JSONDIR} -s ${BATCHSIZE} -a ${TLEVEL} ${MAXTIME}"
       RESULT=$?
       # environment var. CONTINUE allows to proceed with next kernel
       # even if tune_multiply.py returned non-zero exit code


### PR DESCRIPTION
* Made -s|--batchsize available for tune_multiply.sh. Revised script options to be more coherent.
* Always tune primary kernel and avoid automatically enabling kernel for small batches.
* Only consider a default size if the problem-size is not specified.
* Pass problem-size when launching benchmark/executable.
* Adjusted default (BS=1 kernel).