### PR TITLE
Rename DBCSR MPI output that is printed on top of each CP2K run

### DIFF
--- a/src/core/dbcsr_config.F
+++ b/src/core/dbcsr_config.F
@@ -545,10 +545,10 @@ CONTAINS
          BLOCK
             INTEGER :: numnodes, mynode
             CALL mp_environ(numnodes, mynode, mp_comm_world)
-            WRITE (UNIT=unit_nr, FMT='(1X,A,T70,I11)') &
-               "DBCSR| MPI: My node id", mynode
-            WRITE (UNIT=unit_nr, FMT='(1X,A,T70,I11)') &
-               "DBCSR| MPI: Number of nodes", numnodes
+            WRITE (UNIT=unit_nr, FMT='(1X,A,T67,I11)') &
+               "DBCSR| MPI: My process id", mynode
+            WRITE (UNIT=unit_nr, FMT='(1X,A,T66,I11)') &
+               "DBCSR| MPI: Number of processes", numnodes
          END BLOCK
       END IF
 


### PR DESCRIPTION
Please correct if I am wrong: In MPI, I am not aware of the fact that "nodes" are commonly used terminology. From the numbers that are printed on top of each CP2K output, it seems to me that "numnodes" is the number of MPI processes that are used.