### PR TITLE
ocl: wrapper script to schedule an input file to multiple devices

### DIFF
--- a/src/acc/acc_bench_smm.sh
+++ b/src/acc/acc_bench_smm.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+####################################################################################################
+# Copyright (C) by the DBCSR developers group - All rights reserved                                #
+# This file is part of the DBCSR library.                                                          #
+#                                                                                                  #
+# For information on the license, see the LICENSE file.                                            #
+# For further information please visit https://dbcsr.cp2k.org                                      #
+# SPDX-License-Identifier: GPL-2.0+                                                                #
+####################################################################################################
+
+HERE=$(cd "$(dirname "$0")" && pwd -P)
+SED=$(command -v gsed)
+
+# GNU sed is desired (macOS)
+if [ ! "${SED}" ]; then
+  SED=$(command -v sed)
+fi
+
+if [ "${SED}" ] && [ -x "${HERE}/acc_bench_smm" ]; then
+  LIBXSMM_PEXEC=${LIBXSMM_ROOT:-${HOME}/libxsmm}/scripts/tool_pexec.sh
+  if [ -x "${LIBXSMM_PEXEC}" ] && [ -e "$1" ]; then
+    NDEVICES=$(ACC_OPENCL_VERBOSE=1 CHECK=0 "${HERE}/acc_bench_smm" 1 1 1 2>&1 >/dev/null \
+             | ${SED} -n "s/INFO ACC\/OpenCL: ndevices=\([0-9][0-9]*\) ..*$/\1/p")
+  fi
+  if [ "${NDEVICES}" ] && [ "0" != "$((1<NDEVICES))" ]; then
+    NLINES=0
+    while read -r LINE; do
+      echo "ACC_OPENCL_DEVICE=$((NLINES%NDEVICES)) ${HERE}/acc_bench_smm ${LINE}"
+      NLINES=$((NLINES+1))
+    done <"$1" | ${LIBXSMM_PEXEC} "${NDEVICES}"
+  else
+    "${HERE}/acc_bench_smm" "$*"
+  fi
+else
+  >&2 echo "ERROR: missing prerequisites!"
+  exit 1
+fi

--- a/src/acc/acc_triplets.sh
+++ b/src/acc/acc_triplets.sh
@@ -14,7 +14,7 @@ SED=$(command -v gsed)
 CUT=$(command -v cut)
 
 # GNU sed is desired (macOS)
-if [ "" = "${SED}" ]; then
+if [ ! "${SED}" ]; then
   SED=$(command -v sed)
 fi
 

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -31,6 +31,13 @@ MAXEXT ?= 48
 NTRANS ?= 10
 NSMMS ?= 10
 
+MULTI ?= 0
+ifneq (0,$(MULTI))
+  ACC_BENCH_SMM := $(ACCDIR)/acc_bench_smm.sh
+else
+  ACC_BENCH_SMM := $(ACCDIR)/acc_bench_smm
+endif
+
 COMMAND := $(shell which command 2>/dev/null)
 ifneq (,$(COMMAND))
   which = $(shell $(COMMAND) -v $1)
@@ -192,7 +199,7 @@ test-interface: $(ACCDIR)/dbcsr_acc_test
 .PHONY: test-trans
 test-trans: bench
 	$(eval SHAPES = $(shell $(ACCDIR)/acc_triplets.sh -k $(SPECID) -m $(MAXEXT) -n $(NTRANS) -a))
-	$(eval DEVICE = $(shell ACC_OPENCL_VERBOSE=1 CHECK=0 $(ACCDIR)/acc_bench_smm 1 1 1 2>&1 >/dev/null))
+	$(eval DEVICE = $(shell ACC_OPENCL_VERBOSE=1 CHECK=0 $(ACCDIR)/acc_bench_trans 1 1 1 2>&1 >/dev/null))
 	@echo "--- DBCSR OpenCL Transposes ($(words $(SHAPES)))"
 	@echo "$(DEVICE)"
 	@echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
@@ -228,7 +235,7 @@ endif
 	@echo "hostname: $$(hostname)"
 	@echo
 	@echo "$(SHAPES)" | xargs -n1 | \
-		($(GPUENV) CHECK=$(if $(CHECK),$(CHECK),1) stdbuf --output=L $(ACCDIR)/acc_bench_smm /dev/stdin \
+		($(GPUENV) CHECK=$(if $(CHECK),$(CHECK),1) stdbuf --output=L $(ACC_BENCH_SMM) /dev/stdin \
 			2>$(MAKDIR)/test-smm.err && rm $(MAKDIR)/test-smm.err) | tee $@
 	@if [ -s $(MAKDIR)/test-smm.err ]; then cat $(MAKDIR)/test-smm.err && exit 1; fi
 

--- a/src/acc/opencl/acc_getenv.sh
+++ b/src/acc/opencl/acc_getenv.sh
@@ -13,7 +13,7 @@ SORT=$(command -v sort)
 SED=$(command -v gsed)
 
 # GNU sed is desired (macOS)
-if [ "" = "${SED}" ]; then
+if [ ! "${SED}" ]; then
   SED=$(command -v sed)
 fi
 

--- a/src/acc/opencl/acc_opencl.sh
+++ b/src/acc/opencl/acc_opencl.sh
@@ -24,7 +24,7 @@ CPPBASEFLAGS="-dD -P -fpreprocessed"
 DELIMS=";,\t|/"
 
 # GNU sed is desired (macOS)
-if [ "" = "${SED}" ]; then
+if [ ! "${SED}" ]; then
   SED=$(command -v sed)
 fi
 


### PR DESCRIPTION
* Limit number of parallel tasks (and ovoid oversubscribing GPUs).
* Introduced an option permitting multi-device tests (Makefile).
* Aggregated output into one locked section (acc_bench_smm).