### PR TITLE
ocl: execution hints and code cleanup

### DIFF
--- a/src/acc/cuda/Makefile
+++ b/src/acc/cuda/Makefile
@@ -232,9 +232,13 @@ $(DIRSMM)/parameters.h: $(MAKDIR)/Makefile $(DIRSMM)/generate_parameters.py $(PA
 $(DIRSMM)/smm_acc_kernels.h: $(GPUSMM) $(MAKDIR)/Makefile $(DIRSMM)/generate_kernels.py $(PARAMS)
 	@cd $(DIRSMM) && $(PYTHON) ../libsmm_acc/generate_kernels.py ../libsmm_acc/kernels
 
+.PHONY: backend
+backend: $(ACCDIR)/dbcsr_acc.a
 $(ACCDIR)/dbcsr_acc.a: $(OBJACC) $(DIRSMM)/libsmm_acc_init.o
 	$(AR) -rs $@ $^
 
+.PHONY: libsmm
+libsmm: $(ACCDIR)/dbcsr_acc_smm.a
 $(ACCDIR)/dbcsr_acc_smm.a: $(OBJSMM)
 	$(AR) -rs $@ $^
 

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -242,9 +242,13 @@ endif
 $(MAKDIR)/smm/opencl_kernels.h: $(MAKDIR)/acc_opencl.sh $(KERNEL) $(PARAMS)
 	@CPPFLAGS=$(CPP_OPENCL_FLAGS) $(MAKDIR)/acc_opencl.sh $(KERNEL) $(PARAMS) $@
 
+.PHONY: backend
+backend: $(ACCDIR)/dbcsr_acc.a
 $(ACCDIR)/dbcsr_acc.a: $(OBJACC)
 	$(AR) -rs $@ $^
 
+.PHONY: libsmm
+libsmm: $(ACCDIR)/dbcsr_acc_smm.a
 $(ACCDIR)/dbcsr_acc_smm.a: $(OBJSMM)
 	$(AR) -rs $@ $^
 

--- a/src/acc/opencl/acc_opencl_mem.c
+++ b/src/acc/opencl/acc_opencl_mem.c
@@ -59,12 +59,12 @@ c_dbcsr_acc_opencl_info_hostptr_t* c_dbcsr_acc_opencl_info_hostptr(void* memory)
 
 
 int c_dbcsr_acc_host_mem_allocate(void** host_mem, size_t nbytes, void* stream) {
-  cl_context context = NULL;
-  cl_command_queue queue;
-  cl_mem memory = NULL;
-  cl_int result;
+  c_dbcsr_acc_opencl_info_stream_t* const info = c_dbcsr_acc_opencl_info_stream(stream);
   const size_t size_meminfo = sizeof(c_dbcsr_acc_opencl_info_hostptr_t);
   const int alignment = c_dbcsr_acc_opencl_memalignment(nbytes);
+  void* host_ptr = NULL;
+  cl_mem memory = NULL;
+  cl_int result;
 #  if defined(__DBCSR_ACC) && defined(ACC_OPENCL_PROFILE)
   int routine_handle;
   static const char* const routine_name_ptr = LIBXSMM_FUNCNAME;
@@ -72,26 +72,19 @@ int c_dbcsr_acc_host_mem_allocate(void** host_mem, size_t nbytes, void* stream) 
   c_dbcsr_timeset((const char**)&routine_name_ptr, &routine_name_len, &routine_handle);
 #  endif
   nbytes += alignment + size_meminfo - 1;
-  assert(NULL != host_mem && NULL != stream);
-  queue = *ACC_OPENCL_STREAM(stream);
-  result = clGetCommandQueueInfo(queue, CL_QUEUE_CONTEXT, sizeof(cl_context), &context, NULL);
-  if (CL_SUCCESS == result) {
-    memory = (
-#  if defined(ACC_OPENCL_SVM)
-      0 != c_dbcsr_acc_opencl_config.devinfo.svm_interop
-        ? clCreateBuffer(context, CL_MEM_USE_HOST_PTR, nbytes,
-            clSVMAlloc(context, CL_MEM_READ_WRITE, nbytes, sizeof(void*) /*minimal alignment*/), &result)
-        :
-#  endif
-#  if defined(ACC_OPENCL_MALLOC_LIBXSMM)
-        clCreateBuffer(
-          context, CL_MEM_USE_HOST_PTR, nbytes, libxsmm_aligned_malloc(nbytes, sizeof(void*) /*minimal alignment*/), &result));
-#  else
-      clCreateBuffer(context, CL_MEM_ALLOC_HOST_PTR, nbytes, NULL /*host_ptr*/, &result));
-#  endif
+  assert(NULL != host_mem && NULL != stream && NULL != info);
+#  if defined(CL_VERSION_2_0)
+  if (0 != c_dbcsr_acc_opencl_config.device[info->tid].svm_interop) {
+    host_ptr = clSVMAlloc(
+      c_dbcsr_acc_opencl_config.device[info->tid].context, CL_MEM_READ_WRITE, nbytes, sizeof(void*) /*minimal alignment*/);
+    if (NULL == host_ptr) c_dbcsr_acc_opencl_config.device[info->tid].svm_interop = 0; /* sanitize */
   }
+#  endif
+  memory = clCreateBuffer(c_dbcsr_acc_opencl_config.device[info->tid].context,
+    NULL == host_ptr ? CL_MEM_ALLOC_HOST_PTR : CL_MEM_USE_HOST_PTR, nbytes, host_ptr, &result);
   assert(CL_SUCCESS == result || NULL == memory);
   if (CL_SUCCESS == result) {
+    const cl_command_queue queue = *ACC_OPENCL_STREAM(stream);
     void* const mapped = clEnqueueMapBuffer(
       queue, memory, CL_TRUE /*blocking*/, CL_MAP_READ | CL_MAP_WRITE, 0 /*offset*/, nbytes, 0, NULL, NULL, &result);
     assert(CL_SUCCESS == result || NULL == mapped);
@@ -142,16 +135,14 @@ int c_dbcsr_acc_host_mem_deallocate(void* host_mem, void* stream) {
       const cl_command_queue queue = *ACC_OPENCL_STREAM(stream);
       int result_release;
       result = clEnqueueUnmapMemObject(queue, info.memory, info.mapped, 0, NULL, NULL);
-#  if defined(ACC_OPENCL_SVM)
-      /* svm_interop shall be part of c_dbcsr_acc_opencl_info_hostptr_t */
-      assert(0 != c_dbcsr_acc_opencl_config.devinfo.svm_interop);
+#  if defined(CL_VERSION_2_0)
       {
-        cl_context context;
-        result = clGetCommandQueueInfo(queue, CL_QUEUE_CONTEXT, sizeof(cl_context), &context, NULL);
-        if (CL_SUCCESS == result) clSVMFree(context, info.mapped);
+        const c_dbcsr_acc_opencl_info_stream_t* const qinfo = c_dbcsr_acc_opencl_info_stream(stream);
+        assert(NULL != qinfo);
+        if (0 != c_dbcsr_acc_opencl_config.device[qinfo->tid].svm_interop) {
+          clSVMFree(c_dbcsr_acc_opencl_config.device[qinfo->tid].context, info.mapped);
+        }
       }
-#  elif defined(ACC_OPENCL_MALLOC_LIBXSMM)
-      libxsmm_free(info.mapped);
 #  endif
       result_release = clReleaseMemObject(info.memory);
       if (EXIT_SUCCESS == result) result = result_release;
@@ -172,13 +163,13 @@ int c_dbcsr_acc_host_mem_deallocate(void* host_mem, void* stream) {
 
 int c_dbcsr_acc_dev_mem_allocate(void** dev_mem, size_t nbytes) {
   cl_int result;
-  const int try_flag =
-    ((0 != c_dbcsr_acc_opencl_config.devinfo.unified || (0 == c_dbcsr_acc_opencl_config.devinfo.intel_id) ||
-       (0x4905 != c_dbcsr_acc_opencl_config.devinfo.intel_id && 0x020a != c_dbcsr_acc_opencl_config.devinfo.intel_id &&
-         0x0bd5 != c_dbcsr_acc_opencl_config.devinfo.intel_id))
-        ? 0
-        : (1u << 22));
-  const cl_context context = c_dbcsr_acc_opencl_context();
+  int tid = 0;
+  const cl_context context = c_dbcsr_acc_opencl_context(&tid);
+  const int devuid = c_dbcsr_acc_opencl_config.device[tid].uid,
+            try_flag = ((0 != c_dbcsr_acc_opencl_config.device[tid].unified || 0 == c_dbcsr_acc_opencl_config.device[tid].intel ||
+                          (0x4905 != devuid && 0x020a != devuid && (0x0bd0 > devuid || 0x0bdb < devuid)))
+                          ? 0
+                          : (1u << 22));
   cl_mem buffer;
 #  if defined(__DBCSR_ACC) && defined(ACC_OPENCL_PROFILE)
   int routine_handle;
@@ -189,8 +180,8 @@ int c_dbcsr_acc_dev_mem_allocate(void** dev_mem, size_t nbytes) {
   assert(NULL != dev_mem && 0 <= ACC_OPENCL_OVERMALLOC);
   assert(NULL != context);
   buffer = (
-#  if defined(ACC_OPENCL_SVM)
-    0 != c_dbcsr_acc_opencl_config.devinfo.svm_interop
+#  if defined(CL_VERSION_2_0)
+    0 != c_dbcsr_acc_opencl_config.device[tid].svm_interop
       ? clCreateBuffer(context, CL_MEM_USE_HOST_PTR, nbytes + ACC_OPENCL_OVERMALLOC,
           clSVMAlloc(
             context, (cl_mem_flags)(CL_MEM_READ_WRITE | try_flag), nbytes + ACC_OPENCL_OVERMALLOC, 0 /*default alignment*/),
@@ -201,8 +192,8 @@ int c_dbcsr_acc_dev_mem_allocate(void** dev_mem, size_t nbytes) {
         context, (cl_mem_flags)(CL_MEM_READ_WRITE | try_flag), nbytes + ACC_OPENCL_OVERMALLOC, NULL /*host_ptr*/, &result));
   if (0 != try_flag && CL_SUCCESS != result) { /* retry without try_flag */
     buffer = (
-#  if defined(ACC_OPENCL_SVM)
-      0 != c_dbcsr_acc_opencl_config.devinfo.svm_interop
+#  if defined(CL_VERSION_2_0)
+      0 != c_dbcsr_acc_opencl_config.device[tid].svm_interop
         ? clCreateBuffer(context, CL_MEM_USE_HOST_PTR, nbytes + ACC_OPENCL_OVERMALLOC,
             clSVMAlloc(context, CL_MEM_READ_WRITE, nbytes + ACC_OPENCL_OVERMALLOC, 0 /*default alignment*/), &result)
         :
@@ -228,11 +219,11 @@ int c_dbcsr_acc_dev_mem_allocate(void** dev_mem, size_t nbytes) {
       *(cl_mem*)*dev_mem = buffer;
     }
     else {
-#    if defined(ACC_OPENCL_SVM)
-      void* const ptr = (0 != c_dbcsr_acc_opencl_config.devinfo.svm_interop ? c_dbcsr_acc_opencl_get_hostptr(buffer) : NULL);
+#    if defined(CL_VERSION_2_0)
+      void* const ptr = (0 != c_dbcsr_acc_opencl_config.device[tid].svm_interop ? c_dbcsr_acc_opencl_get_hostptr(buffer) : NULL);
 #    endif
       clReleaseMemObject(buffer);
-#    if defined(ACC_OPENCL_SVM)
+#    if defined(CL_VERSION_2_0)
       /*if (NULL != ptr)*/ clSVMFree(context, ptr);
 #    endif
       result = EXIT_FAILURE;
@@ -259,9 +250,9 @@ int c_dbcsr_acc_dev_mem_deallocate(void* dev_mem) {
 #  endif
   if (NULL != dev_mem) {
     const cl_mem buffer = *ACC_OPENCL_MEM(dev_mem);
-#  if defined(ACC_OPENCL_SVM)
-    /* svm_interop shall be part of a device memory info */
-    void* const ptr = (0 != c_dbcsr_acc_opencl_config.devinfo.svm_interop ? c_dbcsr_acc_opencl_get_hostptr(buffer) : NULL);
+#  if defined(CL_VERSION_2_0)
+    const int tid = ACC_OPENCL_OMP_TID();
+    void* const ptr = (0 != c_dbcsr_acc_opencl_config.device[tid].svm_interop ? c_dbcsr_acc_opencl_get_hostptr(buffer) : NULL);
 #  endif
     ACC_OPENCL_CHECK(clReleaseMemObject(buffer), "release device memory buffer", result);
 #  if defined(ACC_OPENCL_MEM_NOALLOC)
@@ -279,13 +270,9 @@ int c_dbcsr_acc_dev_mem_deallocate(void* dev_mem) {
       free(dev_mem);
     }
 #  endif
-#  if defined(ACC_OPENCL_SVM)
-    /*if (NULL != ptr)*/
-    {
-      const cl_context context = c_dbcsr_acc_opencl_context();
-      assert(NULL != context);
-      clSVMFree(context, ptr);
-    }
+#  if defined(CL_VERSION_2_0)
+    assert(NULL != c_dbcsr_acc_opencl_config.device[tid].context);
+    clSVMFree(c_dbcsr_acc_opencl_config.device[tid].context, ptr); /*if (NULL != ptr)*/
 #  endif
   }
 #  if defined(__DBCSR_ACC) && defined(ACC_OPENCL_PROFILE)

--- a/src/acc/opencl/acc_opencl_stream.c
+++ b/src/acc/opencl/acc_opencl_stream.c
@@ -11,8 +11,10 @@
 #  include <string.h>
 
 #  if defined(CL_VERSION_2_0)
+#    define ACC_OPENCL_STREAM_PROPERTIES_TYPE cl_queue_properties
 #    define ACC_OPENCL_CREATE_COMMAND_QUEUE(CTX, DEV, PROPS, RESULT) clCreateCommandQueueWithProperties(CTX, DEV, PROPS, RESULT)
 #  else
+#    define ACC_OPENCL_STREAM_PROPERTIES_TYPE cl_int
 #    define ACC_OPENCL_CREATE_COMMAND_QUEUE(CTX, DEV, PROPS, RESULT) \
       clCreateCommandQueue(CTX, DEV, (cl_command_queue_properties)(NULL != (PROPS) ? ((PROPS)[1]) : 0), RESULT)
 #  endif
@@ -26,18 +28,9 @@ int c_dbcsr_acc_opencl_stream_counter;
 
 
 c_dbcsr_acc_opencl_info_stream_t* c_dbcsr_acc_opencl_info_stream(void* stream) {
-  c_dbcsr_acc_opencl_info_stream_t* result;
-#  if defined(ACC_OPENCL_STREAM_NOALLOC)
-  LIBXSMM_UNUSED(stream);
-#  else
   assert(NULL == stream || sizeof(c_dbcsr_acc_opencl_info_stream_t) <= (uintptr_t)stream);
-  if (NULL != stream) {
-    result = (c_dbcsr_acc_opencl_info_stream_t*)((uintptr_t)stream - sizeof(c_dbcsr_acc_opencl_info_stream_t));
-  }
-  else
-#  endif
-  result = NULL;
-  return result;
+  return (
+    NULL != stream ? ((c_dbcsr_acc_opencl_info_stream_t*)((uintptr_t)stream - sizeof(c_dbcsr_acc_opencl_info_stream_t))) : NULL);
 }
 
 
@@ -57,30 +50,10 @@ const int* c_dbcsr_acc_opencl_stream_priority(const void* stream) {
 }
 
 
-int c_dbcsr_acc_opencl_stream_is_thread_specific(int thread_id, const void* stream) {
-  void** const streams = c_dbcsr_acc_opencl_config.streams + ACC_OPENCL_STREAMS_MAXCOUNT * thread_id;
-  assert(0 <= thread_id && thread_id < c_dbcsr_acc_opencl_config.nthreads);
-  assert(NULL != c_dbcsr_acc_opencl_config.streams);
-  if (NULL != stream) {
-    int i = 0;
-    for (; i < ACC_OPENCL_STREAMS_MAXCOUNT; ++i) {
-      if (stream == streams[i]) return EXIT_SUCCESS;
-    }
-    return EXIT_FAILURE;
-  }
-  return EXIT_SUCCESS;
-}
-
-
 int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int priority) {
-#  if defined(CL_VERSION_2_0)
-  cl_queue_properties
-#  else
-  cl_int
-#  endif
-    properties[8] = {
-      CL_QUEUE_PROPERTIES, 0 /*placeholder*/, 0 /* terminator */
-    };
+  ACC_OPENCL_STREAM_PROPERTIES_TYPE properties[8] = {
+    CL_QUEUE_PROPERTIES, 0 /*placeholder*/, 0 /* terminator */
+  };
   int result, i, tid = 0;
   cl_command_queue queue = NULL;
   cl_context context = NULL;
@@ -118,7 +91,9 @@ int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int priority) {
     properties[4] = 0; /* terminator */
   }
 #  endif
-  if (3 <= c_dbcsr_acc_opencl_config.verbosity || 0 > c_dbcsr_acc_opencl_config.verbosity) {
+  if ((c_dbcsr_acc_opencl_timer_host != c_dbcsr_acc_opencl_config.timer) &&
+      (3 <= c_dbcsr_acc_opencl_config.verbosity || 0 > c_dbcsr_acc_opencl_config.verbosity))
+  {
     properties[1] = CL_QUEUE_PROFILING_ENABLE;
   }
 #  if defined(_OPENMP)
@@ -131,22 +106,59 @@ int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int priority) {
 #    endif
     i = c_dbcsr_acc_opencl_stream_counter++;
     tid = (i < c_dbcsr_acc_opencl_config.nthreads ? i : (i % c_dbcsr_acc_opencl_config.nthreads));
-    if (NULL != c_dbcsr_acc_opencl_config.contexts) { /* inherit master's context if current context is NULL */
-      LIBXSMM_ATOMIC_CMPSWP(
-        c_dbcsr_acc_opencl_config.contexts + tid, NULL, c_dbcsr_acc_opencl_config.contexts[/*master*/ 0], LIBXSMM_ATOMIC_RELAXED);
+    if (NULL != c_dbcsr_acc_opencl_config.device) { /* inherit master's context if current context is NULL */
+      LIBXSMM_ATOMIC_CMPSWP(&c_dbcsr_acc_opencl_config.device[tid].context, NULL,
+        c_dbcsr_acc_opencl_config.device[/*master*/ 0].context, LIBXSMM_ATOMIC_RELAXED);
     }
   }
 #  endif
-  if (NULL != c_dbcsr_acc_opencl_config.contexts) context = c_dbcsr_acc_opencl_config.contexts[tid];
+  if (NULL != c_dbcsr_acc_opencl_config.device) context = c_dbcsr_acc_opencl_config.device[tid].context;
   if (NULL != context) {
     cl_device_id device = NULL;
     result = clGetContextInfo(context, CL_CONTEXT_DEVICES, sizeof(cl_device_id), &device, NULL);
     if (CL_SUCCESS == result) {
-      const int share = c_dbcsr_acc_opencl_config.share, s = (0 >= share ? 0 : (1 < share ? share : 2));
-      if (1 >= s || s > c_dbcsr_acc_opencl_config.nthreads || 0 == (tid % s)) {
+      if (0 == c_dbcsr_acc_opencl_config.share || 0 == (tid % c_dbcsr_acc_opencl_config.share)) {
+        if (0 != c_dbcsr_acc_opencl_config.device[tid].intel) {
+          const int xhints = ((1 == c_dbcsr_acc_opencl_config.xhints || 0 > c_dbcsr_acc_opencl_config.xhints)
+                                ? (0 != c_dbcsr_acc_opencl_config.device[tid].intel ? 1 : 0)
+                                : (c_dbcsr_acc_opencl_config.xhints >> 1));
+          if (0 != (1 & xhints)) { /* attempt to enable command aggregation */
+            const ACC_OPENCL_STREAM_PROPERTIES_TYPE props[4] = {
+              CL_QUEUE_PROPERTIES, CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, 0 /* terminator */
+            };
+            const cl_command_queue q = ACC_OPENCL_CREATE_COMMAND_QUEUE(context, device, props, &result);
+            if (CL_SUCCESS == result) clReleaseCommandQueue(q);
+            else result = CL_SUCCESS;
+          }
+          if (0 != (2 & xhints)) { /* attempt to enable queue families */
+            struct {
+              cl_command_queue_properties properties;
+              cl_bitfield capabilities;
+              cl_uint count;
+              char name[64 /*CL_QUEUE_FAMILY_MAX_NAME_SIZE_INTEL*/];
+            } intel_qfprops[16];
+            size_t nbytes = 0, i;
+            if (CL_SUCCESS == clGetDeviceInfo(device, 0x418B /*CL_DEVICE_QUEUE_FAMILY_PROPERTIES_INTEL*/, sizeof(intel_qfprops),
+                                intel_qfprops, &nbytes))
+            {
+              for (i = 0; (i * sizeof(*intel_qfprops)) < nbytes; ++i) {
+                if (0 /*CL_QUEUE_DEFAULT_CAPABILITIES_INTEL*/ == intel_qfprops[i].capabilities && 1 < intel_qfprops[i].count) {
+                  const int j = (0 /*terminator*/ == properties[2] ? 2 : 4);
+                  properties[j + 0] = 0x418C; /* CL_QUEUE_FAMILY_INTEL */
+                  properties[j + 1] = (int)i;
+                  properties[j + 2] = 0x418D; /* CL_QUEUE_INDEX_INTEL */
+                  properties[j + 3] = (0 == c_dbcsr_acc_opencl_config.share ? tid : (tid / c_dbcsr_acc_opencl_config.share)) %
+                                      (intel_qfprops[i].count);
+                  properties[j + 4] = 0; /* terminator */
+                  break;
+                }
+              }
+            }
+          }
+        }
         queue = ACC_OPENCL_CREATE_COMMAND_QUEUE(context, device, properties, &result);
       }
-      else {
+      else { /* attempt to share existing stream */
         const int maxn = c_dbcsr_acc_opencl_config.nthreads;
         cl_command_queue stream = NULL;
         assert(0 < tid);
@@ -163,7 +175,7 @@ int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int priority) {
             }
           }
         }
-        if (NULL != stream) { /* clone existing stream (share) */
+        if (NULL != stream) { /* clone existing stream */
           result = clRetainCommandQueue(stream);
         }
         else {
@@ -190,11 +202,6 @@ int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int priority) {
       if (NULL == streams[i]) break;
     }
     if (i < ACC_OPENCL_STREAMS_MAXCOUNT) { /* register stream */
-#  if defined(ACC_OPENCL_STREAM_NOALLOC)
-      assert(sizeof(void*) >= sizeof(cl_command_queue) && NULL != queue);
-      streams[i] = *stream_p = (void*)queue;
-      stats[i] = queue;
-#  else
       const size_t size_info = sizeof(c_dbcsr_acc_opencl_info_stream_t);
       const size_t size = sizeof(cl_command_queue) + sizeof(void*) + size_info - 1;
       void* const handle = malloc(size);
@@ -206,6 +213,7 @@ int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int priority) {
         assert(address + size_info <= aligned && NULL != info);
         info->pointer = (void*)address;
         info->priority = priority;
+        info->tid = tid;
         stats[i] = *(cl_command_queue*)aligned = queue;
         streams[i] = *stream_p = (void*)aligned;
         assert(queue == *ACC_OPENCL_STREAM(streams[i]));
@@ -216,7 +224,6 @@ int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int priority) {
         result = EXIT_FAILURE;
         *stream_p = NULL;
       }
-#  endif
     }
     else {
       clReleaseCommandQueue(queue);
@@ -261,7 +268,7 @@ int c_dbcsr_acc_stream_destroy(void* stream) {
             }
             streams[ACC_OPENCL_STREAMS_MAXCOUNT - j] = NULL;
             /* consider breaking outer loop */
-            if (0 >= c_dbcsr_acc_opencl_config.share) {
+            if (0 == c_dbcsr_acc_opencl_config.share) {
               tid = c_dbcsr_acc_opencl_config.nthreads;
               result = result_release; /* promote */
             }
@@ -277,11 +284,7 @@ int c_dbcsr_acc_stream_destroy(void* stream) {
       }
     }
     c_dbcsr_acc_opencl_stream_counter = 0; /* reset */
-#  if defined(ACC_OPENCL_STREAM_NOALLOC)
-    assert(sizeof(void*) >= sizeof(cl_command_queue));
-#  else
     free(c_dbcsr_acc_opencl_info_stream(stream)->pointer);
-#  endif
   }
 #  if defined(__DBCSR_ACC) && defined(ACC_OPENCL_PROFILE)
   c_dbcsr_timestop(&routine_handle);

--- a/src/acc/opencl/smm/opencl_libsmm.c
+++ b/src/acc/opencl/smm/opencl_libsmm.c
@@ -38,9 +38,6 @@
 #  if !defined(OPENCL_LIBSMM_VALIDATE_EXIT) && defined(OPENCL_LIBSMM_VALIDATE) && 1
 #    define OPENCL_LIBSMM_VALIDATE_EXIT
 #  endif
-#  if !defined(OPENCL_LIBSMM_DEVMATCH_PARAMFILE) && 0
-#    define OPENCL_LIBSMM_DEVMATCH_PARAMFILE
-#  endif
 #  if !defined(OPENCL_LIBSMM_KERNELNAME_TRANS)
 #    define OPENCL_LIBSMM_KERNELNAME_TRANS "trans"
 #  endif
@@ -116,7 +113,6 @@ extern "C" {
 
 /* maintain GFLOPS/AI ratios for performance estimates and suitability */
 double opencl_libsmm_shst, opencl_libsmm_dhst, opencl_libsmm_sacc, opencl_libsmm_dacc;
-opencl_libsmm_timer_t opencl_libsmm_timer;
 /* track initialization status of LIBSMM */
 int opencl_libsmm_initialized;
 
@@ -423,7 +419,6 @@ int libsmm_acc_init(void) {
     if (EXIT_SUCCESS == result) {
       opencl_libsmm_perfest_t perfest;
       char* const env_params = getenv("OPENCL_LIBSMM_SMM_PARAMS");
-      const char* const env_timer = getenv("OPENCL_LIBSMM_TIMER");
       const char* const env_suitable = getenv("OPENCL_LIBSMM_SUITABLE");
 #  if defined(OPENCL_LIBSMM_SUITABLE)
       const int suitable = (NULL == env_suitable ? 1 : ('0' != *env_suitable));
@@ -431,12 +426,6 @@ int libsmm_acc_init(void) {
       const int suitable = (NULL == env_suitable ? 0 : ('0' != *env_suitable));
 #  endif
       memset(&perfest, 0, sizeof(perfest));
-      if (NULL != env_timer && (opencl_libsmm_timer_host == atoi(env_timer) ||
-                                 (env_timer == c_dbcsr_acc_opencl_stristr(env_timer, "host") && 4 == strlen(env_timer)) ||
-                                 (env_timer == c_dbcsr_acc_opencl_stristr(env_timer, "cpu") && 3 == strlen(env_timer))))
-      {
-        opencl_libsmm_timer = opencl_libsmm_timer_host;
-      }
       if (NULL == env_params || '0' != *env_params) {
         char buffer[ACC_OPENCL_BUFFERSIZE], bufname[ACC_OPENCL_BUFFERSIZE], control = '0';
 #  if defined(OPENCL_LIBSMM_DEVICES)
@@ -459,15 +448,8 @@ int libsmm_acc_init(void) {
                 memset(&config, 0, sizeof(config));
                 if (EXIT_SUCCESS == opencl_libsmm_read_smm_params(buffer, &key, &config, gflops, device)) {
                   opencl_libsmm_smm_t* config_init;
-#  if defined(OPENCL_LIBSMM_DEVMATCH_PARAMFILE)
-                  if (NULL == device || 0 == c_dbcsr_acc_opencl_config.devinfo.devmatch ||
-                      EXIT_SUCCESS != c_dbcsr_acc_opencl_devuid(device, &key.devuid))
-#  else
-                  c_dbcsr_acc_opencl_config.devinfo.devmatch = 0; /* disable device-match */
-#  endif
-                  {
-                    key.devuid = 0;
-                  }
+                  c_dbcsr_acc_opencl_config.devmatch = 0; /* disable device-match */
+                  key.devuid = 0;
                   config_init = (opencl_libsmm_smm_t*)OPENCL_LIBSMM_DISPATCH(&key, sizeof(key));
                   if (NULL == config_init) {
                     if (NULL == OPENCL_LIBSMM_REGISTER(&key, sizeof(key), sizeof(config), &config)) {
@@ -511,7 +493,7 @@ int libsmm_acc_init(void) {
               {
                 opencl_libsmm_smm_t* config_init;
                 const int i = atoi(bufname);
-                if (0 >= ndevices || 0 == c_dbcsr_acc_opencl_config.devinfo.devmatch || 0 > i || ndevices <= i ||
+                if (0 >= ndevices || 0 == c_dbcsr_acc_opencl_config.devmatch || 0 > i || ndevices <= i ||
                     EXIT_SUCCESS != c_dbcsr_acc_opencl_devuid(OPENCL_LIBSMM_DEVICES[i], &key.devuid))
                 {
                   key.devuid = 0;
@@ -545,7 +527,7 @@ int libsmm_acc_init(void) {
             if (EXIT_SUCCESS == opencl_libsmm_read_smm_params(env_params, &key, &config, NULL /*perfest*/, NULL /*device*/)) {
               key.devuid = 0;
               if (NULL != OPENCL_LIBSMM_REGISTER(&key, sizeof(key), sizeof(config), &config)) {
-                c_dbcsr_acc_opencl_config.devinfo.devmatch = 0; /* disable device-match */
+                c_dbcsr_acc_opencl_config.devmatch = 0; /* disable device-match */
                 ntuned = MAX(ntuned, 1); /* no destinction of overridden or new */
               }
               else result = EXIT_FAILURE;
@@ -557,7 +539,7 @@ int libsmm_acc_init(void) {
 #  if defined(OPENCL_LIBSMM_DEVICES)
           if (0 != c_dbcsr_acc_opencl_config.verbosity && 0 != ntuned) {
             fprintf(stderr, "INFO ACC/OpenCL: %u set%s of tuned parameters loaded targeting ", ntuned, 1 != ntuned ? "s" : "");
-            if (0 != c_dbcsr_acc_opencl_config.devinfo.devmatch) {
+            if (0 != c_dbcsr_acc_opencl_config.devmatch) {
               fprintf(stderr, "%i device%s\n", ndevices, 1 != ndevices ? "s" : "");
               if (1 < c_dbcsr_acc_opencl_config.verbosity || 0 > c_dbcsr_acc_opencl_config.verbosity) {
                 unsigned int devuid, i = 0;
@@ -859,7 +841,7 @@ int libsmm_acc_transpose(const int* dev_trs_stack, int offset, int stack_size, v
     }
     assert((NULL != config && NULL != config->kernel && 0 < config->wgsize) || EXIT_SUCCESS != result);
     if (EXIT_SUCCESS == result) {
-      cl_event event, *const perf_event = ((opencl_libsmm_timer_host == opencl_libsmm_timer ||
+      cl_event event, *const perf_event = ((c_dbcsr_acc_opencl_timer_host == c_dbcsr_acc_opencl_config.timer ||
                                              (0 <= c_dbcsr_acc_opencl_config.verbosity && 2 >= c_dbcsr_acc_opencl_config.verbosity))
                                              ? NULL
                                              : &event);
@@ -1079,11 +1061,11 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
   const void* dev_a_data, const void* dev_b_data, void* dev_c_data, int m_max, int n_max, int k_max, int max_kernel_dim,
   c_dbcsr_acc_bool_t def_mnk, void* stream, void* c_stream) {
   int result = EXIT_SUCCESS;
+  const int nparams = 3;
 #  if !defined(OPENCL_LIBSMM_SOURCE_MULTIPLY)
   result = EXIT_FAILURE;
 #  else
   LIBXSMM_UNUSED(c_stream); /* TODO */
-  const int nparams = 3;
   assert(0 == stack_size || (NULL != dev_a_data && NULL != *ACC_OPENCL_MEM(dev_a_data)));
   assert(0 == stack_size || (NULL != dev_b_data && NULL != *ACC_OPENCL_MEM(dev_b_data)));
   assert(0 == stack_size || (NULL != dev_c_data && NULL != *ACC_OPENCL_MEM(dev_c_data)));
@@ -1096,13 +1078,17 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
     double duration;
     const libxsmm_timer_tickint start = libxsmm_timer_tick();
 #    endif
+    const c_dbcsr_acc_opencl_info_stream_t* const qinfo = c_dbcsr_acc_opencl_info_stream(stream);
+    const c_dbcsr_acc_opencl_device_t* const devinfo = c_dbcsr_acc_opencl_config.device + qinfo->tid;
     const cl_command_queue queue = *ACC_OPENCL_STREAM(stream);
     LIBXSMM_MEMZERO127(&key); /* potentially heterogeneous key-data */
+    key.devuid = ((1 != c_dbcsr_acc_opencl_config.devmatch && ((unsigned int)-1) != c_dbcsr_acc_opencl_config.devmatch)
+                    ? c_dbcsr_acc_opencl_config.devmatch
+                    : devinfo->uid);
     key.type = datatype;
     key.m = m_max;
     key.n = n_max;
     key.k = k_max;
-    key.devuid = c_dbcsr_acc_opencl_config.devinfo.devmatch;
     if (CL_SUCCESS == result) {
       static volatile int locks[OPENCL_LIBSMM_NLOCKS_SMM]; /* OpenCL is thread-safe except for clSetKernelArg */
       const char *const env_s = getenv("OPENCL_LIBSMM_SMM_S"), *const env_bs = getenv("OPENCL_LIBSMM_SMM_BS");
@@ -1195,8 +1181,8 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
           }
           if (NULL != tname) {
             const char* const env_devid = getenv("OPENCL_LIBSMM_SMM_DEVID");
-            const unsigned int devid = (NULL == env_devid || '\0' == *env_devid) ? c_dbcsr_acc_opencl_config.devinfo.intel_id
-                                                                                 : (unsigned int)strtoul(env_devid, NULL, 0);
+            const unsigned int devuid = (NULL == env_devid || '\0' == *env_devid) ? devinfo->uid
+                                                                                  : (unsigned int)strtoul(env_devid, NULL, 0);
             size_t wgsize_max, wgsize_prf, sgs = 0;
             opencl_libsmm_smm_t new_config;
             if (NULL == config) {
@@ -1219,13 +1205,13 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
               const int blockn = ((NULL == env_bn || '\0' == *env_bn) ? 0 : atoi(env_bn));
               const int blockk = ((NULL == env_bk || '\0' == *env_bk) ? 0 : atoi(env_bk));
               const int wgmin = ((NULL == env_ws || '\0' == *env_ws) ? 0 : atoi(env_ws));
-              const int default_aa = ((0x0bd5 != devid) ? ((k_max % OPENCL_LIBSMM_VMIN) ? 1 : 2) : 0);
-              const int default_ab = ((0x0bd5 != devid && 0x020a != devid) ? 3 : 0);
-              const int default_ac = ((0x0bd5 != devid) ? 0 : ((n_max % OPENCL_LIBSMM_VMIN) ? 1 : 2));
-              const int default_bk = ((0x0bd5 != devid && 0x020a != devid)
+              const int default_aa = (((0x0bd0 > devuid || 0x0bdb < devuid)) ? ((k_max % OPENCL_LIBSMM_VMIN) ? 1 : 2) : 0);
+              const int default_ab = (((0x0bd0 > devuid || 0x0bdb < devuid) && 0x020a != devuid) ? 3 : 0);
+              const int default_ac = (((0x0bd0 > devuid || 0x0bdb < devuid)) ? 0 : ((n_max % OPENCL_LIBSMM_VMIN) ? 1 : 2));
+              const int default_bk = (((0x0bd0 > devuid || 0x0bdb < devuid) && 0x020a != devuid)
                                         ? (0 == kernel_idx ? MIN(OPENCL_LIBSMM_DEFAULT_BK, m_max) : MIN(OPENCL_LIBSMM_VMIN, m_max))
                                         : 1);
-              const int default_wg = ((0x0bd5 != devid) ? (0 == kernel_idx ? 0 : -2) : -1);
+              const int default_wg = (((0x0bd0 > devuid || 0x0bdb < devuid)) ? (0 == kernel_idx ? 0 : -2) : -1);
               int nbm, nbn;
               /* two defaults for new_config parameters: 1st - regular, 2nd - BS=1 kernel */
               new_config.bm = (0 >= blockm ? (0 == kernel_idx ? (NULL == config ? MIN(OPENCL_LIBSMM_DEFAULT_BM, m_max)
@@ -1363,8 +1349,7 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
                 const char *barrier_expr = NULL, *atomic_ops = "";
                 const char *atomic_exp = NULL, *atomic_expr2 = "";
                 if (NULL == env_barrier || '0' != *env_barrier) {
-                  barrier_expr = ((0 != std_c11 &&
-                                    (0 == c_dbcsr_acc_opencl_config.devinfo.intel_id || (CL_DEVICE_TYPE_CPU != device_type)))
+                  barrier_expr = ((0 != std_c11 && (0 == devinfo->intel || (CL_DEVICE_TYPE_CPU != device_type)))
                                     ? "-D\"BARRIER(A)=work_group_barrier(A,memory_scope_work_group)\""
                                     : "-D\"BARRIER(A)=barrier(A)\"");
                 }
@@ -1389,14 +1374,11 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
                                       : "atomic_fetch_add_explicit((GLOBAL_VOLATILE(atomic_float)*)A,B,"
                                         "memory_order_relaxed,memory_scope_work_group)");
                     }
-                    else if ((0 != c_dbcsr_acc_opencl_config.devinfo.intel_id &&
-                               0x4905 != c_dbcsr_acc_opencl_config.devinfo.intel_id &&
-                               0 == c_dbcsr_acc_opencl_config.devinfo.unified) ||
-                             0 != atomics_native)
-                    {
-                      if (dbcsr_type_real_4 == datatype || 0x0bd5 == c_dbcsr_acc_opencl_config.devinfo.intel_id ||
-                          0 != atomics_native) {
-                        if (0 == atomics_native && 0x0bd5 != c_dbcsr_acc_opencl_config.devinfo.intel_id) {
+                    else if ((0 != devinfo->intel && 0x4905 != devinfo->uid && 0 == devinfo->unified) || 0 != atomics_native) {
+                      if (dbcsr_type_real_4 == datatype ||
+                          (0 != devinfo->intel && 0x0bd0 <= devinfo->uid && 0x0bdb >= devinfo->uid) || 0 != atomics_native)
+                      {
+                        if (0 == atomics_native && (0 == devinfo->intel || 0x0bd0 > devinfo->uid || 0x0bdb < devinfo->uid)) {
                           extensions[1] = "cl_intel_global_float_atomics";
                           atomic_ops = "-Dcl_intel_global_float_atomics";
                         }
@@ -1414,7 +1396,7 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
                     }
                     else if (cl_nonv) {
                       if (NULL != extensions[1] && 1 < bs && 1 == new_config.bn && new_config.bm >= m_max && 0 == new_config.al &&
-                          (0 == (m_max & 1) || (0 == c_dbcsr_acc_opencl_config.devinfo.intel_id /*&& cl_nonv*/)) /* TODO */
+                          (0 == (m_max & 1) || (0 == devinfo->intel /*&& cl_nonv*/)) /* TODO */
                           && EXIT_SUCCESS == c_dbcsr_acc_opencl_device_ext(active_device, extensions + 1, 1))
                       {
                         assert(dbcsr_type_real_4 == datatype);
@@ -1433,7 +1415,7 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
                   }
                   else if (NULL != c_dbcsr_acc_opencl_stristr(env_atomics, "cmpxchg")) {
                     if (NULL != extensions[1] && 1 < bs && 1 == new_config.bn && new_config.bm >= m_max && 0 == new_config.al &&
-                        (0 == (m_max & 1) || (0 == c_dbcsr_acc_opencl_config.devinfo.intel_id && cl_nonv)) /* TODO */
+                        (0 == (m_max & 1) || (0 == devinfo->intel && cl_nonv)) /* TODO */
                         && '2' == env_atomics[strlen(env_atomics) - 1] &&
                         EXIT_SUCCESS == c_dbcsr_acc_opencl_device_ext(active_device, extensions + 1, 1))
                     {
@@ -1461,7 +1443,7 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
                   "-DMAD=fma -DINTEL=%u -DGLOBAL=%s -DSWG=%i -DSGS=%i -DFN=%s -DREPEAT=%i -DLU=%i "
                   "-DSM=%i -DSN=%i -DSK=%i -DBS=%i -DBM=%i -DBN=%i -DBK=%i -DT=%s -DTN=%i "
                   "%s %s %s %s %s %s %s %s %s %s -D\"ATOMIC_ADD_GLOBAL(A,B)=%s\" %s %s",
-                  c_dbcsr_acc_opencl_config.devinfo.intel_id, cmem, (int)new_config.wgsize[kernel_idx], (int)sgs, fname,
+                  0 != devinfo->intel ? devinfo->uid : 0, cmem, (int)new_config.wgsize[kernel_idx], (int)sgs, fname,
                   NULL == env_nrepeat ? 1 : atoi(env_nrepeat), new_config.lu, m_max, n_max, k_max, bs, new_config.bm, new_config.bn,
                   new_config.bk, tname, datatype, 0 == new_config.nz ? "" : "-DATOMIC_INC_NZ", 0 == new_config.al ? "" : "-DAL",
                   0 == new_config.tb ? "" : "-DTRACK_B", 0 != new_config.tc ? "-DTRACK_C" : "", 0 == new_config.ap ? "" : "-DSLM_P",
@@ -1471,9 +1453,8 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
                   atomic_expr2, barrier_expr);
                 if (0 < nchar && (int)sizeof(build_params) > nchar) {
 #    if !defined(NDBGDEV)
-                  const char* const cl_debug =
-                    ((0 != c_dbcsr_acc_opencl_config.devinfo.intel_id && CL_DEVICE_TYPE_CPU != device_type) ? "-gline-tables-only"
-                                                                                                            : "");
+                  const char* const cl_debug = ((0 != devinfo->intel && CL_DEVICE_TYPE_CPU != device_type) ? "-gline-tables-only"
+                                                                                                           : "");
 #    else
                   const char* const cl_debug = "";
 #    endif
@@ -1581,7 +1562,7 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
       assert(EXIT_SUCCESS != result || (1 <= config->s && 1 <= config->bs));
       if (EXIT_SUCCESS == result) {
         cl_event event, *const perf_event =
-                          ((opencl_libsmm_timer_host == opencl_libsmm_timer ||
+                          ((c_dbcsr_acc_opencl_timer_host == c_dbcsr_acc_opencl_config.timer ||
                              (0 <= c_dbcsr_acc_opencl_config.verbosity && 2 >= c_dbcsr_acc_opencl_config.verbosity))
                               ? NULL
                               : &event);

--- a/src/acc/opencl/smm/opencl_libsmm.h
+++ b/src/acc/opencl/smm/opencl_libsmm.h
@@ -68,8 +68,6 @@ typedef struct opencl_libsmm_smm_t {
   int s, bs, bm, bn, bk, ws, wg, lu, nz, al, tb, tc, ap, aa, ab, ac;
 } opencl_libsmm_smm_t;
 
-typedef enum opencl_libsmm_timer_t { opencl_libsmm_timer_device, opencl_libsmm_timer_host } opencl_libsmm_timer_t;
-
 /** Type to collect statistics about tuned SMM-kernels */
 typedef struct opencl_libsmm_perfest_t {
   double gf_ai_sratio_max, gf_ai_sratio_sumlog, gf_ai_sratio_kahan;


### PR DESCRIPTION
* Removed ACC_OPENCL_MALLOC_LIBXSMM, ACC_OPENCL_STREAM_NOALLOC, ACC_OPENCL_EVENT_NOALLOC, and OPENCL_LIBSMM_DEVMATCH_PARAMFILE.
* Revised cached device properties (intel_id is now split into intel and uid with the latter useful for other vendors too).
* Moved opencl_libsmm_timer_t into c_dbcsr_acc_opencl_config_t, and enable queue-profiling only if timer_device.
* Made devinfo thread-specific information. Moved devmatch property into configuration (not device-specific).
* Introduced ACC_OPENCL_XHINTS, removed ACC_OPENCL_DISABLE, revised ACC_OPENCL_SHARE.
* Default ACC_OPENCL_XHINTS to automatically determine viable setting.
* Removed function (c_dbcsr_acc_opencl_stream_is_thread_specific).
* Introduced build targets "backend" and "libsmm" (Makefile).
* Cleaner decision about SVM like per device/stream, etc.
* Fixed issues pointed out by static analysis.
* Decide SVM-interop purely at runtime.
* Updated device UIDs.