### PR TITLE
ocl: introduce ACC_OPENCL_DEVIDS whitelist of devices

### DIFF
--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -26,7 +26,7 @@ if [ ! -d "${HOME}/libxsmm" ]; then
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout 184f6ddc3e460f27e31a7ea4ad042f73fa7a76e8
+git checkout dda3ff24b87da891a2d159f1132a33ac5590ba68
 make -j
 cd ..
 

--- a/src/acc/acc_bench_smm.c
+++ b/src/acc/acc_bench_smm.c
@@ -223,7 +223,7 @@ int main(int argc, char* argv[]) {
     result = c_dbcsr_acc_get_ndevices(&ndevices);
     if (0 < ndevices && (0 == device || EXIT_SUCCESS == c_dbcsr_acc_set_active_device(device))) {
 #if defined(_DEBUG)
-      fprintf(stderr, "Activated device %i of %i.\n", device, ndevices);
+      fprintf(stderr, "Activated device %i of %i (device%i).\n", device + 1, ndevices, device);
 #endif
     }
     else {

--- a/src/acc/acc_bench_trans.c
+++ b/src/acc/acc_bench_trans.c
@@ -115,7 +115,7 @@ int main(int argc, char* argv[]) {
     result = c_dbcsr_acc_get_ndevices(&ndevices);
     if (0 < ndevices && (0 == device || EXIT_SUCCESS == c_dbcsr_acc_set_active_device(device))) {
 #if defined(_DEBUG)
-      fprintf(stderr, "Activated device %i of %i.\n", device, ndevices);
+      fprintf(stderr, "Activated device %i of %i (device%i).\n", device + 1, ndevices, device);
 #endif
     }
     else {

--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -215,13 +215,14 @@ int c_dbcsr_acc_init(void) {
     char buffer[ACC_OPENCL_BUFFERSIZE];
     const char *const env_devmatch = getenv("ACC_OPENCL_DEVMATCH"), *const env_devtype = getenv("ACC_OPENCL_DEVTYPE");
     const char *const env_priority = getenv("ACC_OPENCL_PRIORITY"), *const env_xhints = getenv("ACC_OPENCL_XHINTS");
-    const char *const env_devcopy = getenv("ACC_OPENCL_DEVCOPY"), *const env_dump_acc = getenv("ACC_OPENCL_DUMP");
-    const char *const env_verbose = getenv("ACC_OPENCL_VERBOSE"), *const env_flush = getenv("ACC_OPENCL_FLUSH");
-    const char *const env_device = getenv("ACC_OPENCL_DEVICE"), *const env_timer = getenv("ACC_OPENCL_TIMER");
-    const char *const env_share = getenv("ACC_OPENCL_SHARE"), *const env_async = getenv("ACC_OPENCL_ASYNC");
+    const char *const env_devcopy = getenv("ACC_OPENCL_DEVCOPY"), *const env_verbose = getenv("ACC_OPENCL_VERBOSE");
+    const char *const env_dump_acc = getenv("ACC_OPENCL_DUMP"), *const env_share = getenv("ACC_OPENCL_SHARE");
+    const char *const env_device = getenv("ACC_OPENCL_DEVICE"), *const env_async = getenv("ACC_OPENCL_ASYNC");
+    const char *const env_flush = getenv("ACC_OPENCL_FLUSH"), *const env_timer = getenv("ACC_OPENCL_TIMER");
     const char* const env_dump = (NULL != env_dump_acc ? env_dump_acc : getenv("IGC_ShaderDumpEnable"));
+    char* const env_devids = getenv("ACC_OPENCL_DEVIDS");
     int device_id = (NULL == env_device ? 0 : atoi(env_device));
-    cl_uint nplatforms = 0, i;
+    cl_uint nplatforms = 0, ndevices = 0, i;
     cl_device_type type = CL_DEVICE_TYPE_ALL;
 #  if defined(_OPENMP)
     const int max_threads = omp_get_max_threads(), num_threads = omp_get_num_threads();
@@ -292,7 +293,6 @@ int c_dbcsr_acc_init(void) {
       }
       c_dbcsr_acc_opencl_config.ndevices = 0;
       for (i = 0; i < nplatforms; ++i) {
-        cl_uint ndevices;
         if (CL_SUCCESS == clGetDeviceIDs(platforms[i], type, 0, NULL, &ndevices) && 0 < ndevices) {
           ACC_OPENCL_CHECK(clGetDeviceIDs(platforms[i], type, ndevices, devices, NULL), "retrieve device ids", result);
           if (EXIT_SUCCESS == result) {
@@ -324,7 +324,7 @@ int c_dbcsr_acc_init(void) {
 #  if defined(CL_VERSION_1_2)
               else if (1 < n) { /* create subdevices */
                 if (ACC_OPENCL_DEVICES_MAXCOUNT < (c_dbcsr_acc_opencl_config.ndevices + n)) {
-                  n = ACC_OPENCL_DEVICES_MAXCOUNT - (cl_uint)c_dbcsr_acc_opencl_config.ndevices;
+                  n = (cl_uint)ACC_OPENCL_DEVICES_MAXCOUNT - c_dbcsr_acc_opencl_config.ndevices;
                 }
                 if (EXIT_SUCCESS == clCreateSubDevices(devices[j], properties, n,
                                       c_dbcsr_acc_opencl_config.devices + c_dbcsr_acc_opencl_config.ndevices, NULL))
@@ -348,13 +348,16 @@ int c_dbcsr_acc_init(void) {
       const char* const env_vendor = getenv("ACC_OPENCL_VENDOR");
       /* filter device by vendor (if requested) */
       if (NULL != env_vendor && '\0' != *env_vendor) {
-        for (i = 0; i < (cl_uint)c_dbcsr_acc_opencl_config.ndevices;) {
+        for (i = 0; (int)i < c_dbcsr_acc_opencl_config.ndevices;) {
           if (CL_SUCCESS ==
               clGetDeviceInfo(c_dbcsr_acc_opencl_config.devices[i], CL_DEVICE_VENDOR, ACC_OPENCL_BUFFERSIZE, buffer, NULL)) {
             if (NULL == c_dbcsr_acc_opencl_stristr(buffer, env_vendor)) {
+#  if defined(CL_VERSION_1_2)
+              ACC_OPENCL_EXPECT(CL_SUCCESS, clReleaseDevice(c_dbcsr_acc_opencl_config.devices[i]));
+#  endif
               --c_dbcsr_acc_opencl_config.ndevices;
-              if (i < (cl_uint)c_dbcsr_acc_opencl_config.ndevices) { /* keep original order (stable) */
-                memmove(c_dbcsr_acc_opencl_config.devices + i, c_dbcsr_acc_opencl_config.devices + i + 1,
+              if ((int)i < c_dbcsr_acc_opencl_config.ndevices) { /* keep original order (stable) */
+                memmove(&c_dbcsr_acc_opencl_config.devices[i], &c_dbcsr_acc_opencl_config.devices[i + 1],
                   sizeof(cl_device_id) * (c_dbcsr_acc_opencl_config.ndevices - i));
               }
             }
@@ -368,17 +371,62 @@ int c_dbcsr_acc_init(void) {
         qsort(c_dbcsr_acc_opencl_config.devices, c_dbcsr_acc_opencl_config.ndevices, sizeof(cl_device_id),
           c_dbcsr_acc_opencl_order_devices);
       }
+      /* ACC_OPENCL_DEVIDS is parsed as a list of devices (whitelist) */
+      if (EXIT_SUCCESS == result && NULL != env_devids && '\0' != *env_devids) {
+        cl_uint devids[ACC_OPENCL_DEVICES_MAXCOUNT], ndevids = 0;
+        const char* const end = env_devids + strlen(env_devids); /* before strtok */
+        char* did = strtok(env_devids, ACC_OPENCL_DELIMS);
+        for (; NULL != did && ndevids < ACC_OPENCL_DEVICES_MAXCOUNT;
+             did = ((did + 1) < end ? strtok((did + 1) + strlen(did), ACC_OPENCL_DELIMS) : NULL))
+        {
+          const int id = atoi(did);
+          if (0 <= id && id < c_dbcsr_acc_opencl_config.ndevices) devids[ndevids++] = id;
+        }
+        if (0 < ndevids) {
+          ndevices = (cl_uint)c_dbcsr_acc_opencl_config.ndevices;
+          for (i = 0; i < ndevices; ++i) {
+            cl_uint match = 0, j = 0;
+            do
+              if (i == devids[j]) {
+                match = 1;
+                break;
+              }
+            while (++j < ndevids);
+            if (0 == match) {
+#  if defined(CL_VERSION_1_2)
+              ACC_OPENCL_EXPECT(CL_SUCCESS, clReleaseDevice(c_dbcsr_acc_opencl_config.devices[i]));
+#  endif
+              c_dbcsr_acc_opencl_config.devices[i] = NULL;
+            }
+          }
+          for (i = c_dbcsr_acc_opencl_config.ndevices - 1;; --i) {
+            if (NULL == c_dbcsr_acc_opencl_config.devices[i]) { /* keep original order (stable) */
+              const cl_uint nmove = c_dbcsr_acc_opencl_config.ndevices - (i + 1);
+              if (0 < nmove) {
+                memmove(
+                  &c_dbcsr_acc_opencl_config.devices[i], &c_dbcsr_acc_opencl_config.devices[i + 1], sizeof(cl_device_id) * nmove);
+              }
+              --c_dbcsr_acc_opencl_config.ndevices;
+            }
+            if (0 == i) break;
+          }
+        }
+      }
     }
     if (EXIT_SUCCESS == result && 0 < c_dbcsr_acc_opencl_config.ndevices) {
       /* preselect any default device or prune to homogeneous set of GPUs */
       if (NULL == env_device || '\0' == *env_device) {
-        const cl_uint ndevices = (cl_uint)c_dbcsr_acc_opencl_config.ndevices;
         char tmp[ACC_OPENCL_BUFFERSIZE] = "";
+        ndevices = (cl_uint)c_dbcsr_acc_opencl_config.ndevices;
         for (i = 0; i < ndevices; ++i) {
           cl_device_type itype;
           result = clGetDeviceInfo(c_dbcsr_acc_opencl_config.devices[i], CL_DEVICE_TYPE, sizeof(cl_device_type), &itype, NULL);
           if (CL_SUCCESS == result) {
             if (0 != (CL_DEVICE_TYPE_DEFAULT & itype)) {
+              if (0 < i) {
+                c_dbcsr_acc_opencl_config.devices[0] = c_dbcsr_acc_opencl_config.devices[i];
+              }
+              c_dbcsr_acc_opencl_config.ndevices = 1;
               device_id = (int)i;
               break;
             }
@@ -419,8 +467,7 @@ int c_dbcsr_acc_init(void) {
           if (1 < c_dbcsr_acc_opencl_config.verbosity || 0 > c_dbcsr_acc_opencl_config.verbosity) {
             char platform_name[ACC_OPENCL_BUFFERSIZE];
             unsigned int devuid;
-            int i = 0;
-            for (; i < c_dbcsr_acc_opencl_config.ndevices; ++i) {
+            for (i = 0; i < (cl_uint)c_dbcsr_acc_opencl_config.ndevices; ++i) {
               if (EXIT_SUCCESS == c_dbcsr_acc_opencl_device_info(c_dbcsr_acc_opencl_config.devices[i], &devuid, buffer,
                                     ACC_OPENCL_BUFFERSIZE, platform_name, ACC_OPENCL_BUFFERSIZE))
               {
@@ -789,7 +836,7 @@ int c_dbcsr_acc_opencl_device_ext(cl_device_id device, const char* const extname
   if (EXIT_SUCCESS == result) {
     do {
       if (NULL != extnames[--num_exts]) {
-        const char* const end = buffer + strlen(extnames[num_exts]);
+        const char* const end = buffer + strlen(extnames[num_exts]); /* before strtok */
         char* ext = strtok(strncpy(buffer, extnames[num_exts], ACC_OPENCL_BUFFERSIZE - 1), ACC_OPENCL_DELIMS " \t");
         for (; NULL != ext; ext = ((ext + 1) < end ? strtok((ext + 1) + strlen(ext), ACC_OPENCL_DELIMS " \t") : NULL)) {
           if (NULL == strstr(extensions, ext)) {
@@ -1044,7 +1091,7 @@ int c_dbcsr_acc_opencl_kernel(const char source[], const char kernel_name[], con
       size_t size_ext = 0;
       for (; 0 < n; --n) {
         if (NULL != extnames[n - 1]) {
-          const char* const end = buffer + strlen(extnames[n - 1]);
+          const char* const end = buffer + strlen(extnames[n - 1]); /* before strtok */
           char* ext = strtok(strncpy(buffer, extnames[n - 1], ACC_OPENCL_BUFFERSIZE - 1), ACC_OPENCL_DELIMS " \t");
           for (; NULL != ext; ext = ((ext + 1) < end ? strtok((ext + 1) + strlen(ext), ACC_OPENCL_DELIMS " \t") : NULL), ++nflat) {
             size_ext += strlen(ext);
@@ -1058,7 +1105,7 @@ int c_dbcsr_acc_opencl_kernel(const char source[], const char kernel_name[], con
         if (NULL != ext_source_buffer) {
           for (n = 0; 0 < num_exts; --num_exts) {
             if (NULL != extnames[num_exts - 1]) {
-              const char* const end = buffer_name + strlen(extnames[num_exts - 1]);
+              const char* const end = buffer_name + strlen(extnames[num_exts - 1]); /* before strtok */
               char* ext = strtok(
                 strncpy(buffer_name, extnames[num_exts - 1], ACC_OPENCL_MAXSTRLEN * 2 - 1), ACC_OPENCL_DELIMS " \t");
               for (; NULL != ext; ext = ((ext + 1) < end ? strtok((ext + 1) + strlen(ext), ACC_OPENCL_DELIMS " \t") : NULL)) {
@@ -1252,7 +1299,7 @@ int c_dbcsr_acc_opencl_kernel(const char source[], const char kernel_name[], con
   if (EXIT_SUCCESS != result) *kernel = NULL;
 #  endif
   if (NULL != try_ok) *try_ok = result | ok;
-  return result;
+  ACC_OPENCL_RETURN_CAUSE(result, buffer);
 }
 
 #  if defined(__cplusplus)

--- a/src/acc/opencl/smm/opencl_libsmm.c
+++ b/src/acc/opencl/smm/opencl_libsmm.c
@@ -235,7 +235,7 @@ int opencl_libsmm_write_smm_params(FILE* stream, int only_key, const opencl_libs
 
 int opencl_libsmm_read_smm_params(
   char* parambuf, opencl_libsmm_smmkey_t* key, opencl_libsmm_smm_t* value, opencl_libsmm_perfest_t* perfest, char* device) {
-  const char* const end = parambuf + strlen(parambuf);
+  const char* const end = parambuf + strlen(parambuf); /* before strtok */
   char* s = strtok(parambuf, ACC_OPENCL_DELIMS);
   int result = EXIT_SUCCESS, i = 0, ivalue, consumed = 0, c = 0;
   const int opt_consumed = (NULL != perfest ? 2 : 0) + (NULL != device ? 1 : 0);
@@ -1400,13 +1400,13 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
                           atomic_ops = "-Dcl_intel_global_float_atomics";
                         }
                         else {
-                          atomic_ops = (2 > atomics_force
+                          atomic_ops = ((0 == std_c11 && 2 > atomics_force)
                                           ? "-DATOMIC_PROTOTYPES=1"
                                           : (3 > atomics_force ? "-DATOMIC_PROTOTYPES=2" : "-DATOMIC_PROTOTYPES=3"));
                         }
-                        atomic_exp = ((0 != std_c11 && 1 < atomics_force) ? "atomic_fetch_add_explicit((GLOBAL_VOLATILE(TF)*)A,B,"
-                                                                            "memory_order_relaxed,memory_scope_work_group)"
-                                                                          : "atomic_add(A,B)");
+                        atomic_exp = ((0 == std_c11 && 2 > atomics_force) ? "atomic_add(A,B)"
+                                                                          : "atomic_fetch_add_explicit((GLOBAL_VOLATILE(TF)*)A,B,"
+                                                                            "memory_order_relaxed,memory_scope_work_group)");
                       }
                       else {
                         atomic_exp = "atomic_add_global_cmpxchg(A,B)";


### PR DESCRIPTION
* Release devices if pruned when enumerating devices (c_dbcsr_acc_init).
* Adjusted interpretation of OPENCL_LIBSMM_SMM_ATOMICS.
* Introduced ACC_OPENCL_DEVIDS (whitelist).
* Improved debug output.