### PR TITLE
ocl: improved checking suitability of kernels

### DIFF
--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -26,7 +26,7 @@ if [ ! -d "${HOME}/libxsmm" ]; then
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout b5ef155aa1412fb362129114d074b082726889f0
+git checkout e9be7eb0dbd243aebad70b8ad56c94f070051872
 make -j
 cd ..
 

--- a/src/acc/opencl/smm/README.md
+++ b/src/acc/opencl/smm/README.md
@@ -8,9 +8,9 @@ The LIBSMM library implements the [ACC LIBSMM interface](https://github.com/cp2k
 
 ### Compile-time Settings
 
-Compile-time settings are (implicitly) documented and can be adjusted by editing [opencl_libsmm.h](https://github.com/cp2k/dbcsr/blob/develop/src/acc/opencl/smm/opencl_libsmm.h) (adjusting the build-line as per `-D` is possible as well but less convenient). For example, `OPENCL_LIBSMM_F32` is enabled by default but can be disabled, or `OPENCL_LIBSMM_DEBUG` (which is disabled by default) can be enabled for debug purpose.
+Compile-time settings are (implicitly) documented and can be adjusted by editing [opencl_libsmm.h](https://github.com/cp2k/dbcsr/blob/develop/src/acc/opencl/smm/opencl_libsmm.h) (adjusting the build-line as per `-D` is possible as well but less convenient). For example, `OPENCL_LIBSMM_F32` is enabled by default but can be disabled, or `OPENCL_LIBSMM_VALIDATE` (which is disabled by default) can be enabled for debug purpose.
 
-The `OPENCL_LIBSMM_DEBUG` compile-time setting enables side-by-side validation of matrix transpose and multiply operations on GPU against a built-in CPU implementation. For example, running DBCSR's unit tests with this setting produces console output to pin-point a kernel causing validation errors.
+The `OPENCL_LIBSMM_VALIDATE` compile-time setting enables side-by-side validation of matrix transpose and multiply operations on GPU against a built-in CPU implementation. For example, running DBCSR's unit tests with this setting produces console output to pin-point a kernel causing validation errors.
 
 ### Runtime Settings
 

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -12,14 +12,17 @@
 #include "../../acc_libsmm.h"
 #include "../acc_opencl.h"
 
+/* Inplace-transpose by default (similar environment variable exists for runtime) */
 #if !defined(OPENCL_LIBSMM_TRANS_INPLACE) && 0
 #  define OPENCL_LIBSMM_TRANS_INPLACE
 #endif
+/* Suitability check by default (similar environment variable exists for runtime) */
 #if !defined(OPENCL_LIBSMM_SUITABLE) && 0
 #  define OPENCL_LIBSMM_SUITABLE
 #endif
-#if !defined(OPENCL_LIBSMM_DEBUG) && 0
-#  define OPENCL_LIBSMM_DEBUG 1
+/* Validate kernels (1: OPENCL_LIBSMM_VALIDATE_SMM, 2: OPENCL_LIBSMM_VALIDATE_TRANS) */
+#if !defined(OPENCL_LIBSMM_VALIDATE) && 0
+#  define OPENCL_LIBSMM_VALIDATE 1
 #endif
 #if !defined(OPENCL_LIBSMM_F32_OFF) && defined(__DBCSR_ACC) && 0
 #  define OPENCL_LIBSMM_F32_OFF
@@ -112,7 +115,7 @@ int opencl_libsmm_write_smm_params(FILE* stream, int only_key, const opencl_libs
 int opencl_libsmm_read_smm_params(
   char* parambuf, opencl_libsmm_smmkey_t* key, opencl_libsmm_smm_t* value, opencl_libsmm_perfest_t* perfest, char* device);
 
-#if defined(OPENCL_LIBSMM_DEBUG) && defined(_DEBUG)
+#if defined(OPENCL_LIBSMM_VALIDATE) && defined(_DEBUG)
 void opencl_libsmm_print_matrix(FILE* ostream, const char* label, libsmm_acc_data_t type, const void* mat, int m, int n);
 #endif
 


### PR DESCRIPTION
* Renamed OPENCL_LIBSMM_DEBUG to OPENCL_LIBSMM_VALIDATE.
* Made OPENCL_LIBSMM_SUITABLE available at runtime.
* Improved suitability message (ACC_OPENCL_VERBOSE).
* Updated LIBXSM (Daint-CI).