### PR TITLE
ocl: fixed kernel code-path and code cleanup

### DIFF
--- a/src/acc/acc.h
+++ b/src/acc/acc.h
@@ -62,6 +62,11 @@ int c_dbcsr_acc_memcpy_d2d(const void* devmem_src, void* devmem_dst, size_t nbyt
 int c_dbcsr_acc_memset_zero(void* dev_mem, size_t offset, size_t nbytes, void* stream);
 int c_dbcsr_acc_dev_mem_info(size_t* mem_free, size_t* mem_total);
 
+#if defined(__DBCSR_ACC)
+void c_dbcsr_timeset(const char** routineN, const int* routineN_len, int* handle);
+void c_dbcsr_timestop(const int* handle);
+#endif
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/acc/acc_libsmm.h
+++ b/src/acc/acc_libsmm.h
@@ -56,9 +56,6 @@ static const int         libsmm_acc_transpose_routine_name_len = (int)sizeof(lib
 static const char        libsmm_acc_process_routine_name_str[] = "jit_kernel_multiply";
 static const char *const libsmm_acc_process_routine_name_ptr = libsmm_acc_process_routine_name_str;
 static const int         libsmm_acc_process_routine_name_len = (int)sizeof(libsmm_acc_process_routine_name_str) - 1;
-
-void c_dbcsr_timeset(const char** routineN, const int* routineN_len, int* handle);
-void c_dbcsr_timestop(const int* handle);
 #endif
 
 #if defined(__cplusplus)

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -85,6 +85,8 @@ ifneq (0,$(DEV))
     CFLAGS += -std=c89
     CFLAGS += -Wno-unused-parameter
   else
+    # DEV=2 (and higher): linking is not intended
+    CFLAGS += -D__DBCSR_ACC
     CFLAGS += -Wno-deprecated -Werror
     ifneq (,$(findstring clang,$(CC) $(CXX)))
       override CC := clang++ --analyze

--- a/src/acc/opencl/acc_opencl_event.c
+++ b/src/acc/opencl/acc_opencl_event.c
@@ -14,6 +14,10 @@
 # include <omp.h>
 #endif
 
+#if !defined(ACC_OPENCL_EVENT_BARRIER) && 0
+# define ACC_OPENCL_EVENT_BARRIER
+#endif
+
 
 #if defined(__cplusplus)
 extern "C" {
@@ -24,6 +28,12 @@ int c_dbcsr_acc_event_create(void** event_p)
   cl_int result = EXIT_SUCCESS;
   const cl_context context = c_dbcsr_acc_opencl_context();
   cl_event event;
+#if defined(__DBCSR_ACC) && defined(ACC_OPENCL_PROFILE)
+  int routine_handle;
+  static const char *const routine_name_ptr = LIBXSMM_FUNCNAME;
+  static const int routine_name_len = (int)sizeof(LIBXSMM_FUNCNAME) - 1;
+  c_dbcsr_timeset((const char**)&routine_name_ptr, &routine_name_len, &routine_handle);
+#endif
   assert(NULL != event_p && NULL != context);
   event  = clCreateUserEvent(context, &result);
   if (CL_SUCCESS == result) {
@@ -32,7 +42,8 @@ int c_dbcsr_acc_event_create(void** event_p)
     /* an empty event (unrecorded) has no work to wait for; hence it is
      * considered occurred and c_dbcsr_acc_event_synchronize must not block
      */
-    if (CL_SUCCESS == clSetUserEventStatus(event, status)) {
+    result = clSetUserEventStatus(event, status);
+    if (CL_SUCCESS == result) {
 #if defined(ACC_OPENCL_EVENT_NOALLOC)
       assert(sizeof(void*) >= sizeof(cl_event));
       *event_p = (void*)event;
@@ -40,25 +51,22 @@ int c_dbcsr_acc_event_create(void** event_p)
       *event_p = malloc(sizeof(cl_event));
       if (NULL != *event_p) {
         *(cl_event*)*event_p = event;
-        result = EXIT_SUCCESS;
       }
       else {
-        clReleaseEvent(event);
+        ACC_OPENCL_EXPECT(CL_SUCCESS, clReleaseEvent(event));
         result = EXIT_FAILURE;
       }
 #endif
     }
-    else {
-      ACC_OPENCL_ERROR("set initial event state", result);
-      clReleaseEvent(event);
+    else { /* error: setting initial event state */
+      ACC_OPENCL_EXPECT(CL_SUCCESS, clReleaseEvent(event));
       *event_p = NULL;
     }
   }
-  else {
-    assert(CL_SUCCESS != result);
-    ACC_OPENCL_ERROR("create user-defined event", result);
-    *event_p = NULL;
-  }
+  else *event_p = NULL; /* error: creating user-defined event */
+#if defined(__DBCSR_ACC) && defined(ACC_OPENCL_PROFILE)
+  c_dbcsr_timestop(&routine_handle);
+#endif
   ACC_OPENCL_RETURN(result);
 }
 
@@ -66,60 +74,62 @@ int c_dbcsr_acc_event_create(void** event_p)
 int c_dbcsr_acc_event_destroy(void* event)
 {
   int result = EXIT_SUCCESS;
+#if defined(__DBCSR_ACC) && defined(ACC_OPENCL_PROFILE)
+  int routine_handle;
+  static const char *const routine_name_ptr = LIBXSMM_FUNCNAME;
+  static const int routine_name_len = (int)sizeof(LIBXSMM_FUNCNAME) - 1;
+  c_dbcsr_timeset((const char**)&routine_name_ptr, &routine_name_len, &routine_handle);
+#endif
   if (NULL != event) {
-    ACC_OPENCL_CHECK(clReleaseEvent(*ACC_OPENCL_EVENT(event)),
-      "release user-defined event", result);
+    result = clReleaseEvent(*ACC_OPENCL_EVENT(event));
 #if defined(ACC_OPENCL_EVENT_NOALLOC)
     assert(sizeof(void*) >= sizeof(cl_event));
 #else
     free(event);
 #endif
   }
+#if defined(__DBCSR_ACC) && defined(ACC_OPENCL_PROFILE)
+  c_dbcsr_timestop(&routine_handle);
+#endif
   ACC_OPENCL_RETURN(result);
-}
-
-
-int c_dbcsr_acc_opencl_enqueue_barrier(void* event, void* stream)
-{
-  int result;
-  assert(NULL != event && NULL != stream);
-#if defined(CL_VERSION_1_2)
-  result =clEnqueueBarrierWithWaitList(*ACC_OPENCL_STREAM(stream),
-    0, NULL, ACC_OPENCL_EVENT(event));
-#else
-  result = EXIT_FAILURE;
-#endif
-  return result;
-}
-
-
-int c_dbcsr_acc_opencl_enqueue_marker(void* event, void* stream)
-{
-  int result;
-  assert(NULL != event && NULL != stream);
-#if defined(CL_VERSION_1_2)
-  result = clEnqueueMarkerWithWaitList(*ACC_OPENCL_STREAM(stream),
-    0, NULL, ACC_OPENCL_EVENT(event));
-#else
-  result = clEnqueueMarker(*ACC_OPENCL_STREAM(stream),
-    ACC_OPENCL_EVENT(event));
-#endif
-  return result;
 }
 
 
 int c_dbcsr_acc_event_record(void* event, void* stream)
 {
   int result;
+  cl_event clevent;
+#if defined(__DBCSR_ACC) && defined(ACC_OPENCL_PROFILE)
+  int routine_handle;
+  static const char *const routine_name_ptr = LIBXSMM_FUNCNAME;
+  static const int routine_name_len = (int)sizeof(LIBXSMM_FUNCNAME) - 1;
+  c_dbcsr_timeset((const char**)&routine_name_ptr, &routine_name_len, &routine_handle);
+#endif
   assert(NULL != event && NULL != stream);
-  assert(NULL != c_dbcsr_acc_opencl_config.devinfo.record_event);
   ACC_OPENCL_DEBUG_IF(EXIT_SUCCESS != c_dbcsr_acc_opencl_stream_is_thread_specific(
-    ACC_OPENCL_OMP_TID(), *ACC_OPENCL_STREAM(stream)))
+    ACC_OPENCL_OMP_TID(), stream))
   {
     ACC_OPENCL_DEBUG_FPRINTF(stderr, "WARNING ACC/OpenCL: "
       "c_dbcsr_acc_event_record called by foreign thread!\n");
   }
-  result = c_dbcsr_acc_opencl_config.devinfo.record_event(event, stream);
+#if defined(ACC_OPENCL_EVENT_BARRIER) && defined(CL_VERSION_1_2)
+  result = clEnqueueBarrierWithWaitList(*ACC_OPENCL_STREAM(stream), 0, NULL, &clevent);
+#elif defined(CL_VERSION_1_2)
+  result = clEnqueueMarkerWithWaitList(*ACC_OPENCL_STREAM(stream), 0, NULL, &clevent);
+#else
+  result = clEnqueueMarker(*ACC_OPENCL_STREAM(stream), &clevent);
+#endif
+  if (CL_SUCCESS == result) {
+#if defined(ACC_OPENCL_EVENT_NOALLOC)
+    assert(!"ACC_OPENCL_EVENT_NOALLOC not supported");
+    result = EXIT_FAILURE;
+#else
+    *(cl_event*)event = clevent;
+#endif
+  }
+#if defined(__DBCSR_ACC) && defined(ACC_OPENCL_PROFILE)
+  c_dbcsr_timestop(&routine_handle);
+#endif
   ACC_OPENCL_RETURN(result);
 }
 
@@ -130,10 +140,16 @@ int c_dbcsr_acc_event_query(void* event, c_dbcsr_acc_bool_t* has_occurred)
     NULL != event ? *ACC_OPENCL_EVENT(event) : NULL,
     CL_EVENT_COMMAND_EXECUTION_STATUS,
     sizeof(cl_int), &status, NULL);
+#if defined(__DBCSR_ACC) && defined(ACC_OPENCL_PROFILE)
+  int routine_handle;
+  static const char *const routine_name_ptr = LIBXSMM_FUNCNAME;
+  static const int routine_name_len = (int)sizeof(LIBXSMM_FUNCNAME) - 1;
+  c_dbcsr_timeset((const char**)&routine_name_ptr, &routine_name_len, &routine_handle);
+#endif
   assert(NULL != has_occurred);
   if (0 <= status) {
     *has_occurred = ((CL_COMPLETE == status || CL_SUCCESS != result) ? 1 : 0);
-    if (!*has_occurred) {
+    if (0 == (8 & c_dbcsr_acc_opencl_config.flush) && 0 == *has_occurred) {
       result = c_dbcsr_acc_opencl_device_synchronize(ACC_OPENCL_OMP_TID());
     }
   }
@@ -141,16 +157,26 @@ int c_dbcsr_acc_event_query(void* event, c_dbcsr_acc_bool_t* has_occurred)
     if (CL_SUCCESS == result) result = EXIT_FAILURE;
     *has_occurred = 1;
   }
+#if defined(__DBCSR_ACC) && defined(ACC_OPENCL_PROFILE)
+  c_dbcsr_timestop(&routine_handle);
+#endif
   ACC_OPENCL_RETURN(result);
 }
 
 
 int c_dbcsr_acc_event_synchronize(void* event)
 { /* waits on the host-side */
-  int result = EXIT_SUCCESS;
-  assert(NULL != event);
-  ACC_OPENCL_CHECK(clWaitForEvents(1, ACC_OPENCL_EVENT(event)),
-    "synchronize event", result);
+  int result;
+#if defined(__DBCSR_ACC) && defined(ACC_OPENCL_PROFILE)
+  int routine_handle;
+  static const char *const routine_name_ptr = LIBXSMM_FUNCNAME;
+  static const int routine_name_len = (int)sizeof(LIBXSMM_FUNCNAME) - 1;
+  c_dbcsr_timeset((const char**)&routine_name_ptr, &routine_name_len, &routine_handle);
+#endif
+  result = clWaitForEvents(1, ACC_OPENCL_EVENT(event));
+#if defined(__DBCSR_ACC) && defined(ACC_OPENCL_PROFILE)
+  c_dbcsr_timestop(&routine_handle);
+#endif
   ACC_OPENCL_RETURN(result);
 }
 

--- a/src/acc/opencl/smm/kernels/multiply.cl
+++ b/src/acc/opencl/smm/kernels/multiply.cl
@@ -546,6 +546,9 @@ kernel void FN(global T *restrict cdata,
           CNM(idx, m) = MAD(AMK(m, k), b, CNM(idx, m));
 #   endif
         }
+#   if defined(BARRIER) && (MAX(1, SGS) < SWG) && defined(SLM_A)
+        BARRIER(CLK_LOCAL_MEM_FENCE);
+#   endif
       }
 #   if (1 == BS)
       UNROLL(SM)

--- a/src/acc/opencl/smm/tune_multiply.py
+++ b/src/acc/opencl/smm/tune_multiply.py
@@ -713,16 +713,17 @@ if __name__ == "__main__":
     if 1 <= args.tlevel or 0 > args.tlevel:
         os.environ["OPENCL_LIBSMM_SMM_BM"] = "{}".format(args.bm)
         os.environ["OPENCL_LIBSMM_SMM_BN"] = "{}".format(args.bn)
+    if 2 <= args.tlevel or 0 > args.tlevel:
         os.environ["OPENCL_LIBSMM_SMM_AP"] = "{}".format(args.ap)
         os.environ["OPENCL_LIBSMM_SMM_NZ"] = "{}".format(args.nz)
         os.environ["OPENCL_LIBSMM_SMM_TB"] = "{}".format(args.tb)
         os.environ["OPENCL_LIBSMM_SMM_TC"] = "{}".format(args.tc)
         os.environ["OPENCL_LIBSMM_SMM_AL"] = "{}".format(args.al)
-    if 2 <= args.tlevel:
+    if 3 <= args.tlevel:
         os.environ["OPENCL_LIBSMM_SMM_BK"] = "{}".format(args.bk)
         os.environ["OPENCL_LIBSMM_SMM_WG"] = "{}".format(args.wg)
         os.environ["OPENCL_LIBSMM_SMM_AC"] = "{}".format(args.ac)
-    if 3 <= args.tlevel:
+    if 4 <= args.tlevel:
         os.environ["OPENCL_LIBSMM_SMM_LU"] = "{}".format(args.lu)
     if 0 == args.mb:
         args.mb = 64

--- a/src/acc/opencl/smm/tune_multiply.sh
+++ b/src/acc/opencl/smm/tune_multiply.sh
@@ -114,7 +114,7 @@ if [ "${SORT}" ] && [ "${SED}" ] && [ "${LS}" ] && [ "${RM}" ] && [ "${WC}" ]; t
     exit 1
   elif [ ! "${HELP}" ] || [ "0" = "${HELP}" ]; then
     if [ "${UPDATE}" ] && [ "0" != "${UPDATE}" ]; then
-      if [ ! "${TLEVEL}" ] || [ "0" != "$((0>TLEVEL))" ]; then TLEVEL=0; fi
+      if [ ! "${TLEVEL}" ] || [ "0" != "$((0>TLEVEL))" ]; then TLEVEL=1; fi
       if [ ! "${MAXTIME}" ]; then MAXTIME=160; fi
       MNKS=$(echo "${JSONS}" | ${SED} -n "s/.*tune_multiply-..*-\(..*x..*x.[^-]*\)-..*gflops\.json/\1/p" \
          | ${SORT} -u -n -tx -k1 -k2 -k3)


### PR DESCRIPTION
* Moved prototypes/declarations of timeset/timestop to ACC-interface.
* Added missing barrier in certain kernel code-path (subgroups).
* Reworked device_synchronize to be based on stream_sync.
* Introduced ACC_OPENCL_PROFILE (using timeset/timestop).
* Renamed OPENCL_LIBSMM_SMM_ID to OPENCL_LIBSMM_SMM_DEVID,
  and limited scope to loading default parameters.
* Fixed reading CSVs with device name containing WS.
* Excluded white spaces from ACC_OPENCL_DELIMS.
* Fixed calling putenv (compiler error/warning).
* Improved testing code-paths (__DBCSR_ACC).
* Adjusted auto-tuning level (wrapper script).
* Implemented ACC_OPENCL_SHARE (stride).
* Count unique streams (statistics).
* Improved handling errors.
* Adjusted tuning levels.
* Adjusted defaults.