### PR TITLE
acc: generate dependency based on GPUVER

### DIFF
--- a/src/acc/acc_makedep.sh
+++ b/src/acc/acc_makedep.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+####################################################################################################
+# Copyright (C) by the DBCSR developers group - All rights reserved                                #
+# This file is part of the DBCSR library.                                                          #
+#                                                                                                  #
+# For information on the license, see the LICENSE file.                                            #
+# For further information please visit https://dbcsr.cp2k.org                                      #
+# SPDX-License-Identifier: GPL-2.0+                                                                #
+####################################################################################################
+
+FILE=$1
+VAL=$2
+
+if [ "${FILE}" ]; then
+  if [ ! -e "${FILE}" ] || [ "$(cat "${FILE}")" != "${VAL}" ]; then
+    echo "${VAL}" >"${FILE}"
+  fi
+  echo "${FILE}"
+else
+  echo "Usage: $0 filename [value]"
+  echo "  The content of the file will be updated with the value"
+  echo "  if the value is different than the current value."
+  echo "  This suitable to form a Makefile dependency."
+fi
+
+


### PR DESCRIPTION
This fixes rebuilding parameters.h (CUDA/HIP) and opencl_kernels.h (OpenCL) when GPUVER changes. There will a corresponding PR for CP2K (exts/build_dbcsr/Makefile). Currently, removing exe, obj, and lib directories in CP2K's root/build directory does not trigger rebuilding aforementioned parameter files since these files are hosted in DBCSR's source-tree. After this (and the related PR for CP2K), the parameter files are generated whenever GPUVER changes.