### PR TITLE
Bugfixes for building DBCSR on macOS, with CUDA, latest-gcc

### DIFF
--- a/.github/workflows/testing-gcc.yml
+++ b/.github/workflows/testing-gcc.yml
@@ -34,6 +34,7 @@ jobs:
 
     - name: Test
       run: |
+        export LSAN_OPTIONS=suppressions=$PWD/tools/docker/lsan.supp
         cd build
         ctest --output-on-failure
 

--- a/.github/workflows/testing-macos.yml
+++ b/.github/workflows/testing-macos.yml
@@ -6,6 +6,10 @@ on:
     - 'develop'
   pull_request:
 
+# Workaround issue in Xcode 14.1/2
+env:
+  DEVELOPER_DIR: /Applications/Xcode_14.0.1.app/Contents/Developer
+
 jobs:
   build-and-test:
     runs-on: macos-latest

--- a/.github/workflows/testing-macos.yml
+++ b/.github/workflows/testing-macos.yml
@@ -20,7 +20,7 @@ jobs:
         use_openmp: [OPENMP=ON]
         use_smm: [SMM=blas]
         blas_impl: [accelerate,openblas]
-        mpi_suffix: [openmpi,mpich]
+        mpi_suffix: [openmpi]
         exclude:
           - use_mpi: MPI=OFF
             mpi_suffix: mpich
@@ -31,19 +31,14 @@ jobs:
         fetch-depth: 0
         submodules: true
 
-    - name: Install dependencies
+    - name: Install common dependencies
       run: |
         env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
-          ninja \
-          openmpi
+          ninja
 
-    - name: Unlink OpenMPI
+    - name: Install ${{ matrix.mpi_suffix }}
       run: |
-        brew unlink openmpi
-
-    - name: Install MPICH
-      run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install mpich
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install ${{ matrix.mpi_suffix }}
 
     - name: Configure
       run: |
@@ -57,7 +52,6 @@ jobs:
           -DUSE_${{ matrix.use_openmp }} \
           -DUSE_${{ matrix.use_smm }} \
           $([ "${{ matrix.blas_impl }}" = "openblas" ] && echo '-DCMAKE_PREFIX_PATH=/usr/local/opt/openblas') \
-          -DMPIEXEC_EXECUTABLE="$([ "${{ matrix.mpi_suffix }}" = "openmpi" ] && command -v /usr/local/Cellar/open-mpi/*/bin/mpiexec || command -v /usr/local/Cellar/mpich/*/bin/mpiexec)" \
           -DMPIEXEC_PREFLAGS="$([ "${{ matrix.mpi_suffix }}" = "openmpi" ] && echo "-mca btl ^openib --allow-run-as-root")" \
           -DTEST_MPI_RANKS=1 \
           ..

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -243,6 +243,7 @@ if (USE_ACCEL)
   target_link_libraries(
     dbcsr
     PRIVATE $<$<STREQUAL:${USE_ACCEL},cuda>:CUDA::cudart>
+            $<$<STREQUAL:${USE_ACCEL},cuda>:CUDA::cuda_driver>
             $<$<STREQUAL:${USE_ACCEL},cuda>:CUDA::cublas>
             $<$<STREQUAL:${USE_ACCEL},cuda>:CUDA::nvrtc>
             $<$<BOOL:${WITH_CUDA_PROFILING}>:CUDA::nvToolsExt>

--- a/src/acc/hip/acc_hip.h
+++ b/src/acc/hip/acc_hip.h
@@ -12,7 +12,11 @@
 
 #include <hip/hip_runtime.h>
 #include <hip/hip_runtime_api.h>
-#include <hipblas.h>
+#if __has_include(<hipblas/hipblas.h>)
+#  include <hipblas/hipblas.h>
+#else
+#  include <hipblas.h>
+#endif
 #include <hip/hiprtc.h>
 
 #define ACC(x) hip##x

--- a/tools/docker/lsan.supp
+++ b/tools/docker/lsan.supp
@@ -1,3 +1,5 @@
 # leak due to compiler bug triggered by combination of OOP and ALLOCATABLE
 leak:__dbcsr_tensor_types_MOD___copy_dbcsr_tensor_types_Dbcsr_tas_dist_t
 leak:__dbcsr_tensor_types_MOD___copy_dbcsr_tensor_types_Dbcsr_tas_blk_size_t
+# similar case, for gcc-13+
+leak:__dbcsr_tas_global_MOD___copy_dbcsr_tas_global_Dbcsr_tas_blk_size_arb


### PR DESCRIPTION
- cmake: add missing cuda library
- gha: drop mpich testing on macOS for now
- acc/hip: fix hipblas include
- docker: add another lsan suppresion for gcc-13
