### PR TITLE
ocl: disabled stream priorities

### DIFF
--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -26,7 +26,7 @@ if [ ! -d "${HOME}/libxsmm" ]; then
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout 011dfb33d01e97274f70aac73f40eb68957f6e32
+git checkout 0ce3a23e48646891763bf068a0e94854c7f8e9ba
 make -j
 cd ..
 

--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -91,7 +91,7 @@
 #if !defined(ACC_OPENCL_DEBUG) && (defined(_DEBUG) || 0)
 #  define ACC_OPENCL_DEBUG
 #endif
-#if !defined(ACC_OPENCL_STREAM_PRIORITIES) && 1
+#if !defined(ACC_OPENCL_STREAM_PRIORITIES) && 0
 #  if defined(CL_QUEUE_PRIORITY_KHR)
 #    define ACC_OPENCL_STREAM_PRIORITIES
 #  endif


### PR DESCRIPTION
* Disabled stream-priorities (not used in DBCSR).
* Updated LIBXSMM (Daint-CI).