### PR TITLE
ocl: enabled fp32 kernels

### DIFF
--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -969,12 +969,9 @@ int c_dbcsr_acc_set_active_device(int device_id) {
 
 int c_dbcsr_acc_opencl_device_synchronize(int thread_id) {
   int result = EXIT_SUCCESS;
-  if (0 == (4 & c_dbcsr_acc_opencl_config.flush)
-#  if defined(ACC_OPENCL_SHARE)
-      && (1 > c_dbcsr_acc_opencl_config.share ||
-           0 == (thread_id % (1 != c_dbcsr_acc_opencl_config.share ? c_dbcsr_acc_opencl_config.share : 2)))
-#  endif
-  ) {
+  if (0 == (4 & c_dbcsr_acc_opencl_config.flush) &&
+      (1 > c_dbcsr_acc_opencl_config.share ||
+        0 == (thread_id % (1 != c_dbcsr_acc_opencl_config.share ? c_dbcsr_acc_opencl_config.share : 2)))) {
     void** const streams = c_dbcsr_acc_opencl_config.streams + ACC_OPENCL_STREAMS_MAXCOUNT * thread_id;
     int i = 0;
     assert(0 <= thread_id && thread_id < c_dbcsr_acc_opencl_config.nthreads);

--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -85,9 +85,6 @@
 #  define ACC_OPENCL_DELIMS ",;"
 #endif
 
-#if !defined(ACC_OPENCL_PROFILE) && 0
-#  define ACC_OPENCL_PROFILE
-#endif
 #if !defined(ACC_OPENCL_DEBUG) && (defined(_DEBUG) || 0)
 #  define ACC_OPENCL_DEBUG
 #endif
@@ -106,8 +103,8 @@
 #if !defined(ACC_OPENCL_DEVMATCH) && 0
 #  define ACC_OPENCL_DEVMATCH
 #endif
-#if !defined(ACC_OPENCL_SHARE) && 0
-#  define ACC_OPENCL_SHARE
+#if !defined(ACC_OPENCL_PROFILE) && 0
+#  define ACC_OPENCL_PROFILE
 #endif
 
 /* can depend on OpenCL implementation (unlikely) */
@@ -130,12 +127,6 @@
 #  define ACC_OPENCL_EVENT(A) ((cl_event*)&(A))
 #else
 #  define ACC_OPENCL_EVENT(A) ((cl_event*)(A))
-#endif
-
-#if defined(CL_VERSION_2_0)
-#  define ACC_OPENCL_COMMAND_QUEUE_PROPERTIES cl_queue_properties
-#else
-#  define ACC_OPENCL_COMMAND_QUEUE_PROPERTIES cl_int
 #endif
 
 #if defined(ACC_OPENCL_DEBUG)

--- a/src/acc/opencl/smm/opencl_libsmm.c
+++ b/src/acc/opencl/smm/opencl_libsmm.c
@@ -54,6 +54,9 @@
 #  if !defined(OPENCL_LIBSMM_NLOCKS_SMM)
 #    define OPENCL_LIBSMM_NLOCKS_SMM 16
 #  endif
+#  if !defined(OPENCL_LIBSMM_CMEM) && 1
+#    define OPENCL_LIBSMM_CMEM
+#  endif
 /* default: decompose C-matrix into column-vectors (Mx1) */
 #  if !defined(OPENCL_LIBSMM_DEFAULT_BM)
 #    define OPENCL_LIBSMM_DEFAULT_BM INT_MAX

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -21,13 +21,13 @@
 #if !defined(OPENCL_LIBSMM_DEBUG) && 0
 #  define OPENCL_LIBSMM_DEBUG 1
 #endif
-#if !defined(OPENCL_LIBSMM_CMEM) && 1
-#  define OPENCL_LIBSMM_CMEM
+#if !defined(OPENCL_LIBSMM_F32_OFF) && defined(__DBCSR_ACC) && 0
+#  define OPENCL_LIBSMM_F32_OFF
 #endif
-#if !defined(OPENCL_LIBSMM_F32) && !defined(__DBCSR_ACC)
+#if !defined(OPENCL_LIBSMM_F32) && !defined(OPENCL_LIBSMM_F32_OFF)
 #  define OPENCL_LIBSMM_F32
 #endif
-#if !defined(OPENCL_LIBSMM_F64) && 1
+#if !defined(OPENCL_LIBSMM_F64) && !defined(OPENCL_LIBSMM_F64_OFF)
 #  define OPENCL_LIBSMM_F64
 #endif
 


### PR DESCRIPTION
* Removed build-time decision about ACC_OPENCL_SHARE.
* Fixed loop-bound.