### PR TITLE
Fix build when testing is disabled

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -14,9 +14,14 @@ add_custom_target(
   COMMENT "Generating API documentation and doc pages"
   COMMAND "${FORD_EXE}" "${FORD_PROJECT_FILE}"
   VERBATIM)
-add_dependencies(doc doc_copy_tests)
+
+if (BUILD_TESTING)
+  add_dependencies(doc doc_copy_tests)
+endif ()
+
 if (WITH_C_API AND WITH_EXAMPLES)
   add_dependencies(doc doc_copy_examples)
 endif ()
+
 add_dependencies(doc fypp) # only depend on the fypp step to avoid building
                            # everything just for the docs


### PR DESCRIPTION
Resolves https://github.com/cp2k/dbcsr/issues/618

Successfully builds with:
- `-DBUILD_TESTING=ON`, `-DWITH_EXAMPLES=ON`
- `-DBUILD_TESTING=OFF`, `-DWITH_EXAMPLES=OFF`
- `-DBUILD_TESTING=ON`, `-DWITH_EXAMPLES=OFF`
- `-DBUILD_TESTING=OFF`, `-DWITH_EXAMPLES=ON`

Previously didn't build with `-DBUILD_TESTING=OFF`.