### PR TITLE
Add the posibility to build dbcsr shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ set(dbcsr_APIVERSION ${VERSION_MAJOR}.${VERSION_MINOR})
 # OPTIONS
 include(CMakeDependentOption)
 
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(USE_OPENMP "Build with OpenMP support" ON)
 option(USE_MPI "Build with MPI support" ON)
 cmake_dependent_option(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -269,9 +269,11 @@ if (WITH_C_API)
   add_library(dbcsr_c ${DBCSR_C_SRCS})
   set_target_properties(dbcsr_c PROPERTIES LINKER_LANGUAGE Fortran)
 
-  set_target_properties(dbcsr_c PROPERTIES VERSION ${dbcsr_VERSION}
-                                           SOVERSION ${dbcsr_APIVERSION}
-                                           POSITION_INDEPENDENT_CODE ON)
+  set_target_properties(
+    dbcsr_c
+    PROPERTIES VERSION ${dbcsr_VERSION}
+               SOVERSION ${dbcsr_APIVERSION}
+               POSITION_INDEPENDENT_CODE ON)
 
   target_link_libraries(dbcsr_c PRIVATE dbcsr)
   target_link_libraries(dbcsr_c PUBLIC MPI::MPI_C) # the C API always needs MPI

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -156,8 +156,13 @@ endif ()
 # DBCSR LIBRARY
 add_library(dbcsr ${DBCSR_SRCS})
 
-set_target_properties(dbcsr PROPERTIES VERSION ${dbcsr_VERSION}
-                                       SOVERSION ${dbcsr_APIVERSION})
+# -fPIC can also be used in the static case. Addresses are resolved during the
+# linking process
+set_target_properties(
+  dbcsr
+  PROPERTIES VERSION ${dbcsr_VERSION}
+             SOVERSION ${dbcsr_APIVERSION}
+             POSITION_INDEPENDENT_CODE ON)
 
 if (USE_SMM MATCHES "libxsmm")
   target_compile_definitions(dbcsr PRIVATE __LIBXSMM)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -270,7 +270,8 @@ if (WITH_C_API)
   set_target_properties(dbcsr_c PROPERTIES LINKER_LANGUAGE Fortran)
 
   set_target_properties(dbcsr_c PROPERTIES VERSION ${dbcsr_VERSION}
-                                           SOVERSION ${dbcsr_APIVERSION})
+                                           SOVERSION ${dbcsr_APIVERSION}
+                                           POSITION_INDEPENDENT_CODE ON)
 
   target_link_libraries(dbcsr_c PRIVATE dbcsr)
   target_link_libraries(dbcsr_c PUBLIC MPI::MPI_C) # the C API always needs MPI


### PR DESCRIPTION
trivial change needed when the shared version of libcp2k is needed. OFF by default 