### PR TITLE
ocl: code cleanup and minor fixes

### DIFF
--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -557,7 +557,7 @@ int c_dbcsr_acc_finalize(void) {
     for (i = 0; i < ACC_OPENCL_DEVICES_MAXCOUNT; ++i) {
       const cl_device_id device_id = c_dbcsr_acc_opencl_config.devices[i];
       if (NULL != device_id) {
-#  if defined(CL_VERSION_1_2)
+#  if defined(CL_VERSION_1_2) && defined(_DEBUG)
         ACC_OPENCL_CHECK(clReleaseDevice(device_id), "release device", result);
 #  endif
         /* c_dbcsr_acc_opencl_create_context scans for non-NULL devices */


### PR DESCRIPTION
* Protect clSVMFree (ACC_OPENCL_SVM/svm_interop).
* Call clReleaseDevice only for explicit debug.
* Compare source and destination before copy.