### PR TITLE
ocl: improved runtime setup

### DIFF
--- a/src/acc/opencl/acc_opencl_stream.c
+++ b/src/acc/opencl/acc_opencl_stream.c
@@ -111,7 +111,8 @@ int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int priority)
       && least != greatest)
     {
       properties[3] = (0 != (2 & c_dbcsr_acc_opencl_config.priority)
-                         && (NULL != strstr(name, "priority")))
+          && (NULL != libxsmm_stristr(name, "calc")
+          || (NULL != strstr(name, "priority"))))
         ? CL_QUEUE_PRIORITY_HIGH_KHR : CL_QUEUE_PRIORITY_MED_KHR;
     }
     else properties[3] = least;
@@ -159,7 +160,8 @@ int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int priority)
       cl_device_id device = NULL;
       result = clGetContextInfo(context, CL_CONTEXT_DEVICES, sizeof(cl_device_id), &device, NULL);
       if (CL_SUCCESS == result) {
-        const int s = c_dbcsr_acc_opencl_config.share;
+        const int s = (0 >= c_dbcsr_acc_opencl_config.share ? 0
+          : (1 < c_dbcsr_acc_opencl_config.share ? c_dbcsr_acc_opencl_config.share : 2));
         if (1 >= s || s >= c_dbcsr_acc_opencl_config.nthreads || 0 == (tid % s)) {
           queue = ACC_OPENCL_CREATE_COMMAND_QUEUE(context, device, properties, &result);
         }

--- a/src/acc/opencl/smm/opencl_libsmm.c
+++ b/src/acc/opencl/smm/opencl_libsmm.c
@@ -363,7 +363,8 @@ int libsmm_acc_init(void)
       opencl_libsmm_perfest_t perfest;
       memset(&perfest, 0, sizeof(perfest));
       if (NULL != env_timer && (opencl_libsmm_timer_host == atoi(env_timer)
-        || (env_timer == libxsmm_stristr(env_timer, "host") && 4 == strlen(env_timer))))
+        || (env_timer == libxsmm_stristr(env_timer, "host") && 4 == strlen(env_timer))
+        || (env_timer == libxsmm_stristr(env_timer, "cpu") && 3 == strlen(env_timer))))
       {
         opencl_libsmm_timer = opencl_libsmm_timer_host;
       }


### PR DESCRIPTION
* Account for cb6a48d6815d35efb796963f5c14645c17e836b6.
* Allow "cpu" keyword (OPENCL_LIBSMM_TIMER).