### PR TITLE
ocl: allow get_ndevices/set_active_device before init

### DIFF
--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -573,7 +573,7 @@ int c_dbcsr_acc_get_ndevices(int* ndevices) {
   static const int routine_name_len = (int)sizeof(LIBXSMM_FUNCNAME) - 1;
   c_dbcsr_timeset((const char**)&routine_name_ptr, &routine_name_len, &routine_handle);
 #  endif
-#  if defined(__DBCSR_ACC)
+#  if defined(ACC_OPENCL_LAZYINIT)
   /* DBCSR calls c_dbcsr_acc_get_ndevices before calling c_dbcsr_acc_init. */
   result = c_dbcsr_acc_init();
   if (EXIT_SUCCESS == result)

--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -85,6 +85,9 @@
 #  define ACC_OPENCL_DELIMS ",;"
 #endif
 
+#if !defined(ACC_OPENCL_LAZYINIT) && (defined(__DBCSR_ACC) || 1)
+#  define ACC_OPENCL_LAZYINIT
+#endif
 #if !defined(ACC_OPENCL_DEBUG) && (defined(_DEBUG) || 0)
 #  define ACC_OPENCL_DEBUG
 #endif

--- a/src/core/dbcsr_lib.F
+++ b/src/core/dbcsr_lib.F
@@ -315,7 +315,7 @@ CONTAINS
          CALL acc_finalize()
 !$OMP    END MASTER
 !$OMP    END PARALLEL
-      ENDIF
+      END IF
 
       ! Check the number of communicators
       IF (check_comm_count .AND. mp_get_comm_count() .NE. 0) THEN

--- a/tests/dbcsr_acc_test.c
+++ b/tests/dbcsr_acc_test.c
@@ -74,6 +74,11 @@ int main(int argc, char* argv[]) {
     randnums[i] = rand();
   }
 
+  /* allow get_ndevices/set_active_device before init */
+  ACC_CHECK(c_dbcsr_acc_get_ndevices(&ndevices));
+  if (0 <= device && device < ndevices) { /* not an error */
+    ACC_CHECK(c_dbcsr_acc_set_active_device(device));
+  }
   ACC_CHECK(c_dbcsr_acc_init());
   ACC_CHECK(c_dbcsr_acc_get_ndevices(&ndevices));
   PRINTF("ndevices: %i\n", ndevices);


### PR DESCRIPTION
* Introduced ACC_OPENCL_LAZYINIT.
* Prettify.