### PR TITLE
Fix hip detection with cmake.

### DIFF
--- a/src/cmake/DBCSRConfig.cmake.in
+++ b/src/cmake/DBCSRConfig.cmake.in
@@ -14,7 +14,15 @@ endif ()
 
 if ("@USE_ACCEL@" MATCHES "cuda")
   enable_language(CUDA)
+  find_dependency(CUDAToolkit)
 endif ()
+
+if ("@USE_ACCEL@" MATCHES "hip")
+  enable_language(HIP)
+  find_dependency(hip)
+  find_dependency(hipblas)
+endif ()
+
 
 if (("@USE_SMM@" MATCHES "libxsmm") OR ("@USE_ACCEL@" MATCHES "opencl"))
   find_package(PkgConfig)


### PR DESCRIPTION
CMake is complaining when dbcsr is compiled with rocm support and the package is used inside other cmake projects. We detected this while working on the cp2k cmake build.
