### PR TITLE
ocl: removed code mostly used during development

### DIFF
--- a/src/acc/opencl/README.md
+++ b/src/acc/opencl/README.md
@@ -21,8 +21,7 @@ Runtime settings are made by the means of environment variables. The OpenCL back
 * `ACC_OPENCL_VERBOSE`: verbosity level (integer) with console output on `stderr`.
     * `ACC_OPENCL_VERBOSE=1`: outputs the number of devices found and the name of the selected device.
     * `ACC_OPENCL_VERBOSE=2`: outputs the duration needed to generate a requested kernel.
-    * `ACC_OPENCL_VERBOSE=3`: outputs device-side measured performance of kernels (geometric mean).
-    * `ACC_OPENCL_VERBOSE=4`: outputs device-side performance of kernels (every launch profiled).
+    * `ACC_OPENCL_VERBOSE=3`: outputs device-side performance of kernels (every launch profiled).
 * `ACC_OPENCL_DUMP`: dump preprocessed kernel source code (1) or dump compiled OpenCL kernels (2).
     * `ACC_OPENCL_DUMP=1`: dump preprocessed kernel source code and use it for JIT compilation. Instantiates the original source code using preprocessor definitions (`-D`) and collapses the code accordingly.
     * `ACC_OPENCL_DUMP=2`: dump compiled OpenCL kernels (depends on OpenCL implementation), e.g., PTX code on Nvidia.

--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -71,12 +71,8 @@ cl_context c_dbcsr_acc_opencl_context(void) {
     for (; i < c_dbcsr_acc_opencl_config.nthreads; ++i) {
       if (tid != i) { /* adopt another context */
         result = c_dbcsr_acc_opencl_config.contexts[i];
-        if (NULL != result && CL_SUCCESS == clRetainContext(result)) {
-          break;
-        }
-        else {
-          result = NULL;
-        }
+        if (NULL != result && CL_SUCCESS == clRetainContext(result)) break;
+        else result = NULL;
       }
     }
   }
@@ -234,8 +230,8 @@ int c_dbcsr_acc_init(void) {
     const char *const env_share = getenv("ACC_OPENCL_SHARE"), *const env_async = getenv("ACC_OPENCL_ASYNC");
     const char *const env_priority = getenv("ACC_OPENCL_PRIORITY"), *const env_flush = getenv("ACC_OPENCL_FLUSH");
     const char *const env_devtype = getenv("ACC_OPENCL_DEVTYPE"), *const env_device = getenv("ACC_OPENCL_DEVICE");
-    const char *const env_dump_acc = getenv("ACC_OPENCL_DUMP"), *const env_dump_igc = getenv("IGC_ShaderDumpEnable");
-    const char* const env_dump = (NULL != env_dump_acc ? env_dump_acc : env_dump_igc);
+    const char *const env_nullify = getenv("ACC_OPENCL_NULLIFY"), *const env_dump_acc = getenv("ACC_OPENCL_DUMP");
+    const char* const env_dump = (NULL != env_dump_acc ? env_dump_acc : getenv("IGC_ShaderDumpEnable"));
     int device_id = (NULL == env_device ? 0 : atoi(env_device));
     cl_uint nplatforms = 0, i;
     cl_device_type type = CL_DEVICE_TYPE_ALL;
@@ -248,6 +244,7 @@ int c_dbcsr_acc_init(void) {
     c_dbcsr_acc_opencl_config.dump = (NULL == env_dump ? /*default*/ 0 : atoi(env_dump));
     c_dbcsr_acc_opencl_config.verbosity = (NULL == env_verbose ? 0 : atoi(env_verbose));
     c_dbcsr_acc_opencl_config.priority = (NULL == env_priority ? /*default*/ 3 : atoi(env_priority));
+    c_dbcsr_acc_opencl_config.nullify = (NULL == env_nullify ? /*default*/ 0 : atoi(env_nullify));
     c_dbcsr_acc_opencl_config.share = (NULL == env_share ? /*default*/ 0 : atoi(env_share));
     c_dbcsr_acc_opencl_config.async = (NULL == env_async ? /*default*/ 3 : atoi(env_async));
     c_dbcsr_acc_opencl_config.flush = (NULL == env_flush ? /*default*/ 0 : atoi(env_flush));
@@ -325,9 +322,7 @@ int c_dbcsr_acc_init(void) {
                     ACC_OPENCL_CHECK(clReleaseDevice(devices[j]), "release device", result);
                     c_dbcsr_acc_opencl_config.ndevices += n;
                   }
-                  else {
-                    break;
-                  }
+                  else break;
                 }
                 else {
                   c_dbcsr_acc_opencl_config.devices[c_dbcsr_acc_opencl_config.ndevices] = devices[j];
@@ -357,9 +352,7 @@ int c_dbcsr_acc_init(void) {
                 ++i;
               }
             }
-            else {
-              break; /* error: retrieving device vendor */
-            }
+            else break; /* error: retrieving device vendor */
           }
         }
         /* reorder devices according to c_dbcsr_acc_opencl_order_devices */
@@ -389,14 +382,10 @@ int c_dbcsr_acc_init(void) {
                   c_dbcsr_acc_opencl_config.ndevices = i + 1;
                   strncpy(tmp, buffer, ACC_OPENCL_BUFFERSIZE);
                 }
-                else {
-                  break; /* error: retrieving device name */
-                }
+                else break; /* error: retrieving device name */
               }
             }
-            else {
-              break; /* error: retrieving device type */
-            }
+            else break; /* error: retrieving device type */
           }
         }
         else { /* prune number of devices to only expose requested ID */
@@ -659,9 +648,7 @@ int c_dbcsr_acc_opencl_device_id(cl_device_id device, int* device_id, int* globa
             break;
           }
         }
-        else {
-          break;
-        }
+        else break;
       }
     }
   }
@@ -1003,9 +990,7 @@ int c_dbcsr_acc_opencl_device_synchronize(int thread_id) {
         result = c_dbcsr_acc_stream_sync(stream);
         if (EXIT_SUCCESS != result) break;
       }
-      else {
-        break;
-      }
+      else break;
     }
   }
   ACC_OPENCL_RETURN(result);
@@ -1129,9 +1114,7 @@ int c_dbcsr_acc_opencl_kernel(const char source[], const char kernel_name[], con
                   if (NULL != line) {
                     ++line;
                   }
-                  else {
-                    break;
-                  }
+                  else break;
                 }
 #  if !defined(NDEBUG)
                 if (EXIT_SUCCESS == c_dbcsr_acc_opencl_device_ext(active_id, (const char**)&ext, 1))

--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -245,6 +245,8 @@ typedef struct c_dbcsr_acc_opencl_config_t {
   cl_int nthreads;
   /** How to apply/use stream priorities. */
   cl_int priority;
+  /** Determines how device-side buffers are zeroed. */
+  cl_int nullify;
   /** Asynchronous memory operations. */
   cl_int async;
   /** Flush level. */

--- a/src/acc/opencl/acc_opencl_stream.c
+++ b/src/acc/opencl/acc_opencl_stream.c
@@ -178,9 +178,7 @@ int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int priority) {
               stream = *ACC_OPENCL_STREAM(c_dbcsr_acc_opencl_config.streams[i]);
               result = clRetainCommandQueue(stream);
             }
-            else {
-              break;
-            }
+            else break;
           }
         }
         if (EXIT_SUCCESS == result) queue = stream;

--- a/src/acc/opencl/smm/README.md
+++ b/src/acc/opencl/smm/README.md
@@ -23,8 +23,7 @@ Runtime settings are made by the means of environment variables. The OpenCL back
 * `ACC_OPENCL_VERBOSE`: verbosity level (integer) with console output on `stderr`.
     * `ACC_OPENCL_VERBOSE=1`: outputs the number of devices found and the name of the selected device.
     * `ACC_OPENCL_VERBOSE=2`: outputs the duration needed to generate a requested kernel.
-    * `ACC_OPENCL_VERBOSE=3`: outputs device-side measured performance of kernels (geometric mean).
-    * `ACC_OPENCL_VERBOSE=4`: outputs device-side performance of kernels (every launch profiled).
+    * `ACC_OPENCL_VERBOSE=3`: outputs device-side performance of kernels (every launch profiled).
 * `ACC_OPENCL_DUMP`: dump preprocessed kernel source code (1) or dump compiled OpenCL kernels (2).
     * `ACC_OPENCL_DUMP=1`: dump preprocessed kernel source code and use it for JIT compilation. Instantiates the original source code using preprocessor definitions (`-D`) and collapses the code accordingly.
     * `ACC_OPENCL_DUMP=2`: dump compiled OpenCL kernels (depends on OpenCL implementation), e.g., PTX code on Nvidia.

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -49,10 +49,6 @@ typedef struct opencl_libsmm_transkey_t {
 typedef struct opencl_libsmm_trans_t {
   cl_kernel kernel; /* must be the 1st data member */
   size_t wgsize;
-  /* ACC_OPENCL_VERBOSE: perf. counters */
-  double membw_sumlog, membw_comp;
-  size_t nexec;
-  int size[7];
 } opencl_libsmm_trans_t;
 
 /** Type for querying SMM-kernel configuration. */
@@ -67,12 +63,9 @@ typedef struct opencl_libsmm_smmkey_t {
 typedef struct opencl_libsmm_smm_t {
   cl_kernel kernel[2]; /* must be the 1st data member */
   size_t wgsize[2];
+  double gflops;
   /* (pseudo-)parameters (either pretuned or determined) */
   int s, bs, bm, bn, bk, ws, wg, lu, nz, al, tb, tc, ap, aa, ab, ac;
-  /* ACC_OPENCL_VERBOSE: perf. counters */
-  double gflops, gflops_sumlog, gflops_comp;
-  size_t nexec;
-  int size[7];
 } opencl_libsmm_smm_t;
 
 typedef enum opencl_libsmm_timer_t { opencl_libsmm_timer_device, opencl_libsmm_timer_host } opencl_libsmm_timer_t;


### PR DESCRIPTION
* Removed built-in summary statistics (ACC_OPENCL_VERBOSE).
* Made ACC_OPENCL_MEM_ZERO_KERNEL a runtime-option.