### PR TITLE
Drop support for the MPI 2 standard

### DIFF
--- a/docs/guide/3-developer-guide/3-programming/1-overview/index.md
+++ b/docs/guide/3-developer-guide/3-programming/1-overview/index.md
@@ -41,7 +41,6 @@ Assumed square matrix with 20x20 matrix with 5x5 blocks and a 2x2 processor grid
 | Macro | Explanation | Language |
 |-|-|-|
 | `__parallel` | Enable MPI runs | Fortran |
-| `__MPI_VERSION=N` | DBCSR assumes that the MPI library implements MPI version 3. If you have an older version of MPI (e.g. MPI 2.0) available you must define `-D__MPI_VERSION=2` | Fortran |
 | `__NO_MPI_THREAD_SUPPORT_CHECK` | Workaround for MPI libraries that do not declare they are thread safe (funneled) but you want to use them with OpenMP code anyways | Fortran |
 | `__MKL` | Enable use of optimized Intel MKL functions | Fortran
 | `__NO_STATM_ACCESS`, `__STATM_RESIDENT` or `__STATM_TOTAL` | Toggle memory usage reporting between resident memory and total memory. In particular, macOS users must use `-D__NO_STATM_ACCESS` | Fortran |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -201,7 +201,7 @@ if (MPI_FOUND)
   # once built, a user of the dbcsr library can not influence anything anymore
   # by setting those flags:
   target_compile_definitions(
-    dbcsr PRIVATE __parallel __MPI_VERSION=${MPI_Fortran_VERSION_MAJOR})
+    dbcsr PRIVATE __parallel)
 
   # Instead of resetting the compiler for MPI, we are adding the compiler flags
   # otherwise added by the mpifort-wrapper directly; based on hints from:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -200,8 +200,7 @@ set_target_properties(dbcsr PROPERTIES LINKER_LANGUAGE Fortran)
 if (MPI_FOUND)
   # once built, a user of the dbcsr library can not influence anything anymore
   # by setting those flags:
-  target_compile_definitions(
-    dbcsr PRIVATE __parallel)
+  target_compile_definitions(dbcsr PRIVATE __parallel)
 
   # Instead of resetting the compiler for MPI, we are adding the compiler flags
   # otherwise added by the mpifort-wrapper directly; based on hints from:

--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -309,7 +309,7 @@ int c_dbcsr_acc_init(void) {
                 CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN, CL_DEVICE_AFFINITY_DOMAIN_NUMA, /*terminator*/ 0};
               cl_uint nunits = 0;
               if (1 < devsplit &&
-                  CL_SUCCESS == clGetDeviceInfo(devices[j], CL_DEVICE_MAX_COMPUTE_UNITS, sizeof(cl_uint), &nunits, NULL)
+                  CL_SUCCESS == clGetDeviceInfo(devices[j], CL_DEVICE_MAX_COMPUTE_UNITS, sizeof(cl_uint), &nunits, NULL))
               {
                 properties[0] = CL_DEVICE_PARTITION_EQUALLY;
                 properties[1] = nunits / devsplit;
@@ -351,7 +351,7 @@ int c_dbcsr_acc_init(void) {
       if (NULL != env_vendor && '\0' != *env_vendor) {
         for (i = 0; (int)i < c_dbcsr_acc_opencl_config.ndevices;) {
           if (CL_SUCCESS ==
-              clGetDeviceInfo(c_dbcsr_acc_opencl_config.devices[i], CL_DEVICE_VENDOR, ACC_OPENCL_BUFFERSIZE, buffer, NULL)
+              clGetDeviceInfo(c_dbcsr_acc_opencl_config.devices[i], CL_DEVICE_VENDOR, ACC_OPENCL_BUFFERSIZE, buffer, NULL))
           {
             if (NULL == c_dbcsr_acc_opencl_stristr(buffer, env_vendor)) {
 #  if defined(CL_VERSION_1_2)

--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -309,7 +309,8 @@ int c_dbcsr_acc_init(void) {
                 CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN, CL_DEVICE_AFFINITY_DOMAIN_NUMA, /*terminator*/ 0};
               cl_uint nunits = 0;
               if (1 < devsplit &&
-                  CL_SUCCESS == clGetDeviceInfo(devices[j], CL_DEVICE_MAX_COMPUTE_UNITS, sizeof(cl_uint), &nunits, NULL)) {
+                  CL_SUCCESS == clGetDeviceInfo(devices[j], CL_DEVICE_MAX_COMPUTE_UNITS, sizeof(cl_uint), &nunits, NULL)
+              {
                 properties[0] = CL_DEVICE_PARTITION_EQUALLY;
                 properties[1] = nunits / devsplit;
               }
@@ -350,7 +351,8 @@ int c_dbcsr_acc_init(void) {
       if (NULL != env_vendor && '\0' != *env_vendor) {
         for (i = 0; (int)i < c_dbcsr_acc_opencl_config.ndevices;) {
           if (CL_SUCCESS ==
-              clGetDeviceInfo(c_dbcsr_acc_opencl_config.devices[i], CL_DEVICE_VENDOR, ACC_OPENCL_BUFFERSIZE, buffer, NULL)) {
+              clGetDeviceInfo(c_dbcsr_acc_opencl_config.devices[i], CL_DEVICE_VENDOR, ACC_OPENCL_BUFFERSIZE, buffer, NULL)
+          {
             if (NULL == c_dbcsr_acc_opencl_stristr(buffer, env_vendor)) {
 #  if defined(CL_VERSION_1_2)
               ACC_OPENCL_EXPECT(CL_SUCCESS, clReleaseDevice(c_dbcsr_acc_opencl_config.devices[i]));

--- a/src/mpi/dbcsr_mpiwrap.F
+++ b/src/mpi/dbcsr_mpiwrap.F
@@ -19,10 +19,6 @@ MODULE dbcsr_mpiwrap
 #include "base/dbcsr_base_uses.f90"
    #:include 'dbcsr_mpiwrap.fypp'
 
-#if defined(__parallel) && !defined(__MPI_VERSION)
-#define __MPI_VERSION 3
-#endif
-
 #if defined(__parallel)
    USE mpi
 ! subroutines: unfortunately, mpi implementations do not provide interfaces for all subroutines (problems with types and ranks explosion),
@@ -70,11 +66,7 @@ MODULE dbcsr_mpiwrap
    ! Set max allocatable memory by MPI to 2 GiByte
    INTEGER(KIND=MPI_ADDRESS_KIND), PARAMETER, PRIVATE :: mp_max_memory_size = HUGE(INT(1, KIND=int_4))
 
-#if __MPI_VERSION > 2
    INTEGER, PARAMETER, PUBLIC :: mp_max_library_version_string = MPI_MAX_LIBRARY_VERSION_STRING
-#else
-   INTEGER, PARAMETER, PUBLIC :: mp_max_library_version_string = 1
-#endif
    INTEGER, PARAMETER, PUBLIC :: mp_max_processor_name = MPI_MAX_PROCESSOR_NAME
 
    INTEGER, PARAMETER, PUBLIC :: file_offset = MPI_OFFSET_KIND
@@ -465,11 +457,7 @@ CONTAINS
 !$       END IF
 !$OMP END MASTER
 !$    END IF
-#if __MPI_VERSION > 2
       CALL mpi_comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN, ierr)
-#else
-      CALL mpi_errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN, ierr)
-#endif
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_set_errhandler @ mp_world_init")
       mp_comm = MPI_COMM_WORLD
       debug_comm_count = 1
@@ -814,14 +802,8 @@ CONTAINS
       CALL timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       CALL mpi_ibarrier(group, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ibarrier @ "//routineN)
-#else
-      MARK_USED(group)
-      MARK_USED(request)
-      DBCSR_ABORT("mp_isum requires MPI-3 standard")
-#endif
 #else
       MARK_USED(group)
       request = mp_request_null
@@ -2081,19 +2063,12 @@ CONTAINS
       ierr = 0
       msglen = SIZE(msg)
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       IF (msglen .GT. 0) THEN
          CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, MPI_LOGICAL, MPI_LOR, gid, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallreduce @ "//routineN)
       ELSE
          request = mp_request_null
       END IF
-#else
-      MARK_USED(msg)
-      MARK_USED(gid)
-      MARK_USED(request)
-      DBCSR_ABORT("mp_isum requires MPI-3 standard")
-#endif
 #else
       MARK_USED(msg)
       MARK_USED(gid)
@@ -2111,7 +2086,6 @@ CONTAINS
          !! Length (in printable characters) of the result returned in version (integer)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_get_library_version'
 
       INTEGER                                            :: ierr
@@ -2119,11 +2093,6 @@ CONTAINS
       ierr = 0
       CALL mpi_get_library_version(version, resultlen, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_get_library_version @ "//routineN)
-#else
-      MARK_USED(version)
-      MARK_USED(resultlen)
-      DBCSR_ABORT("mp_get_library_version requires MPI-3 standard")
-#endif
 #else
       version = ''
       resultlen = 0
@@ -2583,13 +2552,8 @@ CONTAINS
       CALL timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       CALL mpi_win_flush_all(win, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_win_flush_all @ "//routineN)
-#else
-      MARK_USED(win)
-      DBCSR_ABORT("mp_win_flush_all requires MPI-3 standard")
-#endif
 #else
       MARK_USED(win)
 #endif
@@ -2609,12 +2573,7 @@ CONTAINS
 
 #if defined(__parallel)
 
-#if __MPI_VERSION > 2
       CALL mpi_win_lock_all(MPI_MODE_NOCHECK, win, ierr)
-#else
-      MARK_USED(win)
-      DBCSR_ABORT("mp_win_lock_all requires MPI-3 standard")
-#endif
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_win_lock_all @ "//routineN)
 #else
       MARK_USED(win)
@@ -2635,12 +2594,7 @@ CONTAINS
 
 #if defined(__parallel)
 
-#if __MPI_VERSION > 2
       CALL mpi_win_unlock_all(win, ierr)
-#else
-      MARK_USED(win)
-      DBCSR_ABORT("mp_win_unlock_all requires MPI-3 standard")
-#endif
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_win_unlock_all @ "//routineN)
 #else
       MARK_USED(win)
@@ -3031,17 +2985,9 @@ CONTAINS
 
          msglen = 1
 #if defined(__parallel)
-#if __MPI_VERSION > 2
          CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ibcast @ "//routineN)
          CALL add_perf(perf_id=22, msg_size=msglen*${bytes1}$)
-#else
-         MARK_USED(msg)
-         MARK_USED(source)
-         MARK_USED(gid)
-         request = mp_request_null
-         DBCSR_ABORT("mp_ibcast requires MPI-3 standard")
-#endif
 #else
          MARK_USED(msg)
          MARK_USED(source)
@@ -3096,16 +3042,9 @@ CONTAINS
 
          msglen = SIZE(msg)
 #if defined(__parallel)
-#if __MPI_VERSION > 2
          CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ibcast @ "//routineN)
          CALL add_perf(perf_id=22, msg_size=msglen*${bytes1}$)
-#else
-         MARK_USED(source)
-         MARK_USED(gid)
-         request = mp_request_null
-         DBCSR_ABORT("mp_ibcast requires MPI-3 standard")
-#endif
 #else
          MARK_USED(source)
          MARK_USED(gid)
@@ -3250,7 +3189,6 @@ CONTAINS
          CALL timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
          msglen = SIZE(msg)
          IF (msglen > 0) THEN
             CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid, request, ierr)
@@ -3259,13 +3197,6 @@ CONTAINS
             request = mp_request_null
          END IF
          CALL add_perf(perf_id=23, msg_size=msglen*${bytes1}$)
-#else
-         MARK_USED(msg)
-         MARK_USED(msglen)
-         MARK_USED(gid)
-         request = mp_request_null
-         DBCSR_ABORT("mp_isum requires MPI-3 standard")
-#endif
 #else
          MARK_USED(msg)
          MARK_USED(gid)
@@ -3667,19 +3598,10 @@ CONTAINS
 
          msglen = 1
 #if defined(__parallel)
-#if __MPI_VERSION > 2
          CALL mpi_iscatter(msg_scatter, msglen, ${mpi_type1}$, msg, &
                            msglen, ${mpi_type1}$, root, gid, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iscatter @ "//routineN)
          CALL add_perf(perf_id=24, msg_size=1*${bytes1}$)
-#else
-         MARK_USED(msg_scatter)
-         MARK_USED(msg)
-         MARK_USED(root)
-         MARK_USED(gid)
-         request = mp_request_null
-         DBCSR_ABORT("mp_iscatter requires MPI-3 standard")
-#endif
 #else
          MARK_USED(root)
          MARK_USED(gid)
@@ -3712,19 +3634,10 @@ CONTAINS
 
          msglen = SIZE(msg)
 #if defined(__parallel)
-#if __MPI_VERSION > 2
          CALL mpi_iscatter(msg_scatter, msglen, ${mpi_type1}$, msg, &
                            msglen, ${mpi_type1}$, root, gid, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iscatter @ "//routineN)
          CALL add_perf(perf_id=24, msg_size=1*${bytes1}$)
-#else
-         MARK_USED(msg_scatter)
-         MARK_USED(msg)
-         MARK_USED(root)
-         MARK_USED(gid)
-         request = mp_request_null
-         DBCSR_ABORT("mp_iscatter requires MPI-3 standard")
-#endif
 #else
          MARK_USED(root)
          MARK_USED(gid)
@@ -3757,22 +3670,10 @@ CONTAINS
          CALL timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
          CALL mpi_iscatterv(msg_scatter, sendcounts, displs, ${mpi_type1}$, msg, &
                             recvcount, ${mpi_type1}$, root, gid, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iscatterv @ "//routineN)
          CALL add_perf(perf_id=24, msg_size=1*${bytes1}$)
-#else
-         MARK_USED(msg_scatter)
-         MARK_USED(sendcounts)
-         MARK_USED(displs)
-         MARK_USED(msg)
-         MARK_USED(recvcount)
-         MARK_USED(root)
-         MARK_USED(gid)
-         request = mp_request_null
-         DBCSR_ABORT("mp_iscatterv requires MPI-3 standard")
-#endif
 #else
          MARK_USED(sendcounts)
          MARK_USED(displs)
@@ -4055,18 +3956,10 @@ CONTAINS
 #if defined(__parallel)
          scount = 1
          rcount = 1
-#if __MPI_VERSION > 2
          CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                              msgin, rcount, ${mpi_type1}$, &
                              gid, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
-#else
-         MARK_USED(gid)
-         MARK_USED(msgin)
-         MARK_USED(msgout)
-         request = mp_request_null
-         DBCSR_ABORT("mp_iallgather requires MPI-3 standard")
-#endif
 #else
          MARK_USED(gid)
          msgin = msgout
@@ -4243,22 +4136,12 @@ CONTAINS
          CALL timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
          scount = SIZE(msgout(:))
          rcount = scount
          CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                              msgin, rcount, ${mpi_type1}$, &
                              gid, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
-#else
-         MARK_USED(msgout)
-         MARK_USED(msgin)
-         MARK_USED(rcount)
-         MARK_USED(scount)
-         MARK_USED(gid)
-         request = mp_request_null
-         DBCSR_ABORT("mp_iallgather requires MPI-3 standard")
-#endif
 #else
          MARK_USED(gid)
          msgin = msgout
@@ -4289,22 +4172,12 @@ CONTAINS
          CALL timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
          scount = SIZE(msgout(:))
          rcount = scount
          CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                              msgin, rcount, ${mpi_type1}$, &
                              gid, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
-#else
-         MARK_USED(msgout)
-         MARK_USED(msgin)
-         MARK_USED(rcount)
-         MARK_USED(scount)
-         MARK_USED(gid)
-         request = mp_request_null
-         DBCSR_ABORT("mp_iallgather requires MPI-3 standard")
-#endif
 #else
          MARK_USED(gid)
          msgin(:, 1, 1) = msgout(:)
@@ -4335,22 +4208,12 @@ CONTAINS
          CALL timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
          scount = SIZE(msgout(:, :))
          rcount = scount
          CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                              msgin, rcount, ${mpi_type1}$, &
                              gid, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
-#else
-         MARK_USED(msgout)
-         MARK_USED(msgin)
-         MARK_USED(rcount)
-         MARK_USED(scount)
-         MARK_USED(gid)
-         request = mp_request_null
-         DBCSR_ABORT("mp_iallgather requires MPI-3 standard")
-#endif
 #else
          MARK_USED(gid)
          msgin(:, :) = msgout(:, :)
@@ -4381,22 +4244,12 @@ CONTAINS
          CALL timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
          scount = SIZE(msgout(:, :))
          rcount = scount
          CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                              msgin, rcount, ${mpi_type1}$, &
                              gid, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
-#else
-         MARK_USED(msgout)
-         MARK_USED(msgin)
-         MARK_USED(rcount)
-         MARK_USED(scount)
-         MARK_USED(gid)
-         request = mp_request_null
-         DBCSR_ABORT("mp_iallgather requires MPI-3 standard")
-#endif
 #else
          MARK_USED(gid)
          msgin(:, :, 1, 1) = msgout(:, :)
@@ -4427,21 +4280,11 @@ CONTAINS
          CALL timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
          scount = SIZE(msgout(:, :, :))
          rcount = scount
          CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                              msgin, rcount, ${mpi_type1}$, &
                              gid, request, ierr)
-#else
-         MARK_USED(msgout)
-         MARK_USED(msgin)
-         MARK_USED(rcount)
-         MARK_USED(scount)
-         MARK_USED(gid)
-         request = mp_request_null
-         DBCSR_ABORT("mp_iallgather requires MPI-3 standard")
-#endif
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -4541,18 +4384,9 @@ CONTAINS
 #if defined(__parallel)
          scount = SIZE(msgout)
          rsize = SIZE(rcount)
-#if __MPI_VERSION > 2
          CALL mp_iallgatherv_${nametype1}$v_internal(msgout, scount, msgin, rsize, rcount, &
                                                      rdispl, gid, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgatherv @ "//routineN)
-#else
-         MARK_USED(rcount)
-         MARK_USED(rdispl)
-         MARK_USED(gid)
-         MARK_USED(msgin)
-         request = mp_request_null
-         DBCSR_ABORT("mp_iallgatherv requires MPI-3 standard")
-#endif
 #else
          MARK_USED(rcount)
          MARK_USED(rdispl)
@@ -4603,18 +4437,9 @@ CONTAINS
 #if defined(__parallel)
          scount = SIZE(msgout)
          rsize = SIZE(rcount)
-#if __MPI_VERSION > 2
          CALL mp_iallgatherv_${nametype1}$v_internal(msgout, scount, msgin, rsize, rcount, &
                                                      rdispl, gid, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgatherv @ "//routineN)
-#else
-         MARK_USED(rcount)
-         MARK_USED(rdispl)
-         MARK_USED(gid)
-         MARK_USED(msgin)
-         request = mp_request_null
-         DBCSR_ABORT("mp_iallgatherv requires MPI-3 standard")
-#endif
 #else
          MARK_USED(rcount)
          MARK_USED(rdispl)
@@ -4625,7 +4450,7 @@ CONTAINS
          CALL timestop(handle)
       END SUBROUTINE mp_iallgatherv_${nametype1}$v2
 
-#if defined(__parallel) && (__MPI_VERSION > 2)
+#if defined(__parallel)
       SUBROUTINE mp_iallgatherv_${nametype1}$v_internal(msgout, scount, msgin, rsize, rcount, rdispl, gid, request, ierr)
       !! wrapper needed to deal with interfaces as present in openmpi 1.8.1
       !! the issue is with the rank of rcount and rdispl
@@ -5074,7 +4899,7 @@ CONTAINS
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_rget_${nametype1}$v'
 
          INTEGER                                  :: ierr, handle
-#if defined(__parallel) && (__MPI_VERSION > 2)
+#if defined(__parallel)
          INTEGER                                  :: len, &
                                                      handle_origin_datatype, &
                                                      handle_target_datatype, &
@@ -5087,7 +4912,6 @@ CONTAINS
          CALL timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
          len = SIZE(base)
          disp_aint = 0
          IF (PRESENT(disp)) THEN
@@ -5132,18 +4956,6 @@ CONTAINS
             request = mp_request_null
             ierr = 0
          END IF
-#else
-         MARK_USED(source)
-         MARK_USED(win)
-         MARK_USED(disp)
-         MARK_USED(myproc)
-         MARK_USED(origin_datatype)
-         MARK_USED(target_datatype)
-         MARK_USED(win_data)
-
-         request = mp_request_null
-         DBCSR_ABORT("mp_rget requires MPI-3 standard")
-#endif
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_rget @ "//routineN)
 
          CALL add_perf(perf_id=25, msg_size=SIZE(base)*${bytes1}$)


### PR DESCRIPTION
This PR removes the __MPI_VERSION flag to turn off code requiring the MPI 3 standard. Because MPI3 was published 10 years ago, it will be fully supported by all MPI implementations in use.
It is the equivalent to the PR cp2k/cp2k#2438 .