### PR TITLE
OpenCL backend and stand-alone benchs (OpenCL/CUDA): updated for revised LIBXSMM

### DIFF
--- a/src/acc/acc_bench_smm.c
+++ b/src/acc/acc_bench_smm.c
@@ -74,6 +74,22 @@
 #define ACC_BENCH_SMM_EPSILON_double 3E-3
 #define ACC_BENCH_SMM_EPSILON_float 3E-3
 
+#if LIBXSMM_VERSION4(1, 17, 0, 2776) <= LIBXSMM_VERSION_NUMBER
+# define ACC_BENCH_GEMM_BATCH( \
+    IPREC, OPREC, TRANSA, TRANSB, M, N, K, ALPHA, A, LDA, STRIDE_A, B, LDB, STRIDE_B, \
+    BETA, C, LDC, STRIDE_C, INDEX_STRIDE, INDEX_BASE, BATCHSIZE) \
+  ACC_BENCH_USEOMP(libxsmm_gemm_batch)( \
+    IPREC, OPREC, TRANSA, TRANSB, M, N, K, ALPHA, A, LDA, STRIDE_A, B, LDB, STRIDE_B, \
+    BETA, C, LDC, STRIDE_C, INDEX_STRIDE, INDEX_BASE, BATCHSIZE, 0/*batchcheck*/)
+#else
+# define ACC_BENCH_GEMM_BATCH( \
+    IPREC, OPREC, TRANSA, TRANSB, M, N, K, ALPHA, A, LDA, STRIDE_A, B, LDB, STRIDE_B, \
+    BETA, C, LDC, STRIDE_C, INDEX_STRIDE, INDEX_BASE, BATCHSIZE) \
+  ACC_BENCH_USEOMP(libxsmm_gemm_batch)( \
+    IPREC, OPREC, TRANSA, TRANSB, M, N, K, ALPHA, A, LDA, B, LDB, \
+    BETA, C, LDC, INDEX_BASE, INDEX_STRIDE, STRIDE_A, STRIDE_B, STRIDE_C, BATCHSIZE)
+#endif
+
 #define ROUNDUP2(N, NPOT) ((((unsigned long long)N) + ((NPOT)-1)) & ~((NPOT)-1))
 #define CHECK(EXPR, RPTR) \
   if ((NULL != ((const void*)(RPTR)) && EXIT_SUCCESS != *((const int*)(RPTR))) || \
@@ -420,19 +436,17 @@ int main(int argc, char* argv[]) {
 #    endif
         memset(gold_hst, 0, sizeof(ELEM_TYPE) * mn * nc);
         for (r = 0; r < warmup; ++r) {
-          ACC_BENCH_USEOMP(libxsmm_gemm_batch)
-          (LIBXSMM_DATATYPE(ELEM_TYPE), LIBXSMM_DATATYPE(ELEM_TYPE), &transa, &transb, m, n, k, &alpha, amat_hst, &m /*lda*/,
-            bmat_hst, &k /*ldb*/, &beta, gold_hst, &m /*ldc*/, 1 /*index_base*/, sizeof(int) * 3, stack_hst + 0, stack_hst + 1,
-            stack_hst + 2, stack_size);
+          ACC_BENCH_GEMM_BATCH(LIBXSMM_DATATYPE(ELEM_TYPE), LIBXSMM_DATATYPE(ELEM_TYPE), &transa, &transb, m, n, k,
+            &alpha, amat_hst, &m /*lda*/, stack_hst + 0 /*stride_a*/, bmat_hst, &k /*ldb*/, stack_hst + 1 /*stride_b*/,
+            &beta, gold_hst, &m /*ldc*/, stack_hst + 2 /*stride_c*/, sizeof(int) * 3, 1 /*index_base*/, stack_size);
         }
         memset(gold_hst, 0, sizeof(ELEM_TYPE) * mn * nc);
         start = libxsmm_timer_tick();
         /* CPU-kernel operates on data that is not initialized in NUMA-aware fashion */
         for (r = 0; r < (nrepeat * smm_nrepeat); ++r) {
-          ACC_BENCH_USEOMP(libxsmm_gemm_batch)
-          (LIBXSMM_DATATYPE(ELEM_TYPE), LIBXSMM_DATATYPE(ELEM_TYPE), &transa, &transb, m, n, k, &alpha, amat_hst, &m /*lda*/,
-            bmat_hst, &k /*ldb*/, &beta, gold_hst, &m /*ldc*/, 1 /*index_base*/, sizeof(int) * 3, stack_hst + 0, stack_hst + 1,
-            stack_hst + 2, stack_size);
+          ACC_BENCH_GEMM_BATCH(LIBXSMM_DATATYPE(ELEM_TYPE), LIBXSMM_DATATYPE(ELEM_TYPE), &transa, &transb, m, n, k,
+            &alpha, amat_hst, &m /*lda*/, stack_hst + 0 /*stride_a*/, bmat_hst, &k /*ldb*/, stack_hst + 1 /*stride_b*/,
+            &beta, gold_hst, &m /*ldc*/, stack_hst + 2 /*stride_c*/, sizeof(int) * 3, 1 /*index_base*/, stack_size);
         }
         duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
         PRINTF("host: %.2g ms %.1f GFLOPS/s\n", 1000.0 * duration / (nrepeat * smm_nrepeat),

--- a/src/acc/opencl/smm/opencl_libsmm.c
+++ b/src/acc/opencl/smm/opencl_libsmm.c
@@ -22,6 +22,22 @@
 #    define OPENCL_LIBSMM_DISPATCH(KEY, KEY_SIZE) libxsmm_xdispatch(KEY, KEY_SIZE)
 #  endif
 
+#  if LIBXSMM_VERSION4(1, 17, 0, 2776) <= LIBXSMM_VERSION_NUMBER
+#    define OPENCL_LIBSMM_GEMM_BATCH( \
+        IPREC, OPREC, TRANSA, TRANSB, M, N, K, ALPHA, A, LDA, STRIDE_A, B, LDB, STRIDE_B, \
+        BETA, C, LDC, STRIDE_C, INDEX_STRIDE, INDEX_BASE, BATCHSIZE) \
+      OPENCL_LIBSMM_USEOMP(libxsmm_gemm_batch)( \
+        IPREC, OPREC, TRANSA, TRANSB, M, N, K, ALPHA, A, LDA, STRIDE_A, B, LDB, STRIDE_B, \
+        BETA, C, LDC, STRIDE_C, INDEX_STRIDE, INDEX_BASE, BATCHSIZE, 0/*batchcheck*/)
+#  else
+#    define OPENCL_LIBSMM_GEMM_BATCH( \
+        IPREC, OPREC, TRANSA, TRANSB, M, N, K, ALPHA, A, LDA, STRIDE_A, B, LDB, STRIDE_B, \
+        BETA, C, LDC, STRIDE_C, INDEX_STRIDE, INDEX_BASE, BATCHSIZE) \
+      OPENCL_LIBSMM_USEOMP(libxsmm_gemm_batch)( \
+        IPREC, OPREC, TRANSA, TRANSB, M, N, K, ALPHA, A, LDA, B, LDB, \
+        BETA, C, LDC, INDEX_BASE, INDEX_STRIDE, STRIDE_A, STRIDE_B, STRIDE_C, BATCHSIZE)
+#  endif
+
 #  if defined(_OPENMP) && !defined(__DBCSR_ACC)
 #    define OPENCL_LIBSMM_USEOMP(FUNC) LIBXSMM_USEOMP(FUNC)
 #  else
@@ -589,9 +605,9 @@ int libsmm_acc_init(void) {
             memset(c, 0, sizeof(float) * nc * mn);
             start = libxsmm_timer_tick();
             for (i = 0; i < nrepeat; ++i) {
-              OPENCL_LIBSMM_USEOMP(libxsmm_gemm_batch)
-              (LIBXSMM_DATATYPE_F32, LIBXSMM_DATATYPE_F32, &notrans, &notrans, m, n, k, &alpha, a, &m /*lda*/, b, &k /*ldb*/, &beta,
-                c, &m /*ldc*/, 1 /*index_base*/, sizeof(int) * 3, s + 0, s + 1, s + 2, stack_size);
+              OPENCL_LIBSMM_GEMM_BATCH(LIBXSMM_DATATYPE_F32, LIBXSMM_DATATYPE_F32, &notrans, &notrans, m, n, k,
+                &alpha, a, &m /*lda*/, s + 0 /*stride_a*/, b, &k /*ldb*/, s + 1 /*stride_b*/,
+                &beta, c, &m /*ldc*/, s + 2 /*stride_c*/, sizeof(int) * 3, 1 /*index_base*/, stack_size);
             }
             opencl_libsmm_shst = 1E-9 * ((size_t)2 * m * n * k * stack_size * nrepeat) /
                                  (libxsmm_timer_duration(start, libxsmm_timer_tick()) * OPENCL_LIBSMM_AI(m, n, k, sizeof(float)));
@@ -622,9 +638,9 @@ int libsmm_acc_init(void) {
             memset(c, 0, sizeof(double) * nc * mn);
             start = libxsmm_timer_tick();
             for (i = 0; i < nrepeat; ++i) {
-              OPENCL_LIBSMM_USEOMP(libxsmm_gemm_batch)
-              (LIBXSMM_DATATYPE_F64, LIBXSMM_DATATYPE_F64, &notrans, &notrans, m, n, k, &alpha, a, &m /*lda*/, b, &k /*ldb*/, &beta,
-                c, &m /*ldc*/, 1 /*index_base*/, sizeof(int) * 3, s + 0, s + 1, s + 2, stack_size);
+              OPENCL_LIBSMM_GEMM_BATCH(LIBXSMM_DATATYPE_F64, LIBXSMM_DATATYPE_F64, &notrans, &notrans, m, n, k,
+                &alpha, a, &m /*lda*/, s + 0 /*stride_a*/, b, &k /*ldb*/, s + 1 /*stride_b*/,
+                &beta, c, &m /*ldc*/, s + 2 /*stride_c*/, sizeof(int) * 3, 1 /*index_base*/, stack_size);
             }
             opencl_libsmm_dhst = 1E-9 * ((size_t)2 * m * n * k * stack_size * nrepeat) /
                                  (libxsmm_timer_duration(start, libxsmm_timer_tick()) * OPENCL_LIBSMM_AI(m, n, k, sizeof(double)));


### PR DESCRIPTION
* Adjusted for revised arguments/order (libxsmm_gemm_batch).