### PR TITLE
acc: acc_bench_smm to continue if CHECK=0 in case of kernel not available

### DIFF
--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -26,7 +26,7 @@ if [ ! -d "${HOME}/libxsmm" ]; then
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout e225ff65052acdfe71f7da4890035ea9f69db379
+git checkout 184f6ddc3e460f27e31a7ea4ad042f73fa7a76e8
 make -j
 cd ..
 

--- a/src/acc/acc_bench_smm.c
+++ b/src/acc/acc_bench_smm.c
@@ -88,10 +88,21 @@
 #define ACC_BENCH_SMM_EPSILON_float 3E-3
 
 #define ROUNDUP2(N, NPOT) ((((unsigned long long)N) + ((NPOT)-1)) & ~((NPOT)-1))
-#define CHECK(EXPR, RPTR) \
-  if ((NULL != ((const void*)(RPTR)) && EXIT_SUCCESS != *((const int*)(RPTR))) || \
-      EXIT_SUCCESS != (NULL != ((const void*)(RPTR)) ? (*((int*)(RPTR)) = (EXPR)) : (EXPR))) \
-  assert(NULL == ((const void*)(RPTR)) || -1 == *((int*)(RPTR)))
+#define CHECK(EXPR, RPTR, VALUE) \
+  do { \
+    if (NULL != ((const void*)(RPTR))) { \
+      if (0 == *((const int*)(RPTR)) || (0 > *((const int*)(RPTR)) && 0 == (VALUE))) { \
+        const int check_r_ = (EXPR); \
+        if (0 != check_r_) { \
+          *((int*)(RPTR)) = check_r_; \
+          assert(0 > check_r_ && 0 == (VALUE)); \
+        } \
+      } \
+    } \
+    else { \
+      (EXPR); \
+    } \
+  } while (0)
 
 
 static void parse_params(int argc, char* argv[], FILE** file, const char** snr, const char** sss, const char** ssm,
@@ -197,12 +208,12 @@ int main(int argc, char* argv[]) {
 #else
   const int warmup = 0;
 #endif
-  int result = c_dbcsr_acc_init(), *rnd = NULL, nok = 0, i;
+  int result = c_dbcsr_acc_init(), *rnd = NULL, nok = 0, m = 0, n = 0, k = 0, i;
   const char *snr = NULL, *sss = NULL;
   const char *ssm = NULL, *ssn = NULL, *ssk = NULL;
   const char *snc = NULL, *sna = NULL, *snb = NULL;
   FILE* file = NULL;
-  CHECK(libsmm_acc_init(), &result); /* note: libsmm_acc_init() may imply acc_init() */
+  CHECK(libsmm_acc_init(), &result, check); /* note: libsmm_acc_init() may imply acc_init() */
   if (EXIT_SUCCESS == result) {
     const char* const env_device = getenv("DEVICE");
     const int device = ((NULL == env_device || '\0' == *env_device) ? 0 : atoi(env_device));
@@ -215,10 +226,10 @@ int main(int argc, char* argv[]) {
     }
     else {
       if (0 >= ndevices) {
-        fprintf(stderr, "No ACC-device found!\n");
+        fprintf(stderr, "ERROR: No ACC-device found!\n");
       }
       else {
-        fprintf(stderr, "Failed to activate device %i of %i!\n", device, ndevices);
+        fprintf(stderr, "ERROR: Failed to activate device %i of %i!\n", device, ndevices);
       }
       result = EXIT_FAILURE;
     }
@@ -233,296 +244,310 @@ int main(int argc, char* argv[]) {
     }
   }
   else {
-    fprintf(stderr, "ACC initialization failed!\n");
+    fprintf(stderr, "ERROR: ACC initialization failed!\n");
   }
-  while (EXIT_SUCCESS == result) {
+  while (EXIT_SUCCESS == result || (NULL != file && 0 > result && 0 == check)) {
     const int inr = (NULL != snr ? atoi(snr) : 0);
-    const int ism = (NULL != ssm ? atoi(ssm) : 0), m = (0 < ism ? ism : 23);
-    const int isn = (NULL != ssn ? atoi(ssn) : 0), n = (0 < isn ? isn : m);
-    const int isk = (NULL != ssk ? atoi(ssk) : 0), k = (0 < isk ? isk : m);
+    const int ism = (NULL != ssm ? atoi(ssm) : 0);
+    const int isn = (NULL != ssn ? atoi(ssn) : 0);
+    const int isk = (NULL != ssk ? atoi(ssk) : 0);
     const int inc = (NULL != snc ? atoi(snc) : 0);
     const int ina = (NULL != sna ? atoi(sna) : 0);
     const int inb = (NULL != snb ? atoi(snb) : 0);
+    if (NULL != file && 0 > result && 0 == check) result = EXIT_SUCCESS;
+    m = (0 < ism ? ism : 23);
+    n = (0 < isn ? isn : m);
+    k = (0 < isk ? isk : m);
+    {
 #if defined(ALIGNMENT) && (0 < ALIGNMENT)
-    const int ma = (int)ROUNDUP2(sizeof(ELEM_TYPE) * m, ALIGNMENT);
-    const int ka = (int)ROUNDUP2(sizeof(ELEM_TYPE) * k, ALIGNMENT);
-    const int mn = ma * n / (int)sizeof(ELEM_TYPE);
-    const int mk = ma * k / (int)sizeof(ELEM_TYPE);
-    const int kn = ka * n / (int)sizeof(ELEM_TYPE);
+      const int ma = (int)ROUNDUP2(sizeof(ELEM_TYPE) * m, ALIGNMENT);
+      const int ka = (int)ROUNDUP2(sizeof(ELEM_TYPE) * k, ALIGNMENT);
+      const int mn = ma * n / (int)sizeof(ELEM_TYPE);
+      const int mk = ma * k / (int)sizeof(ELEM_TYPE);
+      const int kn = ka * n / (int)sizeof(ELEM_TYPE);
 #else
-    const int mn = m * n, mk = m * k, kn = k * n;
+      const int mn = m * n, mk = m * k, kn = k * n;
 #endif
-    int *stack_hst = NULL, *stack_dev = NULL, *trans_hst = NULL, *trans_dev = NULL;
-    ELEM_TYPE *amat_hst = NULL, *bmat_hst = NULL, *cmat_hst = NULL;
-    ELEM_TYPE *amat_dev = NULL, *bmat_dev = NULL, *cmat_dev = NULL;
-    void* stream = NULL;
+      int *stack_hst = NULL, *stack_dev = NULL, *trans_hst = NULL, *trans_dev = NULL;
+      ELEM_TYPE *amat_hst = NULL, *bmat_hst = NULL, *cmat_hst = NULL;
+      ELEM_TYPE *amat_dev = NULL, *bmat_dev = NULL, *cmat_dev = NULL;
+      void* stream = NULL;
 #if defined(USE_LIBXSMM)
-    libxsmm_timer_tickint start;
-    int print_offset = 0;
-    char print_buffer[1024];
+      libxsmm_timer_tickint start;
+      int print_offset = 0;
+      char print_buffer[1024];
 #  if defined(__OPENCL)
-    const char* const env_smm_repeat = getenv("SMM_NREPEAT");
-    const int smm_nrepeat = (NULL == env_smm_repeat ? 1 : MAX(atoi(env_smm_repeat), 1));
+      const char* const env_smm_repeat = getenv("SMM_NREPEAT");
+      const int smm_nrepeat = (NULL == env_smm_repeat ? 1 : MAX(atoi(env_smm_repeat), 1));
 #  else
-    const int smm_nrepeat = 1;
+      const int smm_nrepeat = 1;
 #  endif
 #  if defined(TRANSPOSE) && defined(VALIDATE)
-    double transpose;
+      double transpose = 0;
 #  endif
-    double duration;
+      double duration = 0;
 #endif
-    const char* const env_stack_size = getenv("SMM_BATCHSIZE");
-    int nrepeat = (0 < inr ? inr : NREPEAT);
-    int stack_size, na, nb, nc, nr, r;
-    if (NULL == env_stack_size) {
-      stack_size = 0;
-      if (NULL != sss) {
-        size_t nelems, s;
-        const size_t nbytes = parse_nbytes(sss, &nelems);
-        if (nbytes != nelems) {
-          while (1) {
-            nc = (0 < inc ? MIN(inc, stack_size) : MAX(stack_size / 16, 1));
-            na = (0 < ina ? ina : (10 * nc));
-            nb = (0 < inb ? inb : (10 * nc));
-            s = sizeof(ELEM_TYPE) * (mk * na + kn * nb) + sizeof(int) * 3 * stack_size;
-            if (s < nbytes) ++stack_size;
-            else break;
+      const char* const env_stack_size = getenv("SMM_BATCHSIZE");
+      int nrepeat = (0 < inr ? inr : NREPEAT);
+      int stack_size, na, nb, nc, nr, r;
+      if (NULL == env_stack_size) {
+        stack_size = 0;
+        if (NULL != sss) {
+          size_t nelems, s;
+          const size_t nbytes = parse_nbytes(sss, &nelems);
+          if (nbytes != nelems) {
+            while (1) {
+              nc = (0 < inc ? MIN(inc, stack_size) : MAX(stack_size / 16, 1));
+              na = (0 < ina ? ina : (10 * nc));
+              nb = (0 < inb ? inb : (10 * nc));
+              s = sizeof(ELEM_TYPE) * (mk * na + kn * nb) + sizeof(int) * 3 * stack_size;
+              if (s < nbytes) ++stack_size;
+              else break;
+            }
           }
+          else stack_size = (int)nelems;
         }
-        else stack_size = (int)nelems;
       }
-    }
-    else { /* parse SMM_BATCHSIZE=batchsize,nrepfactor */
-      i = strcspn(env_stack_size, DELIMS);
-      if (i < (int)sizeof(DELIMS)) {
-        r = atoi(env_stack_size + i + 1);
-        if (0 < r) nrepeat = r;
+      else { /* parse SMM_BATCHSIZE=batchsize,nrepfactor */
+        i = strcspn(env_stack_size, DELIMS);
+        if (i < (int)sizeof(DELIMS)) {
+          r = atoi(env_stack_size + i + 1);
+          if (0 < r) nrepeat = r;
+        }
+        stack_size = atoi(env_stack_size);
       }
-      stack_size = atoi(env_stack_size);
-    }
-    if (0 >= stack_size) { /* trigger default */
-      if (0 > stack_size) { /* randomize batchsize */
-        const int r = rnd[nok % NRAND], ss = -stack_size, bs = (1 < ss ? ss : BATCHSIZE);
-        const int limit = (BATCHGRAIN < ss ? ((bs + BATCHGRAIN - 1) / BATCHGRAIN) : ss);
-        stack_size = (r % limit + 1) * BATCHGRAIN;
-        nrepeat = MAX((BATCHSIZE * nrepeat + stack_size - 1) / stack_size, NREPEAT);
+      if (0 >= stack_size) { /* trigger default */
+        if (0 > stack_size) { /* randomize batchsize */
+          const int r = rnd[nok % NRAND], ss = -stack_size, bs = (1 < ss ? ss : BATCHSIZE);
+          const int limit = (BATCHGRAIN < ss ? ((bs + BATCHGRAIN - 1) / BATCHGRAIN) : ss);
+          stack_size = (r % limit + 1) * BATCHGRAIN;
+          nrepeat = MAX((BATCHSIZE * nrepeat + stack_size - 1) / stack_size, NREPEAT);
+        }
+        else stack_size = BATCHSIZE; /* plain default */
       }
-      else stack_size = BATCHSIZE; /* plain default */
-    }
-    nc = (0 < inc ? MIN(inc, stack_size) : MAX(stack_size / 16, 1));
-    na = (0 < ina ? ina : (10 * nc));
-    nb = (0 < inb ? inb : (10 * nc));
-    nr = nrepeat * nc;
-    assert(m <= (mn / n) && 0 == (mn % n));
-    assert(m <= (mk / k) && 0 == (mk % k));
-    assert(k <= (kn / n) && 0 == (kn % n));
-    PRINTF("%s%s%i %i %i %i %i %i %i %i\n", 0 < argc ? argv[0] : "", 0 < argc ? " " : "", nrepeat, stack_size, m, n, k, nc, na, nb);
-    PRINTF("typename (id=%i): %s\n", DBCSR_TYPE(ELEM_TYPE), DBCSR_STRINGIFY(ELEM_TYPE));
-    if (MAX_KERNEL_DIM < m || MAX_KERNEL_DIM < n || MAX_KERNEL_DIM < k) {
-      fprintf(stderr, "Matrix shape exceeds MAX_KERNEL_DIM!\n");
-      result = EXIT_FAILURE;
-    }
-    CHECK(c_dbcsr_acc_stream_create(&stream, "stream", -1 /*default priority*/), &result);
-    CHECK(c_dbcsr_acc_host_mem_allocate((void**)&amat_hst, sizeof(ELEM_TYPE) * mk * na, stream), &result);
-    CHECK(c_dbcsr_acc_host_mem_allocate((void**)&bmat_hst, sizeof(ELEM_TYPE) * kn * nb, stream), &result);
-    CHECK(c_dbcsr_acc_host_mem_allocate((void**)&cmat_hst, sizeof(ELEM_TYPE) * mn * nc, stream), &result);
-    CHECK(c_dbcsr_acc_host_mem_allocate((void**)&stack_hst, sizeof(int) * 3 * stack_size, stream), &result);
-    CHECK(c_dbcsr_acc_host_mem_allocate((void**)&trans_hst, sizeof(int) * nb, stream), &result);
-    CHECK(c_dbcsr_acc_stream_sync(stream), &result); /* ensure host-data is allocated */
-    if (NULL != amat_hst && NULL != bmat_hst && NULL != trans_hst && NULL != stack_hst) {
-      init_stack(stack_hst, stack_size, NRAND, rnd, mn, mk, kn, nc, na, nb);
+      nc = (0 < inc ? MIN(inc, stack_size) : MAX(stack_size / 16, 1));
+      na = (0 < ina ? ina : (10 * nc));
+      nb = (0 < inb ? inb : (10 * nc));
+      nr = nrepeat * nc;
+      assert(m <= (mn / n) && 0 == (mn % n));
+      assert(m <= (mk / k) && 0 == (mk % k));
+      assert(k <= (kn / n) && 0 == (kn % n));
+      PRINTF(
+        "%s%s%i %i %i %i %i %i %i %i\n", 0 < argc ? argv[0] : "", 0 < argc ? " " : "", nrepeat, stack_size, m, n, k, nc, na, nb);
+      PRINTF("typename (id=%i): %s\n", DBCSR_TYPE(ELEM_TYPE), DBCSR_STRINGIFY(ELEM_TYPE));
+      if (MAX_KERNEL_DIM < m || MAX_KERNEL_DIM < n || MAX_KERNEL_DIM < k) {
+        fprintf(stderr, "ERROR: Matrix shape exceeds MAX_KERNEL_DIM!\n");
+        result = EXIT_FAILURE;
+      }
+      CHECK(c_dbcsr_acc_stream_create(&stream, "stream", -1 /*default priority*/), &result, check);
+      CHECK(c_dbcsr_acc_host_mem_allocate((void**)&amat_hst, sizeof(ELEM_TYPE) * mk * na, stream), &result, check);
+      CHECK(c_dbcsr_acc_host_mem_allocate((void**)&bmat_hst, sizeof(ELEM_TYPE) * kn * nb, stream), &result, check);
+      CHECK(c_dbcsr_acc_host_mem_allocate((void**)&cmat_hst, sizeof(ELEM_TYPE) * mn * nc, stream), &result, check);
+      CHECK(c_dbcsr_acc_host_mem_allocate((void**)&stack_hst, sizeof(int) * 3 * stack_size, stream), &result, check);
+      CHECK(c_dbcsr_acc_host_mem_allocate((void**)&trans_hst, sizeof(int) * nb, stream), &result, check);
+      CHECK(c_dbcsr_acc_stream_sync(stream), &result, check); /* ensure host-data is allocated */
+      if (NULL != amat_hst && NULL != bmat_hst && NULL != trans_hst && NULL != stack_hst) {
+        init_stack(stack_hst, stack_size, NRAND, rnd, mn, mk, kn, nc, na, nb);
 #if defined(_OPENMP)
 #  pragma omp parallel
 #endif
-      {
+        {
 #if defined(_OPENMP)
 #  pragma omp for
 #endif
-        for (i = 0; i < na; ++i) INIT_MAT(ELEM_TYPE, i /*seed*/ + 42, &amat_hst[i * mk], m, k, 1.0 / (nr * na));
+          for (i = 0; i < na; ++i) INIT_MAT(ELEM_TYPE, i /*seed*/ + 42, &amat_hst[i * mk], m, k, 1.0 / (nr * na));
 #if defined(_OPENMP)
 #  pragma omp for
 #endif
-        for (i = 0; i < nb; ++i) {
-          INIT_MAT(ELEM_TYPE, i /*seed*/ + 24, &bmat_hst[i * kn], k, n, 1.0 / (nr * nb));
-          trans_hst[i] = i * kn;
+          for (i = 0; i < nb; ++i) {
+            INIT_MAT(ELEM_TYPE, i /*seed*/ + 24, &bmat_hst[i * kn], k, n, 1.0 / (nr * nb));
+            trans_hst[i] = i * kn;
+          }
         }
       }
-    }
-    CHECK(c_dbcsr_acc_dev_mem_allocate((void**)&amat_dev, sizeof(ELEM_TYPE) * mk * na), &result);
-    CHECK(c_dbcsr_acc_dev_mem_allocate((void**)&bmat_dev, sizeof(ELEM_TYPE) * kn * nb), &result);
-    CHECK(c_dbcsr_acc_dev_mem_allocate((void**)&cmat_dev, sizeof(ELEM_TYPE) * mn * nc), &result);
-    CHECK(c_dbcsr_acc_dev_mem_allocate((void**)&stack_dev, sizeof(int) * 3 * stack_size), &result);
-    CHECK(c_dbcsr_acc_dev_mem_allocate((void**)&trans_dev, sizeof(int) * nb), &result);
-    CHECK(c_dbcsr_acc_memset_zero(cmat_dev, 0 /*offset*/, sizeof(ELEM_TYPE) * mn * nc, stream), &result);
-    CHECK(c_dbcsr_acc_memcpy_h2d(trans_hst, trans_dev, sizeof(int) * nb, stream), &result);
+      CHECK(c_dbcsr_acc_dev_mem_allocate((void**)&amat_dev, sizeof(ELEM_TYPE) * mk * na), &result, check);
+      CHECK(c_dbcsr_acc_dev_mem_allocate((void**)&bmat_dev, sizeof(ELEM_TYPE) * kn * nb), &result, check);
+      CHECK(c_dbcsr_acc_dev_mem_allocate((void**)&cmat_dev, sizeof(ELEM_TYPE) * mn * nc), &result, check);
+      CHECK(c_dbcsr_acc_dev_mem_allocate((void**)&stack_dev, sizeof(int) * 3 * stack_size), &result, check);
+      CHECK(c_dbcsr_acc_dev_mem_allocate((void**)&trans_dev, sizeof(int) * nb), &result, check);
+      CHECK(c_dbcsr_acc_memset_zero(cmat_dev, 0 /*offset*/, sizeof(ELEM_TYPE) * mn * nc, stream), &result, check);
+      CHECK(c_dbcsr_acc_memcpy_h2d(trans_hst, trans_dev, sizeof(int) * nb, stream), &result, check);
 #if defined(USE_LIBXSMM)
-    CHECK(c_dbcsr_acc_stream_sync(stream), &result);
-    start = libxsmm_timer_tick();
+      CHECK(c_dbcsr_acc_stream_sync(stream), &result, check);
+      start = libxsmm_timer_tick();
 #endif
-    CHECK(c_dbcsr_acc_memcpy_h2d(amat_hst, amat_dev, sizeof(ELEM_TYPE) * mk * na, stream), &result);
-    CHECK(c_dbcsr_acc_memcpy_h2d(bmat_hst, bmat_dev, sizeof(ELEM_TYPE) * kn * nb, stream), &result);
-    CHECK(c_dbcsr_acc_memcpy_h2d(stack_hst, stack_dev, sizeof(int) * 3 * stack_size, stream), &result);
+      CHECK(c_dbcsr_acc_memcpy_h2d(amat_hst, amat_dev, sizeof(ELEM_TYPE) * mk * na, stream), &result, check);
+      CHECK(c_dbcsr_acc_memcpy_h2d(bmat_hst, bmat_dev, sizeof(ELEM_TYPE) * kn * nb, stream), &result, check);
+      CHECK(c_dbcsr_acc_memcpy_h2d(stack_hst, stack_dev, sizeof(int) * 3 * stack_size, stream), &result, check);
 #if defined(USE_LIBXSMM)
-    CHECK(c_dbcsr_acc_stream_sync(stream), &result);
-    if (NULL != amat_hst && NULL != bmat_hst && NULL != stack_hst) {
-      const size_t size = sizeof(ELEM_TYPE) * (mk * na + kn * nb) + sizeof(int) * 3 * stack_size;
-      duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
-      PRINTF("copy-in (%i MB): %.2g ms %.1f GB/s\n", (int)((size + (1 << 19)) >> 20), 1000.0 * duration,
-        size / (duration * (1ULL << 30)));
-    }
+      CHECK(c_dbcsr_acc_stream_sync(stream), &result, check);
+      if (NULL != amat_hst && NULL != bmat_hst && NULL != stack_hst) {
+        const size_t size = sizeof(ELEM_TYPE) * (mk * na + kn * nb) + sizeof(int) * 3 * stack_size;
+        duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
+        PRINTF("copy-in (%i MB): %.2g ms %.1f GB/s\n", (int)((size + (1 << 19)) >> 20), 1000.0 * duration,
+          size / (duration * (1ULL << 30)));
+      }
 #endif
 #if defined(TRANSPOSE) && defined(VALIDATE)
-    /* warmup execution and prebuild transpose-kernel */
-    for (r = 0; r < warmup / 2; ++r) {
-      CHECK(
-        libsmm_acc_transpose(trans_dev, 0 /*offset*/, nb, bmat_dev, DBCSR_TYPE(ELEM_TYPE), k, n, MAX_KERNEL_DIM, stream), &result);
-      CHECK(
-        libsmm_acc_transpose(trans_dev, 0 /*offset*/, nb, bmat_dev, DBCSR_TYPE(ELEM_TYPE), n, k, MAX_KERNEL_DIM, stream), &result);
-    }
+      /* warmup execution and prebuild transpose-kernel */
+      for (r = 0; r < warmup / 2; ++r) {
+        CHECK(libsmm_acc_transpose(trans_dev, 0 /*offset*/, nb, bmat_dev, DBCSR_TYPE(ELEM_TYPE), k, n, MAX_KERNEL_DIM, stream),
+          &result, check);
+        CHECK(libsmm_acc_transpose(trans_dev, 0 /*offset*/, nb, bmat_dev, DBCSR_TYPE(ELEM_TYPE), n, k, MAX_KERNEL_DIM, stream),
+          &result, check);
+      }
 #  if defined(USE_LIBXSMM)
-    CHECK(c_dbcsr_acc_stream_sync(stream), &result);
-    start = libxsmm_timer_tick();
+      CHECK(c_dbcsr_acc_stream_sync(stream), &result, check);
+      start = libxsmm_timer_tick();
 #  endif
-    /* to perform NN-SMMs on the device, all B-matrices are transposed upfront (SMM-kernel is limited to NT) */
-    CHECK(
-      libsmm_acc_transpose(trans_dev, 0 /*offset*/, nb, bmat_dev, DBCSR_TYPE(ELEM_TYPE), k, n, MAX_KERNEL_DIM, stream), &result);
+      /* to perform NN-SMMs on the device, all B-matrices are transposed upfront (SMM-kernel is limited to NT) */
+      CHECK(libsmm_acc_transpose(trans_dev, 0 /*offset*/, nb, bmat_dev, DBCSR_TYPE(ELEM_TYPE), k, n, MAX_KERNEL_DIM, stream),
+        &result, check);
 #  if defined(USE_LIBXSMM)
-    CHECK(c_dbcsr_acc_stream_sync(stream), &result);
-    transpose = libxsmm_timer_duration(start, libxsmm_timer_tick());
+      CHECK(c_dbcsr_acc_stream_sync(stream), &result, check);
+      transpose = libxsmm_timer_duration(start, libxsmm_timer_tick());
 #  endif
 #endif
-    /* warmup execution and prebuild SMM-kernel */
-    for (r = 0; r < warmup; ++r) {
-      CHECK(libsmm_acc_process(stack_hst, stack_dev, stack_size, DBCSR_TYPE(ELEM_TYPE), amat_dev, bmat_dev, cmat_dev, m, n, k,
-              MAX_KERNEL_DIM, 1 /*homogeneous*/, stream, stream),
-        &result);
-    }
-    CHECK(c_dbcsr_acc_memset_zero(cmat_dev, 0 /*offset*/, sizeof(ELEM_TYPE) * mn * nc, stream), &result);
+      /* warmup execution and prebuild SMM-kernel */
+      for (r = 0; r < warmup; ++r) {
+        CHECK(libsmm_acc_process(stack_hst, stack_dev, stack_size, DBCSR_TYPE(ELEM_TYPE), amat_dev, bmat_dev, cmat_dev, m, n, k,
+                MAX_KERNEL_DIM, 1 /*homogeneous*/, stream, stream),
+          &result, check);
+      }
+      CHECK(c_dbcsr_acc_memset_zero(cmat_dev, 0 /*offset*/, sizeof(ELEM_TYPE) * mn * nc, stream), &result, check);
 #if defined(USE_LIBXSMM)
-    CHECK(c_dbcsr_acc_stream_sync(stream), &result);
-    start = libxsmm_timer_tick();
+      CHECK(c_dbcsr_acc_stream_sync(stream), &result, check);
+      start = libxsmm_timer_tick();
 #endif
-    for (r = 0; r < nrepeat; ++r) {
-      /* GPU-kernel is limited to C += Ai * Bi^T, i.e., NT (for NN, all Bi must be transposed upfront) */
-      CHECK(libsmm_acc_process(stack_hst, stack_dev, stack_size, DBCSR_TYPE(ELEM_TYPE), amat_dev, bmat_dev, cmat_dev, m, n, k,
-              MAX_KERNEL_DIM, 1 /*homogeneous*/, stream, stream),
-        &result);
-    }
+      for (r = 0; r < nrepeat; ++r) {
+        /* GPU-kernel is limited to C += Ai * Bi^T, i.e., NT (for NN, all Bi must be transposed upfront) */
+        CHECK(libsmm_acc_process(stack_hst, stack_dev, stack_size, DBCSR_TYPE(ELEM_TYPE), amat_dev, bmat_dev, cmat_dev, m, n, k,
+                MAX_KERNEL_DIM, 1 /*homogeneous*/, stream, stream),
+          &result, check);
+      }
 #if defined(USE_LIBXSMM)
-    CHECK(c_dbcsr_acc_stream_sync(stream), &result);
-    duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
-    if (EXIT_SUCCESS == result) {
+      CHECK(c_dbcsr_acc_stream_sync(stream), &result, check);
+      duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
+      if (0 < duration && EXIT_SUCCESS == result) {
 #  if defined(TRANSPOSE)
-      PRINTF("transpose: %.2g ms %.1f GFLOPS/s\n", 1000.0 * (duration + transpose) / (nrepeat * smm_nrepeat),
-        1E-9 * ((size_t)2 * m * n * k * stack_size * nrepeat * smm_nrepeat) / (duration + transpose));
+        PRINTF("transpose: %.2g ms %.1f GFLOPS/s\n", 1000.0 * (duration + transpose) / (nrepeat * smm_nrepeat),
+          1E-9 * ((size_t)2 * m * n * k * stack_size * nrepeat * smm_nrepeat) / (duration + transpose));
 #  endif
-      PRINTF("device: %.2g ms %.1f GFLOPS/s\n", 1000.0 * duration / (nrepeat * smm_nrepeat),
-        1E-9 * ((size_t)2 * m * n * k * stack_size * nrepeat * smm_nrepeat) / duration);
-    }
-#  if defined(VALIDATE)
-    {
-      ELEM_TYPE* const gold_hst = (ELEM_TYPE*)(0 != check ? libxsmm_malloc(sizeof(ELEM_TYPE) * mn * nc) : NULL);
-      /* determine host's performance independent of current result code/status */
-      if (NULL != gold_hst && NULL != amat_hst && NULL != bmat_hst && NULL != stack_hst) {
-        const ELEM_TYPE alpha = 1, beta = 1;
-        const char transa = 'N';
-#    if defined(TRANSPOSE)
-        const char transb = 'N';
-#    else
-        const char transb = 'T';
-#    endif
-        memset(gold_hst, 0, sizeof(ELEM_TYPE) * mn * nc);
-        for (r = 0; r < warmup; ++r) {
-          ACC_BENCH_GEMM_BATCH(LIBXSMM_DATATYPE(ELEM_TYPE), LIBXSMM_DATATYPE(ELEM_TYPE), &transa, &transb, m, n, k, &alpha,
-            amat_hst, &m /*lda*/, stack_hst + 0 /*stride_a*/, bmat_hst, &k /*ldb*/, stack_hst + 1 /*stride_b*/, &beta, gold_hst,
-            &m /*ldc*/, stack_hst + 2 /*stride_c*/, sizeof(int) * 3, 1 /*index_base*/, stack_size);
-        }
-        memset(gold_hst, 0, sizeof(ELEM_TYPE) * mn * nc);
-        start = libxsmm_timer_tick();
-        /* CPU-kernel operates on data that is not initialized in NUMA-aware fashion */
-        for (r = 0; r < (nrepeat * smm_nrepeat); ++r) {
-          ACC_BENCH_GEMM_BATCH(LIBXSMM_DATATYPE(ELEM_TYPE), LIBXSMM_DATATYPE(ELEM_TYPE), &transa, &transb, m, n, k, &alpha,
-            amat_hst, &m /*lda*/, stack_hst + 0 /*stride_a*/, bmat_hst, &k /*ldb*/, stack_hst + 1 /*stride_b*/, &beta, gold_hst,
-            &m /*ldc*/, stack_hst + 2 /*stride_c*/, sizeof(int) * 3, 1 /*index_base*/, stack_size);
-        }
-        duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
-        PRINTF("host: %.2g ms %.1f GFLOPS/s\n", 1000.0 * duration / (nrepeat * smm_nrepeat),
+        PRINTF("device: %.2g ms %.1f GFLOPS/s\n", 1000.0 * duration / (nrepeat * smm_nrepeat),
           1E-9 * ((size_t)2 * m * n * k * stack_size * nrepeat * smm_nrepeat) / duration);
-        /* validate correctness in case of successful result code/status */
-        if (EXIT_SUCCESS == result) {
-          /* transfer result from device to host for validation */
-          CHECK(c_dbcsr_acc_memcpy_d2h(cmat_dev, cmat_hst, sizeof(ELEM_TYPE) * mn * nc, stream), &result);
-          CHECK(c_dbcsr_acc_stream_sync(stream), &result);
-#    if LIBXSMM_VERSION4(1, 17, 0, 0) < LIBXSMM_VERSION_NUMBER
+      }
+      else {
+#  if defined(TRANSPOSE)
+        PRINTF("transpose: 0 ms 0 GFLOPS/s\n");
+#  endif
+        PRINTF("device: 0 ms 0 GFLOPS/s\n");
+      }
+#  if defined(VALIDATE)
+      {
+        ELEM_TYPE* const gold_hst = (ELEM_TYPE*)(0 != check ? libxsmm_malloc(sizeof(ELEM_TYPE) * mn * nc) : NULL);
+        /* determine host's performance independent of current result code/status */
+        if (NULL != gold_hst && NULL != amat_hst && NULL != bmat_hst && NULL != stack_hst) {
+          const ELEM_TYPE alpha = 1, beta = 1;
+          const char transa = 'N';
+#    if defined(TRANSPOSE)
+          const char transb = 'N';
+#    else
+          const char transb = 'T';
+#    endif
+          memset(gold_hst, 0, sizeof(ELEM_TYPE) * mn * nc);
+          for (r = 0; r < warmup; ++r) {
+            ACC_BENCH_GEMM_BATCH(LIBXSMM_DATATYPE(ELEM_TYPE), LIBXSMM_DATATYPE(ELEM_TYPE), &transa, &transb, m, n, k, &alpha,
+              amat_hst, &m /*lda*/, stack_hst + 0 /*stride_a*/, bmat_hst, &k /*ldb*/, stack_hst + 1 /*stride_b*/, &beta, gold_hst,
+              &m /*ldc*/, stack_hst + 2 /*stride_c*/, sizeof(int) * 3, 1 /*index_base*/, stack_size);
+          }
+          memset(gold_hst, 0, sizeof(ELEM_TYPE) * mn * nc);
+          start = libxsmm_timer_tick();
+          /* CPU-kernel operates on data that is not initialized in NUMA-aware fashion */
+          for (r = 0; r < (nrepeat * smm_nrepeat); ++r) {
+            ACC_BENCH_GEMM_BATCH(LIBXSMM_DATATYPE(ELEM_TYPE), LIBXSMM_DATATYPE(ELEM_TYPE), &transa, &transb, m, n, k, &alpha,
+              amat_hst, &m /*lda*/, stack_hst + 0 /*stride_a*/, bmat_hst, &k /*ldb*/, stack_hst + 1 /*stride_b*/, &beta, gold_hst,
+              &m /*ldc*/, stack_hst + 2 /*stride_c*/, sizeof(int) * 3, 1 /*index_base*/, stack_size);
+          }
+          duration = libxsmm_timer_duration(start, libxsmm_timer_tick());
+          PRINTF("host: %.2g ms %.1f GFLOPS/s\n", 1000.0 * duration / (nrepeat * smm_nrepeat),
+            1E-9 * ((size_t)2 * m * n * k * stack_size * nrepeat * smm_nrepeat) / duration);
+          /* validate correctness in case of successful result code/status */
           if (EXIT_SUCCESS == result) {
-            libxsmm_matdiff_info diff;
-            /* validate result buffers at once (including excess/padded space) */
-            result = libxsmm_matdiff(&diff, LIBXSMM_DATATYPE(ELEM_TYPE), mn, nc, gold_hst, cmat_hst, &mn, &mn);
+            /* transfer result from device to host for validation */
+            CHECK(c_dbcsr_acc_memcpy_d2h(cmat_dev, cmat_hst, sizeof(ELEM_TYPE) * mn * nc, stream), &result, check);
+            CHECK(c_dbcsr_acc_stream_sync(stream), &result, check);
+#    if LIBXSMM_VERSION4(1, 17, 0, 0) < LIBXSMM_VERSION_NUMBER
             if (EXIT_SUCCESS == result) {
-              const double relerror = 1.0 - diff.rsq;
-              PRINTF("rel.error: %g", relerror);
-              if (maxerror < relerror && NULL != file) maxerror = relerror;
-              if (0 < relerror) {
-                if (LIBXSMM_NOTNAN(diff.v_tst)) {
-                  PRINTF(" (%g != %g)\n", diff.v_ref, diff.v_tst);
+              libxsmm_matdiff_info diff;
+              /* validate result buffers at once (including excess/padded space) */
+              result = libxsmm_matdiff(&diff, LIBXSMM_DATATYPE(ELEM_TYPE), mn, nc, gold_hst, cmat_hst, &mn, &mn);
+              if (EXIT_SUCCESS == result) {
+                const double relerror = 1.0 - diff.rsq;
+                PRINTF("rel.error: %g", relerror);
+                if (maxerror < relerror && NULL != file) maxerror = relerror;
+                if (0 < relerror) {
+                  if (LIBXSMM_NOTNAN(diff.v_tst)) {
+                    PRINTF(" (%g != %g)\n", diff.v_ref, diff.v_tst);
+                  }
+                  else {
+                    PRINTF(" (%g)\n", diff.v_tst);
+                  }
                 }
                 else {
-                  PRINTF(" (%g)\n", diff.v_tst);
+                  PRINTF("\n");
                 }
+                if (0 < check && check < relerror) result = EXIT_FAILURE;
               }
-              else {
-                PRINTF("\n");
-              }
-              if (0 < check && check < relerror) result = EXIT_FAILURE;
             }
-          }
 #    endif
+          }
         }
+        libxsmm_free(gold_hst);
       }
-      libxsmm_free(gold_hst);
-    }
 #  endif
 #endif
-    CHECK(c_dbcsr_acc_host_mem_deallocate(stack_hst, stream), NULL);
-    CHECK(c_dbcsr_acc_host_mem_deallocate(trans_hst, stream), NULL);
-    CHECK(c_dbcsr_acc_host_mem_deallocate(amat_hst, stream), NULL);
-    CHECK(c_dbcsr_acc_host_mem_deallocate(bmat_hst, stream), NULL);
-    CHECK(c_dbcsr_acc_host_mem_deallocate(cmat_hst, stream), NULL);
-    CHECK(c_dbcsr_acc_dev_mem_deallocate(stack_dev), NULL);
-    CHECK(c_dbcsr_acc_dev_mem_deallocate(trans_dev), NULL);
-    CHECK(c_dbcsr_acc_dev_mem_deallocate(amat_dev), NULL);
-    CHECK(c_dbcsr_acc_dev_mem_deallocate(bmat_dev), NULL);
-    CHECK(c_dbcsr_acc_dev_mem_deallocate(cmat_dev), NULL);
-    CHECK(c_dbcsr_acc_stream_destroy(stream), NULL);
-    if (EXIT_SUCCESS == result) {
-      parse_params(argc, argv, &file, &snr, &sss, &ssm, &ssn, &ssk, &snc, &sna, &snb);
-      if (NULL != file) PRINTF("\n");
-      ++nok;
-    }
+      CHECK(c_dbcsr_acc_host_mem_deallocate(stack_hst, stream), NULL, check);
+      CHECK(c_dbcsr_acc_host_mem_deallocate(trans_hst, stream), NULL, check);
+      CHECK(c_dbcsr_acc_host_mem_deallocate(amat_hst, stream), NULL, check);
+      CHECK(c_dbcsr_acc_host_mem_deallocate(bmat_hst, stream), NULL, check);
+      CHECK(c_dbcsr_acc_host_mem_deallocate(cmat_hst, stream), NULL, check);
+      CHECK(c_dbcsr_acc_dev_mem_deallocate(stack_dev), NULL, check);
+      CHECK(c_dbcsr_acc_dev_mem_deallocate(trans_dev), NULL, check);
+      CHECK(c_dbcsr_acc_dev_mem_deallocate(amat_dev), NULL, check);
+      CHECK(c_dbcsr_acc_dev_mem_deallocate(bmat_dev), NULL, check);
+      CHECK(c_dbcsr_acc_dev_mem_deallocate(cmat_dev), NULL, check);
+      CHECK(c_dbcsr_acc_stream_destroy(stream), NULL, check);
+      if (0 == result || (0 > result && 0 == check)) {
+        parse_params(argc, argv, &file, &snr, &sss, &ssm, &ssn, &ssk, &snc, &sna, &snb);
+        if (NULL != file) PRINTF("\n");
+        ++nok;
+      }
 #if defined(USE_LIBXSMM)
-    LIBXSMM_STDIO_ACQUIRE();
-    fputs(print_buffer, stdout);
-    LIBXSMM_STDIO_RELEASE();
+      if (0 == result) {
+        LIBXSMM_STDIO_ACQUIRE();
+        fputs(print_buffer, stdout);
+        LIBXSMM_STDIO_RELEASE();
+      }
+      else
 #endif
-    if (EXIT_SUCCESS == result && NULL == file) break;
+      {
+        if (0 > result) fprintf(stderr, "WARNING: %ix%ix%i-kernel not available or unsuitable!\n", m, n, k);
+      }
+      if (NULL == file && (0 == result || (0 > result && 0 == check))) break;
+    }
   }
   free(rnd); /* release array of random numbers */
 #if !defined(__CUDA)
-  CHECK(libsmm_acc_finalize(), NULL);
+  CHECK(libsmm_acc_finalize(), NULL, check);
 #endif
-  CHECK(c_dbcsr_acc_finalize(), NULL);
+  CHECK(c_dbcsr_acc_finalize(), NULL, check);
 #if defined(USE_LIBXSMM) && defined(VALIDATE)
   if (1 < nok) printf("\nmax.error: %g\n", maxerror);
 #endif
   if (EXIT_SUCCESS != result) {
     if (NULL != file) fclose(file);
-    if (-1 != result) {
-      fprintf(stderr, "FAILED\n");
-    }
-    else {
-      fprintf(stderr, "Kernel not suitable!\n");
-      result = EXIT_SUCCESS;
-    }
+    if (0 < result) fprintf(stderr, "\nFAILED\n\n");
+    else if (0 == check) result = EXIT_SUCCESS;
   }
   return result;
 }

--- a/src/acc/cuda/Makefile
+++ b/src/acc/cuda/Makefile
@@ -27,7 +27,6 @@ ifeq (,$(LIBXSMMROOT))
   LIBXSMMROOT := $(wildcard $(HOME)/libxsmm)
 endif
 UNAME := $(shell uname)
-WITH_GPU := $(if $(WITH_GPU),$(WITH_GPU),$(if $(GPUVER),$(GPUVER),P100))
 INTEL ?= 0
 DEV ?= 0
 
@@ -49,6 +48,17 @@ endif
 PYTHON := $(call which,python3)
 ifeq (,$(PYTHON))
   PYTHON := $(call which,python)
+endif
+
+WITH_GPU := $(if $(WITH_GPU),$(WITH_GPU),$(GPUVER))
+ifeq (,$(WITH_GPU))
+  ifneq (,$(call which,nvidia-smi))
+    GPU_NAME := $(shell nvidia-smi --query-gpu=gpu_name --format=csv,noheader -i 0 2>/dev/null | tr -c [:alnum:] " ")
+    WITH_GPU := $(filter K20X K40 K80 P100 V100 A100 H100,$(GPU_NAME))
+  endif
+endif
+ifeq (,$(WITH_GPU))
+  WITH_GPU := P100
 endif
 
 NVCC ?= $(call which,nvcc)
@@ -211,20 +221,22 @@ endif
 	@ldd $(ACCDIR)/acc_bench_smm
 	@echo "hostname: $$(hostname)"
 	@echo
-	@echo "$(SHAPES)" | xargs -n1 | \
-		(CHECK=$(if $(CHECK),$(CHECK),1) stdbuf --output=L $(ACCDIR)/acc_bench_smm /dev/stdin \
-			2>$(MAKDIR)/test-smm.err && rm $(MAKDIR)/test-smm.err) | tee $@
-	@if [ -s $(MAKDIR)/test-smm.err ]; then cat $(MAKDIR)/test-smm.err && exit 1; fi
+	@echo "$(SHAPES)" | xargs -n1 | (CHECK=$(if $(CHECK),$(CHECK),1) stdbuf --output=L \
+		$(ACCDIR)/acc_bench_smm /dev/stdin 2>$(MAKDIR)/test-smm.err && rm $(MAKDIR)/test-smm.err) | tee $@
 
 .PHONY: test-smm
 test-smm: $(MAKDIR)/test-smm.log
 ifneq (,$(call which,datamash))
 ifeq (,$(shell datamash geomean 2>&1 | grep invalid))
-	@echo "geomean: $$(sed -n "/device:/p" $< | datamash -W -R 1 geomean 4) GFLOPS/s"
+	@echo "geomean: $$(sed -n "/device:/p" $< 2>/dev/null | datamash -W -R 1 geomean 4) GFLOPS/s"
 endif
-	@echo "median: $$(sed -n "/device:/p" $< | datamash -W -R 1 median 4) GFLOPS/s"
-	@echo "mean: $$(sed -n "/device:/p" $< | datamash -W -R 1 mean 4) GFLOPS/s"
+	@echo "median: $$(sed -n "/device:/p" $< 2>/dev/null | datamash -W -R 1 median 4) GFLOPS/s"
+	@echo "mean: $$(sed -n "/device:/p" $< 2>/dev/null | datamash -W -R 1 mean 4) GFLOPS/s"
 endif
+	@if [ -s $(MAKDIR)/test-smm.err ]; then \
+		echo && cat $(MAKDIR)/test-smm.err; \
+		if [ "0" != "$(if $(CHECK),$(CHECK),1)" ]; then exit 1; fi; \
+	fi
 
 PARDIR := $(DIRSMM)/parameters
 PARAMS := $(wildcard $(PARDIR)/parameters_$(WITH_GPU).json)

--- a/src/acc/cuda_hip/acc_event.cpp
+++ b/src/acc/cuda_hip/acc_event.cpp
@@ -55,7 +55,8 @@ extern "C" int c_dbcsr_acc_event_record(void* event, void* stream) {
   ACC(Stream_t)* acc_stream = (ACC(Stream_t)*)stream;
 
   if (verbose_print)
-    printf("EventRecord): %p -> %ld,  %p -> %ld\n", acc_event, (long int)*acc_event, acc_stream, (long int)*acc_stream);
+    printf("EventRecord): %p -> %ld,  %p -> %ld\n", (const void*)acc_event, (long int)*acc_event, (const void*)acc_stream,
+      (long int)*acc_stream);
   ACC_API_CALL(EventRecord, (*acc_event, *acc_stream));
   return 0;
 }

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -234,20 +234,22 @@ endif
 	@ldd $(ACCDIR)/acc_bench_smm
 	@echo "hostname: $$(hostname)"
 	@echo
-	@echo "$(SHAPES)" | xargs -n1 | \
-		($(GPUENV) CHECK=$(if $(CHECK),$(CHECK),1) stdbuf --output=L $(ACC_BENCH_SMM) /dev/stdin \
-			2>$(MAKDIR)/test-smm.err && rm $(MAKDIR)/test-smm.err) | tee $@
-	@if [ -s $(MAKDIR)/test-smm.err ]; then cat $(MAKDIR)/test-smm.err && exit 1; fi
+	@echo "$(SHAPES)" | xargs -n1 | ($(GPUENV) CHECK=$(if $(CHECK),$(CHECK),1) stdbuf --output=L \
+		$(ACC_BENCH_SMM) /dev/stdin 2>$(MAKDIR)/test-smm.err && rm $(MAKDIR)/test-smm.err) | tee $@
 
 .PHONY: test-smm
 test-smm: $(MAKDIR)/test-smm.log
 ifneq (,$(call which,datamash))
 ifeq (,$(shell datamash geomean 2>&1 | grep invalid))
-	@echo "geomean: $$(sed -n "/device:/p" $< | datamash -W -R 1 geomean 4) GFLOPS/s"
+	@echo "geomean: $$(sed -n "/device:/p" $< 2>/dev/null | datamash -W -R 1 geomean 4) GFLOPS/s"
 endif
-	@echo "median: $$(sed -n "/device:/p" $< | datamash -W -R 1 median 4) GFLOPS/s"
-	@echo "mean: $$(sed -n "/device:/p" $< | datamash -W -R 1 mean 4) GFLOPS/s"
+	@echo "median: $$(sed -n "/device:/p" $< 2>/dev/null | datamash -W -R 1 median 4) GFLOPS/s"
+	@echo "mean: $$(sed -n "/device:/p" $< 2>/dev/null | datamash -W -R 1 mean 4) GFLOPS/s"
 endif
+	@if [ -s $(MAKDIR)/test-smm.err ]; then \
+		echo && cat $(MAKDIR)/test-smm.err; \
+		if [ "0" != "$(if $(CHECK),$(CHECK),1)" ]; then exit 1; fi; \
+	fi
 
 $(MAKDIR)/smm/opencl_kernels.h: $(MAKDIR)/acc_opencl.sh $(KERNEL) $(PARAMS)
 	@CPPFLAGS=$(CPP_OPENCL_FLAGS) $(MAKDIR)/acc_opencl.sh $(KERNEL) $(PARAMS) $@

--- a/src/acc/opencl/smm/opencl_libsmm.c
+++ b/src/acc/opencl/smm/opencl_libsmm.c
@@ -444,12 +444,10 @@ int libsmm_acc_init(void) {
         char buffer[ACC_OPENCL_BUFFERSIZE], bufname[ACC_OPENCL_BUFFERSIZE], control = '0';
 #  if defined(OPENCL_LIBSMM_DEVICES)
         const int ndevices = (int)(sizeof(OPENCL_LIBSMM_DEVICES) / sizeof(*OPENCL_LIBSMM_DEVICES));
-#  else
-        const int ndevices = 0;
+        unsigned int ntuned = 0;
 #  endif
         opencl_libsmm_smm_t config;
         opencl_libsmm_smmkey_t key;
-        unsigned int ntuned = 0;
         LIBXSMM_MEMZERO127(&key); /* potentially heterogeneous key-data (alignment gaps) */
         if (NULL != env_params && '\0' != *env_params) { /* filename */
           FILE* const file = fopen(env_params, "r");
@@ -470,7 +468,9 @@ int libsmm_acc_init(void) {
                       result = EXIT_FAILURE;
                       break;
                     }
+#  if defined(OPENCL_LIBSMM_DEVICES)
                     else ++ntuned;
+#  endif
                   }
                   else if (config_init->gflops < config.gflops) { /* update */
                     memcpy(config_init, &config, sizeof(config));
@@ -542,7 +542,9 @@ int libsmm_acc_init(void) {
               key.devuid = 0;
               if (NULL != OPENCL_LIBSMM_REGISTER(&key, sizeof(key), sizeof(config), &config)) {
                 c_dbcsr_acc_opencl_config.devmatch = 0; /* disable device-match */
+#  if defined(OPENCL_LIBSMM_DEVICES)
                 ntuned = MAX(ntuned, 1); /* no destinction of overridden or new */
+#  endif
               }
               else result = EXIT_FAILURE;
             }


### PR DESCRIPTION
* Allow to continue benchmark if kernel is not available and if CHECK=0. Improved Makefile.
* Print rejected kernel and refined behavior of failing execution (CHECK).
* OCL: Avoid warning about dead store and about unused variable.
* CUDA: auto-detect GPU-kind using nvidia-smi (Makefile).
* CUDA: Avoid compilation warnings (-Wformat).
* Updated LIBXSMM (Daint-CI).