### PR TITLE
ocl: added README.md for tuned parameters

### DIFF
--- a/src/acc/acc_bench_smm.c
+++ b/src/acc/acc_bench_smm.c
@@ -13,7 +13,7 @@
 #include <math.h>
 
 #if defined(__LIBXSMM)
-#  if defined(LIBXSMM_DEFAULT_CONFIG)
+#  if !defined(LIBXSMM_LINKLIB)
 #    include <libxsmm_source.h>
 #  else
 #    include <libxsmm.h>

--- a/src/acc/acc_bench_trans.c
+++ b/src/acc/acc_bench_trans.c
@@ -12,7 +12,7 @@
 #include <stdio.h>
 
 #if defined(__LIBXSMM)
-#  if defined(LIBXSMM_DEFAULT_CONFIG)
+#  if !defined(LIBXSMM_LINKLIB)
 #    include <libxsmm_source.h>
 #  else
 #    include <libxsmm.h>

--- a/src/acc/cuda/Makefile
+++ b/src/acc/cuda/Makefile
@@ -161,12 +161,11 @@ endif
 ifneq (,$(LIBXSMMROOT))
   ifneq (0,$(STATIC))
     ifeq (0,$(HEADERONLY))
-    ifneq (0,$(OMP))
-      LDFLAGS += $(LIBXSMMROOT)/lib/libxsmmext.a
-    endif
+      ifneq (0,$(OMP))
+        LDFLAGS += $(LIBXSMMROOT)/lib/libxsmmext.a
+      endif
       LDFLAGS += $(LIBXSMMROOT)/lib/libxsmm.a
-  else
-      CFLAGS_XSMM += -DLIBXSMM_DEFAULT_CONFIG
+      CFLAGS_XSMM += -DLIBXSMM_LINKLIB
     endif
     LDFLAGS += $(LIBXSMMROOT)/lib/libxsmmnoblas.a
   else

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -153,8 +153,7 @@ ifneq (,$(LIBXSMMROOT))
         LDFLAGS += $(LIBXSMMROOT)/lib/libxsmmext.a
       endif
       LDFLAGS += $(LIBXSMMROOT)/lib/libxsmm.a
-    else
-      CFLAGS_XSMM += -DLIBXSMM_DEFAULT_CONFIG
+      CFLAGS_XSMM += -DLIBXSMM_LINKLIB
     endif
     LDFLAGS += $(LIBXSMMROOT)/lib/libxsmmnoblas.a
   else

--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -35,7 +35,7 @@
 #  define LIBXSMM_SYNC_NPAUSE 0
 #endif
 
-#if defined(__LIBXSMM) && !defined(LIBXSMM_DEFAULT_CONFIG)
+#if defined(__LIBXSMM) && defined(LIBXSMM_LINKLIB)
 #  include <libxsmm.h>
 #  include <libxsmm_sync.h>
 #else

--- a/src/acc/opencl/smm/params/README.md
+++ b/src/acc/opencl/smm/params/README.md
@@ -1,0 +1,9 @@
+# Tuned Parameters
+
+The OpenCL based implementation of LIBSMM supports default kernel-parameters, i.e., kernels can be successfuly generated for every requested multiplication/matrix shape (M, N, K) within the definition of a "Small Matrix Multiplication" (maximum M, N, and K).
+
+Tuned parameters targeting different devices can co-exist and can be embeded into the same executable, i.e., the executable does not depend on a particular build-path or location of parameter-files.
+
+Parameters are selected by matching against a device-ID with fallback to the "best-matching" parameters. The device-ID can be based on a vendor-specific function to identify a certain device or is generated from device's name as exposed by the OpenCL API.
+
+Parameters can be loaded from a CSV-file at runtime (`OPENCL_LIBSMM_SMM_PARAMS` environment variable) and thereby disable matching devices, i.e., parameters loaded this way will take precedence.


### PR DESCRIPTION
* Enable header-only LIBXSMM by default.