### PR TITLE
ocl: fixed OOB-access if invalid device was specified

### DIFF
--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -26,7 +26,7 @@ if [ ! -d "${HOME}/libxsmm" ]; then
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout edd5f524edd9574e887b27f66650db24ec6a9b7e
+git checkout b5ef155aa1412fb362129114d074b082726889f0
 make -j
 cd ..
 

--- a/src/acc/acc_bench_smm.c
+++ b/src/acc/acc_bench_smm.c
@@ -57,7 +57,7 @@
 #endif
 
 #define ACC_BENCH_SMM_EPSILON(T) DBCSR_CONCATENATE(ACC_BENCH_SMM_EPSILON_, T)
-#define ACC_BENCH_SMM_EPSILON_double 1E-3
+#define ACC_BENCH_SMM_EPSILON_double 3E-3
 #define ACC_BENCH_SMM_EPSILON_float 3E-3
 
 #define ROUNDUP2(N, NPOT) ((((unsigned long long)N) + ((NPOT)-1)) & ~((NPOT)-1))
@@ -493,12 +493,10 @@ int main(int argc, char* argv[]) {
   CHECK(libsmm_acc_finalize(), NULL);
 #endif
   CHECK(c_dbcsr_acc_finalize(), NULL);
-  if (EXIT_SUCCESS == result) {
 #if defined(USE_LIBXSMM) && defined(VALIDATE)
-    if (1 < nok) printf("\nmax.error: %g\n", maxerror);
+  if (1 < nok) printf("\nmax.error: %g\n", maxerror);
 #endif
-  }
-  else {
+  if (EXIT_SUCCESS != result) {
     if (NULL != file) fclose(file);
     if (-1 != result) {
       fprintf(stderr, "FAILED\n");

--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -394,7 +394,8 @@ int c_dbcsr_acc_init(void) {
         else { /* prune number of devices to only expose requested ID */
           if (1 < c_dbcsr_acc_opencl_config.ndevices) {
             if (0 < device_id) {
-              c_dbcsr_acc_opencl_config.devices[0] = c_dbcsr_acc_opencl_config.devices[device_id];
+              c_dbcsr_acc_opencl_config.devices[0] =
+                c_dbcsr_acc_opencl_config.devices[device_id % c_dbcsr_acc_opencl_config.ndevices];
             }
             c_dbcsr_acc_opencl_config.ndevices = 1;
           }

--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -215,7 +215,9 @@ typedef struct c_dbcsr_acc_opencl_devinfo_t {
   cl_bool svm_interop;
 #endif
   /** Intel device ID (zero if non-Intel). */
-  cl_int intel_id;
+  cl_uint intel_id;
+  /** Kernel-parameters are matched against device's UID */
+  cl_uint devmatch;
   /** Whether host memory is unified or not. */
   cl_bool unified;
 } c_dbcsr_acc_opencl_devinfo_t;
@@ -229,8 +231,6 @@ typedef struct c_dbcsr_acc_opencl_config_t {
   cl_device_id devices[ACC_OPENCL_DEVICES_MAXCOUNT];
   /** Settings updated during c_dbcsr_acc_set_active_device. */
   c_dbcsr_acc_opencl_devinfo_t devinfo;
-  /** Kernel-parameters are matched against device's UID */
-  cl_bool devmatch;
   /** Table of activated device contexts (thread-specific). */
   cl_context* contexts;
   /** Handle-counter. */
@@ -296,9 +296,9 @@ int c_dbcsr_acc_opencl_device_vendor(cl_device_id device, const char vendor[]);
 /** Confirm that match is matching the name of the given device. */
 int c_dbcsr_acc_opencl_device_name(cl_device_id device, const char match[]);
 /** Capture or calculate UID based on the device-name. */
-int c_dbcsr_acc_opencl_devuid(const char devname[], int* uid);
+int c_dbcsr_acc_opencl_devuid(const char devname[], unsigned int* uid);
 /** Capture or calculate UID based on the device-ID. */
-int c_dbcsr_acc_opencl_device_uid(cl_device_id device, int* uid);
+int c_dbcsr_acc_opencl_device_uid(cl_device_id device, unsigned int* uid);
 /** Return the OpenCL support level for the given device. */
 int c_dbcsr_acc_opencl_device_level(cl_device_id device, int* level_major, int* level_minor, char cl_std[16], cl_device_type* type);
 /** Check if given device supports the extensions. */

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -57,7 +57,7 @@ typedef struct opencl_libsmm_smmkey_t {
   libsmm_acc_data_t type; /* must be the 1st data member */
   int m, n, k;
   /* device matching configuration (parameters) */
-  int devuid;
+  unsigned int devuid;
 } opencl_libsmm_smmkey_t;
 
 /** Type for SMM-kernel configuration. */


### PR DESCRIPTION
* Fixed OOB-access if ACC_OPENCL_DEVICE specifies an invalid device.
* Print max. error even in case of failed validation (acc_bench_smm).
* Adjusted tolerance (acc_bench_smm).