### PR TITLE
ocl: minor update and prettify

### DIFF
--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -22,11 +22,11 @@ export PATH=/project/cray/alazzaro/cmake/bin:$PATH
 # Checkout and build LIBXSMM
 if [ ! -d "${HOME}/libxsmm" ]; then
   cd "${HOME}"
-  git clone https://github.com/hfp/libxsmm.git
+  git clone https://github.com/libxsmm/libxsmm.git
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout dda3ff24b87da891a2d159f1132a33ac5590ba68
+git checkout ad5efd24eb0055c395ead6a4f2d4ef033c96694c
 make -j
 cd ..
 

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -101,6 +101,7 @@ ifneq (0,$(DEV))
     else
       CC := $(CXX)
     endif
+    $(info CC: $(shell $(CC) --version | head -n1))
     OMP := 0
   endif
   CFLAGS += -pedantic

--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -146,9 +146,18 @@
     do { \
       const int acc_opencl_return_cause_result_ = (RESULT); \
       if (EXIT_SUCCESS != acc_opencl_return_cause_result_) { \
-        fprintf(stderr, "ERROR ACC/OpenCL: failed for %s!\n", \
-          (NULL != (CAUSE) && '\0' != *(const char*)(CAUSE)) ? ((const char*)CAUSE) : (LIBXSMM_FUNCNAME)); \
-        assert(!"SUCCESS"); \
+        if (NULL != (CAUSE) && '\0' != *(const char*)(CAUSE)) { \
+          fprintf(stderr, "ERROR ACC/OpenCL: failed for %s!\n", (const char*)CAUSE); \
+          assert(!"SUCCESS"); \
+        } \
+        else if (NULL != (LIBXSMM_FUNCNAME) && '\0' != *(LIBXSMM_FUNCNAME)) { \
+          fprintf(stderr, "ERROR ACC/OpenCL: failed for %s!\n", LIBXSMM_FUNCNAME); \
+          assert(!"SUCCESS"); \
+        } \
+        else { \
+          fprintf(stderr, "ERROR ACC/OpenCL: failure!\n"); \
+          assert(!"SUCCESS"); \
+        } \
       } \
       return acc_opencl_return_cause_result_; \
     } while (0)


### PR DESCRIPTION
* Print compiler version when performing static analysis.
* Improved handling failures.
* Updated LIBXSMM (Daint-CI).
* Prettify.