### PR TITLE
Wrap the MPI handles

### DIFF
--- a/src/core/dbcsr_lib.F
+++ b/src/core/dbcsr_lib.F
@@ -27,7 +27,7 @@ MODULE dbcsr_lib
                             mp_environ, mp_cart_rank, &
                             rm_mp_perf_env, &
                             mp_comm_free, &
-                            mp_get_comm_count
+                            mp_get_comm_count, mp_comm_type, mp_comm_null
    USE dbcsr_mm, ONLY: dbcsr_multiply_clear_mempools, &
                        dbcsr_multiply_lib_finalize, &
                        dbcsr_multiply_lib_init, &
@@ -75,7 +75,8 @@ MODULE dbcsr_lib
 
    TYPE(dbcsr_logger_type), POINTER :: logger => Null()
    TYPE(dbcsr_mp_obj), SAVE         :: mp_env
-   INTEGER, SAVE                    :: default_group, ext_io_unit
+   TYPE(mp_comm_type), SAVE         :: default_group = mp_comm_null
+   INTEGER, SAVE                    :: ext_io_unit
 
    INTERFACE dbcsr_init_lib
       MODULE PROCEDURE dbcsr_init_lib_def
@@ -106,6 +107,8 @@ CONTAINS
 
    SUBROUTINE dbcsr_init_lib_def(mp_comm, io_unit, accdrv_active_device_id)
       !! Initialize the DBCSR library using internal loggers and timer callbacks
+      !! We do not need this routine within the library, so we keep the communicator as a handle
+      !! and convert it here to a communicator type
       INTEGER, INTENT(IN)  :: mp_comm
       INTEGER, INTENT(IN), OPTIONAL :: io_unit, accdrv_active_device_id
 
@@ -114,7 +117,7 @@ CONTAINS
          IF (.NOT. ASSOCIATED(logger) .AND. PRESENT(io_unit)) ext_io_unit = io_unit
          RETURN
       END IF
-      CALL dbcsr_init_lib_pre(mp_comm, io_unit, accdrv_active_device_id)
+      CALL dbcsr_init_lib_pre(mp_comm_type(mp_comm), io_unit, accdrv_active_device_id)
       !
       ! Declare loggers
       CALL dbcsr_logger_create(logger, mp_env=mp_env, &
@@ -138,6 +141,8 @@ CONTAINS
                                    in_abort_hook, in_warn_hook, io_unit, &
                                    accdrv_active_device_id)
       !! Initialize the DBCSR library using external loggers and timer callbacks
+      !! We do not need this routine within the library, so we keep the communicator as a handle
+      !! and convert it here to a communicator type
       INTEGER, INTENT(IN)  :: mp_comm
       PROCEDURE(timeset_interface), INTENT(IN), POINTER :: in_timeset_hook
       PROCEDURE(timestop_interface), INTENT(IN), POINTER :: in_timestop_hook
@@ -150,7 +155,7 @@ CONTAINS
          IF (.NOT. ASSOCIATED(logger) .AND. PRESENT(io_unit)) ext_io_unit = io_unit
          RETURN
       END IF
-      CALL dbcsr_init_lib_pre(mp_comm, io_unit, accdrv_active_device_id)
+      CALL dbcsr_init_lib_pre(mp_comm_type(mp_comm), io_unit, accdrv_active_device_id)
       ! abort/warn hooks
       dbcsr_abort_hook => in_abort_hook
       dbcsr_warn_hook => in_warn_hook
@@ -169,7 +174,7 @@ CONTAINS
 #if defined(__LIBXSMM)
       USE libxsmm, ONLY: libxsmm_init
 #endif
-      INTEGER, INTENT(IN)  :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)  :: mp_comm
       INTEGER, INTENT(IN), OPTIONAL :: io_unit, accdrv_active_device_id
 
       INTEGER :: numnodes, mynode

--- a/src/core/dbcsr_lib.F
+++ b/src/core/dbcsr_lib.F
@@ -112,12 +112,15 @@ CONTAINS
       INTEGER, INTENT(IN)  :: mp_comm
       INTEGER, INTENT(IN), OPTIONAL :: io_unit, accdrv_active_device_id
 
+      TYPE(mp_comm_type) :: my_mp_comm
+
       IF (is_initialized) THEN
          ! Update ext_io_unit
          IF (.NOT. ASSOCIATED(logger) .AND. PRESENT(io_unit)) ext_io_unit = io_unit
          RETURN
       END IF
-      CALL dbcsr_init_lib_pre(mp_comm_type(mp_comm), io_unit, accdrv_active_device_id)
+      CALL my_mp_comm%set_handle(mp_comm)
+      CALL dbcsr_init_lib_pre(my_mp_comm, io_unit, accdrv_active_device_id)
       !
       ! Declare loggers
       CALL dbcsr_logger_create(logger, mp_env=mp_env, &
@@ -150,12 +153,15 @@ CONTAINS
       PROCEDURE(dbcsr_warn_interface), INTENT(IN), POINTER :: in_warn_hook
       INTEGER, INTENT(IN), OPTIONAL :: io_unit, accdrv_active_device_id
 
+      TYPE(mp_comm_type) :: my_mp_comm
+
       IF (is_initialized) THEN
          ! Update ext_io_unit
          IF (.NOT. ASSOCIATED(logger) .AND. PRESENT(io_unit)) ext_io_unit = io_unit
          RETURN
       END IF
-      CALL dbcsr_init_lib_pre(mp_comm_type(mp_comm), io_unit, accdrv_active_device_id)
+      CALL my_mp_comm%set_handle(mp_comm)
+      CALL dbcsr_init_lib_pre(my_mp_comm, io_unit, accdrv_active_device_id)
       ! abort/warn hooks
       dbcsr_abort_hook => in_abort_hook
       dbcsr_warn_hook => in_warn_hook

--- a/src/core/dbcsr_log_handling.F
+++ b/src/core/dbcsr_log_handling.F
@@ -535,7 +535,7 @@ CONTAINS
                CALL m_hostnm(host_name)
                PRINT *, " *** Error trying to WRITE to the local logger ***"
                PRINT *, " *** MPI_id           = ", lggr%mp_env%mp%mynode
-               PRINT *, " *** MPI_Communicator = ", lggr%mp_env%mp%mp_group
+               PRINT *, " *** MPI_Communicator = ", lggr%mp_env%mp%mp_group%get_handle()
                PRINT *, " *** PID              = ", pid
                PRINT *, " *** Hostname         = "//TRIM(host_name)
                CALL print_stack(default_output_unit)
@@ -554,7 +554,7 @@ CONTAINS
                            unit_number=lggr%default_local_unit_nr)
             WRITE (UNIT=lggr%default_local_unit_nr, FMT='(/,T2,A,I0,A,I0,A)', IOSTAT=iostat) &
                '*** Local logger file of MPI task ', lggr%mp_env%mp%mynode, &
-               ' in communicator ', lggr%mp_env%mp%mp_group, ' ***'
+               ' in communicator ', lggr%mp_env%mp%mp_group%get_handle(), ' ***'
             IF (iostat == 0) THEN
                CALL m_getpid(pid)
                CALL m_hostnm(host_name)
@@ -568,7 +568,7 @@ CONTAINS
                CALL m_hostnm(host_name)
                PRINT *, " *** Error trying to WRITE to the local logger ***"
                PRINT *, " *** MPI_id           = ", lggr%mp_env%mp%mynode
-               PRINT *, " *** MPI_Communicator = ", lggr%mp_env%mp%mp_group
+               PRINT *, " *** MPI_Communicator = ", lggr%mp_env%mp%mp_group%get_handle()
                PRINT *, " *** PID              = ", pid
                PRINT *, " *** Hostname         = "//TRIM(host_name)
                CALL print_stack(default_output_unit)

--- a/src/core/dbcsr_types.F
+++ b/src/core/dbcsr_types.F
@@ -22,6 +22,7 @@ MODULE dbcsr_types
       dbcsr_type_real_8_2d, dbcsr_type_real_default
    USE dbcsr_kinds, ONLY: default_string_length, &
                           int_8
+   USE dbcsr_mpiwrap, ONLY: mp_comm_type, mp_comm_null
 
 !$ USE OMP_LIB, ONLY: omp_get_max_threads, omp_get_thread_num, omp_get_num_threads
 
@@ -117,7 +118,7 @@ MODULE dbcsr_types
          !! my process grid row
       INTEGER                            :: mypcol = -1
          !! my process grid column
-      INTEGER                            :: mp_group = -1
+      TYPE(mp_comm_type)                 :: mp_group = mp_comm_null
          !! message-passing group ID
       INTEGER, DIMENSION(:, :), POINTER, CONTIGUOUS :: pgrid => Null()
          !! processor grid
@@ -125,9 +126,9 @@ MODULE dbcsr_types
          !! reference counter
       LOGICAL                            :: subgroups_defined = .FALSE.
          !! whether the subgroups are defined
-      INTEGER                            :: prow_group = -1
+      TYPE(mp_comm_type)                 :: prow_group = mp_comm_null
          !! per-process-row communicator
-      INTEGER                            :: pcol_group = -1
+      TYPE(mp_comm_type)                 :: pcol_group = mp_comm_null
          !! pre-process-column communicator
       INTEGER                            :: source = -1
    END TYPE dbcsr_mp_type

--- a/src/dbcsr_api.F
+++ b/src/dbcsr_api.F
@@ -139,8 +139,6 @@ MODULE dbcsr_api
                           int_8, &
                           real_4, &
                           real_8
-   USE dbcsr_mpiwrap, ONLY: mp_cart_rank, &
-                            mp_environ
 
 !$ USE OMP_LIB, ONLY: omp_get_max_threads, omp_get_thread_num, omp_get_num_threads
 #include "base/dbcsr_base_uses.f90"

--- a/src/dbcsr_api.F
+++ b/src/dbcsr_api.F
@@ -703,7 +703,7 @@ CONTAINS
          distribution%prv = dist
       END IF
 
-      IF (PRESENT(group)) group = my_group%handle
+      IF (PRESENT(group)) group = my_group%get_handle()
 
    END SUBROUTINE dbcsr_get_info
 
@@ -728,9 +728,9 @@ CONTAINS
                                       my_group, mynode, numnodes, nprows, npcols, myprow, mypcol, pgrid, &
                                       subgroups_defined, my_prow_group, my_pcol_group)
 
-      IF (PRESENT(group)) group = my_group%handle
-      IF (PRESENT(prow_group)) prow_group = my_prow_group%handle
-      IF (PRESENT(pcol_group)) pcol_group = my_pcol_group%handle
+      IF (PRESENT(group)) group = my_group%get_handle()
+      IF (PRESENT(prow_group)) prow_group = my_prow_group%get_handle()
+      IF (PRESENT(pcol_group)) pcol_group = my_pcol_group%get_handle()
    END SUBROUTINE dbcsr_distribution_get
 
    SUBROUTINE dbcsr_distribution_hold(dist)
@@ -862,6 +862,8 @@ CONTAINS
 
       INTEGER, DIMENSION(:), POINTER, CONTIGUOUS         :: cont_row_dist, cont_col_dist
 
+      TYPE(mp_comm_type)                                 :: my_mp_group
+
       ! Make the arrays contiguous, avoid change in the API
       ALLOCATE (cont_row_dist(SIZE(row_dist)), cont_col_dist(SIZE(col_dist)))
       cont_row_dist(:) = row_dist(:)
@@ -874,13 +876,25 @@ CONTAINS
          END IF
       END IF
 
-      IF (PRESENT(template)) THEN
-         call dbcsr_distribution_new_prv(dist%prv, template%prv, mp_comm_type(group), pgrid, cont_row_dist, cont_col_dist, &
-                                         reuse_arrays=.TRUE.)
+      IF (PRESENT(group)) THEN
+         CALL my_mp_group%set_handle(group)
+         IF (PRESENT(template)) THEN
+            call dbcsr_distribution_new_prv(dist%prv, template%prv, my_mp_group, pgrid, cont_row_dist, cont_col_dist, &
+                                            reuse_arrays=.TRUE.)
+         ELSE
+            call dbcsr_distribution_new_prv(dist%prv, group=my_mp_group, pgrid=pgrid, &
+                                            row_dist=cont_row_dist, col_dist=cont_col_dist, &
+                                            reuse_arrays=.TRUE.)
+         END IF
       ELSE
-         call dbcsr_distribution_new_prv(dist%prv, group=mp_comm_type(group), pgrid=pgrid, &
-                                         row_dist=cont_row_dist, col_dist=cont_col_dist, &
-                                         reuse_arrays=.TRUE.)
+         IF (PRESENT(template)) THEN
+            call dbcsr_distribution_new_prv(dist%prv, template%prv, pgrid=pgrid, row_dist=cont_row_dist, col_dist=cont_col_dist, &
+                                            reuse_arrays=.TRUE.)
+         ELSE
+            call dbcsr_distribution_new_prv(dist%prv, pgrid=pgrid, &
+                                            row_dist=cont_row_dist, col_dist=cont_col_dist, &
+                                            reuse_arrays=.TRUE.)
+         END IF
       END IF
    END SUBROUTINE dbcsr_distribution_new
 
@@ -1038,7 +1052,11 @@ CONTAINS
       INTEGER, INTENT(IN), OPTIONAL                      :: groupid
       TYPE(dbcsr_type), INTENT(INOUT)                    :: matrix_new
 
-      CALL dbcsr_binary_read_prv(filepath, distribution%prv, groupid, matrix_new%prv)
+      TYPE(mp_comm_type)                                 :: my_comm
+
+      CALL my_comm%set_handle(groupid)
+
+      CALL dbcsr_binary_read_prv(filepath, distribution%prv, my_comm, matrix_new%prv)
    END SUBROUTINE dbcsr_binary_read
 
    SUBROUTINE dbcsr_copy(matrix_b, matrix_a, name, keep_sparsity, &
@@ -1134,8 +1152,12 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: mp_group
       INTEGER, INTENT(IN), OPTIONAL                      :: data_type
 
+      TYPE(mp_comm_type)                                 :: my_mp_group
+
+      CALL my_mp_group%set_handle(mp_group)
+
       CALL csr_create_new_prv(csr_mat, nrows_total, ncols_total, nze_total, &
-                              nze_local, nrows_local, mp_comm_type(mp_group), data_type)
+                              nze_local, nrows_local, my_mp_group, data_type)
 
    END SUBROUTINE csr_create_new
 
@@ -1219,7 +1241,11 @@ CONTAINS
       REAL(kind=dp), INTENT(in)                          :: eps
       LOGICAL, INTENT(in)                                :: retain_sparsity, always_checksum
 
-      CALL dbcsr_run_tests_prv(mp_comm_type(mp_group), io_unit, nproc, matrix_sizes, trs, &
+      TYPE(mp_comm_type)                                 :: my_mp_group
+
+      CALL my_mp_group%set_handle(mp_group)
+
+      CALL dbcsr_run_tests_prv(my_mp_group, io_unit, nproc, matrix_sizes, trs, &
                                bs_m, bs_n, bs_k, sparsities, alpha, beta, data_type, test_type, &
                                n_loops, eps, retain_sparsity, always_checksum)
 

--- a/src/dbcsr_api.F
+++ b/src/dbcsr_api.F
@@ -30,13 +30,13 @@ MODULE dbcsr_api
    USE dbcsr_csr_conversions, ONLY: &
       convert_csr_to_dbcsr_prv => convert_csr_to_dbcsr, &
       convert_dbcsr_to_csr_prv => convert_dbcsr_to_csr, &
-      csr_create_from_dbcsr_prv => csr_create_from_dbcsr, csr_create_new, &
+      csr_create_from_dbcsr_prv => csr_create_from_dbcsr, csr_create_new_prv => csr_create_new, &
       csr_create_template, dbcsr_csr_dbcsr_blkrow_dist => csr_dbcsr_blkrow_dist, &
       dbcsr_csr_destroy => csr_destroy, dbcsr_csr_eqrow_ceil_dist => csr_eqrow_ceil_dist, &
       dbcsr_csr_eqrow_floor_dist => csr_eqrow_floor_dist, dbcsr_csr_p_type => csr_p_type, &
       dbcsr_csr_print_sparsity => csr_print_sparsity, dbcsr_csr_type => csr_type, &
       dbcsr_csr_write => csr_write, &
-      dbcsr_to_csr_filter_prv => dbcsr_to_csr_filter
+      dbcsr_to_csr_filter_prv => dbcsr_to_csr_filter, csr_type
    USE dbcsr_data_methods, ONLY: dbcsr_get_data_p_prv => dbcsr_get_data_p, &
                                  dbcsr_scalar, &
                                  dbcsr_scalar_fill_all, &
@@ -76,10 +76,8 @@ MODULE dbcsr_api
       dbcsr_release_prv => dbcsr_release, &
       dbcsr_setname_prv => dbcsr_setname, &
       dbcsr_valid_index_prv => dbcsr_valid_index, dbcsr_wm_use_mutable
-   USE dbcsr_mp_methods, ONLY: dbcsr_mp_grid_setup_prv => dbcsr_mp_grid_setup, &
-                               dbcsr_mp_group, &
-                               dbcsr_mp_new_prv => dbcsr_mp_new, &
-                               dbcsr_mp_release
+   USE dbcsr_mpiwrap, ONLY: mp_comm_type
+   USE dbcsr_mp_methods, ONLY: dbcsr_mp_grid_setup_prv => dbcsr_mp_grid_setup
    USE dbcsr_multiply_api, ONLY: dbcsr_multiply_prv => dbcsr_multiply
    USE dbcsr_operations, ONLY: &
       dbcsr_add_on_diag_prv => dbcsr_add_on_diag, &
@@ -111,14 +109,13 @@ MODULE dbcsr_api
       dbcsr_add_block_node_prv => dbcsr_add_block_node, &
       dbcsr_conform_scalar_prv => dbcsr_conform_scalar
    USE dbcsr_test_methods, ONLY: dbcsr_reset_randmat_seed
-   USE dbcsr_tests, ONLY: dbcsr_run_tests, &
+   USE dbcsr_tests, ONLY: dbcsr_run_tests_prv => dbcsr_run_tests, &
                           dbcsr_test_binary_io, &
                           dbcsr_test_mm
    USE dbcsr_string_utilities, ONLY: uppercase
    USE dbcsr_transformations, ONLY: dbcsr_complete_redistribute_prv => dbcsr_complete_redistribute, &
                                     dbcsr_desymmetrize_deep_prv => dbcsr_desymmetrize_deep, &
                                     dbcsr_distribute_prv => dbcsr_distribute, &
-                                    dbcsr_new_transposed_prv => dbcsr_new_transposed, &
                                     dbcsr_replicate_all_prv => dbcsr_replicate_all, &
                                     dbcsr_transposed_prv => dbcsr_transposed
    USE dbcsr_types, ONLY: &
@@ -675,6 +672,7 @@ CONTAINS
       INTEGER, INTENT(OUT), OPTIONAL                     :: data_type, group
 
       TYPE(dbcsr_dist_prv_obj)                           :: dist
+      TYPE(mp_comm_type)                                 :: my_group
 
       CALL dbcsr_get_info_prv(matrix=matrix%prv, &
                               nblkrows_total=nblkrows_total, &
@@ -699,11 +697,13 @@ CONTAINS
                               name=name, &
                               matrix_type=matrix_type, &
                               data_type=data_type, &
-                              group=group)
+                              group=my_group)
 
       IF (PRESENT(distribution)) THEN
          distribution%prv = dist
       END IF
+
+      IF (PRESENT(group)) group = my_group%handle
 
    END SUBROUTINE dbcsr_get_info
 
@@ -721,10 +721,16 @@ CONTAINS
       LOGICAL, INTENT(OUT), OPTIONAL                     :: subgroups_defined
       INTEGER, INTENT(OUT), OPTIONAL                     :: prow_group, pcol_group
 
+      TYPE(mp_comm_type) :: my_group, my_prow_group, my_pcol_group
+
       call dbcsr_distribution_get_prv(dist%prv, row_dist, col_dist, &
                                       nrows, ncols, has_threads, &
-                                      group, mynode, numnodes, nprows, npcols, myprow, mypcol, pgrid, &
-                                      subgroups_defined, prow_group, pcol_group)
+                                      my_group, mynode, numnodes, nprows, npcols, myprow, mypcol, pgrid, &
+                                      subgroups_defined, my_prow_group, my_pcol_group)
+
+      IF (PRESENT(group)) group = my_group%handle
+      IF (PRESENT(prow_group)) prow_group = my_prow_group%handle
+      IF (PRESENT(pcol_group)) pcol_group = my_pcol_group%handle
    END SUBROUTINE dbcsr_distribution_get
 
    SUBROUTINE dbcsr_distribution_hold(dist)
@@ -869,10 +875,11 @@ CONTAINS
       END IF
 
       IF (PRESENT(template)) THEN
-         call dbcsr_distribution_new_prv(dist%prv, template%prv, group, pgrid, cont_row_dist, cont_col_dist, &
+         call dbcsr_distribution_new_prv(dist%prv, template%prv, mp_comm_type(group), pgrid, cont_row_dist, cont_col_dist, &
                                          reuse_arrays=.TRUE.)
       ELSE
-         call dbcsr_distribution_new_prv(dist%prv, group=group, pgrid=pgrid, row_dist=cont_row_dist, col_dist=cont_col_dist, &
+         call dbcsr_distribution_new_prv(dist%prv, group=mp_comm_type(group), pgrid=pgrid, &
+                                         row_dist=cont_row_dist, col_dist=cont_col_dist, &
                                          reuse_arrays=.TRUE.)
       END IF
    END SUBROUTINE dbcsr_distribution_new
@@ -1118,6 +1125,20 @@ CONTAINS
       has_symmetry = dbcsr_has_symmetry_prv(matrix%prv)
    END FUNCTION dbcsr_has_symmetry
 
+   SUBROUTINE csr_create_new(csr_mat, nrows_total, ncols_total, nze_total, &
+                             nze_local, nrows_local, mp_group, data_type)
+      TYPE(dbcsr_csr_type), INTENT(OUT)                  :: csr_mat
+      INTEGER, INTENT(IN)                                :: nrows_total, ncols_total
+      INTEGER(KIND=int_8)                                :: nze_total
+      INTEGER, INTENT(IN)                                :: nze_local, nrows_local
+      INTEGER, INTENT(IN)                                :: mp_group
+      INTEGER, INTENT(IN), OPTIONAL                      :: data_type
+
+      CALL csr_create_new_prv(csr_mat, nrows_total, ncols_total, nze_total, &
+                              nze_local, nrows_local, mp_comm_type(mp_group), data_type)
+
+   END SUBROUTINE csr_create_new
+
    SUBROUTINE dbcsr_csr_create_from_dbcsr(dbcsr_mat, csr_mat, dist_format, csr_sparsity, numnodes)
 
       TYPE(dbcsr_type), INTENT(IN)                       :: dbcsr_mat
@@ -1182,6 +1203,27 @@ CONTAINS
 
       call dbcsr_add_block_node_prv(matrix%prv, block_row, block_col, block)
    END SUBROUTINE dbcsr_add_block_node
+
+   SUBROUTINE dbcsr_run_tests(mp_group, io_unit, nproc, matrix_sizes, trs, &
+                              bs_m, bs_n, bs_k, sparsities, alpha, beta, data_type, test_type, &
+                              n_loops, eps, retain_sparsity, always_checksum)
+
+      INTEGER, INTENT(IN)                                :: mp_group, io_unit
+      INTEGER, DIMENSION(:), POINTER                     :: nproc
+      INTEGER, DIMENSION(:), INTENT(in)                  :: matrix_sizes
+      LOGICAL, DIMENSION(2), INTENT(in)                  :: trs
+      INTEGER, DIMENSION(:), POINTER                     :: bs_m, bs_n, bs_k
+      REAL(kind=dp), DIMENSION(3), INTENT(in)            :: sparsities
+      REAL(kind=dp), INTENT(in)                          :: alpha, beta
+      INTEGER, INTENT(IN)                                :: data_type, test_type, n_loops
+      REAL(kind=dp), INTENT(in)                          :: eps
+      LOGICAL, INTENT(in)                                :: retain_sparsity, always_checksum
+
+      CALL dbcsr_run_tests_prv(mp_comm_type(mp_group), io_unit, nproc, matrix_sizes, trs, &
+                               bs_m, bs_n, bs_k, sparsities, alpha, beta, data_type, test_type, &
+                               n_loops, eps, retain_sparsity, always_checksum)
+
+   END SUBROUTINE dbcsr_run_tests
 
    #:include 'data/dbcsr.fypp'
    #:for n, nametype1, base1, prec1, kind1, type1, dkind1 in inst_params_float

--- a/src/dist/dbcsr_dist_methods.F
+++ b/src/dist/dbcsr_dist_methods.F
@@ -25,6 +25,7 @@ MODULE dbcsr_dist_methods
                              dbcsr_heap_release, &
                              dbcsr_heap_reset_first, &
                              dbcsr_heap_type
+   USE dbcsr_mpiwrap, ONLY: mp_comm_type
    USE dbcsr_mp_methods, ONLY: dbcsr_mp_hold, &
                                dbcsr_mp_mypcol, &
                                dbcsr_mp_myprow, &
@@ -75,7 +76,7 @@ CONTAINS
          !! distribution
       TYPE(dbcsr_distribution_obj), INTENT(IN), &
          OPTIONAL                                        :: template
-      INTEGER, INTENT(IN), OPTIONAL                      :: group
+      TYPE(mp_comm_type), INTENT(IN), OPTIONAL                      :: group
       INTEGER, DIMENSION(:, :), OPTIONAL, POINTER        :: pgrid
       INTEGER, DIMENSION(:), INTENT(IN), POINTER, CONTIGUOUS :: row_dist, col_dist
       LOGICAL, INTENT(IN), OPTIONAL                      :: reuse_arrays
@@ -240,11 +241,12 @@ CONTAINS
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: row_dist, col_dist
       INTEGER, INTENT(OUT), OPTIONAL                     :: nrows, ncols
       LOGICAL, INTENT(OUT), OPTIONAL                     :: has_threads
-      INTEGER, INTENT(OUT), OPTIONAL                     :: group, mynode, numnodes, nprows, npcols, &
+      TYPE(mp_comm_type), INTENT(OUT), OPTIONAL          :: group
+      INTEGER, INTENT(OUT), OPTIONAL                     :: mynode, numnodes, nprows, npcols, &
                                                             myprow, mypcol
       INTEGER, DIMENSION(:, :), OPTIONAL, POINTER        :: pgrid
       LOGICAL, INTENT(OUT), OPTIONAL                     :: subgroups_defined
-      INTEGER, INTENT(OUT), OPTIONAL                     :: prow_group, pcol_group
+      TYPE(mp_comm_type), INTENT(OUT), OPTIONAL          :: prow_group, pcol_group
 
       IF (PRESENT(row_dist)) row_dist => array_data(dist%d%row_dist_block)
       IF (PRESENT(col_dist)) col_dist => array_data(dist%d%col_dist_block)

--- a/src/mm/dbcsr_mm.F
+++ b/src/mm/dbcsr_mm.F
@@ -82,7 +82,7 @@ MODULE dbcsr_mm
                             mp_min, &
                             mp_request_null, &
                             mp_sum, &
-                            mp_wait
+                            mp_wait, mp_comm_type
    USE dbcsr_operations, ONLY: dbcsr_conjg, &
                                dbcsr_copy, &
                                dbcsr_get_occupation, &
@@ -203,7 +203,8 @@ CONTAINS
 
    SUBROUTINE dbcsr_multiply_print_statistics(group, output_unit)
       !! Print statistics
-      INTEGER, INTENT(IN)                                :: group, output_unit
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
+      INTEGER, INTENT(IN)                                :: output_unit
 
       INTEGER(KIND=int_8)                                :: total_nexchanged
       INTEGER(KIND=int_8), &
@@ -385,7 +386,7 @@ CONTAINS
       REAL(real_8), PARAMETER                            :: make_dense_occ_thresh = 1.0_dp
 
       CHARACTER                                          :: transa_l, transb_l
-      INTEGER :: comm, f_col, f_k, f_row, handle, handle2, ithread, l_col, l_k, l_row, &
+      INTEGER :: f_col, f_k, f_row, handle, handle2, ithread, l_col, l_k, l_row, &
                  nimages_left_rows, nimages_match, nimages_right_cols, npcols, nprows, numnodes, &
                  output_unit
       INTEGER(KIND=int_8)                                :: my_flop
@@ -403,6 +404,7 @@ CONTAINS
                                                             rdist_left, rdist_right
       TYPE(dbcsr_mp_obj)                                 :: mp_obj
       TYPE(dbcsr_type)                                   :: matrix_left, matrix_right, product_matrix
+      TYPE(mp_comm_type)                                 :: comm
 
       CALL timeset(routineN, handle)
 

--- a/src/mm/dbcsr_mm_3d.F
+++ b/src/mm/dbcsr_mm_3d.F
@@ -87,7 +87,7 @@ MODULE dbcsr_mm_3d
    USE dbcsr_mpiwrap, ONLY: &
       mp_allgather, mp_alltoall, mp_comm_free, mp_comm_null, mp_comm_split_direct, &
       mp_iallgather, mp_isendrecv, mp_isum, mp_request_null, mp_rget, mp_wait, mp_waitall, &
-      mp_win_create, mp_win_free, mp_win_lock_all, mp_win_unlock_all, mp_environ
+      mp_win_create, mp_win_free, mp_win_lock_all, mp_win_unlock_all, mp_environ, mp_comm_type
    USE dbcsr_ptr_util, ONLY: ensure_array_size, &
                              memory_deallocate
    USE dbcsr_types, ONLY: &
@@ -123,7 +123,7 @@ MODULE dbcsr_mm_3d
                                                      trs_stackbuf
       INTEGER                                     :: vprow, vpcol
       INTEGER                                     :: myproc = -1
-      INTEGER                                     :: grp = mp_comm_null, & ! Global communicator
+      TYPE(mp_comm_type)                          :: grp = mp_comm_null, & ! Global communicator
                                                      subgrp = mp_comm_null ! Communicator for A and B
       INTEGER                                     :: data_win, meta_win
       INTEGER, DIMENSION(:), POINTER, CONTIGUOUS  :: meta => Null(), &
@@ -148,7 +148,7 @@ MODULE dbcsr_mm_3d
    END TYPE mn_local_sizes
 
    TYPE dbcsr_layers_3D_C_reduction
-      INTEGER                            :: grp = mp_comm_null, &
+      TYPE(mp_comm_type)                 :: grp = mp_comm_null, &
                                             grp3D = mp_comm_null, &
                                             rowgrp3D = mp_comm_null
       INTEGER                            :: num_layers_3D = 1, &
@@ -245,7 +245,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'make_buffers'
       INTEGER :: blk, blk_p, bp, col, col_img, col_size, data_type, dst_proc, f_col_f, f_row_f, &
-                 grp, handle, handle2, irequests, it, ithread, l_col_l, l_row_l, mynode, myt, &
+                 handle, handle2, irequests, it, ithread, l_col_l, l_row_l, mynode, myt, &
                  nblkcols_local, nblkrows_local, ncols_images, nimages, nprocs, nprocs_total, &
                  nrows_images, nsymmetries, nthreads, nze, pcol, prow, row, row_img, row_size, size_index, &
                  stored_col, stored_row, symmetry_i, tr_col_size, tr_row_size
@@ -275,6 +275,7 @@ CONTAINS
       TYPE(dbcsr_mp_obj)                                 :: mp_obj
       TYPE(dbcsr_scalar_type)                            :: scale_neg_one
       TYPE(dbcsr_type)                                   :: sm
+      TYPE(mp_comm_type)                                 :: grp
 
 !$    INTEGER(kind=omp_lock_kind), ALLOCATABLE, DIMENSION(:) :: locks
 
@@ -640,7 +641,7 @@ CONTAINS
       ! Allocate data and meta buffers
       do_win_create(:) = .NOT. buffer%has_rma_win
       IF (buffer%has_rma_win) THEN
-         IF (buffer%grp .NE. grp .OR. dbcsr_data_get_type(buffer%data) .NE. data_type) THEN
+         IF (buffer%grp%handle .NE. grp%handle .OR. dbcsr_data_get_type(buffer%data) .NE. data_type) THEN
             do_win_create(:) = .TRUE.
          END IF
       END IF
@@ -985,11 +986,12 @@ CONTAINS
       LOGICAL, INTENT(IN)                                :: is_left
       TYPE(dbcsr_buffer), INTENT(INOUT)                  :: buffer
 
-      INTEGER                                            :: color, key, mygrp, mypcol, myprow
+      INTEGER                                            :: color, key, mypcol, myprow
+      TYPE(mp_comm_type)                                 :: mygrp
 
       ! Switch to single layer communicator
       IF (my_num_layers_3D .LE. 1) THEN
-         IF (buffer%num_layers_3D .GT. 1 .AND. buffer%subgrp .NE. mp_comm_null) &
+         IF (buffer%num_layers_3D .GT. 1 .AND. buffer%subgrp%handle .NE. mp_comm_null%handle) &
             CALL mp_comm_free(buffer%subgrp)
          buffer%num_layers_3D = 1
          IF (is_left) THEN
@@ -1002,10 +1004,10 @@ CONTAINS
       !
       ! Check if any existing 3D communicator can be reused
       mygrp = dbcsr_mp_group(mp_obj)
-      IF (buffer%grp .EQ. mygrp .AND. buffer%num_layers_3D .EQ. my_num_layers_3D) RETURN
+      IF (buffer%grp%handle .EQ. mygrp%handle .AND. buffer%num_layers_3D .EQ. my_num_layers_3D) RETURN
       !
       ! Reset previous 3D communicator
-      IF (buffer%num_layers_3D .GT. 1 .AND. buffer%subgrp .NE. mp_comm_null) &
+      IF (buffer%num_layers_3D .GT. 1 .AND. buffer%subgrp%handle .NE. mp_comm_null%handle) &
          CALL mp_comm_free(buffer%subgrp)
       !
       myprow = dbcsr_mp_myprow(mp_obj)
@@ -1037,10 +1039,11 @@ CONTAINS
       TYPE(dbcsr_mp_obj), INTENT(INOUT)                  :: mp_obj
 
       CHARACTER(len=100)                                 :: msg
-      INTEGER                                            :: color, key, mygrp, mypcol, myprow, &
+      INTEGER                                            :: color, key, mypcol, myprow, &
                                                             npcols, nprows, numnodes
       LOGICAL                                            :: do_layers_3D
       LOGICAL, SAVE                                      :: warning = .TRUE.
+      TYPE(mp_comm_type)                                 :: mygrp
 
       CALL dbcsr_mp_grid_setup(mp_obj)
       IF (my_num_layers_3D .LE. 1) THEN
@@ -1051,7 +1054,7 @@ CONTAINS
       !
       ! Check if any existing 3D communicator can be reused
       mygrp = dbcsr_mp_group(mp_obj)
-      IF (layers_3D_C_reduction%grp .EQ. mygrp .AND. &
+      IF (layers_3D_C_reduction%grp%handle .EQ. mygrp%handle .AND. &
           layers_3D_C_reduction%num_layers_3D .EQ. my_num_layers_3D) RETURN
       !
       ! Reset 3D communicator
@@ -1112,8 +1115,8 @@ CONTAINS
       INTEGER                                            :: ibuff
 
       layers_3D_C_reduction%grp = mp_comm_null
-      IF (layers_3D_C_reduction%rowgrp3D .NE. mp_comm_null) CALL mp_comm_free(layers_3D_C_reduction%rowgrp3D)
-      IF (layers_3D_C_reduction%grp3D .NE. mp_comm_null) CALL mp_comm_free(layers_3D_C_reduction%grp3D)
+      IF (layers_3D_C_reduction%rowgrp3D%handle .NE. mp_comm_null%handle) CALL mp_comm_free(layers_3D_C_reduction%rowgrp3D)
+      IF (layers_3D_C_reduction%grp3D%handle .NE. mp_comm_null%handle) CALL mp_comm_free(layers_3D_C_reduction%grp3D)
       layers_3D_C_reduction%rowgrp3D = mp_comm_null
       layers_3D_C_reduction%grp3D = mp_comm_null
       layers_3D_C_reduction%num_layers_3D = 1
@@ -1150,7 +1153,7 @@ CONTAINS
       LOGICAL, INTENT(IN)                                :: keep_product_data
 
       CHARACTER(len=*), PARAMETER :: routineN = 'multiply_3D'
-      INTEGER :: blk, data_type, data_type_byte, final_step_k, grp_left, grp_right, handle, &
+      INTEGER :: blk, data_type, data_type_byte, final_step_k, handle, &
                  handle1, handle2, icol3D, icol3D_send, ileft_buffer_calc, ileft_buffer_comm, &
                  iright_buffer_calc, iright_buffer_comm, irow3D, irow3D_send, istep_k_ordered, ithread, &
                  ivirt_k, last_step_k, left_col_mult, left_col_nimages, left_col_total_nimages, &
@@ -1201,6 +1204,7 @@ CONTAINS
          DIMENSION(:, :, :)                              :: multrec
       TYPE(dbcsr_mp_obj)                                 :: left_mp_obj, product_mp_obj, right_mp_obj
       TYPE(mn_local_sizes), ALLOCATABLE, DIMENSION(:)    :: m_sizes, n_sizes
+      TYPE(mp_comm_type)                                 :: grp_left, grp_right
 
       CALL timeset(routineN, handle)
       !
@@ -2619,7 +2623,7 @@ CONTAINS
          CALL mp_win_free(buffer%meta_win)
          buffer%has_rma_win = .FALSE.
          buffer%grp = mp_comm_null
-         IF (buffer%subgrp .NE. mp_comm_null .AND. buffer%num_layers_3D .GT. 1) &
+         IF (buffer%subgrp%handle .NE. mp_comm_null%handle .AND. buffer%num_layers_3D .GT. 1) &
             CALL mp_comm_free(buffer%subgrp)
          buffer%subgrp = mp_comm_null
          buffer%num_layers_3D = 1

--- a/src/mm/dbcsr_mm_3d.F
+++ b/src/mm/dbcsr_mm_3d.F
@@ -87,7 +87,8 @@ MODULE dbcsr_mm_3d
    USE dbcsr_mpiwrap, ONLY: &
       mp_allgather, mp_alltoall, mp_comm_free, mp_comm_null, mp_comm_split_direct, &
       mp_iallgather, mp_isendrecv, mp_isum, mp_request_null, mp_rget, mp_wait, mp_waitall, &
-      mp_win_create, mp_win_free, mp_win_lock_all, mp_win_unlock_all, mp_environ, mp_comm_type, mp_request_type
+      mp_win_create, mp_win_free, mp_win_lock_all, mp_win_unlock_all, mp_environ, &
+      mp_comm_type, mp_request_type, mp_win_type
    USE dbcsr_ptr_util, ONLY: ensure_array_size, &
                              memory_deallocate
    USE dbcsr_types, ONLY: &
@@ -125,7 +126,7 @@ MODULE dbcsr_mm_3d
       INTEGER                                     :: myproc = -1
       TYPE(mp_comm_type)                          :: grp = mp_comm_null, & ! Global communicator
                                                      subgrp = mp_comm_null ! Communicator for A and B
-      INTEGER                                     :: data_win, meta_win
+      TYPE(mp_win_type)                           :: data_win, meta_win
       INTEGER, DIMENSION(:), POINTER, CONTIGUOUS  :: meta => Null(), &
                                                      meta_before_resize => Null(), &
                                                      meta_red3D => Null()
@@ -2419,7 +2420,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: recv_vproc, nimages
       INTEGER, DIMENSION(:), INTENT(IN)                  :: size_layers3D, displ_layers3D
       TYPE(dbcsr_buffer), INTENT(INOUT)                  :: buffer
-      INTEGER, INTENT(IN)                                :: meta_win, data_win
+      TYPE(mp_win_type), INTENT(IN)                      :: meta_win, data_win
       TYPE(dbcsr_data_obj), INTENT(INOUT)                :: data_get
       INTEGER, INTENT(IN)                                :: data_type_byte
       TYPE(dbcsr_buffer), INTENT(IN)                     :: buffer_win

--- a/src/mm/dbcsr_mm_3d.F
+++ b/src/mm/dbcsr_mm_3d.F
@@ -87,7 +87,7 @@ MODULE dbcsr_mm_3d
    USE dbcsr_mpiwrap, ONLY: &
       mp_allgather, mp_alltoall, mp_comm_free, mp_comm_null, mp_comm_split_direct, &
       mp_iallgather, mp_isendrecv, mp_isum, mp_request_null, mp_rget, mp_wait, mp_waitall, &
-      mp_win_create, mp_win_free, mp_win_lock_all, mp_win_unlock_all, mp_environ, mp_comm_type
+      mp_win_create, mp_win_free, mp_win_lock_all, mp_win_unlock_all, mp_environ, mp_comm_type, mp_request_type
    USE dbcsr_ptr_util, ONLY: ensure_array_size, &
                              memory_deallocate
    USE dbcsr_types, ONLY: &
@@ -129,7 +129,7 @@ MODULE dbcsr_mm_3d
       INTEGER, DIMENSION(:), POINTER, CONTIGUOUS  :: meta => Null(), &
                                                      meta_before_resize => Null(), &
                                                      meta_red3D => Null()
-      INTEGER, DIMENSION(2)                       :: get_requests
+      TYPE(mp_request_type), DIMENSION(2)         :: get_requests = mp_request_null
       INTEGER                                     :: meta_size
       INTEGER                                     :: num_layers_3D = 1
       INTEGER                                     :: coord3D = 1
@@ -182,11 +182,11 @@ MODULE dbcsr_mm_3d
 
    INTEGER, ALLOCATABLE, DIMENSION(:), TARGET, PRIVATE :: g2l_map_cols, g2l_map_rows
 
-   INTEGER, PRIVATE                :: request_count_rows
-   INTEGER, DIMENSION(2), PRIVATE  :: requests
-   INTEGER, DIMENSION(2), PRIVATE  :: requests_win_create
+   TYPE(mp_request_type), PRIVATE               :: request_count_rows
+   TYPE(mp_request_type), DIMENSION(2), PRIVATE :: requests
+   TYPE(mp_request_type), DIMENSION(2), PRIVATE :: requests_win_create
 
-   INTEGER :: request_sync_mult = mp_request_null
+   TYPE(mp_request_type) :: request_sync_mult = mp_request_null
 
    ! Buffers used in make_buffers
    TYPE(dbcsr_data_obj), TARGET, SAVE :: make_buffers_data_recv, make_buffers_data_send
@@ -1163,7 +1163,7 @@ CONTAINS
                  mycol3D, mypcol, myprow
       INTEGER :: myrank3D, myrow3D, myt, nblkrows_local, nbuffers, nbuffers_norms, ncols3D, &
                  nranks3D, nrows3D, nthreads, numnodes, nvirt_k, proc3D_recv, proc3D_send, recv_vcol, &
-                 recv_vrow, request_epss, request_keep_sparsity, right_col_mult, right_col_nimages, &
+                 recv_vrow, right_col_mult, right_col_nimages, &
                  right_max_data_size, right_max_meta_size, right_myfirstvcol, right_myfirstvrow, &
                  right_mypcol, right_myprow, right_npcols, right_nprows, right_row_mult, &
                  right_row_nimages, right_row_total_nimages, row, shift3D, shift3D_comm, shift3D_recv, &
@@ -1171,10 +1171,12 @@ CONTAINS
       INTEGER(KIND=int_8)                                :: mem
       INTEGER, ALLOCATABLE, DIMENSION(:) :: left_vrow, product_matrix_epss_displ, &
                                             product_matrix_epss_size, product_matrix_meta, product_matrix_size_recv, &
-                                            product_matrix_size_send, requests_reduction, right_vcol
+                                            product_matrix_size_send, right_vcol
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: product_matrix_meta_displ, &
                                                             product_matrix_meta_size
-      INTEGER, DIMENSION(2)                              :: requests_reduction_size
+      TYPE(mp_request_type)                              :: request_epss, request_keep_sparsity
+      TYPE(mp_request_type), DIMENSION(2)                :: requests_reduction_size
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:)   :: requests_reduction
       INTEGER, DIMENSION(:), POINTER, CONTIGUOUS :: col_blk_sizes2enum, enum2col_blk_sizes, &
                                                     enum2row_blk_sizes, product_matrix_meta_recv, product_matrix_meta_send, &
                                                     row_blk_sizes2enum
@@ -2253,7 +2255,7 @@ CONTAINS
    SUBROUTINE win_setup(buffer, do_win_create, request)
       TYPE(dbcsr_buffer), INTENT(INOUT)                  :: buffer
       LOGICAL, DIMENSION(:), INTENT(INOUT)               :: do_win_create
-      INTEGER, INTENT(INOUT)                             :: request
+      TYPE(mp_request_type), INTENT(INOUT)               :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'win_setup'
       INTEGER                                            :: handle, handle1, myproc

--- a/src/mm/dbcsr_mm_3d.F
+++ b/src/mm/dbcsr_mm_3d.F
@@ -641,7 +641,7 @@ CONTAINS
       ! Allocate data and meta buffers
       do_win_create(:) = .NOT. buffer%has_rma_win
       IF (buffer%has_rma_win) THEN
-         IF (buffer%grp%handle .NE. grp%handle .OR. dbcsr_data_get_type(buffer%data) .NE. data_type) THEN
+         IF (buffer%grp .NE. grp .OR. dbcsr_data_get_type(buffer%data) .NE. data_type) THEN
             do_win_create(:) = .TRUE.
          END IF
       END IF
@@ -991,7 +991,7 @@ CONTAINS
 
       ! Switch to single layer communicator
       IF (my_num_layers_3D .LE. 1) THEN
-         IF (buffer%num_layers_3D .GT. 1 .AND. buffer%subgrp%handle .NE. mp_comm_null%handle) &
+         IF (buffer%num_layers_3D .GT. 1 .AND. buffer%subgrp .NE. mp_comm_null) &
             CALL mp_comm_free(buffer%subgrp)
          buffer%num_layers_3D = 1
          IF (is_left) THEN
@@ -1004,10 +1004,10 @@ CONTAINS
       !
       ! Check if any existing 3D communicator can be reused
       mygrp = dbcsr_mp_group(mp_obj)
-      IF (buffer%grp%handle .EQ. mygrp%handle .AND. buffer%num_layers_3D .EQ. my_num_layers_3D) RETURN
+      IF (buffer%grp .EQ. mygrp .AND. buffer%num_layers_3D .EQ. my_num_layers_3D) RETURN
       !
       ! Reset previous 3D communicator
-      IF (buffer%num_layers_3D .GT. 1 .AND. buffer%subgrp%handle .NE. mp_comm_null%handle) &
+      IF (buffer%num_layers_3D .GT. 1 .AND. buffer%subgrp .NE. mp_comm_null) &
          CALL mp_comm_free(buffer%subgrp)
       !
       myprow = dbcsr_mp_myprow(mp_obj)
@@ -1054,7 +1054,7 @@ CONTAINS
       !
       ! Check if any existing 3D communicator can be reused
       mygrp = dbcsr_mp_group(mp_obj)
-      IF (layers_3D_C_reduction%grp%handle .EQ. mygrp%handle .AND. &
+      IF (layers_3D_C_reduction%grp .EQ. mygrp .AND. &
           layers_3D_C_reduction%num_layers_3D .EQ. my_num_layers_3D) RETURN
       !
       ! Reset 3D communicator
@@ -1115,8 +1115,8 @@ CONTAINS
       INTEGER                                            :: ibuff
 
       layers_3D_C_reduction%grp = mp_comm_null
-      IF (layers_3D_C_reduction%rowgrp3D%handle .NE. mp_comm_null%handle) CALL mp_comm_free(layers_3D_C_reduction%rowgrp3D)
-      IF (layers_3D_C_reduction%grp3D%handle .NE. mp_comm_null%handle) CALL mp_comm_free(layers_3D_C_reduction%grp3D)
+      IF (layers_3D_C_reduction%rowgrp3D .NE. mp_comm_null) CALL mp_comm_free(layers_3D_C_reduction%rowgrp3D)
+      IF (layers_3D_C_reduction%grp3D .NE. mp_comm_null) CALL mp_comm_free(layers_3D_C_reduction%grp3D)
       layers_3D_C_reduction%rowgrp3D = mp_comm_null
       layers_3D_C_reduction%grp3D = mp_comm_null
       layers_3D_C_reduction%num_layers_3D = 1
@@ -2623,7 +2623,7 @@ CONTAINS
          CALL mp_win_free(buffer%meta_win)
          buffer%has_rma_win = .FALSE.
          buffer%grp = mp_comm_null
-         IF (buffer%subgrp%handle .NE. mp_comm_null%handle .AND. buffer%num_layers_3D .GT. 1) &
+         IF (buffer%subgrp .NE. mp_comm_null .AND. buffer%num_layers_3D .GT. 1) &
             CALL mp_comm_free(buffer%subgrp)
          buffer%subgrp = mp_comm_null
          buffer%num_layers_3D = 1

--- a/src/mm/dbcsr_mm_cannon.F
+++ b/src/mm/dbcsr_mm_cannon.F
@@ -80,6 +80,7 @@ MODULE dbcsr_mm_cannon
                                   dbcsr_isend_any, &
                                   hybrid_alltoall_any, &
                                   hybrid_alltoall_i1
+   USE dbcsr_mpiwrap, ONLY: mp_comm_type
    USE dbcsr_operations, ONLY: dbcsr_copy, &
                                dbcsr_crop_matrix
    USE dbcsr_ptr_util, ONLY: ensure_array_size
@@ -303,7 +304,7 @@ CONTAINS
 
       CHARACTER                                          :: predist_type, predist_type_fwd
       INTEGER :: blk, blk_l, blk_p, bp, col, col_img, col_size, coli, data_type, dst_p, handle, &
-                 handle2, ithread, mp_group, ncol_images, nrow_images, nsymmetries, nthreads, numproc, &
+                 handle2, ithread, ncol_images, nrow_images, nsymmetries, nthreads, numproc, &
                  nze, pcol, prow, row, row_img, row_size, rowi, sd_pos, sm_pos, src_p, stored_blk_p, &
                  stored_col, stored_row, symmetry_i, tr_col_size, tr_row_size, vcol, vrow
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: myt_sdp, myt_smp, rd_disp, recv_meta, &
@@ -325,6 +326,7 @@ CONTAINS
       TYPE(dbcsr_mp_obj)                                 :: mp_obj
       TYPE(dbcsr_scalar_type)                            :: scale_neg_one
       TYPE(dbcsr_type)                                   :: sm
+      TYPE(mp_comm_type)                                 :: mp_group
 
 !   ---------------------------------------------------------------------------
 ! Check input matrix
@@ -843,7 +845,7 @@ CONTAINS
       INTEGER, PARAMETER                                 :: idata = 1, ileft = 0, imeta = 2, &
                                                             iright = 2
 
-      INTEGER :: data_type, data_type_byte, grp, handle, handle1, handle2, handle3, i, ithread, &
+      INTEGER :: data_type, data_type_byte, handle, handle1, handle2, handle3, i, ithread, &
                  left_col_image, left_col_mult, left_col_nimages, left_dst_icol, left_dst_irow, &
                  left_dst_p, left_dst_pcol, left_dst_prow, left_dst_vcol, left_dst_vrow, left_max_nblks, &
                  left_max_nze, left_myfirstvcol, left_myfirstvrow, left_mypcol, left_myprow, left_npcols, &
@@ -852,7 +854,7 @@ CONTAINS
                  left_send_icol, left_send_irow, left_send_p, left_send_pcol, left_send_prow
       INTEGER :: left_send_vcol, left_send_vrow, left_src_icol, left_src_irow, left_src_p, &
                  left_src_pcol, left_src_prow, left_src_vcol, left_src_vrow, metronome, min_nimages, &
-                 mp_group, mynode, nblkrows_used, nsteps_k, nthreads, numnodes, nvirt_k, &
+                 mynode, nblkrows_used, nsteps_k, nthreads, numnodes, nvirt_k, &
                  output_unit, right_col_image, right_col_mult, right_col_nimages, right_dst_icol, &
                  right_dst_irow, right_dst_p, right_dst_pcol, right_dst_prow, right_dst_vcol, &
                  right_dst_vrow, right_max_nblks, right_max_nze, right_myfirstvcol, right_myfirstvrow, &
@@ -893,6 +895,7 @@ CONTAINS
       TYPE(dbcsr_mm_multrec_type_p), DIMENSION(:), ALLOCATABLE :: multrec
       TYPE(dbcsr_mp_obj)                       :: left_mp_obj, product_mp_obj, &
                                                   right_mp_obj
+      TYPE(mp_comm_type)                       :: grp, mp_group
 
 !   ---------------------------------------------------------------------------
 

--- a/src/mm/dbcsr_mm_cannon.F
+++ b/src/mm/dbcsr_mm_cannon.F
@@ -80,7 +80,6 @@ MODULE dbcsr_mm_cannon
                                   dbcsr_isend_any, &
                                   hybrid_alltoall_any, &
                                   hybrid_alltoall_i1
-   USE dbcsr_mpiwrap, ONLY: mp_comm_type
    USE dbcsr_operations, ONLY: dbcsr_copy, &
                                dbcsr_crop_matrix
    USE dbcsr_ptr_util, ONLY: ensure_array_size
@@ -111,7 +110,7 @@ MODULE dbcsr_mm_cannon
                             mp_request_null, &
                             mp_sum, &
                             mp_testany, &
-                            mp_waitall
+                            mp_waitall, mp_comm_type, mp_request_type
 #include "base/dbcsr_base_uses.f90"
 
 !$ USE OMP_LIB, ONLY: omp_get_max_threads, omp_get_thread_num, omp_get_num_threads
@@ -870,12 +869,10 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: left_sizes, my_sizes, right_sizes
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :, :)        :: all_sizes
       INTEGER, DIMENSION(:), POINTER, CONTIGUOUS :: col_blk_sizes2enum, enum2col_blk_sizes, &
-                                                    enum2row_blk_sizes, left_data_rr, left_data_sr, &
-                                                    left_index_rp, left_index_rr, &
-                                                    left_index_sp, left_index_sr, m_sizes, n_sizes, &
-                                                    right_data_rr, right_data_sr, &
-                                                    right_index_rp, right_index_rr, right_index_sp, &
-                                                    right_index_sr, row_blk_sizes2enum
+                                                    enum2row_blk_sizes, &
+                                                    left_index_rp, left_index_sp, m_sizes, n_sizes, &
+                                                    right_index_rp, right_index_sp, &
+                                                    row_blk_sizes2enum
       INTEGER, DIMENSION(:), POINTER, CONTIGUOUS         :: k_sizes
       INTEGER, DIMENSION(:, :), POINTER, CONTIGUOUS      :: left_pgrid, product_pgrid, right_pgrid
       INTEGER, SAVE                                      :: mult_id = 0
@@ -896,6 +893,8 @@ CONTAINS
       TYPE(dbcsr_mp_obj)                       :: left_mp_obj, product_mp_obj, &
                                                   right_mp_obj
       TYPE(mp_comm_type)                       :: grp, mp_group
+      TYPE(mp_request_type), DIMENSION(:), ALLOCATABLE :: left_data_rr, left_data_sr, left_index_rr, &
+         left_index_sr, right_data_rr, right_data_sr, right_index_rr, right_index_sr
 
 !   ---------------------------------------------------------------------------
 

--- a/src/mm/dbcsr_mm_cannon.F
+++ b/src/mm/dbcsr_mm_cannon.F
@@ -894,7 +894,7 @@ CONTAINS
                                                   right_mp_obj
       TYPE(mp_comm_type)                       :: grp, mp_group
       TYPE(mp_request_type), DIMENSION(:), ALLOCATABLE :: left_data_rr, left_data_sr, left_index_rr, &
-         left_index_sr, right_data_rr, right_data_sr, right_index_rr, right_index_sr
+                                                         left_index_sr, right_data_rr, right_data_sr, right_index_rr, right_index_sr
 
 !   ---------------------------------------------------------------------------
 

--- a/src/mm/dbcsr_mm_sched.F
+++ b/src/mm/dbcsr_mm_sched.F
@@ -43,7 +43,7 @@ MODULE dbcsr_mm_sched
    USE dbcsr_mpiwrap, ONLY: mp_bcast, &
                             mp_environ, &
                             mp_max, &
-                            mp_sum
+                            mp_sum, mp_comm_type
    USE dbcsr_toollib, ONLY: sort
    USE dbcsr_types, ONLY: dbcsr_type, &
                           dbcsr_work_type
@@ -139,7 +139,8 @@ CONTAINS
 
    SUBROUTINE dbcsr_mm_sched_print_statistics(group, output_unit)
       !! Prints DBCSR statistics
-      INTEGER, INTENT(IN)                                :: group, output_unit
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
+      INTEGER, INTENT(IN)                                :: output_unit
 
       TYPE(stats_type)                                   :: report
       ! Collect and output statistics ---------------------------------------------
@@ -491,7 +492,7 @@ CONTAINS
    SUBROUTINE stats_collect_from_ranks(report, group)
       !! Collects statistics from all MPI-ranks
       TYPE(stats_type), INTENT(INOUT)                    :: report
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                                :: group
 
       INTEGER                                            :: i, myrank, nranks, sending_rank
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: mnk_collected

--- a/src/mpi/dbcsr_mp_methods.F
+++ b/src/mpi/dbcsr_mp_methods.F
@@ -243,7 +243,7 @@ CONTAINS
          CALL mp_dims_create(numnodes, npdims)
       END IF
       CALL mp_cart_create(mp_group, 2, npdims, myploc, cart_group)
-      alive = cart_group%handle .NE. mp_comm_null%handle
+      alive = cart_group .NE. mp_comm_null
       IF (alive) THEN
          CALL mp_environ(numnodes, mynode, cart_group)
          ALLOCATE (pgrid(0:npdims(1) - 1, 0:npdims(2) - 1))

--- a/src/mpi/dbcsr_mp_methods.F
+++ b/src/mpi/dbcsr_mp_methods.F
@@ -16,7 +16,7 @@ MODULE dbcsr_mp_methods
                             mp_environ, &
                             mp_cart_rank, &
                             mp_dims_create, &
-                            mp_comm_null
+                            mp_comm_null, mp_comm_type
    USE dbcsr_types, ONLY: dbcsr_mp_obj
 
 !$ USE OMP_LIB, ONLY: omp_get_max_threads, omp_get_thread_num, omp_get_num_threads
@@ -66,7 +66,8 @@ CONTAINS
 
       TYPE(dbcsr_mp_obj), INTENT(OUT)                    :: mp_env
          !! multiprocessor environment
-      INTEGER, INTENT(IN)                                :: mp_group, mynode
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_group
+      INTEGER, INTENT(IN)                                :: mynode
          !! my processor number
       INTEGER, DIMENSION(0:, 0:), INTENT(IN)             :: pgrid
          !! process grid
@@ -114,7 +115,7 @@ CONTAINS
       !! Creates a new dbcsr_mp_obj based on a input template
 
       TYPE(dbcsr_mp_obj), INTENT(OUT)                    :: mp_env
-      INTEGER, INTENT(IN)                                :: mp_group
+      TYPE(mp_comm_type), INTENT(IN)                                :: mp_group
       INTEGER, DIMENSION(:, :), OPTIONAL, POINTER        :: pgrid
          !! Optional, if not provided group is assumed to be a 2D cartesian communicator
 
@@ -173,9 +174,10 @@ CONTAINS
       TYPE(dbcsr_mp_obj), INTENT(INOUT)                  :: mp_env
          !! multiprocessor environment
 
-      INTEGER                                            :: ndims, tmp_group
+      INTEGER                                            :: ndims
       INTEGER, DIMENSION(2)                              :: dims, my_pos
       LOGICAL, DIMENSION(2)                              :: remain
+      TYPE(mp_comm_type)                                 :: tmp_group
 
 !   ---------------------------------------------------------------------------
 
@@ -207,9 +209,9 @@ CONTAINS
 
       TYPE(dbcsr_mp_obj), INTENT(OUT)                    :: mp_env
          !! Message-passing environment object to create
-      INTEGER, INTENT(OUT)                               :: cart_group
+      TYPE(mp_comm_type), INTENT(OUT)                               :: cart_group
          !! the created cartesian group (to be freed by the user)
-      INTEGER, INTENT(IN)                                :: mp_group
+      TYPE(mp_comm_type), INTENT(IN)                                :: mp_group
          !! MPI group
       INTEGER, INTENT(IN), OPTIONAL                      :: nprocs
          !! Number of processes
@@ -241,7 +243,7 @@ CONTAINS
          CALL mp_dims_create(numnodes, npdims)
       END IF
       CALL mp_cart_create(mp_group, 2, npdims, myploc, cart_group)
-      alive = cart_group .NE. mp_comm_null
+      alive = cart_group%handle .NE. mp_comm_null%handle
       IF (alive) THEN
          CALL mp_environ(numnodes, mynode, cart_group)
          ALLOCATE (pgrid(0:npdims(1) - 1, 0:npdims(2) - 1))
@@ -300,7 +302,7 @@ CONTAINS
 
    PURE FUNCTION dbcsr_mp_group(mp_env) RESULT(mp_group)
       TYPE(dbcsr_mp_obj), INTENT(IN)                     :: mp_env
-      INTEGER                                            :: mp_group
+      TYPE(mp_comm_type)                                            :: mp_group
 
       mp_group = mp_env%mp%mp_group
    END FUNCTION dbcsr_mp_group
@@ -342,14 +344,14 @@ CONTAINS
 
    PURE FUNCTION dbcsr_mp_my_row_group(mp_env) RESULT(row_group)
       TYPE(dbcsr_mp_obj), INTENT(IN)                     :: mp_env
-      INTEGER                                            :: row_group
+      TYPE(mp_comm_type)                                            :: row_group
 
       row_group = mp_env%mp%prow_group
    END FUNCTION dbcsr_mp_my_row_group
 
    PURE FUNCTION dbcsr_mp_my_col_group(mp_env) RESULT(col_group)
       TYPE(dbcsr_mp_obj), INTENT(IN)                     :: mp_env
-      INTEGER                                            :: col_group
+      TYPE(mp_comm_type)                                            :: col_group
 
       col_group = mp_env%mp%pcol_group
    END FUNCTION dbcsr_mp_my_col_group

--- a/src/mpi/dbcsr_mp_operations.F
+++ b/src/mpi/dbcsr_mp_operations.F
@@ -30,7 +30,7 @@ MODULE dbcsr_mp_operations
       mp_allgather, mp_alltoall, mp_gatherv, mp_ibcast, mp_irecv, mp_iscatter, mp_isend, &
       mp_isendrecv, mp_rget, mp_sendrecv, mp_type_descriptor_type, mp_type_indexed_make_c, &
       mp_type_indexed_make_d, mp_type_indexed_make_r, mp_type_indexed_make_z, mp_type_make, &
-      mp_waitall, mp_win_create
+      mp_waitall, mp_win_create, mp_comm_type
 #include "base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -127,9 +127,9 @@ CONTAINS
          !! Use point-to-point for remaining; default is no
          !! Use regular global collective; default is no
 
-      INTEGER :: all_group, mynode, mypcol, myprow, nall_rr, nall_sr, ncol_rr, &
+      INTEGER :: mynode, mypcol, myprow, nall_rr, nall_sr, ncol_rr, &
                  ncol_sr, npcols, nprows, nrow_rr, nrow_sr, numnodes, dst, src, &
-                 prow, pcol, send_cnt, recv_cnt, tag, grp, i
+                 prow, pcol, send_cnt, recv_cnt, tag, i
       INTEGER, ALLOCATABLE, DIMENSION(:) :: all_rr, all_sr, col_rr, col_sr, &
                                             new_rcount, new_rdispl, new_scount, new_sdispl, row_rr, row_sr
       INTEGER, DIMENSION(:, :), POINTER        :: pgrid
@@ -137,6 +137,7 @@ CONTAINS
                                                   remainder_collective, no_h
       INTEGER, DIMENSION(:), POINTER, CONTIGUOUS :: send_data_p, recv_data_p
       TYPE(dbcsr_mp_obj)                       :: mpe
+      TYPE(mp_comm_type)                       :: all_group, grp
 
       IF (.NOT. dbcsr_mp_has_subgroups(mp_env)) THEN
          mpe = mp_env
@@ -339,7 +340,8 @@ CONTAINS
       TYPE(dbcsr_data_obj), INTENT(IN)                   :: msgin
       INTEGER, INTENT(IN)                                :: dest
       TYPE(dbcsr_data_obj), INTENT(INOUT)                :: msgout
-      INTEGER, INTENT(IN)                                :: source, comm
+      INTEGER, INTENT(IN)                                :: source
+      TYPE(mp_comm_type), INTENT(IN)                     :: comm
 
       IF (dbcsr_data_get_type(msgin) .NE. dbcsr_data_get_type(msgout)) &
          DBCSR_ABORT("Different data type for msgin and msgout")
@@ -363,7 +365,8 @@ CONTAINS
       !! @note see mp_isend_iv
 
       TYPE(dbcsr_data_obj), INTENT(IN)                   :: msgin
-      INTEGER, INTENT(IN)                                :: dest, comm
+      INTEGER, INTENT(IN)                                :: dest
+      TYPE(mp_comm_type), INTENT(IN)                     :: comm
       INTEGER, INTENT(OUT)                               :: request
       INTEGER, INTENT(IN), OPTIONAL                      :: tag
 
@@ -386,7 +389,8 @@ CONTAINS
       !! @note see mp_irecv_iv
 
       TYPE(dbcsr_data_obj), INTENT(IN)                   :: msgin
-      INTEGER, INTENT(IN)                                :: source, comm
+      INTEGER, INTENT(IN)                                :: source
+      TYPE(mp_comm_type), INTENT(IN)                     :: comm
       INTEGER, INTENT(OUT)                               :: request
       INTEGER, INTENT(IN), OPTIONAL                      :: tag
 
@@ -407,7 +411,7 @@ CONTAINS
    SUBROUTINE dbcsr_win_create_any(base, comm, win)
       !! Window initialization function of encapsulated data.
       TYPE(dbcsr_data_obj), INTENT(IN)                   :: base
-      INTEGER, INTENT(IN)                                :: comm
+      TYPE(mp_comm_type), INTENT(IN)                                :: comm
       INTEGER, INTENT(OUT)                               :: win
 
       SELECT CASE (dbcsr_data_get_type(base))
@@ -459,7 +463,8 @@ CONTAINS
    SUBROUTINE dbcsr_ibcast_any(base, source, grp, request)
       !! Bcast function of encapsulated data.
       TYPE(dbcsr_data_obj), INTENT(IN)                   :: base
-      INTEGER, INTENT(IN)                                :: source, grp
+      INTEGER, INTENT(IN)                                :: source
+      TYPE(mp_comm_type), INTENT(IN)                     :: grp
       INTEGER, INTENT(INOUT)                             :: request
 
       SELECT CASE (dbcsr_data_get_type(base))
@@ -481,7 +486,8 @@ CONTAINS
       TYPE(dbcsr_data_obj), INTENT(IN)                   :: base
       INTEGER, DIMENSION(:), INTENT(IN), CONTIGUOUS      :: counts, displs
       TYPE(dbcsr_data_obj), INTENT(INOUT)                :: msg
-      INTEGER, INTENT(IN)                                :: recvcount, root, grp
+      INTEGER, INTENT(IN)                                :: recvcount, root
+      TYPE(mp_comm_type), INTENT(IN)                     :: grp
       INTEGER, INTENT(INOUT)                             :: request
 
       IF (dbcsr_data_get_type(base) .NE. dbcsr_data_get_type(msg)) &
@@ -507,7 +513,8 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: ub_base
       TYPE(dbcsr_data_obj), INTENT(INOUT)                :: msg
       INTEGER, DIMENSION(:), CONTIGUOUS, INTENT(IN)      :: counts, displs
-      INTEGER, INTENT(IN)                                :: root, grp
+      INTEGER, INTENT(IN)                                :: root
+      TYPE(mp_comm_type), INTENT(IN)                     :: grp
 
       IF (dbcsr_data_get_type(base) .NE. dbcsr_data_get_type(msg)) &
          DBCSR_ABORT("Different data type for msgin and msgout")
@@ -531,7 +538,8 @@ CONTAINS
       TYPE(dbcsr_data_obj), INTENT(IN)                   :: msgin
       INTEGER, INTENT(IN)                                :: dest
       TYPE(dbcsr_data_obj), INTENT(INOUT)                :: msgout
-      INTEGER, INTENT(IN)                                :: source, grp
+      INTEGER, INTENT(IN)                                :: source
+      TYPE(mp_comm_type), INTENT(IN)                     :: grp
       INTEGER, INTENT(OUT)                               :: send_request, recv_request
 
       IF (dbcsr_data_get_type(msgin) .NE. dbcsr_data_get_type(msgout)) &
@@ -567,7 +575,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: scount
       TYPE(dbcsr_data_obj), INTENT(INOUT)                :: recv_data
       INTEGER, DIMENSION(:), CONTIGUOUS, INTENT(IN)      :: recv_count, recv_displ
-      INTEGER, INTENT(IN)                                :: gid
+      TYPE(mp_comm_type), INTENT(IN)                                :: gid
 
       IF (dbcsr_data_get_type(send_data) /= dbcsr_data_get_type(recv_data)) &
          DBCSR_ABORT("Data type mismatch")
@@ -616,9 +624,9 @@ CONTAINS
          !! Use point-to-point for remaining; default is no
          !! Use regular global collective; default is no
 
-         INTEGER :: all_group, mynode, mypcol, myprow, nall_rr, nall_sr, ncol_rr, &
+         INTEGER :: mynode, mypcol, myprow, nall_rr, nall_sr, ncol_rr, &
                     ncol_sr, npcols, nprows, nrow_rr, nrow_sr, numnodes, dst, src, &
-                    prow, pcol, send_cnt, recv_cnt, tag, grp, i
+                    prow, pcol, send_cnt, recv_cnt, tag, i
          INTEGER, ALLOCATABLE, DIMENSION(:) :: all_rr, all_sr, col_rr, col_sr, &
                                                new_rcount, new_rdispl, new_scount, new_sdispl, row_rr, row_sr
          INTEGER, DIMENSION(:, :), CONTIGUOUS, POINTER :: pgrid
@@ -626,6 +634,7 @@ CONTAINS
                                                      remainder_collective, no_h
          ${type1}$, DIMENSION(:), CONTIGUOUS, POINTER :: send_data_p, recv_data_p
          TYPE(dbcsr_mp_obj)                       :: mpe
+         TYPE(mp_comm_type)                       :: all_group, grp
 
          IF (.NOT. dbcsr_mp_has_subgroups(mp_env)) THEN
             mpe = mp_env

--- a/src/mpi/dbcsr_mp_operations.F
+++ b/src/mpi/dbcsr_mp_operations.F
@@ -30,7 +30,7 @@ MODULE dbcsr_mp_operations
       mp_allgather, mp_alltoall, mp_gatherv, mp_ibcast, mp_irecv, mp_iscatter, mp_isend, &
       mp_isendrecv, mp_rget, mp_sendrecv, mp_type_descriptor_type, mp_type_indexed_make_c, &
       mp_type_indexed_make_d, mp_type_indexed_make_r, mp_type_indexed_make_z, mp_type_make, &
-      mp_waitall, mp_win_create, mp_comm_type
+      mp_waitall, mp_win_create, mp_comm_type, mp_request_type
 #include "base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -130,14 +130,14 @@ CONTAINS
       INTEGER :: mynode, mypcol, myprow, nall_rr, nall_sr, ncol_rr, &
                  ncol_sr, npcols, nprows, nrow_rr, nrow_sr, numnodes, dst, src, &
                  prow, pcol, send_cnt, recv_cnt, tag, i
-      INTEGER, ALLOCATABLE, DIMENSION(:) :: all_rr, all_sr, col_rr, col_sr, &
-                                            new_rcount, new_rdispl, new_scount, new_sdispl, row_rr, row_sr
+      INTEGER, ALLOCATABLE, DIMENSION(:) :: new_rcount, new_rdispl, new_scount, new_sdispl
       INTEGER, DIMENSION(:, :), POINTER        :: pgrid
       LOGICAL                                  :: most_collective, &
                                                   remainder_collective, no_h
       INTEGER, DIMENSION(:), POINTER, CONTIGUOUS :: send_data_p, recv_data_p
       TYPE(dbcsr_mp_obj)                       :: mpe
       TYPE(mp_comm_type)                       :: all_group, grp
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:) :: all_rr, all_sr, col_rr, col_sr, row_rr, row_sr
 
       IF (.NOT. dbcsr_mp_has_subgroups(mp_env)) THEN
          mpe = mp_env
@@ -367,7 +367,7 @@ CONTAINS
       TYPE(dbcsr_data_obj), INTENT(IN)                   :: msgin
       INTEGER, INTENT(IN)                                :: dest
       TYPE(mp_comm_type), INTENT(IN)                     :: comm
-      INTEGER, INTENT(OUT)                               :: request
+      TYPE(mp_request_type), INTENT(OUT)                 :: request
       INTEGER, INTENT(IN), OPTIONAL                      :: tag
 
       SELECT CASE (dbcsr_data_get_type(msgin))
@@ -391,7 +391,7 @@ CONTAINS
       TYPE(dbcsr_data_obj), INTENT(IN)                   :: msgin
       INTEGER, INTENT(IN)                                :: source
       TYPE(mp_comm_type), INTENT(IN)                     :: comm
-      INTEGER, INTENT(OUT)                               :: request
+      TYPE(mp_request_type), INTENT(OUT)                 :: request
       INTEGER, INTENT(IN), OPTIONAL                      :: tag
 
       SELECT CASE (dbcsr_data_get_type(msgin))
@@ -411,7 +411,7 @@ CONTAINS
    SUBROUTINE dbcsr_win_create_any(base, comm, win)
       !! Window initialization function of encapsulated data.
       TYPE(dbcsr_data_obj), INTENT(IN)                   :: base
-      TYPE(mp_comm_type), INTENT(IN)                                :: comm
+      TYPE(mp_comm_type), INTENT(IN)                     :: comm
       INTEGER, INTENT(OUT)                               :: win
 
       SELECT CASE (dbcsr_data_get_type(base))
@@ -435,7 +435,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: source, win
       TYPE(dbcsr_data_obj), INTENT(IN)                   :: win_data
       INTEGER, INTENT(IN), OPTIONAL                      :: myproc, disp
-      INTEGER, INTENT(OUT)                               :: request
+      TYPE(mp_request_type), INTENT(OUT)                 :: request
       TYPE(mp_type_descriptor_type), INTENT(IN), &
          OPTIONAL                                        :: origin_datatype, target_datatype
 
@@ -465,7 +465,7 @@ CONTAINS
       TYPE(dbcsr_data_obj), INTENT(IN)                   :: base
       INTEGER, INTENT(IN)                                :: source
       TYPE(mp_comm_type), INTENT(IN)                     :: grp
-      INTEGER, INTENT(INOUT)                             :: request
+      TYPE(mp_request_type), INTENT(INOUT)               :: request
 
       SELECT CASE (dbcsr_data_get_type(base))
       CASE (dbcsr_type_real_4)
@@ -488,7 +488,7 @@ CONTAINS
       TYPE(dbcsr_data_obj), INTENT(INOUT)                :: msg
       INTEGER, INTENT(IN)                                :: recvcount, root
       TYPE(mp_comm_type), INTENT(IN)                     :: grp
-      INTEGER, INTENT(INOUT)                             :: request
+      TYPE(mp_request_type), INTENT(INOUT)               :: request
 
       IF (dbcsr_data_get_type(base) .NE. dbcsr_data_get_type(msg)) &
          DBCSR_ABORT("Different data type for msgin and msgout")
@@ -540,7 +540,7 @@ CONTAINS
       TYPE(dbcsr_data_obj), INTENT(INOUT)                :: msgout
       INTEGER, INTENT(IN)                                :: source
       TYPE(mp_comm_type), INTENT(IN)                     :: grp
-      INTEGER, INTENT(OUT)                               :: send_request, recv_request
+      TYPE(mp_request_type), INTENT(OUT)                 :: send_request, recv_request
 
       IF (dbcsr_data_get_type(msgin) .NE. dbcsr_data_get_type(msgout)) &
          DBCSR_ABORT("Different data type for msgin and msgout")
@@ -575,7 +575,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: scount
       TYPE(dbcsr_data_obj), INTENT(INOUT)                :: recv_data
       INTEGER, DIMENSION(:), CONTIGUOUS, INTENT(IN)      :: recv_count, recv_displ
-      TYPE(mp_comm_type), INTENT(IN)                                :: gid
+      TYPE(mp_comm_type), INTENT(IN)                     :: gid
 
       IF (dbcsr_data_get_type(send_data) /= dbcsr_data_get_type(recv_data)) &
          DBCSR_ABORT("Data type mismatch")
@@ -627,14 +627,14 @@ CONTAINS
          INTEGER :: mynode, mypcol, myprow, nall_rr, nall_sr, ncol_rr, &
                     ncol_sr, npcols, nprows, nrow_rr, nrow_sr, numnodes, dst, src, &
                     prow, pcol, send_cnt, recv_cnt, tag, i
-         INTEGER, ALLOCATABLE, DIMENSION(:) :: all_rr, all_sr, col_rr, col_sr, &
-                                               new_rcount, new_rdispl, new_scount, new_sdispl, row_rr, row_sr
+         INTEGER, ALLOCATABLE, DIMENSION(:) :: new_rcount, new_rdispl, new_scount, new_sdispl
          INTEGER, DIMENSION(:, :), CONTIGUOUS, POINTER :: pgrid
          LOGICAL                                  :: most_collective, &
                                                      remainder_collective, no_h
          ${type1}$, DIMENSION(:), CONTIGUOUS, POINTER :: send_data_p, recv_data_p
          TYPE(dbcsr_mp_obj)                       :: mpe
          TYPE(mp_comm_type)                       :: all_group, grp
+         TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:) :: all_rr, all_sr, col_rr, col_sr, row_rr, row_sr
 
          IF (.NOT. dbcsr_mp_has_subgroups(mp_env)) THEN
             mpe = mp_env

--- a/src/mpi/dbcsr_mp_operations.F
+++ b/src/mpi/dbcsr_mp_operations.F
@@ -30,7 +30,7 @@ MODULE dbcsr_mp_operations
       mp_allgather, mp_alltoall, mp_gatherv, mp_ibcast, mp_irecv, mp_iscatter, mp_isend, &
       mp_isendrecv, mp_rget, mp_sendrecv, mp_type_descriptor_type, mp_type_indexed_make_c, &
       mp_type_indexed_make_d, mp_type_indexed_make_r, mp_type_indexed_make_z, mp_type_make, &
-      mp_waitall, mp_win_create, mp_comm_type, mp_request_type
+      mp_waitall, mp_win_create, mp_comm_type, mp_request_type, mp_win_type
 #include "base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -412,7 +412,7 @@ CONTAINS
       !! Window initialization function of encapsulated data.
       TYPE(dbcsr_data_obj), INTENT(IN)                   :: base
       TYPE(mp_comm_type), INTENT(IN)                     :: comm
-      INTEGER, INTENT(OUT)                               :: win
+      TYPE(mp_win_type), INTENT(OUT)                     :: win
 
       SELECT CASE (dbcsr_data_get_type(base))
       CASE (dbcsr_type_real_4)
@@ -432,7 +432,8 @@ CONTAINS
       !! Single-sided Get function of encapsulated data.
                              origin_datatype, target_datatype)
       TYPE(dbcsr_data_obj), INTENT(IN)                   :: base
-      INTEGER, INTENT(IN)                                :: source, win
+      INTEGER, INTENT(IN)                                :: source
+      TYPE(mp_win_type), INTENT(IN)                      :: win
       TYPE(dbcsr_data_obj), INTENT(IN)                   :: win_data
       INTEGER, INTENT(IN), OPTIONAL                      :: myproc, disp
       TYPE(mp_request_type), INTENT(OUT)                 :: request

--- a/src/mpi/dbcsr_mpiwrap.F
+++ b/src/mpi/dbcsr_mpiwrap.F
@@ -481,116 +481,116 @@ MODULE dbcsr_mpiwrap
 
 CONTAINS
 
-   INTEGER FUNCTION mp_get_comm_handle(comm)
+   ELEMENTAL INTEGER FUNCTION mp_get_comm_handle(comm)
       CLASS(mp_comm_type), INTENT(IN) :: comm
 
       mp_get_comm_handle = comm%handle
 
    END FUNCTION mp_get_comm_handle
 
-   SUBROUTINE mp_set_comm_handle(comm, handle)
-      CLASS(mp_comm_type), INTENT(OUT) :: comm
+   ELEMENTAL SUBROUTINE mp_set_comm_handle(comm, handle)
+      CLASS(mp_comm_type), INTENT(INOUT) :: comm
       INTEGER, INTENT(IN) :: handle
 
       comm%handle = handle
 
    END SUBROUTINE mp_set_comm_handle
 
-   PURE LOGICAL FUNCTION mp_comm_op_eq(comm1, comm2)
+   ELEMENTAL LOGICAL FUNCTION mp_comm_op_eq(comm1, comm2)
       CLASS(mp_comm_type), INTENT(IN) :: comm1, comm2
 
       mp_comm_op_eq = (comm1%handle .EQ. comm2%handle)
 
    END FUNCTION mp_comm_op_eq
 
-   PURE LOGICAL FUNCTION mp_comm_op_ne(comm1, comm2)
+   ELEMENTAL LOGICAL FUNCTION mp_comm_op_ne(comm1, comm2)
       CLASS(mp_comm_type), INTENT(IN) :: comm1, comm2
 
       mp_comm_op_ne = (comm1%handle .NE. comm2%handle)
 
    END FUNCTION mp_comm_op_ne
 
-   INTEGER FUNCTION mp_get_request_handle(request)
+   ELEMENTAL INTEGER FUNCTION mp_get_request_handle(request)
       CLASS(mp_request_type), INTENT(IN) :: request
 
       mp_get_request_handle = request%handle
 
    END FUNCTION mp_get_request_handle
 
-   SUBROUTINE mp_set_request_handle(request, handle)
-      CLASS(mp_request_type), INTENT(OUT) :: request
+   ELEMENTAL SUBROUTINE mp_set_request_handle(request, handle)
+      CLASS(mp_request_type), INTENT(INOUT) :: request
       INTEGER, INTENT(IN) :: handle
 
       request%handle = handle
 
    END SUBROUTINE mp_set_request_handle
 
-   PURE LOGICAL FUNCTION mp_request_op_eq(request1, request2)
+   ELEMENTAL LOGICAL FUNCTION mp_request_op_eq(request1, request2)
       CLASS(mp_request_type), INTENT(IN) :: request1, request2
 
       mp_request_op_eq = (request1%handle .EQ. request2%handle)
 
    END FUNCTION mp_request_op_eq
 
-   PURE LOGICAL FUNCTION mp_request_op_ne(request1, request2)
+   ELEMENTAL LOGICAL FUNCTION mp_request_op_ne(request1, request2)
       CLASS(mp_request_type), INTENT(IN) :: request1, request2
 
       mp_request_op_ne = (request1%handle .NE. request2%handle)
 
    END FUNCTION mp_request_op_ne
 
-   INTEGER FUNCTION mp_get_win_handle(win)
+   ELEMENTAL INTEGER FUNCTION mp_get_win_handle(win)
       CLASS(mp_win_type), INTENT(IN) :: win
 
       mp_get_win_handle = win%handle
 
    END FUNCTION mp_get_win_handle
 
-   SUBROUTINE mp_set_win_handle(win, handle)
-      CLASS(mp_win_type), INTENT(OUT) :: win
+   ELEMENTAL SUBROUTINE mp_set_win_handle(win, handle)
+      CLASS(mp_win_type), INTENT(INOUT) :: win
       INTEGER, INTENT(IN) :: handle
 
       win%handle = handle
 
    END SUBROUTINE mp_set_win_handle
 
-   PURE LOGICAL FUNCTION mp_win_op_eq(win1, win2)
+   ELEMENTAL LOGICAL FUNCTION mp_win_op_eq(win1, win2)
       CLASS(mp_win_type), INTENT(IN) :: win1, win2
 
       mp_win_op_eq = (win1%handle .EQ. win2%handle)
 
    END FUNCTION mp_win_op_eq
 
-   PURE LOGICAL FUNCTION mp_win_op_ne(win1, win2)
+   ELEMENTAL LOGICAL FUNCTION mp_win_op_ne(win1, win2)
       CLASS(mp_win_type), INTENT(IN) :: win1, win2
 
       mp_win_op_ne = (win1%handle .NE. win2%handle)
 
    END FUNCTION mp_win_op_ne
 
-   INTEGER FUNCTION mp_get_file_handle(file)
+   ELEMENTAL INTEGER FUNCTION mp_get_file_handle(file)
       CLASS(mp_file_type), INTENT(IN) :: file
 
       mp_get_file_handle = file%handle
 
    END FUNCTION mp_get_file_handle
 
-   SUBROUTINE mp_set_file_handle(file, handle)
-      CLASS(mp_file_type), INTENT(OUT) :: file
+   ELEMENTAL SUBROUTINE mp_set_file_handle(file, handle)
+      CLASS(mp_file_type), INTENT(INOUT) :: file
       INTEGER, INTENT(IN) :: handle
 
       file%handle = handle
 
    END SUBROUTINE mp_set_file_handle
 
-   PURE LOGICAL FUNCTION mp_file_op_eq(file1, file2)
+   ELEMENTAL LOGICAL FUNCTION mp_file_op_eq(file1, file2)
       CLASS(mp_file_type), INTENT(IN) :: file1, file2
 
       mp_file_op_eq = (file1%handle .EQ. file2%handle)
 
    END FUNCTION mp_file_op_eq
 
-   PURE LOGICAL FUNCTION mp_file_op_ne(file1, file2)
+   ELEMENTAL LOGICAL FUNCTION mp_file_op_ne(file1, file2)
       CLASS(mp_file_type), INTENT(IN) :: file1, file2
 
       mp_file_op_ne = (file1%handle .NE. file2%handle)

--- a/src/mpi/dbcsr_mpiwrap.F
+++ b/src/mpi/dbcsr_mpiwrap.F
@@ -60,7 +60,7 @@ MODULE dbcsr_mpiwrap
    INTEGER, PARAMETER :: mp_comm_self_handle = MPI_COMM_SELF
    INTEGER, PARAMETER :: mp_comm_world_handle = MPI_COMM_WORLD
    INTEGER, PARAMETER :: mp_request_null_handle = MPI_REQUEST_NULL
-   INTEGER, PARAMETER, PUBLIC :: mp_win_null = MPI_WIN_NULL
+   INTEGER, PARAMETER :: mp_win_null_handle = MPI_WIN_NULL
    INTEGER, PARAMETER, PUBLIC :: mp_status_size = MPI_STATUS_SIZE
    INTEGER, PARAMETER, PUBLIC :: mp_proc_null = MPI_PROC_NULL
    ! Set max allocatable memory by MPI to 2 GiByte
@@ -85,7 +85,7 @@ MODULE dbcsr_mpiwrap
    INTEGER, PARAMETER :: mp_comm_self_handle = -11
    INTEGER, PARAMETER :: mp_comm_world_handle = -12
    INTEGER, PARAMETER :: mp_request_null_handle = -4
-   INTEGER, PARAMETER, PUBLIC :: mp_win_null = -5
+   INTEGER, PARAMETER :: mp_win_null_handle = -5
    INTEGER, PARAMETER, PUBLIC :: mp_status_size = -6
    INTEGER, PARAMETER, PUBLIC :: mp_proc_null = -7
    INTEGER, PARAMETER, PUBLIC :: mp_max_library_version_string = 1
@@ -126,11 +126,24 @@ MODULE dbcsr_mpiwrap
       GENERIC, PUBLIC :: OPERATOR(.NE.) => mp_request_op_ne
    END TYPE mp_request_type
 
+   TYPE mp_win_type
+      PRIVATE
+      INTEGER :: handle = mp_win_null_handle
+   CONTAINS
+      PROCEDURE, PUBLIC, PASS(win), NON_OVERRIDABLE :: get_handle => mp_get_win_handle
+      PROCEDURE, PUBLIC, PASS(win), NON_OVERRIDABLE :: set_handle => mp_set_win_handle
+      PROCEDURE, PRIVATE, PASS(win1), NON_OVERRIDABLE :: mp_win_op_eq
+      GENERIC, PUBLIC :: OPERATOR(.EQ.) => mp_win_op_eq
+      PROCEDURE, PRIVATE, PASS(win1), NON_OVERRIDABLE :: mp_win_op_ne
+      GENERIC, PUBLIC :: OPERATOR(.NE.) => mp_win_op_ne
+   END TYPE mp_win_type
+
    ! The actual MPI wrapper constants
    TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_null = mp_comm_type(mp_comm_null_handle)
    TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_self = mp_comm_type(mp_comm_self_handle)
    TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_world = mp_comm_type(mp_comm_world_handle)
    TYPE(mp_request_type), PARAMETER, PUBLIC :: mp_request_null = mp_request_type(mp_request_null_handle)
+   TYPE(mp_win_type), PARAMETER, PUBLIC :: mp_win_null = mp_win_type(mp_win_null_handle)
 
    ! we need to fix this to a given number (crossing fingers)
    ! so that the serial code using Fortran stream IO and the MPI have the same sizes.
@@ -147,6 +160,7 @@ MODULE dbcsr_mpiwrap
    ! types
    PUBLIC :: mp_comm_type
    PUBLIC :: mp_request_type
+   PUBLIC :: mp_win_type
 
    ! init and error
    PUBLIC :: mp_world_init, mp_world_finalize
@@ -509,6 +523,35 @@ CONTAINS
       mp_request_op_ne = (request1%handle .NE. request2%handle)
 
    END FUNCTION mp_request_op_ne
+
+   INTEGER FUNCTION mp_get_win_handle(win)
+      CLASS(mp_win_type), INTENT(IN) :: win
+
+      mp_get_win_handle = win%handle
+
+   END FUNCTION mp_get_win_handle
+
+   SUBROUTINE mp_set_win_handle(win, handle)
+      CLASS(mp_win_type), INTENT(OUT) :: win
+      INTEGER, INTENT(IN) :: handle
+
+      win%handle = handle
+
+   END SUBROUTINE mp_set_win_handle
+
+   PURE LOGICAL FUNCTION mp_win_op_eq(win1, win2)
+      CLASS(mp_win_type), INTENT(IN) :: win1, win2
+
+      mp_win_op_eq = (win1%handle .EQ. win2%handle)
+
+   END FUNCTION mp_win_op_eq
+
+   PURE LOGICAL FUNCTION mp_win_op_ne(win1, win2)
+      CLASS(mp_win_type), INTENT(IN) :: win1, win2
+
+      mp_win_op_ne = (win1%handle .NE. win2%handle)
+
+   END FUNCTION mp_win_op_ne
 
    SUBROUTINE mp_world_init(mp_comm)
       !! initializes the system default communicator
@@ -2656,7 +2699,7 @@ CONTAINS
 
    SUBROUTINE mp_win_free(win)
       !! Window free
-      INTEGER, INTENT(INOUT)                             :: win
+      TYPE(mp_win_type), INTENT(INOUT)                   :: win
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_win_free'
 
@@ -2667,7 +2710,7 @@ CONTAINS
 
 #if defined(__parallel)
 
-      CALL mpi_win_free(win, ierr)
+      CALL mpi_win_free(win%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_win_free @ "//routineN)
 #else
       MARK_USED(win)
@@ -2678,7 +2721,7 @@ CONTAINS
 
    SUBROUTINE mp_win_flush_all(win)
       !! Window flush
-      INTEGER, INTENT(IN)                                :: win
+      TYPE(mp_win_type), INTENT(IN)                      :: win
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_win_flush_all'
 
@@ -2688,7 +2731,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
 #if defined(__parallel)
-      CALL mpi_win_flush_all(win, ierr)
+      CALL mpi_win_flush_all(win%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_win_flush_all @ "//routineN)
 #else
       MARK_USED(win)
@@ -2698,7 +2741,7 @@ CONTAINS
 
    SUBROUTINE mp_win_lock_all(win)
       !! Window lock
-      INTEGER, INTENT(INOUT)                             :: win
+      TYPE(mp_win_type), INTENT(INOUT)                   :: win
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_win_lock_all'
 
@@ -2709,7 +2752,7 @@ CONTAINS
 
 #if defined(__parallel)
 
-      CALL mpi_win_lock_all(MPI_MODE_NOCHECK, win, ierr)
+      CALL mpi_win_lock_all(MPI_MODE_NOCHECK, win%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_win_lock_all @ "//routineN)
 #else
       MARK_USED(win)
@@ -2719,7 +2762,7 @@ CONTAINS
 
    SUBROUTINE mp_win_unlock_all(win)
       !! Window lock
-      INTEGER, INTENT(INOUT)                             :: win
+      TYPE(mp_win_type), INTENT(INOUT)                   :: win
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_win_unlock_all'
 
@@ -2730,7 +2773,7 @@ CONTAINS
 
 #if defined(__parallel)
 
-      CALL mpi_win_unlock_all(win, ierr)
+      CALL mpi_win_unlock_all(win%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_win_unlock_all @ "//routineN)
 #else
       MARK_USED(win)
@@ -5017,8 +5060,8 @@ CONTAINS
       !! arrays can be pointers or assumed shape, but they must be contiguous!
 
          ${type1}$, CONTIGUOUS, DIMENSION(:) :: base
-         TYPE(mp_comm_type), INTENT(IN)            :: comm
-         INTEGER, INTENT(INOUT)         :: win
+         TYPE(mp_comm_type), INTENT(IN)      :: comm
+         TYPE(mp_win_type), INTENT(OUT)      :: win
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_win_create_${nametype1}$v'
 
@@ -5035,9 +5078,9 @@ CONTAINS
 
          len = SIZE(base)*${bytes1}$
          IF (len > 0) THEN
-            CALL mpi_win_create(base(1), len, ${bytes1}$, MPI_INFO_NULL, comm%handle, win, ierr)
+            CALL mpi_win_create(base(1), len, ${bytes1}$, MPI_INFO_NULL, comm%handle, win%handle, ierr)
          ELSE
-            CALL mpi_win_create(foo, len, ${bytes1}$, MPI_INFO_NULL, comm%handle, win, ierr)
+            CALL mpi_win_create(foo, len, ${bytes1}$, MPI_INFO_NULL, comm%handle, win%handle, ierr)
          END IF
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_win_create @ "//routineN)
 #else
@@ -5055,7 +5098,8 @@ CONTAINS
       !! arrays can be pointers or assumed shape, but they must be contiguous!
 
          ${type1}$, CONTIGUOUS, DIMENSION(:)                 :: base
-         INTEGER, INTENT(IN)                                 :: source, win
+         INTEGER, INTENT(IN)                                 :: source
+         TYPE(mp_win_type), INTENT(IN)                       :: win
          ${type1}$, CONTIGUOUS, DIMENSION(:)                 :: win_data
          INTEGER, INTENT(IN), OPTIONAL                       :: myproc, disp
          TYPE(mp_request_type), INTENT(OUT)                  :: request
@@ -5115,7 +5159,7 @@ CONTAINS
                ierr = 0
             ELSE
                CALL mpi_rget(base(1), origin_len, handle_origin_datatype, source, disp_aint, &
-                             target_len, handle_target_datatype, win, request%handle, ierr)
+                             target_len, handle_target_datatype, win%handle, request%handle, ierr)
             END IF
          ELSE
             request = mp_request_null

--- a/src/mpi/dbcsr_mpiwrap.F
+++ b/src/mpi/dbcsr_mpiwrap.F
@@ -61,6 +61,7 @@ MODULE dbcsr_mpiwrap
    INTEGER, PARAMETER :: mp_comm_world_handle = MPI_COMM_WORLD
    INTEGER, PARAMETER :: mp_request_null_handle = MPI_REQUEST_NULL
    INTEGER, PARAMETER :: mp_win_null_handle = MPI_WIN_NULL
+   INTEGER, PARAMETER :: mp_file_null_handle = MPI_FILE_NULL
    INTEGER, PARAMETER, PUBLIC :: mp_status_size = MPI_STATUS_SIZE
    INTEGER, PARAMETER, PUBLIC :: mp_proc_null = MPI_PROC_NULL
    ! Set max allocatable memory by MPI to 2 GiByte
@@ -86,8 +87,9 @@ MODULE dbcsr_mpiwrap
    INTEGER, PARAMETER :: mp_comm_world_handle = -12
    INTEGER, PARAMETER :: mp_request_null_handle = -4
    INTEGER, PARAMETER :: mp_win_null_handle = -5
-   INTEGER, PARAMETER, PUBLIC :: mp_status_size = -6
-   INTEGER, PARAMETER, PUBLIC :: mp_proc_null = -7
+   INTEGER, PARAMETER :: mp_file_null_handle = -6
+   INTEGER, PARAMETER, PUBLIC :: mp_status_size = -7
+   INTEGER, PARAMETER, PUBLIC :: mp_proc_null = -8
    INTEGER, PARAMETER, PUBLIC :: mp_max_library_version_string = 1
    INTEGER, PARAMETER, PUBLIC :: mp_max_processor_name = 1
 
@@ -138,6 +140,18 @@ MODULE dbcsr_mpiwrap
       GENERIC, PUBLIC :: OPERATOR(.NE.) => mp_win_op_ne
    END TYPE mp_win_type
 
+   TYPE mp_file_type
+      PRIVATE
+      INTEGER :: handle = mp_file_null_handle
+   CONTAINS
+      PROCEDURE, PUBLIC, PASS(file), NON_OVERRIDABLE :: get_handle => mp_get_file_handle
+      PROCEDURE, PUBLIC, PASS(file), NON_OVERRIDABLE :: set_handle => mp_set_file_handle
+      PROCEDURE, PRIVATE, PASS(file1), NON_OVERRIDABLE :: mp_file_op_eq
+      GENERIC, PUBLIC :: OPERATOR(.EQ.) => mp_file_op_eq
+      PROCEDURE, PRIVATE, PASS(file1), NON_OVERRIDABLE :: mp_file_op_ne
+      GENERIC, PUBLIC :: OPERATOR(.NE.) => mp_file_op_ne
+   END TYPE mp_file_type
+
    ! The actual MPI wrapper constants
    TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_null = mp_comm_type(mp_comm_null_handle)
    TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_self = mp_comm_type(mp_comm_self_handle)
@@ -161,6 +175,7 @@ MODULE dbcsr_mpiwrap
    PUBLIC :: mp_comm_type
    PUBLIC :: mp_request_type
    PUBLIC :: mp_win_type
+   PUBLIC :: mp_file_type
 
    ! init and error
    PUBLIC :: mp_world_init, mp_world_finalize
@@ -552,6 +567,35 @@ CONTAINS
       mp_win_op_ne = (win1%handle .NE. win2%handle)
 
    END FUNCTION mp_win_op_ne
+
+   INTEGER FUNCTION mp_get_file_handle(file)
+      CLASS(mp_file_type), INTENT(IN) :: file
+
+      mp_get_file_handle = file%handle
+
+   END FUNCTION mp_get_file_handle
+
+   SUBROUTINE mp_set_file_handle(file, handle)
+      CLASS(mp_file_type), INTENT(OUT) :: file
+      INTEGER, INTENT(IN) :: handle
+
+      file%handle = handle
+
+   END SUBROUTINE mp_set_file_handle
+
+   PURE LOGICAL FUNCTION mp_file_op_eq(file1, file2)
+      CLASS(mp_file_type), INTENT(IN) :: file1, file2
+
+      mp_file_op_eq = (file1%handle .EQ. file2%handle)
+
+   END FUNCTION mp_file_op_eq
+
+   PURE LOGICAL FUNCTION mp_file_op_ne(file1, file2)
+      CLASS(mp_file_type), INTENT(IN) :: file1, file2
+
+      mp_file_op_ne = (file1%handle .NE. file2%handle)
+
+   END FUNCTION mp_file_op_ne
 
    SUBROUTINE mp_world_init(mp_comm)
       !! initializes the system default communicator
@@ -2306,9 +2350,9 @@ CONTAINS
       !!
       !! STREAM-I/O mapping  OPEN
 
-      TYPE(mp_comm_type), INTENT(IN)                      :: groupid
+      TYPE(mp_comm_type), INTENT(IN)           :: groupid
          !! message passing environment identifier
-      INTEGER, INTENT(OUT)                     :: fh
+      TYPE(mp_file_type), INTENT(OUT)          :: fh
          !! file handle (file storage unit)
       CHARACTER(LEN=*), INTENT(IN)             :: filepath
          !! path to the file
@@ -2331,8 +2375,8 @@ CONTAINS
 #if defined(__parallel)
       my_info = mpi_info_null
       IF (PRESENT(info)) my_info = info
-      CALL mpi_file_open(groupid%handle, filepath, amode_status, my_info, fh, ierr)
-      CALL mpi_file_set_errhandler(fh, MPI_ERRORS_RETURN, ierr)
+      CALL mpi_file_open(groupid%handle, filepath, amode_status, my_info, fh%handle, ierr)
+      CALL mpi_file_set_errhandler(fh%handle, MPI_ERRORS_RETURN, ierr)
       IF (ierr .NE. 0) CALL mp_stop(ierr, "mpi_file_set_errhandler @ mp_file_open")
 #else
       MARK_USED(groupid)
@@ -2352,11 +2396,11 @@ CONTAINS
          fstatus = "OLD"
       END IF
       ! Get a new unit number
-      DO fh = 1, 999
-         INQUIRE (UNIT=fh, EXIST=exists, OPENED=is_open, IOSTAT=istat)
+      DO fh%handle = 1, 999
+         INQUIRE (UNIT=fh%handle, EXIST=exists, OPENED=is_open, IOSTAT=istat)
          IF (exists .AND. (.NOT. is_open) .AND. (istat == 0)) EXIT
       END DO
-      OPEN (UNIT=fh, FILE=filepath, STATUS=fstatus, ACCESS="STREAM", POSITION=fposition)
+      OPEN (UNIT=fh%handle, FILE=filepath, STATUS=fstatus, ACCESS="STREAM", POSITION=fposition)
 #endif
    END SUBROUTINE mp_file_open
 
@@ -2397,18 +2441,18 @@ CONTAINS
       !!
       !! STREAM-I/O mapping   CLOSE
 
-      INTEGER, INTENT(INOUT)                             :: fh
+      TYPE(mp_file_type), INTENT(INOUT)                  :: fh
          !! file handle (file storage unit)
 
       INTEGER                                            :: ierr
 
       ierr = 0
 #if defined(__parallel)
-      CALL mpi_file_set_errhandler(fh, MPI_ERRORS_RETURN, ierr)
-      CALL mpi_file_close(fh, ierr)
+      CALL mpi_file_set_errhandler(fh%handle, MPI_ERRORS_RETURN, ierr)
+      CALL mpi_file_close(fh%handle, ierr)
       IF (ierr .NE. 0) CALL mp_stop(ierr, "mpi_file_set_errhandler @ mp_file_close")
 #else
-      CLOSE (fh)
+      CLOSE (fh%handle)
 #endif
    END SUBROUTINE mp_file_close
 
@@ -2419,7 +2463,7 @@ CONTAINS
       !!
       !! STREAM-I/O mapping   INQUIRE
 
-      INTEGER, INTENT(IN)                                :: fh
+      TYPE(mp_file_type), INTENT(IN)                     :: fh
          !! file handle (file storage unit)
       INTEGER(kind=file_offset), INTENT(OUT)             :: file_size
          !! the file size
@@ -2428,11 +2472,11 @@ CONTAINS
 
       ierr = 0
 #if defined(__parallel)
-      CALL mpi_file_set_errhandler(fh, MPI_ERRORS_RETURN, ierr)
-      CALL mpi_file_get_size(fh, file_size, ierr)
+      CALL mpi_file_set_errhandler(fh%handle, MPI_ERRORS_RETURN, ierr)
+      CALL mpi_file_get_size(fh%handle, file_size, ierr)
       IF (ierr .NE. 0) CALL mp_stop(ierr, "mpi_file_set_errhandler @ mp_file_get_size")
 #else
-      INQUIRE (UNIT=fh, SIZE=file_size)
+      INQUIRE (UNIT=fh%handle, SIZE=file_size)
 #endif
    END SUBROUTINE mp_file_get_size
 
@@ -2443,7 +2487,7 @@ CONTAINS
       !!
       !! STREAM-I/O mapping   INQUIRE
 
-      INTEGER, INTENT(IN)                                :: fh
+      TYPE(mp_file_type), INTENT(IN)                     :: fh
          !! file handle (file storage unit)
       INTEGER(kind=file_offset), INTENT(OUT)             :: pos
          !! the file position
@@ -2452,17 +2496,17 @@ CONTAINS
 
       ierr = 0
 #if defined(__parallel)
-      CALL mpi_file_set_errhandler(fh, MPI_ERRORS_RETURN, ierr)
-      CALL mpi_file_get_position(fh, pos, ierr)
+      CALL mpi_file_set_errhandler(fh%handle, MPI_ERRORS_RETURN, ierr)
+      CALL mpi_file_get_position(fh%handle, pos, ierr)
       IF (ierr .NE. 0) CALL mp_stop(ierr, "mpi_file_set_errhandler @ mp_file_get_position")
 #else
-      INQUIRE (UNIT=fh, POS=pos)
+      INQUIRE (UNIT=fh%handle, POS=pos)
 #endif
    END SUBROUTINE mp_file_get_position
 
    SUBROUTINE mp_file_write_at_ch(fh, offset, msg)
       CHARACTER(LEN=*), INTENT(IN)               :: msg
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)             :: fh
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
 #if defined(__parallel)
@@ -2470,17 +2514,17 @@ CONTAINS
 
       INTEGER                                    :: ierr
 
-      CALL MPI_FILE_WRITE_AT(fh, offset, msg, LEN(msg), MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_WRITE_AT(fh%handle, offset, msg, LEN(msg), MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          DBCSR_ABORT("mpi_file_write_at_ch @ "//routineN)
 #else
-      WRITE (UNIT=fh, POS=offset + 1) msg
+      WRITE (UNIT=fh%handle, POS=offset + 1) msg
 #endif
    END SUBROUTINE mp_file_write_at_ch
 
    SUBROUTINE mp_file_write_at_all_ch(fh, offset, msg)
       CHARACTER(LEN=*), INTENT(IN)               :: msg
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)             :: fh
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
 #if defined(__parallel)
@@ -2488,17 +2532,17 @@ CONTAINS
 
       INTEGER                                    :: ierr
 
-      CALL MPI_FILE_WRITE_AT_ALL(fh, offset, msg, LEN(msg), MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_WRITE_AT_ALL(fh%handle, offset, msg, LEN(msg), MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          DBCSR_ABORT("mpi_file_write_at_all_ch @ "//routineN)
 #else
-      WRITE (UNIT=fh, POS=offset + 1) msg
+      WRITE (UNIT=fh%handle, POS=offset + 1) msg
 #endif
    END SUBROUTINE mp_file_write_at_all_ch
 
    SUBROUTINE mp_file_read_at_all_ch(fh, offset, msg)
       CHARACTER(LEN=*), INTENT(OUT)              :: msg
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)             :: fh
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
 #if defined(__parallel)
@@ -2506,11 +2550,11 @@ CONTAINS
 
       INTEGER                                    :: ierr
 
-      CALL MPI_FILE_READ_AT_ALL(fh, offset, msg, LEN(msg), MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_READ_AT_ALL(fh%handle, offset, msg, LEN(msg), MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          DBCSR_ABORT("mpi_file_read_at_all_ch @ "//routineN)
 #else
-      READ (UNIT=fh, POS=offset + 1) msg
+      READ (UNIT=fh%handle, POS=offset + 1) msg
 #endif
    END SUBROUTINE mp_file_read_at_all_ch
 
@@ -5294,7 +5338,7 @@ CONTAINS
 
          ${type1}$, INTENT(IN)                      :: msg(:)
          !! data to be written to the file
-         INTEGER, INTENT(IN)                        :: fh
+         TYPE(mp_file_type), INTENT(IN)             :: fh
          !! file handle (file storage unit)
          INTEGER, INTENT(IN), OPTIONAL              :: msglen
          !! number of the elements of data
@@ -5311,12 +5355,12 @@ CONTAINS
             CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_file_write_at_${nametype1}$v'
             INTEGER :: ierr
             ierr = 0
-            CALL MPI_FILE_WRITE_AT(fh, offset, msg, msg_len, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
+            CALL MPI_FILE_WRITE_AT(fh%handle, offset, msg, msg_len, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
             IF (ierr .NE. 0) &
                DBCSR_ABORT("mpi_file_write_at_${nametype1}$v @ "//routineN)
          END BLOCK
 #else
-         WRITE (UNIT=fh, POS=offset + 1) msg(1:msg_len)
+         WRITE (UNIT=fh%handle, POS=offset + 1) msg(1:msg_len)
 #endif
       END SUBROUTINE mp_file_write_at_${nametype1}$v
 
@@ -5324,7 +5368,7 @@ CONTAINS
 ! *****************************************************************************
       SUBROUTINE mp_file_write_at_${nametype1}$ (fh, offset, msg)
          ${type1}$, INTENT(IN)                      :: msg
-         INTEGER, INTENT(IN)                        :: fh
+         TYPE(mp_file_type), INTENT(IN)             :: fh
          INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
 #if defined(__parallel)
@@ -5333,11 +5377,11 @@ CONTAINS
          INTEGER                                    :: ierr
 
          ierr = 0
-         CALL MPI_FILE_WRITE_AT(fh, offset, msg, 1, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
+         CALL MPI_FILE_WRITE_AT(fh%handle, offset, msg, 1, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
          IF (ierr .NE. 0) &
             DBCSR_ABORT("mpi_file_write_at_${nametype1}$ @ "//routineN)
 #else
-         WRITE (UNIT=fh, POS=offset + 1) msg
+         WRITE (UNIT=fh%handle, POS=offset + 1) msg
 #endif
       END SUBROUTINE mp_file_write_at_${nametype1}$
 
@@ -5350,7 +5394,7 @@ CONTAINS
       !! STREAM-I/O mapping   WRITE
 
          ${type1}$, INTENT(IN)                      :: msg(:)
-         INTEGER, INTENT(IN)                        :: fh
+         TYPE(mp_file_type), INTENT(IN)             :: fh
          INTEGER, INTENT(IN), OPTIONAL              :: msglen
          INTEGER                                    :: msg_len
          INTEGER(kind=file_offset), INTENT(IN)      :: offset
@@ -5363,12 +5407,12 @@ CONTAINS
             INTEGER                                    :: ierr
             ierr = 0
 
-            CALL MPI_FILE_WRITE_AT_ALL(fh, offset, msg, msg_len, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
+            CALL MPI_FILE_WRITE_AT_ALL(fh%handle, offset, msg, msg_len, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
             IF (ierr .NE. 0) &
                DBCSR_ABORT("mpi_file_write_at_all_${nametype1}$v @ "//routineN)
          END BLOCK
 #else
-         WRITE (UNIT=fh, POS=offset + 1) msg(1:msg_len)
+         WRITE (UNIT=fh%handle, POS=offset + 1) msg(1:msg_len)
 #endif
       END SUBROUTINE mp_file_write_at_all_${nametype1}$v
 
@@ -5376,7 +5420,7 @@ CONTAINS
 ! *****************************************************************************
       SUBROUTINE mp_file_write_at_all_${nametype1}$ (fh, offset, msg)
          ${type1}$, INTENT(IN)                      :: msg
-         INTEGER, INTENT(IN)                        :: fh
+         TYPE(mp_file_type), INTENT(IN)             :: fh
          INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
 #if defined(__parallel)
@@ -5385,11 +5429,11 @@ CONTAINS
          INTEGER                                    :: ierr
 
          ierr = 0
-         CALL MPI_FILE_WRITE_AT_ALL(fh, offset, msg, 1, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
+         CALL MPI_FILE_WRITE_AT_ALL(fh%handle, offset, msg, 1, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
          IF (ierr .NE. 0) &
             DBCSR_ABORT("mpi_file_write_at_all_${nametype1}$ @ "//routineN)
 #else
-         WRITE (UNIT=fh, POS=offset + 1) msg
+         WRITE (UNIT=fh%handle, POS=offset + 1) msg
 #endif
       END SUBROUTINE mp_file_write_at_all_${nametype1}$
 
@@ -5404,7 +5448,7 @@ CONTAINS
       !! STREAM-I/O mapping   READ
 
          ${type1}$, INTENT(OUT)                     :: msg(:)
-         INTEGER, INTENT(IN)                        :: fh
+         TYPE(mp_file_type), INTENT(IN)             :: fh
          INTEGER, INTENT(IN), OPTIONAL              :: msglen
          INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
@@ -5418,12 +5462,12 @@ CONTAINS
             INTEGER                                    :: ierr
             ierr = 0
 
-            CALL MPI_FILE_READ_AT_ALL(fh, offset, msg, msg_len, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
+            CALL MPI_FILE_READ_AT_ALL(fh%handle, offset, msg, msg_len, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
             IF (ierr .NE. 0) &
                DBCSR_ABORT("mpi_file_read_at_all_${nametype1}$v @ "//routineN)
          END BLOCK
 #else
-         READ (UNIT=fh, POS=offset + 1) msg(1:msg_len)
+         READ (UNIT=fh%handle, POS=offset + 1) msg(1:msg_len)
 #endif
       END SUBROUTINE mp_file_read_at_all_${nametype1}$v
 
@@ -5431,7 +5475,7 @@ CONTAINS
 ! *****************************************************************************
       SUBROUTINE mp_file_read_at_all_${nametype1}$ (fh, offset, msg)
          ${type1}$, INTENT(OUT)                     :: msg
-         INTEGER, INTENT(IN)                        :: fh
+         TYPE(mp_file_type), INTENT(IN)             :: fh
          INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
 #if defined(__parallel)
@@ -5440,11 +5484,11 @@ CONTAINS
          INTEGER                                    :: ierr
 
          ierr = 0
-         CALL MPI_FILE_READ_AT_ALL(fh, offset, msg, 1, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
+         CALL MPI_FILE_READ_AT_ALL(fh%handle, offset, msg, 1, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
          IF (ierr .NE. 0) &
             DBCSR_ABORT("mpi_file_read_at_all_${nametype1}$ @ "//routineN)
 #else
-         READ (UNIT=fh, POS=offset + 1) msg
+         READ (UNIT=fh%handle, POS=offset + 1) msg
 #endif
       END SUBROUTINE mp_file_read_at_all_${nametype1}$
 

--- a/src/mpi/dbcsr_mpiwrap.F
+++ b/src/mpi/dbcsr_mpiwrap.F
@@ -59,7 +59,7 @@ MODULE dbcsr_mpiwrap
    INTEGER, PARAMETER :: mp_comm_null_handle = MPI_COMM_NULL
    INTEGER, PARAMETER :: mp_comm_self_handle = MPI_COMM_SELF
    INTEGER, PARAMETER :: mp_comm_world_handle = MPI_COMM_WORLD
-   INTEGER, PARAMETER, PUBLIC :: mp_request_null = MPI_REQUEST_NULL
+   INTEGER, PARAMETER :: mp_request_null_handle = MPI_REQUEST_NULL
    INTEGER, PARAMETER, PUBLIC :: mp_win_null = MPI_WIN_NULL
    INTEGER, PARAMETER, PUBLIC :: mp_status_size = MPI_STATUS_SIZE
    INTEGER, PARAMETER, PUBLIC :: mp_proc_null = MPI_PROC_NULL
@@ -84,7 +84,7 @@ MODULE dbcsr_mpiwrap
    INTEGER, PARAMETER :: mp_comm_null_handle = -3
    INTEGER, PARAMETER :: mp_comm_self_handle = -11
    INTEGER, PARAMETER :: mp_comm_world_handle = -12
-   INTEGER, PARAMETER, PUBLIC :: mp_request_null = -4
+   INTEGER, PARAMETER :: mp_request_null_handle = -4
    INTEGER, PARAMETER, PUBLIC :: mp_win_null = -5
    INTEGER, PARAMETER, PUBLIC :: mp_status_size = -6
    INTEGER, PARAMETER, PUBLIC :: mp_proc_null = -7
@@ -114,10 +114,23 @@ MODULE dbcsr_mpiwrap
       GENERIC, PUBLIC :: OPERATOR(.NE.) => mp_comm_op_ne
    END TYPE mp_comm_type
 
+   TYPE mp_request_type
+      PRIVATE
+      INTEGER :: handle = mp_request_null_handle
+   CONTAINS
+      PROCEDURE, PUBLIC, PASS(request), NON_OVERRIDABLE :: get_handle => mp_get_request_handle
+      PROCEDURE, PUBLIC, PASS(request), NON_OVERRIDABLE :: set_handle => mp_set_request_handle
+      PROCEDURE, PRIVATE, PASS(request1), NON_OVERRIDABLE :: mp_request_op_eq
+      GENERIC, PUBLIC :: OPERATOR(.EQ.) => mp_request_op_eq
+      PROCEDURE, PRIVATE, PASS(request1), NON_OVERRIDABLE :: mp_request_op_ne
+      GENERIC, PUBLIC :: OPERATOR(.NE.) => mp_request_op_ne
+   END TYPE mp_request_type
+
    ! The actual MPI wrapper constants
    TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_null = mp_comm_type(mp_comm_null_handle)
    TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_self = mp_comm_type(mp_comm_self_handle)
    TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_world = mp_comm_type(mp_comm_world_handle)
+   TYPE(mp_request_type), PARAMETER, PUBLIC :: mp_request_null = mp_request_type(mp_request_null_handle)
 
    ! we need to fix this to a given number (crossing fingers)
    ! so that the serial code using Fortran stream IO and the MPI have the same sizes.
@@ -133,6 +146,7 @@ MODULE dbcsr_mpiwrap
 
    ! types
    PUBLIC :: mp_comm_type
+   PUBLIC :: mp_request_type
 
    ! init and error
    PUBLIC :: mp_world_init, mp_world_finalize
@@ -466,6 +480,35 @@ CONTAINS
       mp_comm_op_ne = (comm1%handle .NE. comm2%handle)
 
    END FUNCTION mp_comm_op_ne
+
+   INTEGER FUNCTION mp_get_request_handle(request)
+      CLASS(mp_request_type), INTENT(IN) :: request
+
+      mp_get_request_handle = request%handle
+
+   END FUNCTION mp_get_request_handle
+
+   SUBROUTINE mp_set_request_handle(request, handle)
+      CLASS(mp_request_type), INTENT(OUT) :: request
+      INTEGER, INTENT(IN) :: handle
+
+      request%handle = handle
+
+   END SUBROUTINE mp_set_request_handle
+
+   PURE LOGICAL FUNCTION mp_request_op_eq(request1, request2)
+      CLASS(mp_request_type), INTENT(IN) :: request1, request2
+
+      mp_request_op_eq = (request1%handle .EQ. request2%handle)
+
+   END FUNCTION mp_request_op_eq
+
+   PURE LOGICAL FUNCTION mp_request_op_ne(request1, request2)
+      CLASS(mp_request_type), INTENT(IN) :: request1, request2
+
+      mp_request_op_ne = (request1%handle .NE. request2%handle)
+
+   END FUNCTION mp_request_op_ne
 
    SUBROUTINE mp_world_init(mp_comm)
       !! initializes the system default communicator
@@ -841,7 +884,7 @@ CONTAINS
 
       TYPE(mp_comm_type), INTENT(IN)                                :: group
          !! mpi communicator
-      INTEGER, INTENT(OUT)                               :: request
+      TYPE(mp_request_type), INTENT(OUT)                               :: request
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_isync'
 
@@ -851,7 +894,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
 #if defined(__parallel)
-      CALL mpi_ibarrier(group%handle, request, ierr)
+      CALL mpi_ibarrier(group%handle, request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ibarrier @ "//routineN)
 #else
       MARK_USED(group)
@@ -1235,7 +1278,7 @@ CONTAINS
       !! @note
       !! see isendrecv
 
-      INTEGER, INTENT(inout)                             :: request
+      TYPE(mp_request_type), INTENT(inout)                             :: request
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_wait'
 
@@ -1245,7 +1288,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
 #if defined(__parallel)
-      CALL mpi_wait(request, MPI_STATUS_IGNORE, ierr)
+      CALL mpi_wait(request%handle, MPI_STATUS_IGNORE, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_wait @ "//routineN)
 #else
       MARK_USED(request)
@@ -1258,7 +1301,7 @@ CONTAINS
       !! @note
       !! see isendrecv
 
-      INTEGER, DIMENSION(:), CONTIGUOUS, INTENT(inout) :: requests
+      TYPE(mp_request_type), DIMENSION(:), INTENT(inout) :: requests
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_waitall_1'
 
@@ -1285,7 +1328,7 @@ CONTAINS
 
    SUBROUTINE mp_waitall_2(requests)
       !! waits for completion of the given requests
-      INTEGER, DIMENSION(:, :), CONTIGUOUS, INTENT(inout)  :: requests
+      TYPE(mp_request_type), DIMENSION(:, :), INTENT(inout)  :: requests
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_waitall_2'
 
@@ -1317,26 +1360,38 @@ CONTAINS
       !! the issue is with the rank or requests
 
       INTEGER, INTENT(in)                                :: count
-      INTEGER, DIMENSION(count), INTENT(inout)           :: array_of_requests
+      TYPE(mp_request_type), DIMENSION(count), INTENT(inout)           :: array_of_requests
       INTEGER, DIMENSION(MPI_STATUS_SIZE, *), &
          INTENT(out)                                     :: array_of_statuses
       INTEGER, INTENT(out)                               :: ierr
 
-      CALL mpi_waitall(count, array_of_requests, array_of_statuses, ierr)
+      INTEGER :: i
+      INTEGER, DIMENSION(count) :: request_handles
+
+      DO i = 1, count
+         request_handles(i) = array_of_requests(i)%handle
+      END DO
+
+      CALL mpi_waitall(count, request_handles, array_of_statuses, ierr)
+
+      DO i = 1, count
+         array_of_requests(i)%handle = request_handles(i)
+      END DO
 
    END SUBROUTINE mpi_waitall_internal
 #endif
 
    SUBROUTINE mp_waitany(requests, completed)
       !! waits for completion of any of the given requests
-      INTEGER, DIMENSION(:), CONTIGUOUS, INTENT(inout) :: requests
+      TYPE(mp_request_type), DIMENSION(:), INTENT(inout) :: requests
       INTEGER, INTENT(out)                     :: completed
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_waitany'
 
       INTEGER                                  :: handle, ierr
 #if defined(__parallel)
-      INTEGER                                  :: count
+      INTEGER                                  :: count, i
+      INTEGER, DIMENSION(SIZE(requests))       :: request_handles
 #endif
 
       ierr = 0
@@ -1345,8 +1400,16 @@ CONTAINS
 #if defined(__parallel)
       count = SIZE(requests)
 
-      CALL mpi_waitany(count, requests, completed, MPI_STATUS_IGNORE, ierr)
+      DO i = 1, count
+         request_handles(i) = requests(i)%handle
+      END DO
+
+      CALL mpi_waitany(count, request_handles, completed, MPI_STATUS_IGNORE, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_waitany @ "//routineN)
+
+      DO i = 1, count
+         requests(i)%handle = request_handles(i)
+      END DO
 #else
       MARK_USED(requests)
       completed = 1
@@ -1358,7 +1421,7 @@ CONTAINS
       !! Tests for completion of the given requests.
       !! We use mpi_test so that we can use a single status.
 
-      INTEGER, DIMENSION(:)                 :: requests
+      TYPE(mp_request_type), DIMENSION(:)   :: requests
          !! the list of requests to test
       LOGICAL                               :: flag
          !! logical which determines if requests are complete
@@ -1367,7 +1430,7 @@ CONTAINS
 
 #if defined(__parallel)
       INTEGER                               :: i
-      LOGICAL, DIMENSION(:), POINTER        :: flags
+      LOGICAL, DIMENSION(:), ALLOCATABLE    :: flags
 #endif
 
       ierr = 0
@@ -1376,7 +1439,7 @@ CONTAINS
 #if defined(__parallel)
       ALLOCATE (flags(SIZE(requests)))
       DO i = 1, SIZE(requests)
-         CALL mpi_test(requests(i), flags(i), MPI_STATUS_IGNORE, ierr)
+         CALL mpi_test(requests(i)%handle, flags(i), MPI_STATUS_IGNORE, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_test @ mp_testall_tv")
          flag = flag .AND. flags(i)
       END DO
@@ -1389,7 +1452,7 @@ CONTAINS
    SUBROUTINE mp_test_1(request, flag)
       !! Tests for completion of the given request.
 
-      INTEGER, INTENT(inout)                             :: request
+      TYPE(mp_request_type), INTENT(inout)               :: request
          !! the request
       LOGICAL, INTENT(out)                               :: flag
          !! logical which determines if the request is completed
@@ -1399,7 +1462,7 @@ CONTAINS
       ierr = 0
 
 #if defined(__parallel)
-      CALL mpi_test(request, flag, MPI_STATUS_IGNORE, ierr)
+      CALL mpi_test(request%handle, flag, MPI_STATUS_IGNORE, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_test @ mp_test_1")
 #else
       MARK_USED(request)
@@ -1409,7 +1472,7 @@ CONTAINS
 
    SUBROUTINE mp_testany_1(requests, completed, flag)
       !! tests for completion of the given requests
-      INTEGER, DIMENSION(:), CONTIGUOUS, INTENT(inout) :: requests
+      TYPE(mp_request_type), DIMENSION(:), INTENT(inout) :: requests
       INTEGER, INTENT(out), OPTIONAL           :: completed
       LOGICAL, INTENT(out), OPTIONAL           :: flag
 
@@ -1438,7 +1501,7 @@ CONTAINS
 
    SUBROUTINE mp_testany_2(requests, completed, flag)
       !! tests for completion of the given requests
-      INTEGER, DIMENSION(:, :), CONTIGUOUS, INTENT(inout)   :: requests
+      TYPE(mp_request_type), DIMENSION(:, :), INTENT(inout)   :: requests
       INTEGER, INTENT(out), OPTIONAL           :: completed
       LOGICAL, INTENT(out), OPTIONAL           :: flag
 
@@ -1471,13 +1534,24 @@ CONTAINS
       !! the issue is with the rank or requests
 
       INTEGER, INTENT(in)                                :: count
-      INTEGER, DIMENSION(count), INTENT(inout)           :: array_of_requests
+      TYPE(mp_request_type), DIMENSION(count), INTENT(inout)           :: array_of_requests
       INTEGER, INTENT(out)                               :: index
       LOGICAL, INTENT(out)                               :: flag
       INTEGER, DIMENSION(MPI_STATUS_SIZE), INTENT(out)   :: status
       INTEGER, INTENT(out)                               :: ierr
 
-      CALL mpi_testany(count, array_of_requests, index, flag, status, ierr)
+      INTEGER :: i
+      INTEGER, DIMENSION(count) :: request_handles
+
+      DO i = 1, count
+         request_handles(i) = array_of_requests(i)%handle
+      END DO
+
+      CALL mpi_testany(count, request_handles, index, flag, status, ierr)
+
+      DO i = 1, count
+         array_of_requests(i)%handle = request_handles(i)
+      END DO
 
    END SUBROUTINE mpi_testany_internal
 #endif
@@ -1750,7 +1824,7 @@ CONTAINS
          !! the destination processor
       TYPE(mp_comm_type), INTENT(IN)           :: comm
          !! the communicator object
-      INTEGER, INTENT(out)                     :: request
+      TYPE(mp_request_type), INTENT(out)       :: request
          !! communication request index
       INTEGER, INTENT(in), OPTIONAL            :: tag
          !! message tag
@@ -1773,10 +1847,10 @@ CONTAINS
       msglen = SIZE(msgin, 1)
       IF (msglen > 0) THEN
          CALL mpi_isend(msgin(1), msglen, MPI_LOGICAL, dest, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       ELSE
          CALL mpi_isend(foo, msglen, MPI_LOGICAL, dest, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -1806,7 +1880,7 @@ CONTAINS
          !! the source processor
       TYPE(mp_comm_type), INTENT(IN)           :: comm
          !! the communicator object
-      INTEGER, INTENT(out)                     :: request
+      TYPE(mp_request_type), INTENT(out)                     :: request
          !! communication request index
       INTEGER, INTENT(in), OPTIONAL            :: tag
          !! message tag
@@ -1829,10 +1903,10 @@ CONTAINS
       msglen = SIZE(msgout, 1)
       IF (msglen > 0) THEN
          CALL mpi_irecv(msgout(1), msglen, MPI_LOGICAL, source, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       ELSE
          CALL mpi_irecv(foo, msglen, MPI_LOGICAL, source, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ircv @ "//routineN)
 
@@ -2111,9 +2185,9 @@ CONTAINS
 
       LOGICAL, DIMENSION(:), CONTIGUOUS, INTENT(INOUT)   :: msg
          !! Datum to perform inclusive disjunction (input) and resultant inclusive disjunction (output)
-      TYPE(mp_comm_type), INTENT(IN)                                :: gid
+      TYPE(mp_comm_type), INTENT(IN)                     :: gid
          !! Message passing environment identifier
-      INTEGER, INTENT(INOUT)                             :: request
+      TYPE(mp_request_type), INTENT(INOUT)               :: request
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_isum_bv'
 
@@ -2124,7 +2198,7 @@ CONTAINS
       msglen = SIZE(msg)
 #if defined(__parallel)
       IF (msglen .GT. 0) THEN
-         CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, MPI_LOGICAL, MPI_LOR, gid%handle, request, ierr)
+         CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, MPI_LOGICAL, MPI_LOR, gid%handle, request%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallreduce @ "//routineN)
       ELSE
          request = mp_request_null
@@ -2520,7 +2594,7 @@ CONTAINS
       TYPE(mp_type_descriptor_type), INTENT(IN)          :: msgin
       INTEGER, INTENT(IN)                                :: dest
       TYPE(mp_comm_type), INTENT(IN)                     :: comm
-      INTEGER, INTENT(out)                               :: request
+      TYPE(mp_request_type), INTENT(out)                 :: request
       INTEGER, INTENT(in), OPTIONAL                      :: tag
 
       INTEGER                                            :: ierr
@@ -2533,7 +2607,7 @@ CONTAINS
 
       ierr = 0
       CALL mpi_isend(MPI_BOTTOM, 1, msgin%type_handle, dest, my_tag, &
-                     comm%handle, request, ierr)
+                     comm%handle, request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 #else
       MARK_USED(msgin)
@@ -2542,7 +2616,7 @@ CONTAINS
       MARK_USED(request)
       MARK_USED(tag)
       ierr = 1
-      request = 0
+      request = mp_request_null
       CALL mp_stop(ierr, "mp_isend called in non parallel case")
 #endif
    END SUBROUTINE mp_isend_custom
@@ -2552,7 +2626,7 @@ CONTAINS
       TYPE(mp_type_descriptor_type), INTENT(INOUT)       :: msgout
       INTEGER, INTENT(IN)                                :: source
       TYPE(mp_comm_type), INTENT(IN)                     :: comm
-      INTEGER, INTENT(out)                               :: request
+      TYPE(mp_request_type), INTENT(out)                 :: request
       INTEGER, INTENT(in), OPTIONAL                      :: tag
 
       INTEGER                                            :: ierr
@@ -2566,7 +2640,7 @@ CONTAINS
       IF (PRESENT(tag)) my_tag = tag
 
       CALL mpi_irecv(MPI_BOTTOM, 1, msgout%type_handle, source, my_tag, &
-                     comm%handle, request, ierr)
+                     comm%handle, request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 #else
       MARK_USED(msgout)
@@ -2575,7 +2649,7 @@ CONTAINS
       MARK_USED(request)
       MARK_USED(tag)
       ierr = 1
-      request = 0
+      request = mp_request_null
       DBCSR_ABORT("mp_irecv called in non parallel case")
 #endif
    END SUBROUTINE mp_irecv_custom
@@ -3043,7 +3117,7 @@ CONTAINS
          !! Processes which broadcasts
          TYPE(mp_comm_type), INTENT(IN)           :: gid
          !! Message passing environment identifier
-         INTEGER, INTENT(INOUT)                   :: request
+         TYPE(mp_request_type), INTENT(INOUT)     :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_ibcast_${nametype1}$'
 
@@ -3054,7 +3128,7 @@ CONTAINS
 
          msglen = 1
 #if defined(__parallel)
-         CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid%handle, request, ierr)
+         CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid%handle, request%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ibcast @ "//routineN)
          CALL add_perf(perf_id=22, msg_size=msglen*${bytes1}$)
 #else
@@ -3102,7 +3176,7 @@ CONTAINS
          !! Data to broadcast
          INTEGER                                  :: source
          TYPE(mp_comm_type), INTENT(IN)           :: gid
-         INTEGER, INTENT(INOUT)                   :: request
+         TYPE(mp_request_type), INTENT(INOUT)     :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_ibcast_${nametype1}$v'
 
@@ -3113,7 +3187,7 @@ CONTAINS
 
          msglen = SIZE(msg)
 #if defined(__parallel)
-         CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid%handle, request, ierr)
+         CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid%handle, request%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ibcast @ "//routineN)
          CALL add_perf(perf_id=22, msg_size=msglen*${bytes1}$)
 #else
@@ -3248,8 +3322,8 @@ CONTAINS
 
          ${type1}$, CONTIGUOUS, INTENT(INOUT)     :: msg(:)
          !! Vector to sum and result
-         TYPE(mp_comm_type), INTENT(IN)                      :: gid
-         INTEGER, INTENT(INOUT)                   :: request
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
+         TYPE(mp_request_type), INTENT(INOUT)     :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_isum_${nametype1}$v'
 
@@ -3264,7 +3338,7 @@ CONTAINS
 #if defined(__parallel)
          msglen = SIZE(msg)
          IF (msglen > 0) THEN
-            CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid%handle, request, ierr)
+            CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid%handle, request%handle, ierr)
             IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallreduce @ "//routineN)
          ELSE
             request = mp_request_null
@@ -3663,7 +3737,7 @@ CONTAINS
          !! Process which scatters data
          TYPE(mp_comm_type), INTENT(IN)           :: gid
          !! Message passing environment identifier
-         INTEGER, INTENT(INOUT)                   :: request
+         TYPE(mp_request_type), INTENT(INOUT)     :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_iscatter_${nametype1}$'
 
@@ -3675,7 +3749,7 @@ CONTAINS
          msglen = 1
 #if defined(__parallel)
          CALL mpi_iscatter(msg_scatter, msglen, ${mpi_type1}$, msg, &
-                           msglen, ${mpi_type1}$, root, gid%handle, request, ierr)
+                           msglen, ${mpi_type1}$, root, gid%handle, request%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iscatter @ "//routineN)
          CALL add_perf(perf_id=24, msg_size=1*${bytes1}$)
 #else
@@ -3700,7 +3774,7 @@ CONTAINS
          !! Process which scatters data
          TYPE(mp_comm_type), INTENT(IN)           :: gid
          !! Message passing environment identifier
-         INTEGER, INTENT(INOUT)                   :: request
+         TYPE(mp_request_type), INTENT(INOUT)     :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_iscatter_${nametype1}$v2'
 
@@ -3712,7 +3786,7 @@ CONTAINS
          msglen = SIZE(msg)
 #if defined(__parallel)
          CALL mpi_iscatter(msg_scatter, msglen, ${mpi_type1}$, msg, &
-                           msglen, ${mpi_type1}$, root, gid%handle, request, ierr)
+                           msglen, ${mpi_type1}$, root, gid%handle, request%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iscatter @ "//routineN)
          CALL add_perf(perf_id=24, msg_size=1*${bytes1}$)
 #else
@@ -3738,7 +3812,7 @@ CONTAINS
          !! Process which scatters data
          TYPE(mp_comm_type), INTENT(IN)           :: gid
          !! Message passing environment identifier
-         INTEGER, INTENT(INOUT)                   :: request
+         TYPE(mp_request_type), INTENT(INOUT)                   :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_iscatterv_${nametype1}$v'
 
@@ -3749,7 +3823,7 @@ CONTAINS
 
 #if defined(__parallel)
          CALL mpi_iscatterv(msg_scatter, sendcounts, displs, ${mpi_type1}$, msg, &
-                            recvcount, ${mpi_type1}$, root, gid%handle, request, ierr)
+                            recvcount, ${mpi_type1}$, root, gid%handle, request%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iscatterv @ "//routineN)
          CALL add_perf(perf_id=24, msg_size=1*${bytes1}$)
 #else
@@ -4021,9 +4095,9 @@ CONTAINS
          !! Datum to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:)
          !! Received data
-         TYPE(mp_comm_type), INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
          !! Message passing environment identifier
-         INTEGER, INTENT(INOUT)                   :: request
+         TYPE(mp_request_type), INTENT(INOUT)     :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$'
 
@@ -4040,7 +4114,7 @@ CONTAINS
          rcount = 1
          CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                              msgin, rcount, ${mpi_type1}$, &
-                             gid%handle, request, ierr)
+                             gid%handle, request%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -4204,8 +4278,8 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(IN)        :: msgout(:)
          !! Rank-1 data to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:)
-         TYPE(mp_comm_type), INTENT(IN)                      :: gid
-         INTEGER, INTENT(OUT)                     :: request
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
+         TYPE(mp_request_type), INTENT(OUT)       :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$11'
 
@@ -4222,7 +4296,7 @@ CONTAINS
          rcount = scount
          CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                              msgin, rcount, ${mpi_type1}$, &
-                             gid%handle, request, ierr)
+                             gid%handle, request%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -4240,8 +4314,8 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(IN)        :: msgout(:)
          !! Rank-2 data to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:, :, :)
-         TYPE(mp_comm_type), INTENT(IN)                      :: gid
-         INTEGER, INTENT(OUT)                     :: request
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
+         TYPE(mp_request_type), INTENT(OUT)       :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$13'
 
@@ -4258,7 +4332,7 @@ CONTAINS
          rcount = scount
          CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                              msgin, rcount, ${mpi_type1}$, &
-                             gid%handle, request, ierr)
+                             gid%handle, request%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -4276,8 +4350,8 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(IN)        :: msgout(:, :)
          !! Rank-2 data to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:, :)
-         TYPE(mp_comm_type), INTENT(IN)                      :: gid
-         INTEGER, INTENT(OUT)                     :: request
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
+         TYPE(mp_request_type), INTENT(OUT)       :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$22'
 
@@ -4294,7 +4368,7 @@ CONTAINS
          rcount = scount
          CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                              msgin, rcount, ${mpi_type1}$, &
-                             gid%handle, request, ierr)
+                             gid%handle, request%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -4312,8 +4386,8 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(IN)        :: msgout(:, :)
          !! Rank-2 data to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:, :, :, :)
-         TYPE(mp_comm_type), INTENT(IN)                      :: gid
-         INTEGER, INTENT(OUT)                     :: request
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
+         TYPE(mp_request_type), INTENT(OUT)       :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$24'
 
@@ -4330,7 +4404,7 @@ CONTAINS
          rcount = scount
          CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                              msgin, rcount, ${mpi_type1}$, &
-                             gid%handle, request, ierr)
+                             gid%handle, request%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -4348,8 +4422,8 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(IN)        :: msgout(:, :, :)
          !! Rank-3 data to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:, :, :)
-         TYPE(mp_comm_type), INTENT(IN)                      :: gid
-         INTEGER, INTENT(OUT)                     :: request
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
+         TYPE(mp_request_type), INTENT(OUT)       :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$33'
 
@@ -4366,7 +4440,7 @@ CONTAINS
          rcount = scount
          CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                              msgin, rcount, ${mpi_type1}$, &
-                             gid%handle, request, ierr)
+                             gid%handle, request%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -4447,11 +4521,11 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:)
          !! Received data
          INTEGER, CONTIGUOUS, INTENT(IN)          :: rcount(:), rdispl(:)
-         TYPE(mp_comm_type), INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
          !! Size of sent data for every process
          !! Offset of sent data for every process
          !! Message passing environment identifier
-         INTEGER, INTENT(INOUT)                   :: request
+         TYPE(mp_request_type), INTENT(INOUT)     :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_iallgatherv_${nametype1}$v'
 
@@ -4500,11 +4574,11 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:)
          !! Received data
          INTEGER, CONTIGUOUS, INTENT(IN)          :: rcount(:, :), rdispl(:, :)
-         TYPE(mp_comm_type), INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
          !! Size of sent data for every process
          !! Offset of sent data for every process
          !! Message passing environment identifier
-         INTEGER, INTENT(INOUT)                   :: request
+         TYPE(mp_request_type), INTENT(INOUT)     :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_iallgatherv_${nametype1}$v2'
 
@@ -4542,10 +4616,11 @@ CONTAINS
          INTEGER, INTENT(IN)                      :: rsize
          INTEGER, INTENT(IN)                      :: rcount(rsize), rdispl(rsize), scount
          TYPE(mp_comm_type), INTENT(IN)           :: gid
-         INTEGER, INTENT(INOUT)                   :: request, ierr
+         TYPE(mp_request_type), INTENT(INOUT)     :: request
+         INTEGER, INTENT(INOUT)                   :: ierr
 
          CALL MPI_IALLGATHERV(msgout, scount, ${mpi_type1}$, msgin, rcount, &
-                              rdispl, ${mpi_type1}$, gid%handle, request, ierr)
+                              rdispl, ${mpi_type1}$, gid%handle, request%handle, ierr)
 
       END SUBROUTINE mp_iallgatherv_${nametype1}$v_internal
 #endif
@@ -4611,7 +4686,7 @@ CONTAINS
          !! Process to receive from
          TYPE(mp_comm_type), INTENT(IN)           :: comm
          !! Message passing environment identifier
-         INTEGER, INTENT(out)                     :: send_request, recv_request
+         TYPE(mp_request_type), INTENT(out)       :: send_request, recv_request
          !! Request handle for the send
          !! Request handle for the receive
          INTEGER, INTENT(in), OPTIONAL            :: tag
@@ -4632,11 +4707,11 @@ CONTAINS
          IF (PRESENT(tag)) my_tag = tag
 
          CALL mpi_irecv(msgout, 1, ${mpi_type1}$, source, my_tag, &
-                        comm%handle, recv_request, ierr)
+                        comm%handle, recv_request%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 
          CALL mpi_isend(msgin, 1, ${mpi_type1}$, dest, my_tag, &
-                        comm%handle, send_request, ierr)
+                        comm%handle, send_request%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
          CALL add_perf(perf_id=8, msg_size=2*${bytes1}$)
@@ -4645,8 +4720,8 @@ CONTAINS
          MARK_USED(source)
          MARK_USED(comm)
          MARK_USED(tag)
-         send_request = 0
-         recv_request = 0
+         send_request = mp_request_null
+         recv_request = mp_request_null
          msgout = msgin
 #endif
          CALL timestop(handle)
@@ -4671,7 +4746,7 @@ CONTAINS
          !! Process to receive from
          TYPE(mp_comm_type), INTENT(IN)           :: comm
          !! Message passing environment identifier
-         INTEGER, INTENT(out)                     :: send_request, recv_request
+         TYPE(mp_request_type), INTENT(out)       :: send_request, recv_request
          !! Request handle for the send
          !! Request handle for the receive
          INTEGER, INTENT(in), OPTIONAL            :: tag
@@ -4695,20 +4770,20 @@ CONTAINS
          msglen = SIZE(msgout, 1)
          IF (msglen > 0) THEN
             CALL mpi_irecv(msgout(1), msglen, ${mpi_type1}$, source, my_tag, &
-                           comm%handle, recv_request, ierr)
+                           comm%handle, recv_request%handle, ierr)
          ELSE
             CALL mpi_irecv(foo, msglen, ${mpi_type1}$, source, my_tag, &
-                           comm%handle, recv_request, ierr)
+                           comm%handle, recv_request%handle, ierr)
          END IF
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 
          msglen = SIZE(msgin, 1)
          IF (msglen > 0) THEN
             CALL mpi_isend(msgin(1), msglen, ${mpi_type1}$, dest, my_tag, &
-                           comm%handle, send_request, ierr)
+                           comm%handle, send_request%handle, ierr)
          ELSE
             CALL mpi_isend(foo, msglen, ${mpi_type1}$, dest, my_tag, &
-                           comm%handle, send_request, ierr)
+                           comm%handle, send_request%handle, ierr)
          END IF
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -4719,8 +4794,8 @@ CONTAINS
          MARK_USED(source)
          MARK_USED(comm)
          MARK_USED(tag)
-         send_request = 0
-         recv_request = 0
+         send_request = mp_request_null
+         recv_request = mp_request_null
          msgout = msgin
 #endif
          CALL timestop(handle)
@@ -4736,7 +4811,7 @@ CONTAINS
          ${type1}$, CONTIGUOUS, DIMENSION(:)      :: msgin
          INTEGER, INTENT(IN)                      :: dest
          TYPE(mp_comm_type), INTENT(IN)           :: comm
-         INTEGER, INTENT(out)                     :: request
+         TYPE(mp_request_type), INTENT(out)       :: request
          INTEGER, INTENT(in), OPTIONAL            :: tag
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_isend_${nametype1}$v'
@@ -4757,10 +4832,10 @@ CONTAINS
          msglen = SIZE(msgin)
          IF (msglen > 0) THEN
             CALL mpi_isend(msgin(1), msglen, ${mpi_type1}$, dest, my_tag, &
-                           comm%handle, request, ierr)
+                           comm%handle, request%handle, ierr)
          ELSE
             CALL mpi_isend(foo, msglen, ${mpi_type1}$, dest, my_tag, &
-                           comm%handle, request, ierr)
+                           comm%handle, request%handle, ierr)
          END IF
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -4772,7 +4847,7 @@ CONTAINS
          MARK_USED(request)
          MARK_USED(tag)
          ierr = 1
-         request = 0
+         request = mp_request_null
          CALL mp_stop(ierr, "mp_isend called in non parallel case")
 #endif
          CALL timestop(handle)
@@ -4790,7 +4865,7 @@ CONTAINS
          ${type1}$, DIMENSION(:, :), CONTIGUOUS   :: msgin
          INTEGER, INTENT(IN)                      :: dest
          TYPE(mp_comm_type), INTENT(IN)           :: comm
-         INTEGER, INTENT(out)                     :: request
+         TYPE(mp_request_type), INTENT(out)       :: request
          INTEGER, INTENT(in), OPTIONAL            :: tag
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_isend_${nametype1}$m2'
@@ -4811,10 +4886,10 @@ CONTAINS
          msglen = SIZE(msgin, 1)*SIZE(msgin, 2)
          IF (msglen > 0) THEN
             CALL mpi_isend(msgin(1, 1), msglen, ${mpi_type1}$, dest, my_tag, &
-                           comm%handle, request, ierr)
+                           comm%handle, request%handle, ierr)
          ELSE
             CALL mpi_isend(foo, msglen, ${mpi_type1}$, dest, my_tag, &
-                           comm%handle, request, ierr)
+                           comm%handle, request%handle, ierr)
          END IF
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -4826,7 +4901,7 @@ CONTAINS
          MARK_USED(request)
          MARK_USED(tag)
          ierr = 1
-         request = 0
+         request = mp_request_null
          CALL mp_stop(ierr, "mp_isend called in non parallel case")
 #endif
          CALL timestop(handle)
@@ -4842,7 +4917,7 @@ CONTAINS
          ${type1}$, CONTIGUOUS, DIMENSION(:)      :: msgout
          INTEGER, INTENT(IN)                      :: source
          TYPE(mp_comm_type), INTENT(IN)           :: comm
-         INTEGER, INTENT(out)                     :: request
+         TYPE(mp_request_type), INTENT(out)       :: request
          INTEGER, INTENT(in), OPTIONAL            :: tag
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_irecv_${nametype1}$v'
@@ -4863,10 +4938,10 @@ CONTAINS
          msglen = SIZE(msgout)
          IF (msglen > 0) THEN
             CALL mpi_irecv(msgout(1), msglen, ${mpi_type1}$, source, my_tag, &
-                           comm%handle, request, ierr)
+                           comm%handle, request%handle, ierr)
          ELSE
             CALL mpi_irecv(foo, msglen, ${mpi_type1}$, source, my_tag, &
-                           comm%handle, request, ierr)
+                           comm%handle, request%handle, ierr)
          END IF
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 
@@ -4878,7 +4953,7 @@ CONTAINS
          MARK_USED(comm)
          MARK_USED(request)
          MARK_USED(tag)
-         request = 0
+         request = mp_request_null
 #endif
          CALL timestop(handle)
       END SUBROUTINE mp_irecv_${nametype1}$v
@@ -4895,7 +4970,7 @@ CONTAINS
          ${type1}$, DIMENSION(:, :), CONTIGUOUS   :: msgout
          INTEGER, INTENT(IN)                      :: source
          TYPE(mp_comm_type), INTENT(IN)           :: comm
-         INTEGER, INTENT(out)                     :: request
+         TYPE(mp_request_type), INTENT(out)       :: request
          INTEGER, INTENT(in), OPTIONAL            :: tag
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_irecv_${nametype1}$m2'
@@ -4916,10 +4991,10 @@ CONTAINS
          msglen = SIZE(msgout, 1)*SIZE(msgout, 2)
          IF (msglen > 0) THEN
             CALL mpi_irecv(msgout(1, 1), msglen, ${mpi_type1}$, source, my_tag, &
-                           comm%handle, request, ierr)
+                           comm%handle, request%handle, ierr)
          ELSE
             CALL mpi_irecv(foo, msglen, ${mpi_type1}$, source, my_tag, &
-                           comm%handle, request, ierr)
+                           comm%handle, request%handle, ierr)
          END IF
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 
@@ -4930,7 +5005,7 @@ CONTAINS
          MARK_USED(comm)
          MARK_USED(request)
          MARK_USED(tag)
-         request = 0
+         request = mp_request_null
          DBCSR_ABORT("mp_irecv called in non parallel case")
 #endif
          CALL timestop(handle)
@@ -4983,7 +5058,7 @@ CONTAINS
          INTEGER, INTENT(IN)                                 :: source, win
          ${type1}$, CONTIGUOUS, DIMENSION(:)                 :: win_data
          INTEGER, INTENT(IN), OPTIONAL                       :: myproc, disp
-         INTEGER, INTENT(OUT)                                :: request
+         TYPE(mp_request_type), INTENT(OUT)                  :: request
          TYPE(mp_type_descriptor_type), INTENT(IN), OPTIONAL :: origin_datatype, target_datatype
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_rget_${nametype1}$v'
@@ -5040,7 +5115,7 @@ CONTAINS
                ierr = 0
             ELSE
                CALL mpi_rget(base(1), origin_len, handle_origin_datatype, source, disp_aint, &
-                             target_len, handle_target_datatype, win, request, ierr)
+                             target_len, handle_target_datatype, win, request%handle, ierr)
             END IF
          ELSE
             request = mp_request_null

--- a/src/mpi/dbcsr_mpiwrap.F
+++ b/src/mpi/dbcsr_mpiwrap.F
@@ -101,9 +101,17 @@ MODULE dbcsr_mpiwrap
    INTEGER, PARAMETER, PUBLIC :: file_amode_append = 128
 #endif
 
-   ! MPI wrapper types
+   ! MPI wrapper types (keep the handles private for to switch between serial mode/old mpi module and mpi_f08!)
    TYPE mp_comm_type
+      PRIVATE
       INTEGER :: handle = mp_comm_null_handle
+   CONTAINS
+      PROCEDURE, PUBLIC, PASS(comm), NON_OVERRIDABLE :: get_handle => mp_get_comm_handle
+      PROCEDURE, PUBLIC, PASS(comm), NON_OVERRIDABLE :: set_handle => mp_set_comm_handle
+      PROCEDURE, PRIVATE, PASS(comm1), NON_OVERRIDABLE :: mp_comm_op_eq
+      GENERIC, PUBLIC :: OPERATOR(.EQ.) => mp_comm_op_eq
+      PROCEDURE, PRIVATE, PASS(comm1), NON_OVERRIDABLE :: mp_comm_op_ne
+      GENERIC, PUBLIC :: OPERATOR(.NE.) => mp_comm_op_ne
    END TYPE mp_comm_type
 
    ! The actual MPI wrapper constants
@@ -429,6 +437,35 @@ MODULE dbcsr_mpiwrap
    INTEGER, SAVE, PRIVATE :: last_mp_perf_env_id = 0
 
 CONTAINS
+
+   INTEGER FUNCTION mp_get_comm_handle(comm)
+      CLASS(mp_comm_type), INTENT(IN) :: comm
+
+      mp_get_comm_handle = comm%handle
+
+   END FUNCTION mp_get_comm_handle
+
+   SUBROUTINE mp_set_comm_handle(comm, handle)
+      CLASS(mp_comm_type), INTENT(OUT) :: comm
+      INTEGER, INTENT(IN) :: handle
+
+      comm%handle = handle
+
+   END SUBROUTINE mp_set_comm_handle
+
+   PURE LOGICAL FUNCTION mp_comm_op_eq(comm1, comm2)
+      CLASS(mp_comm_type), INTENT(IN) :: comm1, comm2
+
+      mp_comm_op_eq = (comm1%handle .EQ. comm2%handle)
+
+   END FUNCTION mp_comm_op_eq
+
+   PURE LOGICAL FUNCTION mp_comm_op_ne(comm1, comm2)
+      CLASS(mp_comm_type), INTENT(IN) :: comm1, comm2
+
+      mp_comm_op_ne = (comm1%handle .NE. comm2%handle)
+
+   END FUNCTION mp_comm_op_ne
 
    SUBROUTINE mp_world_init(mp_comm)
       !! initializes the system default communicator

--- a/src/mpi/dbcsr_mpiwrap.F
+++ b/src/mpi/dbcsr_mpiwrap.F
@@ -56,9 +56,9 @@ MODULE dbcsr_mpiwrap
    LOGICAL, PARAMETER :: dbcsr_is_parallel = .TRUE.
    INTEGER, PARAMETER, PUBLIC :: mp_any_tag = MPI_ANY_TAG
    INTEGER, PARAMETER, PUBLIC :: mp_any_source = MPI_ANY_SOURCE
-   INTEGER, PARAMETER, PUBLIC :: mp_comm_null = MPI_COMM_NULL
-   INTEGER, PARAMETER, PUBLIC :: mp_comm_self = MPI_COMM_SELF
-   INTEGER, PARAMETER, PUBLIC :: mp_comm_world = MPI_COMM_WORLD
+   INTEGER, PARAMETER :: mp_comm_null_handle = MPI_COMM_NULL
+   INTEGER, PARAMETER :: mp_comm_self_handle = MPI_COMM_SELF
+   INTEGER, PARAMETER :: mp_comm_world_handle = MPI_COMM_WORLD
    INTEGER, PARAMETER, PUBLIC :: mp_request_null = MPI_REQUEST_NULL
    INTEGER, PARAMETER, PUBLIC :: mp_win_null = MPI_WIN_NULL
    INTEGER, PARAMETER, PUBLIC :: mp_status_size = MPI_STATUS_SIZE
@@ -81,9 +81,9 @@ MODULE dbcsr_mpiwrap
    LOGICAL, PARAMETER :: dbcsr_is_parallel = .FALSE.
    INTEGER, PARAMETER, PUBLIC :: mp_any_tag = -1
    INTEGER, PARAMETER, PUBLIC :: mp_any_source = -2
-   INTEGER, PARAMETER, PUBLIC :: mp_comm_null = -3
-   INTEGER, PARAMETER, PUBLIC :: mp_comm_self = -11
-   INTEGER, PARAMETER, PUBLIC :: mp_comm_world = -12
+   INTEGER, PARAMETER :: mp_comm_null_handle = -3
+   INTEGER, PARAMETER :: mp_comm_self_handle = -11
+   INTEGER, PARAMETER :: mp_comm_world_handle = -12
    INTEGER, PARAMETER, PUBLIC :: mp_request_null = -4
    INTEGER, PARAMETER, PUBLIC :: mp_win_null = -5
    INTEGER, PARAMETER, PUBLIC :: mp_status_size = -6
@@ -101,6 +101,16 @@ MODULE dbcsr_mpiwrap
    INTEGER, PARAMETER, PUBLIC :: file_amode_append = 128
 #endif
 
+   ! MPI wrapper types
+   TYPE mp_comm_type
+      INTEGER :: handle = mp_comm_null_handle
+   END TYPE mp_comm_type
+
+   ! The actual MPI wrapper constants
+   TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_null = mp_comm_type(mp_comm_null_handle)
+   TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_self = mp_comm_type(mp_comm_self_handle)
+   TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_world = mp_comm_type(mp_comm_world_handle)
+
    ! we need to fix this to a given number (crossing fingers)
    ! so that the serial code using Fortran stream IO and the MPI have the same sizes.
    INTEGER, PARAMETER, PUBLIC :: mpi_character_size = 1
@@ -112,6 +122,9 @@ MODULE dbcsr_mpiwrap
    ! internal reference counter used to debug communicator leaks
    INTEGER, PRIVATE, SAVE :: debug_comm_count = 0
 #endif
+
+   ! types
+   PUBLIC :: mp_comm_type
 
    ! init and error
    PUBLIC :: mp_world_init, mp_world_finalize
@@ -422,7 +435,7 @@ CONTAINS
       !! @note
       !! should only be called once
 
-      INTEGER, INTENT(OUT)                     :: mp_comm
+      TYPE(mp_comm_type), INTENT(OUT)          :: mp_comm
          !! [output] : handle of the default communicator
 #if defined(__parallel)
       INTEGER                                  :: ierr
@@ -459,11 +472,9 @@ CONTAINS
 !$    END IF
       CALL mpi_comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_set_errhandler @ mp_world_init")
-      mp_comm = MPI_COMM_WORLD
       debug_comm_count = 1
-#else
-      mp_comm = 0
 #endif
+      mp_comm = mp_comm_world
       CALL add_mp_perf_env()
    END SUBROUTINE mp_world_init
 
@@ -483,28 +494,29 @@ CONTAINS
       !! @note
       !! should only be called once, at very beginning of CP2K run
 
-      INTEGER, INTENT(IN)                      :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                      :: mp_comm
          !! [output] : handle of the default communicator
-      INTEGER, INTENT(out)                     :: mp_new_comm
+      TYPE(mp_comm_type), INTENT(out)                     :: mp_new_comm
       INTEGER, DIMENSION(:), CONTIGUOUS        :: ranks_order
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_reordering'
 
       INTEGER                                  :: handle, ierr
 #if defined(__parallel)
-      INTEGER                                  :: newcomm, newgroup, oldgroup
+      INTEGER                                  :: newgroup, oldgroup
+      TYPE(mp_comm_type)                       :: newcomm
 #endif
 
       CALL timeset(routineN, handle)
       ierr = 0
 #if defined(__parallel)
 
-      CALL mpi_comm_group(mp_comm, oldgroup, ierr)
+      CALL mpi_comm_group(mp_comm%handle, oldgroup, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_group @ "//routineN)
       CALL mpi_group_incl(oldgroup, SIZE(ranks_order), ranks_order, newgroup, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_group_incl @ "//routineN)
 
-      CALL mpi_comm_create(mp_comm, newgroup, newcomm, ierr)
+      CALL mpi_comm_create(mp_comm%handle, newgroup, newcomm%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_create @ "//routineN)
 
       CALL mpi_group_free(oldgroup, ierr)
@@ -767,7 +779,7 @@ CONTAINS
    SUBROUTINE mp_sync(group)
       !! synchronizes with a barrier a given group of mpi tasks
 
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                                :: group
          !! mpi communicator
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_sync'
@@ -778,7 +790,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
 #if defined(__parallel)
-      CALL mpi_barrier(group, ierr)
+      CALL mpi_barrier(group%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_barrier @ "//routineN)
 #else
       MARK_USED(group)
@@ -790,7 +802,7 @@ CONTAINS
    SUBROUTINE mp_isync(group, request)
       !! synchronizes with a barrier a given group of mpi tasks
 
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                                :: group
          !! mpi communicator
       INTEGER, INTENT(OUT)                               :: request
 
@@ -802,7 +814,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
 #if defined(__parallel)
-      CALL mpi_ibarrier(group, request, ierr)
+      CALL mpi_ibarrier(group%handle, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ibarrier @ "//routineN)
 #else
       MARK_USED(group)
@@ -819,7 +831,7 @@ CONTAINS
       !! ..mp_world_setup is gone, use mp_environ instead (i.e. give a groupid explicitly)
 
       INTEGER, OPTIONAL, INTENT(OUT)                     :: numtask, taskid
-      INTEGER, INTENT(IN)                                :: groupid
+      TYPE(mp_comm_type), INTENT(IN)                                :: groupid
          !! mpi communicator
 
       INTEGER                                            :: ierr
@@ -830,12 +842,12 @@ CONTAINS
       IF (PRESENT(taskid)) taskid = 0
 #if defined(__parallel)
       IF (PRESENT(taskid)) THEN
-         CALL mpi_comm_rank(groupid, taskid, ierr)
+         CALL mpi_comm_rank(groupid%handle, taskid, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_rank @ mp_environ_l")
       END IF
 
       IF (PRESENT(numtask)) THEN
-         CALL mpi_comm_size(groupid, numtask, ierr)
+         CALL mpi_comm_size(groupid%handle, numtask, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ mp_environ_l")
       END IF
 #else
@@ -848,7 +860,7 @@ CONTAINS
 
       INTEGER, INTENT(OUT)                     :: numtask, dims(2), &
                                                   task_coor(2)
-      INTEGER, INTENT(IN)                      :: groupid
+      TYPE(mp_comm_type), INTENT(IN)                      :: groupid
 
       INTEGER                                  :: ierr
 #if defined(__parallel)
@@ -860,10 +872,10 @@ CONTAINS
       task_coor = 0
       dims = 1
 #if defined(__parallel)
-      CALL mpi_comm_size(groupid, numtask, ierr)
+      CALL mpi_comm_size(groupid%handle, numtask, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ mp_environ_c")
 
-      CALL mpi_cart_get(groupid, 2, dims, periods, task_coor, ierr)
+      CALL mpi_cart_get(groupid%handle, 2, dims, periods, task_coor, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_cart_get @ mp_environ_c")
 #else
       MARK_USED(groupid)
@@ -873,7 +885,8 @@ CONTAINS
 
    SUBROUTINE mp_environ_c2(comm, ndims, dims, task_coor, periods)
 
-      INTEGER, INTENT(IN)                                :: comm, ndims
+      TYPE(mp_comm_type), INTENT(IN)                     :: comm
+      INTEGER, INTENT(IN)                                :: ndims
       INTEGER, INTENT(OUT)                               :: dims(ndims), task_coor(ndims)
       LOGICAL, INTENT(out)                               :: periods(ndims)
 
@@ -885,7 +898,7 @@ CONTAINS
       dims = 1
       periods = .FALSE.
 #if defined(__parallel)
-      CALL mpi_cart_get(comm, ndims, dims, periods, task_coor, ierr)
+      CALL mpi_cart_get(comm%handle, ndims, dims, periods, task_coor, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_cart_get @ mp_environ_c")
 #else
       MARK_USED(comm)
@@ -896,10 +909,11 @@ CONTAINS
 !..mp_cart_create
    SUBROUTINE mp_cart_create(comm_old, ndims, dims, pos, comm_cart)
 
-      INTEGER, INTENT(IN)                      :: comm_old, ndims
+      TYPE(mp_comm_type), INTENT(IN)           :: comm_old
+      INTEGER, INTENT(IN)                      :: ndims
       INTEGER, CONTIGUOUS, INTENT(INOUT)       :: dims(:)
       INTEGER, CONTIGUOUS, INTENT(OUT)         :: pos(:)
-      INTEGER, INTENT(OUT)                     :: comm_cart
+      TYPE(mp_comm_type), INTENT(OUT)                     :: comm_cart
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_cart_create'
 
@@ -917,7 +931,7 @@ CONTAINS
       comm_cart = comm_old
 #if defined(__parallel)
 
-      CALL mpi_comm_size(comm_old, nodes, ierr)
+      CALL mpi_comm_size(comm_old%handle, nodes, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ "//routineN)
 
       IF (ANY(dims == 0)) CALL mpi_dims_create(nodes, ndims, dims, ierr)
@@ -928,13 +942,13 @@ CONTAINS
       ! communicator
       reorder = .FALSE.
       period = .TRUE.
-      CALL mpi_cart_create(comm_old, ndims, dims, period, reorder, comm_cart, &
+      CALL mpi_cart_create(comm_old%handle, ndims, dims, period, reorder, comm_cart%handle, &
                            ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_cart_create @ "//routineN)
 
-      IF (comm_cart /= MPI_COMM_NULL) THEN
+      IF (comm_cart%handle /= MP_COMM_NULL%handle) THEN
          debug_comm_count = debug_comm_count + 1
-         CALL mpi_cart_get(comm_cart, ndims, dims, period, pos, ierr)
+         CALL mpi_cart_get(comm_cart%handle, ndims, dims, period, pos, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_cart_get @ "//routineN)
       END IF
 #else
@@ -949,7 +963,8 @@ CONTAINS
 !..mp_cart_coords
    SUBROUTINE mp_cart_coords(comm, rank, coords)
 
-      INTEGER, INTENT(IN)                                :: comm, rank
+      TYPE(mp_comm_type), INTENT(IN)                     :: comm
+      INTEGER, INTENT(IN)                                :: rank
       INTEGER, DIMENSION(:), CONTIGUOUS, INTENT(OUT)     :: coords
 
       INTEGER                                            :: ierr, m
@@ -958,7 +973,7 @@ CONTAINS
 
       m = SIZE(coords)
 #if defined(__parallel)
-      CALL mpi_cart_coords(comm, rank, m, coords, ierr)
+      CALL mpi_cart_coords(comm%handle, rank, m, coords, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_cart_coords @ mp_cart_coords")
 #else
       coords = 0
@@ -971,7 +986,7 @@ CONTAINS
 !..mp_comm_compare
    SUBROUTINE mp_comm_compare(comm1, comm2, res)
 
-      INTEGER, INTENT(IN)                                :: comm1, comm2
+      TYPE(mp_comm_type), INTENT(IN)                                :: comm1, comm2
       INTEGER, INTENT(OUT)                               :: res
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_comm_compare'
@@ -984,7 +999,7 @@ CONTAINS
       iout = 0
       res = 0
 #if defined(__parallel)
-      CALL mpi_comm_compare(comm1, comm2, iout, ierr)
+      CALL mpi_comm_compare(comm1%handle, comm2%handle, iout, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_compare @ "//routineN)
       SELECT CASE (iout)
       CASE (MPI_IDENT)
@@ -1009,9 +1024,9 @@ CONTAINS
 !..mp_cart_sub
    SUBROUTINE mp_cart_sub(comm, rdim, sub_comm)
 
-      INTEGER, INTENT(IN)                                :: comm
+      TYPE(mp_comm_type), INTENT(IN)                                :: comm
       LOGICAL, DIMENSION(:), CONTIGUOUS, INTENT(IN)      :: rdim
-      INTEGER, INTENT(OUT)                               :: sub_comm
+      TYPE(mp_comm_type), INTENT(OUT)                               :: sub_comm
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_cart_sub'
 
@@ -1020,9 +1035,9 @@ CONTAINS
       ierr = 0
       CALL timeset(routineN, handle)
 
-      sub_comm = 0
+      sub_comm = comm
 #if defined(__parallel)
-      CALL mpi_cart_sub(comm, rdim, sub_comm, ierr)
+      CALL mpi_cart_sub(comm%handle, rdim, sub_comm%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_cart_sub @ "//routineN)
       debug_comm_count = debug_comm_count + 1
 #else
@@ -1036,7 +1051,7 @@ CONTAINS
 !..mp_comm_free
    SUBROUTINE mp_comm_free(comm)
 
-      INTEGER, INTENT(INOUT)                             :: comm
+      TYPE(mp_comm_type), INTENT(INOUT)                             :: comm
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_comm_free'
 
@@ -1046,7 +1061,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
 #if defined(__parallel)
-      CALL mpi_comm_free(comm, ierr)
+      CALL mpi_comm_free(comm%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_free @ "//routineN)
       debug_comm_count = debug_comm_count - 1
 #else
@@ -1059,8 +1074,8 @@ CONTAINS
 !..mp_comm_dup
    SUBROUTINE mp_comm_dup(comm1, comm2)
 
-      INTEGER, INTENT(IN)                                :: comm1
-      INTEGER, INTENT(OUT)                               :: comm2
+      TYPE(mp_comm_type), INTENT(IN)                                :: comm1
+      TYPE(mp_comm_type), INTENT(OUT)                               :: comm2
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_comm_dup'
 
@@ -1070,7 +1085,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
 #if defined(__parallel)
-      CALL mpi_comm_dup(comm1, comm2, ierr)
+      CALL mpi_comm_dup(comm1%handle, comm2%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_dup @ "//routineN)
       debug_comm_count = debug_comm_count + 1
 #else
@@ -1083,7 +1098,7 @@ CONTAINS
 !..mp_rank_compare
    SUBROUTINE mp_rank_compare(comm1, comm2, rank)
 
-      INTEGER, INTENT(IN)                      :: comm1, comm2
+      TYPE(mp_comm_type), INTENT(IN)                      :: comm1, comm2
       INTEGER, DIMENSION(:), CONTIGUOUS, INTENT(OUT) :: rank
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_rank_compare'
@@ -1099,14 +1114,14 @@ CONTAINS
 
       rank = 0
 #if defined(__parallel)
-      CALL mpi_comm_size(comm1, n1, ierr)
+      CALL mpi_comm_size(comm1%handle, n1, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ "//routineN)
-      CALL mpi_comm_size(comm2, n2, ierr)
+      CALL mpi_comm_size(comm2%handle, n2, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ "//routineN)
       n = MAX(n1, n2)
-      CALL mpi_comm_group(comm1, g1, ierr)
+      CALL mpi_comm_group(comm1%handle, g1, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_group @ "//routineN)
-      CALL mpi_comm_group(comm2, g2, ierr)
+      CALL mpi_comm_group(comm2%handle, g2, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_group @ "//routineN)
       ALLOCATE (rin(0:n - 1), STAT=ierr)
       IF (ierr /= 0) &
@@ -1159,7 +1174,7 @@ CONTAINS
 
 !..mp_cart_rank
    SUBROUTINE mp_cart_rank(group, pos, rank)
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                                :: group
       INTEGER, DIMENSION(:), CONTIGUOUS, INTENT(IN)      :: pos
       INTEGER, INTENT(OUT)                               :: rank
 
@@ -1168,7 +1183,7 @@ CONTAINS
       ierr = 0
 
 #if defined(__parallel)
-      CALL mpi_cart_rank(group, pos, rank, ierr)
+      CALL mpi_cart_rank(group%handle, pos, rank, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_cart_rank @ mp_cart_rank")
 #else
       rank = 0
@@ -1434,8 +1449,8 @@ CONTAINS
       !! the direct way to split a communicator each color is a sub_comm,
       !! the rank order is accoring to the order in the orig comm
 
-      INTEGER, INTENT(in)                                :: comm
-      INTEGER, INTENT(OUT)                               :: sub_comm
+      TYPE(mp_comm_type), INTENT(in)                                :: comm
+      TYPE(mp_comm_type), INTENT(OUT)                               :: sub_comm
       INTEGER, INTENT(in)                                :: color
       INTEGER, INTENT(in), OPTIONAL                      :: key
 
@@ -1449,7 +1464,7 @@ CONTAINS
       my_key = 0
 #if defined(__parallel)
       IF (PRESENT(key)) my_key = key
-      CALL mpi_comm_split(comm, color, my_key, sub_comm, ierr)
+      CALL mpi_comm_split(comm%handle, color, my_key, sub_comm%handle, ierr)
       debug_comm_count = debug_comm_count + 1
       IF (ierr /= mpi_success) CALL mp_stop(ierr, routineN)
 #else
@@ -1460,6 +1475,7 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE mp_comm_split_direct
+
    SUBROUTINE mp_comm_split(comm, sub_comm, ngroups, group_distribution, &
                             subgroup_min_size, n_subgroups, group_partition, stride)
       !! splits the given communicator in group in subgroups trying to organize
@@ -1471,10 +1487,11 @@ CONTAINS
       !! if less cpus are present than needed for subgroup min size, n_subgroups,
       !! just one comm is created that contains all cpus
 
-      INTEGER, INTENT(in)                      :: comm
+      TYPE(mp_comm_type), INTENT(in)                      :: comm
          !! the mpi communicator that you want to split
-      INTEGER, INTENT(out)                     :: sub_comm, ngroups
+      TYPE(mp_comm_type), INTENT(out)                     :: sub_comm
          !! the communicator for the subgroup (created, needs to be freed later)
+      INTEGER, INTENT(out)                     :: ngroups
          !! actual number of groups
       INTEGER, DIMENSION(0:)                   :: group_distribution
          !! input  : allocated with array with the nprocs entries (0 .. nprocs-1)
@@ -1566,7 +1583,7 @@ CONTAINS
          END IF
       END IF
       color = group_distribution(mepos)
-      CALL mpi_comm_split(comm, color, 0, sub_comm, ierr)
+      CALL mpi_comm_split(comm%handle, color, 0, sub_comm%handle, ierr)
       debug_comm_count = debug_comm_count + 1
       IF (ierr /= mpi_success) CALL mp_stop(ierr, "in "//routineP//" split")
 #else
@@ -1587,7 +1604,7 @@ CONTAINS
          !! the source of the possible incoming message, if MP_ANY_SOURCE it is a blocking one and return value is the source of the
          !! next incoming message if source is a different value it is a non-blocking probe retuning MP_ANY_SOURCE if there is no
          !! incoming message
-      INTEGER, INTENT(IN)                      :: comm
+      TYPE(mp_comm_type), INTENT(IN)                      :: comm
          !! the communicator
       INTEGER, INTENT(OUT)                     :: tag
          !! the tag of the incoming message
@@ -1607,13 +1624,13 @@ CONTAINS
       ierr = 0
 #if defined(__parallel)
       IF (source .EQ. mp_any_source) THEN
-         CALL mpi_probe(mp_any_source, mp_any_tag, comm, status_single, ierr)
+         CALL mpi_probe(mp_any_source, mp_any_tag, comm%handle, status_single, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_probe @ "//routineN)
          source = status_single(MPI_SOURCE)
          tag = status_single(MPI_TAG)
       ELSE
          flag = .FALSE.
-         CALL mpi_iprobe(source, mp_any_tag, comm, flag, status_single, ierr)
+         CALL mpi_iprobe(source, mp_any_tag, comm%handle, flag, status_single, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iprobe @ "//routineN)
          IF (flag .EQV. .FALSE.) THEN
             source = mp_any_source
@@ -1636,7 +1653,8 @@ CONTAINS
 
    SUBROUTINE mp_bcast_b(msg, source, gid)
       LOGICAL                                            :: msg
-      INTEGER                                            :: source, gid
+      INTEGER                                            :: source
+      TYPE(mp_comm_type), INTENT(IN)                     :: gid
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_bcast_b'
 
@@ -1647,7 +1665,7 @@ CONTAINS
 
       msglen = 1
 #if defined(__parallel)
-      CALL mpi_bcast(msg, msglen, MPI_LOGICAL, source, gid, ierr)
+      CALL mpi_bcast(msg, msglen, MPI_LOGICAL, source, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
       CALL add_perf(perf_id=2, msg_size=msglen*loglen)
 #else
@@ -1660,7 +1678,8 @@ CONTAINS
 
    SUBROUTINE mp_bcast_bv(msg, source, gid)
       LOGICAL, CONTIGUOUS                                :: msg(:)
-      INTEGER                                            :: source, gid
+      INTEGER                                            :: source
+      TYPE(mp_comm_type), INTENT(IN)                     :: gid
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_bcast_bv'
 
@@ -1671,7 +1690,7 @@ CONTAINS
 
       msglen = SIZE(msg)
 #if defined(__parallel)
-      CALL mpi_bcast(msg, msglen, MPI_LOGICAL, source, gid, ierr)
+      CALL mpi_bcast(msg, msglen, MPI_LOGICAL, source, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
       CALL add_perf(perf_id=2, msg_size=msglen*loglen)
 #else
@@ -1690,8 +1709,9 @@ CONTAINS
 
       LOGICAL, DIMENSION(:), CONTIGUOUS        :: msgin
          !! the input message
-      INTEGER, INTENT(IN)                      :: dest, comm
+      INTEGER, INTENT(IN)                      :: dest
          !! the destination processor
+      TYPE(mp_comm_type), INTENT(IN)           :: comm
          !! the communicator object
       INTEGER, INTENT(out)                     :: request
          !! communication request index
@@ -1716,10 +1736,10 @@ CONTAINS
       msglen = SIZE(msgin, 1)
       IF (msglen > 0) THEN
          CALL mpi_isend(msgin(1), msglen, MPI_LOGICAL, dest, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       ELSE
          CALL mpi_isend(foo, msglen, MPI_LOGICAL, dest, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -1745,8 +1765,9 @@ CONTAINS
 
       LOGICAL, DIMENSION(:), CONTIGUOUS        :: msgout
          !! the received message
-      INTEGER, INTENT(IN)                      :: source, comm
+      INTEGER, INTENT(IN)                      :: source
          !! the source processor
+      TYPE(mp_comm_type), INTENT(IN)           :: comm
          !! the communicator object
       INTEGER, INTENT(out)                     :: request
          !! communication request index
@@ -1771,10 +1792,10 @@ CONTAINS
       msglen = SIZE(msgout, 1)
       IF (msglen > 0) THEN
          CALL mpi_irecv(msgout(1), msglen, MPI_LOGICAL, source, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       ELSE
          CALL mpi_irecv(foo, msglen, MPI_LOGICAL, source, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ircv @ "//routineN)
 
@@ -1793,7 +1814,8 @@ CONTAINS
 
    SUBROUTINE mp_bcast_av(msg, source, gid)
       CHARACTER(LEN=*)                         :: msg
-      INTEGER                                  :: source, gid
+      INTEGER                                  :: source
+      TYPE(mp_comm_type), INTENT(IN)           :: gid
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_bcast_av'
 
@@ -1821,7 +1843,7 @@ CONTAINS
       DO i = 1, msglen
          imsg(i) = ICHAR(msg(i:i))
       END DO
-      CALL mpi_bcast(imsg, msglen, MPI_INTEGER, source, gid, ierr)
+      CALL mpi_bcast(imsg, msglen, MPI_INTEGER, source, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
       msg = ""
       DO i = 1, msglen
@@ -1839,7 +1861,8 @@ CONTAINS
 
    SUBROUTINE mp_bcast_am(msg, source, gid)
       CHARACTER(LEN=*)                         :: msg(:)
-      INTEGER                                  :: source, gid
+      INTEGER                                  :: source
+      TYPE(mp_comm_type), INTENT(IN)           :: gid
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_bcast_am'
 
@@ -1876,7 +1899,7 @@ CONTAINS
             imsg(k) = ICHAR(msg(j) (i:i))
          END DO
       END DO
-      CALL mpi_bcast(imsg, msglen, MPI_INTEGER, source, gid, ierr)
+      CALL mpi_bcast(imsg, msglen, MPI_INTEGER, source, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
       msg = ""
       k = 0
@@ -1908,7 +1931,7 @@ CONTAINS
 
       REAL(kind=real_8), CONTIGUOUS, INTENT(INOUT)         :: msg(:)
          !! Find location of maximum element among these data (input).
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN)                      :: gid
          !! Message passing environment identifier
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_minloc_dv'
@@ -1930,7 +1953,7 @@ CONTAINS
       ALLOCATE (res(1:msglen), STAT=ierr)
       IF (ierr /= 0) &
          DBCSR_ABORT("allocate @ "//routineN)
-      CALL mpi_allreduce(msg, res, msglen/2, MPI_2DOUBLE_PRECISION, MPI_MINLOC, gid, ierr)
+      CALL mpi_allreduce(msg, res, msglen/2, MPI_2DOUBLE_PRECISION, MPI_MINLOC, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       msg = res
       DEALLOCATE (res)
@@ -1953,7 +1976,7 @@ CONTAINS
 
       REAL(kind=real_8), CONTIGUOUS, INTENT(INOUT)         :: msg(:)
          !! Find location of maximum element among these data (input).
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN)                      :: gid
          !! Message passing environment identifier
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_maxloc_dv'
@@ -1973,7 +1996,7 @@ CONTAINS
 #if defined(__parallel)
       msglen = SIZE(msg)
       ALLOCATE (res(1:msglen))
-      CALL mpi_allreduce(msg, res, msglen/2, MPI_2DOUBLE_PRECISION, MPI_MAXLOC, gid, ierr)
+      CALL mpi_allreduce(msg, res, msglen/2, MPI_2DOUBLE_PRECISION, MPI_MAXLOC, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       msg = res
       DEALLOCATE (res)
@@ -1993,7 +2016,7 @@ CONTAINS
 
       LOGICAL, INTENT(INOUT)                             :: msg
          !! Datum to perform inclusive disjunction (input) and resultant inclusive disjunction (output)
-      INTEGER, INTENT(IN)                                :: gid
+      TYPE(mp_comm_type), INTENT(IN)                                :: gid
          !! Message passing environment identifier
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_sum_b'
@@ -2004,7 +2027,7 @@ CONTAINS
       ierr = 0
       msglen = 1
 #if defined(__parallel)
-      CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, MPI_LOGICAL, MPI_LOR, gid, ierr)
+      CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, MPI_LOGICAL, MPI_LOR, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
 #else
       MARK_USED(msg)
@@ -2021,7 +2044,7 @@ CONTAINS
 
       LOGICAL, DIMENSION(:), CONTIGUOUS, INTENT(INOUT)   :: msg
          !! Datum to perform inclusive disjunction (input) and resultant inclusive disjunction (output)
-      INTEGER, INTENT(IN)                                :: gid
+      TYPE(mp_comm_type), INTENT(IN)                                :: gid
          !! Message passing environment identifier
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_sum_bv'
@@ -2033,7 +2056,7 @@ CONTAINS
       msglen = SIZE(msg)
 #if defined(__parallel)
       IF (msglen .GT. 0) THEN
-         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, MPI_LOGICAL, MPI_LOR, gid, ierr)
+         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, MPI_LOGICAL, MPI_LOR, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       END IF
 #else
@@ -2051,7 +2074,7 @@ CONTAINS
 
       LOGICAL, DIMENSION(:), CONTIGUOUS, INTENT(INOUT)   :: msg
          !! Datum to perform inclusive disjunction (input) and resultant inclusive disjunction (output)
-      INTEGER, INTENT(IN)                                :: gid
+      TYPE(mp_comm_type), INTENT(IN)                                :: gid
          !! Message passing environment identifier
       INTEGER, INTENT(INOUT)                             :: request
 
@@ -2064,7 +2087,7 @@ CONTAINS
       msglen = SIZE(msg)
 #if defined(__parallel)
       IF (msglen .GT. 0) THEN
-         CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, MPI_LOGICAL, MPI_LOR, gid, request, ierr)
+         CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, MPI_LOGICAL, MPI_LOR, gid%handle, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallreduce @ "//routineN)
       ELSE
          request = mp_request_null
@@ -2129,7 +2152,7 @@ CONTAINS
       !!
       !! STREAM-I/O mapping  OPEN
 
-      INTEGER, INTENT(IN)                      :: groupid
+      TYPE(mp_comm_type), INTENT(IN)                      :: groupid
          !! message passing environment identifier
       INTEGER, INTENT(OUT)                     :: fh
          !! file handle (file storage unit)
@@ -2154,7 +2177,7 @@ CONTAINS
 #if defined(__parallel)
       my_info = mpi_info_null
       IF (PRESENT(info)) my_info = info
-      CALL mpi_file_open(groupid, filepath, amode_status, my_info, fh, ierr)
+      CALL mpi_file_open(groupid%handle, filepath, amode_status, my_info, fh, ierr)
       CALL mpi_file_set_errhandler(fh, MPI_ERRORS_RETURN, ierr)
       IF (ierr .NE. 0) CALL mp_stop(ierr, "mpi_file_set_errhandler @ mp_file_open")
 #else
@@ -2458,7 +2481,8 @@ CONTAINS
    SUBROUTINE mp_isend_custom(msgin, dest, comm, request, tag)
       !! Non-blocking send of custom type
       TYPE(mp_type_descriptor_type), INTENT(IN)          :: msgin
-      INTEGER, INTENT(IN)                                :: dest, comm
+      INTEGER, INTENT(IN)                                :: dest
+      TYPE(mp_comm_type), INTENT(IN)                     :: comm
       INTEGER, INTENT(out)                               :: request
       INTEGER, INTENT(in), OPTIONAL                      :: tag
 
@@ -2472,7 +2496,7 @@ CONTAINS
 
       ierr = 0
       CALL mpi_isend(MPI_BOTTOM, 1, msgin%type_handle, dest, my_tag, &
-                     comm, request, ierr)
+                     comm%handle, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 #else
       MARK_USED(msgin)
@@ -2489,7 +2513,8 @@ CONTAINS
    SUBROUTINE mp_irecv_custom(msgout, source, comm, request, tag)
       !! Non-blocking receive of vector data
       TYPE(mp_type_descriptor_type), INTENT(INOUT)       :: msgout
-      INTEGER, INTENT(IN)                                :: source, comm
+      INTEGER, INTENT(IN)                                :: source
+      TYPE(mp_comm_type), INTENT(IN)                     :: comm
       INTEGER, INTENT(out)                               :: request
       INTEGER, INTENT(in), OPTIONAL                      :: tag
 
@@ -2504,7 +2529,7 @@ CONTAINS
       IF (PRESENT(tag)) my_tag = tag
 
       CALL mpi_irecv(MPI_BOTTOM, 1, msgout%type_handle, source, my_tag, &
-                     comm, request, ierr)
+                     comm%handle, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 #else
       MARK_USED(msgout)
@@ -2626,7 +2651,7 @@ CONTAINS
          INTEGER, CONTIGUOUS, INTENT(IN)          :: rcount(:), rdispl(:)
          !! Data counts for data received from other processes
          !! Respective data offsets for data received from other processes
-         INTEGER, INTENT(IN)                      :: group
+         TYPE(mp_comm_type), INTENT(IN)                      :: group
          !! Message passing environment identifier
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$11v'
@@ -2643,7 +2668,7 @@ CONTAINS
          ierr = 0
 #if defined(__parallel)
          CALL mpi_alltoallv(sb, scount, sdispl, ${mpi_type1}$, &
-                            rb, rcount, rdispl, ${mpi_type1}$, group, ierr)
+                            rb, rcount, rdispl, ${mpi_type1}$, group%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_alltoallv @ "//routineN)
          msglen = SUM(scount) + SUM(rcount)
          CALL add_perf(perf_id=6, msg_size=msglen*${bytes1}$)
@@ -2678,8 +2703,9 @@ CONTAINS
          !! array with data to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: rb(:)
          !! array into which data is received
-         INTEGER, INTENT(IN)                      :: count, group
+         INTEGER, INTENT(IN)                      :: count
          !! number of elements to send/receive (product of the extents of the first two dimensions)
+         TYPE(mp_comm_type), INTENT(IN)           :: group
          !! Message passing environment identifier
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$'
@@ -2694,9 +2720,9 @@ CONTAINS
 
 #if defined(__parallel)
          CALL mpi_alltoall(sb, count, ${mpi_type1}$, &
-                           rb, count, ${mpi_type1}$, group, ierr)
+                           rb, count, ${mpi_type1}$, group%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_alltoall @ "//routineN)
-         CALL mpi_comm_size(group, np, ierr)
+         CALL mpi_comm_size(group%handle, np, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ "//routineN)
          msglen = 2*count*np
          CALL add_perf(perf_id=6, msg_size=msglen*${bytes1}$)
@@ -2715,7 +2741,8 @@ CONTAINS
 
          ${type1}$, CONTIGUOUS, INTENT(IN)        :: sb(:, :)
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: rb(:, :)
-         INTEGER, INTENT(IN)                      :: count, group
+         INTEGER, INTENT(IN)                      :: count
+         TYPE(mp_comm_type), INTENT(IN)           :: group
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$22'
 
@@ -2729,9 +2756,9 @@ CONTAINS
 
 #if defined(__parallel)
          CALL mpi_alltoall(sb, count, ${mpi_type1}$, &
-                           rb, count, ${mpi_type1}$, group, ierr)
+                           rb, count, ${mpi_type1}$, group%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_alltoall @ "//routineN)
-         CALL mpi_comm_size(group, np, ierr)
+         CALL mpi_comm_size(group%handle, np, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ "//routineN)
          msglen = 2*SIZE(sb)*np
          CALL add_perf(perf_id=6, msg_size=msglen*${bytes1}$)
@@ -2752,7 +2779,8 @@ CONTAINS
             INTENT(IN)                            :: sb
          ${type1}$, DIMENSION(:, :, :, :), CONTIGUOUS, &
             INTENT(OUT)                           :: rb
-         INTEGER, INTENT(IN)                      :: count, group
+         INTEGER, INTENT(IN)                      :: count
+         TYPE(mp_comm_type), INTENT(IN)           :: group
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$44'
 
@@ -2766,9 +2794,9 @@ CONTAINS
 
 #if defined(__parallel)
          CALL mpi_alltoall(sb, count, ${mpi_type1}$, &
-                           rb, count, ${mpi_type1}$, group, ierr)
+                           rb, count, ${mpi_type1}$, group%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_alltoall @ "//routineN)
-         CALL mpi_comm_size(group, np, ierr)
+         CALL mpi_comm_size(group%handle, np, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ "//routineN)
          msglen = 2*count*np
          CALL add_perf(perf_id=6, msg_size=msglen*${bytes1}$)
@@ -2789,9 +2817,10 @@ CONTAINS
 
          ${type1}$                                :: msg
          !! Scalar to send
-         INTEGER                                  :: dest, tag, gid
+         INTEGER                                  :: dest, tag
          !! Destination process
          !! Transfer identifier
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
          !! Message passing environment identifier
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_send_${nametype1}$'
@@ -2803,7 +2832,7 @@ CONTAINS
 
          msglen = 1
 #if defined(__parallel)
-         CALL mpi_send(msg, msglen, ${mpi_type1}$, dest, tag, gid, ierr)
+         CALL mpi_send(msg, msglen, ${mpi_type1}$, dest, tag, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_send @ "//routineN)
          CALL add_perf(perf_id=13, msg_size=msglen*${bytes1}$)
 #else
@@ -2823,7 +2852,8 @@ CONTAINS
 
          ${type1}$, CONTIGUOUS                    :: msg(:)
          !! Rank-1 data to send
-         INTEGER                                  :: dest, tag, gid
+         INTEGER                                  :: dest, tag
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_send_${nametype1}$v'
 
@@ -2834,7 +2864,7 @@ CONTAINS
 
          msglen = SIZE(msg)
 #if defined(__parallel)
-         CALL mpi_send(msg, msglen, ${mpi_type1}$, dest, tag, gid, ierr)
+         CALL mpi_send(msg, msglen, ${mpi_type1}$, dest, tag, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_send @ "//routineN)
          CALL add_perf(perf_id=13, msg_size=msglen*${bytes1}$)
 #else
@@ -2859,7 +2889,7 @@ CONTAINS
          INTEGER, INTENT(INOUT)                   :: source, tag
          !! Process to receive from
          !! Transfer identifier
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
          !! Message passing environment identifier
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_recv_${nametype1}$'
@@ -2875,7 +2905,7 @@ CONTAINS
          msglen = 1
 #if defined(__parallel)
          ALLOCATE (status(MPI_STATUS_SIZE))
-         CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, gid, status, ierr)
+         CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, gid%handle, status, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_recv @ "//routineN)
          CALL add_perf(perf_id=14, msg_size=msglen*${bytes1}$)
          source = status(MPI_SOURCE)
@@ -2899,7 +2929,7 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(INOUT)     :: msg(:)
          !! Place received data into this rank-1 array
          INTEGER, INTENT(INOUT)                   :: source, tag
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_recv_${nametype1}$v'
 
@@ -2914,7 +2944,7 @@ CONTAINS
          msglen = SIZE(msg)
 #if defined(__parallel)
          ALLOCATE (status(MPI_STATUS_SIZE))
-         CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, gid, status, ierr)
+         CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, gid%handle, status, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_recv @ "//routineN)
          CALL add_perf(perf_id=14, msg_size=msglen*${bytes1}$)
          source = status(MPI_SOURCE)
@@ -2939,8 +2969,9 @@ CONTAINS
 
          ${type1}$                                :: msg
          !! Datum to broadcast
-         INTEGER                                  :: source, gid
+         INTEGER                                  :: source
          !! Processes which broadcasts
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
          !! Message passing environment identifier
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_bcast_${nametype1}$'
@@ -2952,7 +2983,7 @@ CONTAINS
 
          msglen = 1
 #if defined(__parallel)
-         CALL mpi_bcast(msg, msglen, ${mpi_type1}$, source, gid, ierr)
+         CALL mpi_bcast(msg, msglen, ${mpi_type1}$, source, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
          CALL add_perf(perf_id=2, msg_size=msglen*${bytes1}$)
 #else
@@ -2971,8 +3002,9 @@ CONTAINS
 
          ${type1}$                                :: msg
          !! Datum to broadcast
-         INTEGER                                  :: source, gid
+         INTEGER                                  :: source
          !! Processes which broadcasts
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
          !! Message passing environment identifier
          INTEGER, INTENT(INOUT)                   :: request
 
@@ -2985,7 +3017,7 @@ CONTAINS
 
          msglen = 1
 #if defined(__parallel)
-         CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid, request, ierr)
+         CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid%handle, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ibcast @ "//routineN)
          CALL add_perf(perf_id=22, msg_size=msglen*${bytes1}$)
 #else
@@ -3003,7 +3035,8 @@ CONTAINS
 
          ${type1}$, CONTIGUOUS                    :: msg(:)
          !! Data to broadcast
-         INTEGER                                  :: source, gid
+         INTEGER                                  :: source
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_bcast_${nametype1}$v'
 
@@ -3014,7 +3047,7 @@ CONTAINS
 
          msglen = SIZE(msg)
 #if defined(__parallel)
-         CALL mpi_bcast(msg, msglen, ${mpi_type1}$, source, gid, ierr)
+         CALL mpi_bcast(msg, msglen, ${mpi_type1}$, source, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
          CALL add_perf(perf_id=2, msg_size=msglen*${bytes1}$)
 #else
@@ -3030,7 +3063,8 @@ CONTAINS
 
          ${type1}$, CONTIGUOUS                    :: msg(:)
          !! Data to broadcast
-         INTEGER                                  :: source, gid
+         INTEGER                                  :: source
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
          INTEGER, INTENT(INOUT)                   :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_ibcast_${nametype1}$v'
@@ -3042,7 +3076,7 @@ CONTAINS
 
          msglen = SIZE(msg)
 #if defined(__parallel)
-         CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid, request, ierr)
+         CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid%handle, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ibcast @ "//routineN)
          CALL add_perf(perf_id=22, msg_size=msglen*${bytes1}$)
 #else
@@ -3059,7 +3093,8 @@ CONTAINS
 
          ${type1}$, CONTIGUOUS                    :: msg(:, :)
          !! Data to broadcast
-         INTEGER                                  :: source, gid
+         INTEGER                                  :: source
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_bcast_im'
 
@@ -3070,7 +3105,7 @@ CONTAINS
 
          msglen = SIZE(msg)
 #if defined(__parallel)
-         CALL mpi_bcast(msg, msglen, ${mpi_type1}$, source, gid, ierr)
+         CALL mpi_bcast(msg, msglen, ${mpi_type1}$, source, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
          CALL add_perf(perf_id=2, msg_size=msglen*${bytes1}$)
 #else
@@ -3086,7 +3121,8 @@ CONTAINS
 
          ${type1}$, CONTIGUOUS                    :: msg(:, :, :)
          !! Data to broadcast
-         INTEGER                                  :: source, gid
+         INTEGER                                  :: source
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_bcast_${nametype1}$3'
 
@@ -3097,7 +3133,7 @@ CONTAINS
 
          msglen = SIZE(msg)
 #if defined(__parallel)
-         CALL mpi_bcast(msg, msglen, ${mpi_type1}$, source, gid, ierr)
+         CALL mpi_bcast(msg, msglen, ${mpi_type1}$, source, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
          CALL add_perf(perf_id=2, msg_size=msglen*${bytes1}$)
 #else
@@ -3115,7 +3151,7 @@ CONTAINS
 
          ${type1}$, INTENT(INOUT)    :: msg
          !! Datum to sum (input) and result (output)
-         INTEGER, INTENT(IN)         :: gid
+         TYPE(mp_comm_type), INTENT(IN)         :: gid
          !! Message passing environment identifier
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_sum_${nametype1}$'
@@ -3127,7 +3163,7 @@ CONTAINS
 
          msglen = 1
 #if defined(__parallel)
-         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid, ierr)
+         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
          CALL add_perf(perf_id=3, msg_size=msglen*${bytes1}$)
 #else
@@ -3143,7 +3179,7 @@ CONTAINS
 
          ${type1}$, CONTIGUOUS, INTENT(INOUT)     :: msg(:)
          !! Vector to sum and result
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_sum_${nametype1}$v'
 
@@ -3158,7 +3194,7 @@ CONTAINS
 #if defined(__parallel)
          msglen = SIZE(msg)
          IF (msglen > 0) THEN
-            CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid, ierr)
+            CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid%handle, ierr)
             IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
          END IF
          CALL add_perf(perf_id=3, msg_size=msglen*${bytes1}$)
@@ -3175,7 +3211,7 @@ CONTAINS
 
          ${type1}$, CONTIGUOUS, INTENT(INOUT)     :: msg(:)
          !! Vector to sum and result
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
          INTEGER, INTENT(INOUT)                   :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_isum_${nametype1}$v'
@@ -3191,7 +3227,7 @@ CONTAINS
 #if defined(__parallel)
          msglen = SIZE(msg)
          IF (msglen > 0) THEN
-            CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid, request, ierr)
+            CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid%handle, request, ierr)
             IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallreduce @ "//routineN)
          ELSE
             request = mp_request_null
@@ -3211,7 +3247,7 @@ CONTAINS
 
          ${type1}$, CONTIGUOUS, INTENT(INOUT)     :: msg(:, :)
          !! Matrix to sum and result
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_sum_${nametype1}$m'
 
@@ -3232,7 +3268,7 @@ CONTAINS
             msglen = SIZE(msg, 1)*(MIN(UBOUND(msg, 2), m1 + step - 1) - m1 + 1)
             msglensum = msglensum + msglen
             IF (msglen > 0) THEN
-               CALL mpi_allreduce(MPI_IN_PLACE, msg(LBOUND(msg, 1), m1), msglen, ${mpi_type1}$, MPI_SUM, gid, ierr)
+               CALL mpi_allreduce(MPI_IN_PLACE, msg(LBOUND(msg, 1), m1), msglen, ${mpi_type1}$, MPI_SUM, gid%handle, ierr)
                IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
             END IF
          END DO
@@ -3250,7 +3286,7 @@ CONTAINS
 
          ${type1}$, CONTIGUOUS, INTENT(INOUT)     :: msg(:, :, :)
          !! Array to sum and result
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_sum_${nametype1}$m3'
 
@@ -3262,7 +3298,7 @@ CONTAINS
          msglen = SIZE(msg)
 #if defined(__parallel)
          IF (msglen > 0) THEN
-            CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid, ierr)
+            CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid%handle, ierr)
             IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
          END IF
          CALL add_perf(perf_id=3, msg_size=msglen*${bytes1}$)
@@ -3278,7 +3314,7 @@ CONTAINS
 
          ${type1}$, CONTIGUOUS, INTENT(INOUT)     :: msg(:, :, :, :)
          !! Array to sum and result
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_sum_${nametype1}$m4'
 
@@ -3291,7 +3327,7 @@ CONTAINS
          msglen = SIZE(msg)
 #if defined(__parallel)
          IF (msglen > 0) THEN
-            CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid, ierr)
+            CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid%handle, ierr)
             IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
          END IF
          CALL add_perf(perf_id=3, msg_size=msglen*${bytes1}$)
@@ -3310,7 +3346,8 @@ CONTAINS
 
          ${type1}$, CONTIGUOUS, INTENT(INOUT)     :: msg(:)
          !! Vector to sum (input) and (only on process root) result (output)
-         INTEGER, INTENT(IN)                      :: root, gid
+         INTEGER, INTENT(IN)                      :: root
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
          !! Message passing environment identifier
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_sum_root_${nametype1}$v'
@@ -3326,13 +3363,13 @@ CONTAINS
 
          msglen = SIZE(msg)
 #if defined(__parallel)
-         CALL mpi_comm_rank(gid, taskid, ierr)
+         CALL mpi_comm_rank(gid%handle, taskid, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_rank @ "//routineN)
          IF (msglen > 0) THEN
             m1 = SIZE(msg, 1)
             ALLOCATE (res(m1))
             CALL mpi_reduce(msg, res, msglen, ${mpi_type1}$, MPI_SUM, &
-                            root, gid, ierr)
+                            root, gid%handle, ierr)
             IF (ierr /= 0) CALL mp_stop(ierr, "mpi_reduce @ "//routineN)
             IF (taskid == root) THEN
                msg = res
@@ -3354,7 +3391,8 @@ CONTAINS
 
          ${type1}$, CONTIGUOUS, INTENT(INOUT)     :: msg(:, :)
          !! Matrix to sum (input) and (only on process root) result (output)
-         INTEGER, INTENT(IN)                      :: root, gid
+         INTEGER, INTENT(IN)                      :: root
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_sum_root_rm'
 
@@ -3369,13 +3407,13 @@ CONTAINS
 
          msglen = SIZE(msg)
 #if defined(__parallel)
-         CALL mpi_comm_rank(gid, taskid, ierr)
+         CALL mpi_comm_rank(gid%handle, taskid, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_rank @ "//routineN)
          IF (msglen > 0) THEN
             m1 = SIZE(msg, 1)
             m2 = SIZE(msg, 2)
             ALLOCATE (res(m1, m2))
-            CALL mpi_reduce(msg, res, msglen, ${mpi_type1}$, MPI_SUM, root, gid, ierr)
+            CALL mpi_reduce(msg, res, msglen, ${mpi_type1}$, MPI_SUM, root, gid%handle, ierr)
             IF (ierr /= 0) CALL mp_stop(ierr, "mpi_reduce @ "//routineN)
             IF (taskid == root) THEN
                msg = res
@@ -3397,7 +3435,7 @@ CONTAINS
          !! Matrix to sum (input)
          ${type1}$, CONTIGUOUS, INTENT(OUT) :: res(:, :)
          !! Matrix containing result (output)
-         INTEGER, INTENT(IN)                :: gid
+         TYPE(mp_comm_type), INTENT(IN)                :: gid
          !! Message passing environment identifier
 
          CHARACTER(LEN=*), PARAMETER        :: routineN = 'mp_sum_partial_${nametype1}$m'
@@ -3412,10 +3450,10 @@ CONTAINS
 
          msglen = SIZE(msg)
 #if defined(__parallel)
-         CALL mpi_comm_rank(gid, taskid, ierr)
+         CALL mpi_comm_rank(gid%handle, taskid, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_rank @ "//routineN)
          IF (msglen > 0) THEN
-            CALL mpi_scan(msg, res, msglen, ${mpi_type1}$, MPI_SUM, gid, ierr)
+            CALL mpi_scan(msg, res, msglen, ${mpi_type1}$, MPI_SUM, gid%handle, ierr)
             IF (ierr /= 0) CALL mp_stop(ierr, "mpi_scan @ "//routineN)
          END IF
          CALL add_perf(perf_id=3, msg_size=msglen*${bytes1}$)
@@ -3435,7 +3473,7 @@ CONTAINS
 
          ${type1}$, INTENT(INOUT)                 :: msg
          !! Find maximum among these data (input) and maximum (output)
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
          !! Message passing environment identifier
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_max_${nametype1}$'
@@ -3447,7 +3485,7 @@ CONTAINS
 
          msglen = 1
 #if defined(__parallel)
-         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_MAX, gid, ierr)
+         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_MAX, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
          CALL add_perf(perf_id=3, msg_size=msglen*${bytes1}$)
 #else
@@ -3464,7 +3502,7 @@ CONTAINS
 
          ${type1}$, CONTIGUOUS, INTENT(INOUT)     :: msg(:)
          !! Find maximum among these data (input) and maximum (output)
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_max_${nametype1}$v'
 
@@ -3475,7 +3513,7 @@ CONTAINS
 
          msglen = SIZE(msg)
 #if defined(__parallel)
-         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_MAX, gid, ierr)
+         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_MAX, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
          CALL add_perf(perf_id=3, msg_size=msglen*${bytes1}$)
 #else
@@ -3492,7 +3530,7 @@ CONTAINS
 
          ${type1}$, INTENT(INOUT)                 :: msg
          !! Find minimum among these data (input) and maximum (output)
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
          !! Message passing environment identifier
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_min_${nametype1}$'
@@ -3504,7 +3542,7 @@ CONTAINS
 
          msglen = 1
 #if defined(__parallel)
-         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_MIN, gid, ierr)
+         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_MIN, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
          CALL add_perf(perf_id=3, msg_size=msglen*${bytes1}$)
 #else
@@ -3524,7 +3562,7 @@ CONTAINS
 
          ${type1}$, CONTIGUOUS, INTENT(INOUT)     :: msg(:)
          !! Find minimum among these data (input) and maximum (output)
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_min_${nametype1}$v'
 
@@ -3535,7 +3573,7 @@ CONTAINS
 
          msglen = SIZE(msg)
 #if defined(__parallel)
-         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_MIN, gid, ierr)
+         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_MIN, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
          CALL add_perf(perf_id=3, msg_size=msglen*${bytes1}$)
 #else
@@ -3553,7 +3591,7 @@ CONTAINS
 
          ${type1}$, INTENT(INOUT)                 :: msg
          !! a number to multiply (input) and result (output)
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
          !! message passing environment identifier
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_sum_${nametype1}$'
@@ -3565,7 +3603,7 @@ CONTAINS
 
          msglen = 1
 #if defined(__parallel)
-         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_PROD, gid, ierr)
+         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_PROD, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
          CALL add_perf(perf_id=3, msg_size=msglen*${bytes1}$)
 #else
@@ -3584,8 +3622,9 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(IN)        :: msg_scatter(:)
          !! Data to scatter (for root process)
          ${type1}$, INTENT(INOUT)                 :: msg
-         INTEGER, INTENT(IN)                      :: root, gid
+         INTEGER, INTENT(IN)                      :: root
          !! Process which scatters data
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
          !! Message passing environment identifier
          INTEGER, INTENT(INOUT)                   :: request
 
@@ -3599,7 +3638,7 @@ CONTAINS
          msglen = 1
 #if defined(__parallel)
          CALL mpi_iscatter(msg_scatter, msglen, ${mpi_type1}$, msg, &
-                           msglen, ${mpi_type1}$, root, gid, request, ierr)
+                           msglen, ${mpi_type1}$, root, gid%handle, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iscatter @ "//routineN)
          CALL add_perf(perf_id=24, msg_size=1*${bytes1}$)
 #else
@@ -3620,8 +3659,9 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(IN)        :: msg_scatter(:, :)
          !! Data to scatter (for root process)
          ${type1}$, CONTIGUOUS, INTENT(INOUT)     :: msg(:)
-         INTEGER, INTENT(IN)                      :: root, gid
+         INTEGER, INTENT(IN)                      :: root
          !! Process which scatters data
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
          !! Message passing environment identifier
          INTEGER, INTENT(INOUT)                   :: request
 
@@ -3635,7 +3675,7 @@ CONTAINS
          msglen = SIZE(msg)
 #if defined(__parallel)
          CALL mpi_iscatter(msg_scatter, msglen, ${mpi_type1}$, msg, &
-                           msglen, ${mpi_type1}$, root, gid, request, ierr)
+                           msglen, ${mpi_type1}$, root, gid%handle, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iscatter @ "//routineN)
          CALL add_perf(perf_id=24, msg_size=1*${bytes1}$)
 #else
@@ -3657,8 +3697,9 @@ CONTAINS
          !! Data to scatter (for root process)
          INTEGER, CONTIGUOUS, INTENT(IN)          :: sendcounts(:), displs(:)
          ${type1}$, CONTIGUOUS, INTENT(INOUT)     :: msg(:)
-         INTEGER, INTENT(IN)                      :: recvcount, root, gid
+         INTEGER, INTENT(IN)                      :: recvcount, root
          !! Process which scatters data
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
          !! Message passing environment identifier
          INTEGER, INTENT(INOUT)                   :: request
 
@@ -3671,7 +3712,7 @@ CONTAINS
 
 #if defined(__parallel)
          CALL mpi_iscatterv(msg_scatter, sendcounts, displs, ${mpi_type1}$, msg, &
-                            recvcount, ${mpi_type1}$, root, gid, request, ierr)
+                            recvcount, ${mpi_type1}$, root, gid%handle, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iscatterv @ "//routineN)
          CALL add_perf(perf_id=24, msg_size=1*${bytes1}$)
 #else
@@ -3696,8 +3737,9 @@ CONTAINS
          !! Datum to send to root
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msg_gather(:)
          !! Received data (on root)
-         INTEGER, INTENT(IN)                      :: root, gid
+         INTEGER, INTENT(IN)                      :: root
          !! Process which gathers the data
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
          !! Message passing environment identifier
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_gather_${nametype1}$'
@@ -3710,7 +3752,7 @@ CONTAINS
          msglen = 1
 #if defined(__parallel)
          CALL mpi_gather(msg, msglen, ${mpi_type1}$, msg_gather, &
-                         msglen, ${mpi_type1}$, root, gid, ierr)
+                         msglen, ${mpi_type1}$, root, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_gather @ "//routineN)
          CALL add_perf(perf_id=4, msg_size=msglen*${bytes1}$)
 #else
@@ -3734,7 +3776,8 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(IN)        :: msg(:)
          !! Datum to send to root
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msg_gather(:)
-         INTEGER, INTENT(IN)                      :: root, gid
+         INTEGER, INTENT(IN)                      :: root
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_gather_${nametype1}$v'
 
@@ -3746,7 +3789,7 @@ CONTAINS
          msglen = SIZE(msg)
 #if defined(__parallel)
          CALL mpi_gather(msg, msglen, ${mpi_type1}$, msg_gather, &
-                         msglen, ${mpi_type1}$, root, gid, ierr)
+                         msglen, ${mpi_type1}$, root, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_gather @ "//routineN)
          CALL add_perf(perf_id=4, msg_size=msglen*${bytes1}$)
 #else
@@ -3770,7 +3813,8 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(IN)        :: msg(:, :)
          !! Datum to send to root
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msg_gather(:, :)
-         INTEGER, INTENT(IN)                      :: root, gid
+         INTEGER, INTENT(IN)                      :: root
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_gather_${nametype1}$m'
 
@@ -3782,7 +3826,7 @@ CONTAINS
          msglen = SIZE(msg)
 #if defined(__parallel)
          CALL mpi_gather(msg, msglen, ${mpi_type1}$, msg_gather, &
-                         msglen, ${mpi_type1}$, root, gid, ierr)
+                         msglen, ${mpi_type1}$, root, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_gather @ "//routineN)
          CALL add_perf(perf_id=4, msg_size=msglen*${bytes1}$)
 #else
@@ -3812,8 +3856,9 @@ CONTAINS
          INTEGER, DIMENSION(:), CONTIGUOUS, INTENT(IN)        :: recvcounts, displs
          !! Sizes of data received from processes
          !! Offsets of data received from processes
-         INTEGER, INTENT(IN)                      :: root, comm
+         INTEGER, INTENT(IN)                      :: root
          !! Process which gathers the data
+         TYPE(mp_comm_type), INTENT(IN)           :: comm
          !! Message passing environment identifier
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_gatherv_${nametype1}$v'
@@ -3830,7 +3875,7 @@ CONTAINS
          sendcount = SIZE(sendbuf)
          CALL mpi_gatherv(sendbuf, sendcount, ${mpi_type1}$, &
                           recvbuf, recvcounts, displs, ${mpi_type1}$, &
-                          root, comm, ierr)
+                          root, comm%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_gatherv @ "//routineN)
          CALL add_perf(perf_id=4, &
                        msg_size=sendcount*${bytes1}$)
@@ -3857,7 +3902,7 @@ CONTAINS
          !! Datum to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:)
          !! Received data
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
          !! Message passing environment identifier
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_allgather_${nametype1}$'
@@ -3875,7 +3920,7 @@ CONTAINS
          rcount = 1
          CALL MPI_ALLGATHER(msgout, scount, ${mpi_type1}$, &
                             msgin, rcount, ${mpi_type1}$, &
-                            gid, ierr)
+                            gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -3898,7 +3943,7 @@ CONTAINS
          !! Datum to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:, :)
          !! Received data
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
          !! Message passing environment identifier
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_allgather_${nametype1}$2'
@@ -3916,7 +3961,7 @@ CONTAINS
          rcount = 1
          CALL MPI_ALLGATHER(msgout, scount, ${mpi_type1}$, &
                             msgin, rcount, ${mpi_type1}$, &
-                            gid, ierr)
+                            gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -3939,7 +3984,7 @@ CONTAINS
          !! Datum to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:)
          !! Received data
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
          !! Message passing environment identifier
          INTEGER, INTENT(INOUT)                   :: request
 
@@ -3958,7 +4003,7 @@ CONTAINS
          rcount = 1
          CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                              msgin, rcount, ${mpi_type1}$, &
-                             gid, request, ierr)
+                             gid%handle, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -3985,7 +4030,7 @@ CONTAINS
          !! Rank-1 data to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:, :)
          !! Received data
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
          !! Message passing environment identifier
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_allgather_${nametype1}$12'
@@ -4003,7 +4048,7 @@ CONTAINS
          rcount = scount
          CALL MPI_ALLGATHER(msgout, scount, ${mpi_type1}$, &
                             msgin, rcount, ${mpi_type1}$, &
-                            gid, ierr)
+                            gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -4020,7 +4065,7 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(IN)        :: msgout(:, :)
          !! Rank-2 data to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:, :, :)
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_allgather_${nametype1}$23'
 
@@ -4037,7 +4082,7 @@ CONTAINS
          rcount = scount
          CALL MPI_ALLGATHER(msgout, scount, ${mpi_type1}$, &
                             msgin, rcount, ${mpi_type1}$, &
-                            gid, ierr)
+                            gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -4054,7 +4099,7 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(IN)        :: msgout(:, :, :)
          !! Rank-3 data to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:, :, :, :)
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_allgather_${nametype1}$34'
 
@@ -4071,7 +4116,7 @@ CONTAINS
          rcount = scount
          CALL MPI_ALLGATHER(msgout, scount, ${mpi_type1}$, &
                             msgin, rcount, ${mpi_type1}$, &
-                            gid, ierr)
+                            gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -4088,7 +4133,7 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(IN)        :: msgout(:, :)
          !! Rank-2 data to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:, :)
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_allgather_${nametype1}$22'
 
@@ -4105,7 +4150,7 @@ CONTAINS
          rcount = scount
          CALL MPI_ALLGATHER(msgout, scount, ${mpi_type1}$, &
                             msgin, rcount, ${mpi_type1}$, &
-                            gid, ierr)
+                            gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -4122,7 +4167,7 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(IN)        :: msgout(:)
          !! Rank-1 data to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:)
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
          INTEGER, INTENT(OUT)                     :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$11'
@@ -4140,7 +4185,7 @@ CONTAINS
          rcount = scount
          CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                              msgin, rcount, ${mpi_type1}$, &
-                             gid, request, ierr)
+                             gid%handle, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -4158,7 +4203,7 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(IN)        :: msgout(:)
          !! Rank-2 data to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:, :, :)
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
          INTEGER, INTENT(OUT)                     :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$13'
@@ -4176,7 +4221,7 @@ CONTAINS
          rcount = scount
          CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                              msgin, rcount, ${mpi_type1}$, &
-                             gid, request, ierr)
+                             gid%handle, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -4194,7 +4239,7 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(IN)        :: msgout(:, :)
          !! Rank-2 data to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:, :)
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
          INTEGER, INTENT(OUT)                     :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$22'
@@ -4212,7 +4257,7 @@ CONTAINS
          rcount = scount
          CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                              msgin, rcount, ${mpi_type1}$, &
-                             gid, request, ierr)
+                             gid%handle, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -4230,7 +4275,7 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(IN)        :: msgout(:, :)
          !! Rank-2 data to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:, :, :, :)
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
          INTEGER, INTENT(OUT)                     :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$24'
@@ -4248,7 +4293,7 @@ CONTAINS
          rcount = scount
          CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                              msgin, rcount, ${mpi_type1}$, &
-                             gid, request, ierr)
+                             gid%handle, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -4266,7 +4311,7 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(IN)        :: msgout(:, :, :)
          !! Rank-3 data to send
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:, :, :)
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
          INTEGER, INTENT(OUT)                     :: request
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$33'
@@ -4284,7 +4329,7 @@ CONTAINS
          rcount = scount
          CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                              msgin, rcount, ${mpi_type1}$, &
-                             gid, request, ierr)
+                             gid%handle, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
          MARK_USED(gid)
@@ -4315,7 +4360,7 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:)
          !! Received data
          INTEGER, CONTIGUOUS, INTENT(IN)          :: rcount(:), rdispl(:)
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
          !! Size of sent data for every process
          !! Offset of sent data for every process
          !! Message passing environment identifier
@@ -4333,7 +4378,7 @@ CONTAINS
 #if defined(__parallel)
          scount = SIZE(msgout)
          CALL MPI_ALLGATHERV(msgout, scount, ${mpi_type1}$, msgin, rcount, &
-                             rdispl, ${mpi_type1}$, gid, ierr)
+                             rdispl, ${mpi_type1}$, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allgatherv @ "//routineN)
 #else
          MARK_USED(rcount)
@@ -4365,7 +4410,7 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:)
          !! Received data
          INTEGER, CONTIGUOUS, INTENT(IN)          :: rcount(:), rdispl(:)
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
          !! Size of sent data for every process
          !! Offset of sent data for every process
          !! Message passing environment identifier
@@ -4418,7 +4463,7 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgin(:)
          !! Received data
          INTEGER, CONTIGUOUS, INTENT(IN)          :: rcount(:, :), rdispl(:, :)
-         INTEGER, INTENT(IN)                      :: gid
+         TYPE(mp_comm_type), INTENT(IN)                      :: gid
          !! Size of sent data for every process
          !! Offset of sent data for every process
          !! Message passing environment identifier
@@ -4458,11 +4503,12 @@ CONTAINS
          ${type1}$, CONTIGUOUS, INTENT(IN)                      :: msgout(:)
          ${type1}$, CONTIGUOUS, INTENT(OUT)                     :: msgin(:)
          INTEGER, INTENT(IN)                      :: rsize
-         INTEGER, INTENT(IN)                      :: rcount(rsize), rdispl(rsize), gid, scount
+         INTEGER, INTENT(IN)                      :: rcount(rsize), rdispl(rsize), scount
+         TYPE(mp_comm_type), INTENT(IN)           :: gid
          INTEGER, INTENT(INOUT)                   :: request, ierr
 
          CALL MPI_IALLGATHERV(msgout, scount, ${mpi_type1}$, msgin, rcount, &
-                              rdispl, ${mpi_type1}$, gid, request, ierr)
+                              rdispl, ${mpi_type1}$, gid%handle, request, ierr)
 
       END SUBROUTINE mp_iallgatherv_${nametype1}$v_internal
 #endif
@@ -4476,8 +4522,9 @@ CONTAINS
          !! Process to send data to
          ${type1}$, CONTIGUOUS, INTENT(OUT)       :: msgout(:)
          !! Received data
-         INTEGER, INTENT(IN)                      :: source, comm
+         INTEGER, INTENT(IN)                      :: source
          !! Process from which to receive
+         TYPE(mp_comm_type), INTENT(IN)           :: comm
          !! Message passing environment identifier
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_sendrecv_${nametype1}$v'
@@ -4497,7 +4544,7 @@ CONTAINS
          send_tag = 0 ! cannot think of something better here, this might be dangerous
          recv_tag = 0 ! cannot think of something better here, this might be dangerous
          CALL mpi_sendrecv(msgin, msglen_in, ${mpi_type1}$, dest, send_tag, msgout, &
-                           msglen_out, ${mpi_type1}$, source, recv_tag, comm, MPI_STATUS_IGNORE, ierr)
+                           msglen_out, ${mpi_type1}$, source, recv_tag, comm%handle, MPI_STATUS_IGNORE, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_sendrecv @ "//routineN)
          CALL add_perf(perf_id=7, &
                        msg_size=(msglen_in + msglen_out)*${bytes1}$/2)
@@ -4523,8 +4570,9 @@ CONTAINS
          !! Which process to send to
          ${type1}$                                :: msgout
          !! Receive data into this pointer
-         INTEGER, INTENT(IN)                      :: source, comm
+         INTEGER, INTENT(IN)                      :: source
          !! Process to receive from
+         TYPE(mp_comm_type), INTENT(IN)           :: comm
          !! Message passing environment identifier
          INTEGER, INTENT(out)                     :: send_request, recv_request
          !! Request handle for the send
@@ -4547,11 +4595,11 @@ CONTAINS
          IF (PRESENT(tag)) my_tag = tag
 
          CALL mpi_irecv(msgout, 1, ${mpi_type1}$, source, my_tag, &
-                        comm, recv_request, ierr)
+                        comm%handle, recv_request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 
          CALL mpi_isend(msgin, 1, ${mpi_type1}$, dest, my_tag, &
-                        comm, send_request, ierr)
+                        comm%handle, send_request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
          CALL add_perf(perf_id=8, msg_size=2*${bytes1}$)
@@ -4582,8 +4630,9 @@ CONTAINS
          !! Which process to send to
          ${type1}$, CONTIGUOUS, DIMENSION(:)      :: msgout
          !! Receive data into this pointer
-         INTEGER, INTENT(IN)                      :: source, comm
+         INTEGER, INTENT(IN)                      :: source
          !! Process to receive from
+         TYPE(mp_comm_type), INTENT(IN)           :: comm
          !! Message passing environment identifier
          INTEGER, INTENT(out)                     :: send_request, recv_request
          !! Request handle for the send
@@ -4609,20 +4658,20 @@ CONTAINS
          msglen = SIZE(msgout, 1)
          IF (msglen > 0) THEN
             CALL mpi_irecv(msgout(1), msglen, ${mpi_type1}$, source, my_tag, &
-                           comm, recv_request, ierr)
+                           comm%handle, recv_request, ierr)
          ELSE
             CALL mpi_irecv(foo, msglen, ${mpi_type1}$, source, my_tag, &
-                           comm, recv_request, ierr)
+                           comm%handle, recv_request, ierr)
          END IF
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 
          msglen = SIZE(msgin, 1)
          IF (msglen > 0) THEN
             CALL mpi_isend(msgin(1), msglen, ${mpi_type1}$, dest, my_tag, &
-                           comm, send_request, ierr)
+                           comm%handle, send_request, ierr)
          ELSE
             CALL mpi_isend(foo, msglen, ${mpi_type1}$, dest, my_tag, &
-                           comm, send_request, ierr)
+                           comm%handle, send_request, ierr)
          END IF
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -4648,7 +4697,8 @@ CONTAINS
       !! arrays can be pointers or assumed shape, but they must be contiguous!
 
          ${type1}$, CONTIGUOUS, DIMENSION(:)      :: msgin
-         INTEGER, INTENT(IN)                      :: dest, comm
+         INTEGER, INTENT(IN)                      :: dest
+         TYPE(mp_comm_type), INTENT(IN)           :: comm
          INTEGER, INTENT(out)                     :: request
          INTEGER, INTENT(in), OPTIONAL            :: tag
 
@@ -4670,10 +4720,10 @@ CONTAINS
          msglen = SIZE(msgin)
          IF (msglen > 0) THEN
             CALL mpi_isend(msgin(1), msglen, ${mpi_type1}$, dest, my_tag, &
-                           comm, request, ierr)
+                           comm%handle, request, ierr)
          ELSE
             CALL mpi_isend(foo, msglen, ${mpi_type1}$, dest, my_tag, &
-                           comm, request, ierr)
+                           comm%handle, request, ierr)
          END IF
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -4701,7 +4751,8 @@ CONTAINS
       !! arrays can be pointers or assumed shape, but they must be contiguous!
 
          ${type1}$, DIMENSION(:, :), CONTIGUOUS   :: msgin
-         INTEGER, INTENT(IN)                      :: dest, comm
+         INTEGER, INTENT(IN)                      :: dest
+         TYPE(mp_comm_type), INTENT(IN)           :: comm
          INTEGER, INTENT(out)                     :: request
          INTEGER, INTENT(in), OPTIONAL            :: tag
 
@@ -4723,10 +4774,10 @@ CONTAINS
          msglen = SIZE(msgin, 1)*SIZE(msgin, 2)
          IF (msglen > 0) THEN
             CALL mpi_isend(msgin(1, 1), msglen, ${mpi_type1}$, dest, my_tag, &
-                           comm, request, ierr)
+                           comm%handle, request, ierr)
          ELSE
             CALL mpi_isend(foo, msglen, ${mpi_type1}$, dest, my_tag, &
-                           comm, request, ierr)
+                           comm%handle, request, ierr)
          END IF
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -4752,7 +4803,8 @@ CONTAINS
       !! arrays can be pointers or assumed shape, but they must be contiguous!
 
          ${type1}$, CONTIGUOUS, DIMENSION(:)      :: msgout
-         INTEGER, INTENT(IN)                      :: source, comm
+         INTEGER, INTENT(IN)                      :: source
+         TYPE(mp_comm_type), INTENT(IN)           :: comm
          INTEGER, INTENT(out)                     :: request
          INTEGER, INTENT(in), OPTIONAL            :: tag
 
@@ -4774,10 +4826,10 @@ CONTAINS
          msglen = SIZE(msgout)
          IF (msglen > 0) THEN
             CALL mpi_irecv(msgout(1), msglen, ${mpi_type1}$, source, my_tag, &
-                           comm, request, ierr)
+                           comm%handle, request, ierr)
          ELSE
             CALL mpi_irecv(foo, msglen, ${mpi_type1}$, source, my_tag, &
-                           comm, request, ierr)
+                           comm%handle, request, ierr)
          END IF
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 
@@ -4804,7 +4856,8 @@ CONTAINS
       !! arrays can be pointers or assumed shape, but they must be contiguous!
 
          ${type1}$, DIMENSION(:, :), CONTIGUOUS   :: msgout
-         INTEGER, INTENT(IN)                      :: source, comm
+         INTEGER, INTENT(IN)                      :: source
+         TYPE(mp_comm_type), INTENT(IN)           :: comm
          INTEGER, INTENT(out)                     :: request
          INTEGER, INTENT(in), OPTIONAL            :: tag
 
@@ -4826,10 +4879,10 @@ CONTAINS
          msglen = SIZE(msgout, 1)*SIZE(msgout, 2)
          IF (msglen > 0) THEN
             CALL mpi_irecv(msgout(1, 1), msglen, ${mpi_type1}$, source, my_tag, &
-                           comm, request, ierr)
+                           comm%handle, request, ierr)
          ELSE
             CALL mpi_irecv(foo, msglen, ${mpi_type1}$, source, my_tag, &
-                           comm, request, ierr)
+                           comm%handle, request, ierr)
          END IF
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 
@@ -4852,7 +4905,7 @@ CONTAINS
       !! arrays can be pointers or assumed shape, but they must be contiguous!
 
          ${type1}$, CONTIGUOUS, DIMENSION(:) :: base
-         INTEGER, INTENT(IN)            :: comm
+         TYPE(mp_comm_type), INTENT(IN)            :: comm
          INTEGER, INTENT(INOUT)         :: win
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'mp_win_create_${nametype1}$v'
@@ -4870,9 +4923,9 @@ CONTAINS
 
          len = SIZE(base)*${bytes1}$
          IF (len > 0) THEN
-            CALL mpi_win_create(base(1), len, ${bytes1}$, MPI_INFO_NULL, comm, win, ierr)
+            CALL mpi_win_create(base(1), len, ${bytes1}$, MPI_INFO_NULL, comm%handle, win, ierr)
          ELSE
-            CALL mpi_win_create(foo, len, ${bytes1}$, MPI_INFO_NULL, comm, win, ierr)
+            CALL mpi_win_create(foo, len, ${bytes1}$, MPI_INFO_NULL, comm%handle, win, ierr)
          END IF
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_win_create @ "//routineN)
 #else

--- a/src/mpi/dbcsr_mpiwrap.F
+++ b/src/mpi/dbcsr_mpiwrap.F
@@ -1121,7 +1121,7 @@ CONTAINS
 #else
       pos(1:ndims) = 0
       dims = 1
-      comm_cart = 0
+      comm_cart = mp_comm_self
 #endif
       CALL timestop(handle)
 
@@ -1949,7 +1949,7 @@ CONTAINS
       MARK_USED(comm)
       MARK_USED(request)
       MARK_USED(tag)
-      request = 0
+      request = mp_request_null
 #endif
       CALL timestop(handle)
    END SUBROUTINE mp_isend_bv
@@ -2005,7 +2005,7 @@ CONTAINS
       MARK_USED(comm)
       MARK_USED(request)
       MARK_USED(tag)
-      request = 0
+      request = mp_request_null
 #endif
       CALL timestop(handle)
    END SUBROUTINE mp_irecv_bv
@@ -2366,7 +2366,7 @@ CONTAINS
       INTEGER                                  :: my_info
 #else
       CHARACTER(LEN=10)                        :: fstatus, fposition
-      INTEGER                                  :: amode
+      INTEGER                                  :: amode, file_handle
       LOGICAL                                  :: exists, is_open
 #endif
 
@@ -2396,10 +2396,11 @@ CONTAINS
          fstatus = "OLD"
       END IF
       ! Get a new unit number
-      DO fh%handle = 1, 999
-         INQUIRE (UNIT=fh%handle, EXIST=exists, OPENED=is_open, IOSTAT=istat)
+      DO file_handle = 1, 999
+         INQUIRE (UNIT=file_handle, EXIST=exists, OPENED=is_open, IOSTAT=istat)
          IF (exists .AND. (.NOT. is_open) .AND. (istat == 0)) EXIT
       END DO
+      fh%handle = file_handle
       OPEN (UNIT=fh%handle, FILE=filepath, STATUS=fstatus, ACCESS="STREAM", POSITION=fposition)
 #endif
    END SUBROUTINE mp_file_open

--- a/src/ops/dbcsr_csr_conversions.F
+++ b/src/ops/dbcsr_csr_conversions.F
@@ -46,7 +46,7 @@ MODULE dbcsr_csr_conversions
                             mp_gather, &
                             mp_recv, &
                             mp_send, &
-                            mp_sum
+                            mp_sum, mp_comm_type
    USE dbcsr_operations, ONLY: dbcsr_copy, &
                                dbcsr_get_info, &
                                dbcsr_set
@@ -116,11 +116,12 @@ MODULE dbcsr_csr_conversions
       !! Type for CSR matrices
 
       INTEGER                                  :: nrows_total, ncols_total, &
-                                                  nze_local, nrows_local, mp_group
+                                                  nze_local, nrows_local
          !! total number of rows
          !! total number of columns
          !! local number of nonzero elements
          !! local number of rows
+      TYPE(mp_comm_type)                       :: mp_group
          !! message-passing group ID
       INTEGER(KIND=int_8)                      :: nze_total
          !! total number of nonzero elements
@@ -170,9 +171,10 @@ CONTAINS
          !! total number of columns
       INTEGER(KIND=int_8)                                :: nze_total
          !! total number of non-zero elements
-      INTEGER, INTENT(IN)                                :: nze_local, nrows_local, mp_group
+      INTEGER, INTENT(IN)                                :: nze_local, nrows_local
          !! local number of non-zero elements
          !! local number of rows
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_group
       INTEGER, INTENT(IN), OPTIONAL                      :: data_type
          !! data type of the CSR matrix (default real double prec.)
 
@@ -385,12 +387,13 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'csr_create_from_brd'
 
-      INTEGER                                            :: data_type, handle, mp_group, &
+      INTEGER                                            :: data_type, handle, &
                                                             nfullcols_total, nfullrows, &
                                                             nfullrows_total, nze_local
       INTEGER(KIND=int_8)                                :: nze_total
       INTEGER, DIMENSION(:), POINTER                     :: cdist, csr_index, dbcsr_index
       TYPE(dbcsr_distribution_obj)                       :: dist_current
+      TYPE(mp_comm_type)                                 :: mp_group
 
       CALL timeset(routineN, handle)
       NULLIFY (dbcsr_index, csr_index, cdist)
@@ -1336,7 +1339,7 @@ CONTAINS
 
       CHARACTER                                          :: matrix_type
       CHARACTER(LEN=default_string_length)               :: matrix_name
-      INTEGER :: cs, data_type, end_ind, handle, i, k, l, m, mp_group, mynode, nblkcols_total, &
+      INTEGER :: cs, data_type, end_ind, handle, i, k, l, m, mynode, nblkcols_total, &
                  nblkrows_total, nfullrows_local, nfullrows_total, node_size, numnodes_total, row_index, &
                  split_row, start_ind
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: rdist_tmp, row_blk_size_new_tmp
@@ -1346,6 +1349,7 @@ CONTAINS
       REAL(KIND=real_8)                                  :: chunk_size
       TYPE(dbcsr_distribution_obj)                       :: dist_current, dist_new
       TYPE(dbcsr_mp_obj)                                 :: mp_obj_current, mp_obj_new
+      TYPE(mp_comm_type)                                 :: mp_group
 
       CALL timeset(routineN, handle)
 

--- a/src/ops/dbcsr_io.F
+++ b/src/ops/dbcsr_io.F
@@ -762,7 +762,7 @@ CONTAINS
          !! path to the file
       TYPE(dbcsr_distribution_obj), INTENT(IN)     :: distribution
          !! row and column distribution
-      INTEGER, INTENT(IN), OPTIONAL                :: groupid
+      TYPE(mp_comm_type), INTENT(IN), OPTIONAL                :: groupid
          !! message passing environment identifier
       TYPE(dbcsr_type), INTENT(INOUT)               :: matrix_new
          !! DBCSR matrix
@@ -816,7 +816,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       IF (PRESENT(groupid)) THEN
-         group_id%handle = groupid
+         group_id = groupid
       ELSE
          mp_env = dbcsr_distribution_mp(distribution)
          group_id = dbcsr_mp_group(mp_env)

--- a/src/ops/dbcsr_io.F
+++ b/src/ops/dbcsr_io.F
@@ -35,7 +35,7 @@ MODULE dbcsr_io
       file_amode_create, file_amode_rdonly, file_amode_wronly, file_offset, mp_allgather, &
       mp_environ, mp_file_close, mp_file_get_size, mp_file_open, mp_file_read_at_all, &
       mp_file_write_at, mp_file_write_at_all, mp_sum, mp_type_descriptor_type, mp_type_size, &
-      mpi_character_size, mpi_integer_size, mp_comm_type
+      mpi_character_size, mpi_integer_size, mp_comm_type, mp_file_type
    USE dbcsr_transformations, ONLY: dbcsr_datablock_redistribute
    USE dbcsr_types, ONLY: dbcsr_data_obj, &
                           dbcsr_distribution_obj, &
@@ -604,7 +604,7 @@ CONTAINS
 
       INTEGER                               :: nblkrows_total, nblkcols_total, &
                                                nblks, size_of_pgrid, &
-                                               thefile, i, sendbuf, data_area_size, &
+                                               i, sendbuf, data_area_size, &
                                                data_type, type_size, &
                                                mynode, numnodes, &
                                                ginfo_size, linfo_size, handle
@@ -623,6 +623,7 @@ CONTAINS
       CHARACTER(LEN=80)                     :: matrix_name_v_1_0
       CHARACTER(LEN=default_string_length)  :: matrix_name
       TYPE(mp_comm_type)                    :: mp_group
+      TYPE(mp_file_type)                    :: thefile
       INTEGER, PARAMETER                    :: version_len = 10
       CHARACTER(LEN=version_len), PARAMETER :: version = "DBCSRv_1.0"
       INTEGER, ALLOCATABLE, DIMENSION(:) :: linfo_sizes, da_sizes
@@ -773,7 +774,7 @@ CONTAINS
                                                nblks, darea_size, data_type, type_size, &
                                                globalinfo_size, &
                                                size_of_pgrid, &
-                                               thefile, i, j, &
+                                               i, j, &
                                                nblocks, &
                                                share_size, order, cur_blks, &
                                                job_count, start_index, end_index, &
@@ -786,6 +787,7 @@ CONTAINS
       CHARACTER(LEN=80)                     :: matrix_name_v_1_0
       CHARACTER(LEN=version_len), PARAMETER :: version_v_1_0 = "DBCSRv_1.0"
       TYPE(mp_comm_type)                    :: group_id
+      TYPE(mp_file_type)                    :: thefile
 
       INTEGER, DIMENSION(:), POINTER        :: row_p, col_i, blk_p, &
                                                proc_nblks, proc_darea_sizes

--- a/src/ops/dbcsr_io.F
+++ b/src/ops/dbcsr_io.F
@@ -35,7 +35,7 @@ MODULE dbcsr_io
       file_amode_create, file_amode_rdonly, file_amode_wronly, file_offset, mp_allgather, &
       mp_environ, mp_file_close, mp_file_get_size, mp_file_open, mp_file_read_at_all, &
       mp_file_write_at, mp_file_write_at_all, mp_sum, mp_type_descriptor_type, mp_type_size, &
-      mpi_character_size, mpi_integer_size
+      mpi_character_size, mpi_integer_size, mp_comm_type
    USE dbcsr_transformations, ONLY: dbcsr_datablock_redistribute
    USE dbcsr_types, ONLY: dbcsr_data_obj, &
                           dbcsr_distribution_obj, &
@@ -606,7 +606,7 @@ CONTAINS
                                                nblks, size_of_pgrid, &
                                                thefile, i, sendbuf, data_area_size, &
                                                data_type, type_size, &
-                                               mp_group, mynode, numnodes, &
+                                               mynode, numnodes, &
                                                ginfo_size, linfo_size, handle
       INTEGER, DIMENSION(:), POINTER        :: row_p, col_i, blk_p, &
                                                row_blk_size, col_blk_size
@@ -622,6 +622,7 @@ CONTAINS
       CHARACTER                             :: matrix_type
       CHARACTER(LEN=80)                     :: matrix_name_v_1_0
       CHARACTER(LEN=default_string_length)  :: matrix_name
+      TYPE(mp_comm_type)                    :: mp_group
       INTEGER, PARAMETER                    :: version_len = 10
       CHARACTER(LEN=version_len), PARAMETER :: version = "DBCSRv_1.0"
       INTEGER, ALLOCATABLE, DIMENSION(:) :: linfo_sizes, da_sizes
@@ -777,13 +778,14 @@ CONTAINS
                                                share_size, order, cur_blks, &
                                                job_count, start_index, end_index, &
                                                localinfo_length, blockdata_length, &
-                                               group_id, worker_id, group_list_size, handle, linfo_length
+                                               worker_id, group_list_size, handle, linfo_length
       CHARACTER                             :: matrix_type
       CHARACTER(LEN=default_string_length)  :: matrix_name
       INTEGER, PARAMETER                    :: version_len = 10
       CHARACTER(LEN=version_len)            :: version
       CHARACTER(LEN=80)                     :: matrix_name_v_1_0
       CHARACTER(LEN=version_len), PARAMETER :: version_v_1_0 = "DBCSRv_1.0"
+      TYPE(mp_comm_type)                    :: group_id
 
       INTEGER, DIMENSION(:), POINTER        :: row_p, col_i, blk_p, &
                                                proc_nblks, proc_darea_sizes
@@ -814,7 +816,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       IF (PRESENT(groupid)) THEN
-         group_id = groupid
+         group_id%handle = groupid
       ELSE
          mp_env = dbcsr_distribution_mp(distribution)
          group_id = dbcsr_mp_group(mp_env)

--- a/src/ops/dbcsr_operations.F
+++ b/src/ops/dbcsr_operations.F
@@ -58,6 +58,7 @@ MODULE dbcsr_operations
       dbcsr_nblkcols_total, dbcsr_nblkrows_total, dbcsr_nfullcols_total, dbcsr_nfullrows_total, &
       dbcsr_row_block_offsets, dbcsr_valid_index, dbcsr_get_nze, dbcsr_nfullcols_local, &
       dbcsr_nfullrows_local, dbcsr_get_num_blocks, dbcsr_release, dbcsr_wm_use_mutable
+   USE dbcsr_mpiwrap, ONLY: mp_comm_type
    USE dbcsr_mp_methods, ONLY: dbcsr_mp_group, &
                                dbcsr_mp_mynode, &
                                dbcsr_mp_mypcol, &
@@ -2387,10 +2388,11 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'dbcsr_sum_replicated'
 
-      INTEGER                                            :: comm, handle, index_checksum, mynode, &
+      INTEGER                                            :: handle, index_checksum, mynode, &
                                                             numnodes
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: all_checksums
       TYPE(dbcsr_mp_obj)                                 :: mp
+      TYPE(mp_comm_type)                                 :: comm
 
 !   ---------------------------------------------------------------------------
 
@@ -2468,7 +2470,7 @@ CONTAINS
          !! matrix type (regular, symmetric, see dbcsr_types.F for values)
       INTEGER, OPTIONAL                                  :: data_type
          !! data type (single/double precision real/complex)
-      INTEGER, INTENT(OUT), OPTIONAL                     :: group
+      TYPE(mp_comm_type), INTENT(OUT), OPTIONAL                     :: group
 
 !   ---------------------------------------------------------------------------
 

--- a/src/ops/dbcsr_test_methods.F
+++ b/src/ops/dbcsr_test_methods.F
@@ -48,7 +48,7 @@ MODULE dbcsr_test_methods
                                dbcsr_mp_numnodes, &
                                dbcsr_mp_release
    USE dbcsr_mpiwrap, ONLY: mp_comm_null, &
-                            mp_environ
+                            mp_environ, mp_comm_type
    USE dbcsr_ptr_util, ONLY: ensure_array_size
    USE dbcsr_types, ONLY: &
       dbcsr_data_obj, dbcsr_distribution_obj, dbcsr_iterator, dbcsr_mp_obj, dbcsr_scalar_type, &
@@ -324,7 +324,7 @@ CONTAINS
       INTEGER, DIMENSION(:), INTENT(INOUT), POINTER, CONTIGUOUS :: row_blk_sizes, col_blk_sizes
       CHARACTER(len=*), INTENT(in)                       :: name
       REAL(kind=real_8), INTENT(in)                      :: sparsity
-      INTEGER, INTENT(in)                                :: mp_group
+      TYPE(mp_comm_type), INTENT(in)                     :: mp_group
       INTEGER, INTENT(in), OPTIONAL                      :: data_type
       CHARACTER, INTENT(in), OPTIONAL                    :: symmetry
       TYPE(dbcsr_distribution_obj), INTENT(IN), OPTIONAL :: dist
@@ -517,7 +517,7 @@ CONTAINS
 
    SUBROUTINE dbcsr_make_null_mp(mp_env, group)
       TYPE(dbcsr_mp_obj), INTENT(out)                    :: mp_env
-      INTEGER, INTENT(in), OPTIONAL                      :: group
+      TYPE(mp_comm_type), INTENT(in), OPTIONAL           :: group
 
       INTEGER                                            :: mynode, numnodes
 
@@ -538,7 +538,7 @@ CONTAINS
    SUBROUTINE dbcsr_make_null_dist(distribution, nblkrows, nblkcols, group)
       TYPE(dbcsr_distribution_obj), INTENT(out)          :: distribution
       INTEGER, INTENT(in)                                :: nblkrows, nblkcols
-      INTEGER, INTENT(in), OPTIONAL                      :: group
+      TYPE(mp_comm_type), INTENT(in), OPTIONAL           :: group
 
       INTEGER, DIMENSION(:), POINTER, CONTIGUOUS         :: col_dist, row_dist
       TYPE(dbcsr_mp_obj)                                 :: mp_env

--- a/src/ops/dbcsr_tests.F
+++ b/src/ops/dbcsr_tests.F
@@ -39,7 +39,7 @@ MODULE dbcsr_tests
                                dbcsr_mp_release, &
                                dbcsr_mp_make_env
    USE dbcsr_mpiwrap, ONLY: &
-      mp_comm_free, mp_environ, mp_max, mp_sum, mp_sync
+      mp_comm_free, mp_environ, mp_max, mp_sum, mp_sync, mp_comm_type
    USE dbcsr_multiply_api, ONLY: dbcsr_multiply
    USE dbcsr_operations, ONLY: dbcsr_add, &
                                dbcsr_copy, &
@@ -77,7 +77,8 @@ CONTAINS
       !! Performs a variety of matrix multiplies of same matrices on different
       !! processor grids
 
-      INTEGER, INTENT(IN)                                :: mp_group, io_unit
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_group
+      INTEGER, INTENT(IN)                                :: io_unit
          !! MPI communicator
          !! which unit to write to, if not negative
       INTEGER, DIMENSION(:), POINTER                     :: nproc
@@ -107,7 +108,7 @@ CONTAINS
                                      routineN = 'dbcsr_run_tests'
 
       CHARACTER                                          :: t_a, t_b
-      INTEGER                                            :: bmax, bmin, cart_group, error_handle, &
+      INTEGER                                            :: bmax, bmin, error_handle, &
                                                             mynode, numnodes
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: group_sizes
       INTEGER, DIMENSION(2)                              :: npdims
@@ -118,6 +119,7 @@ CONTAINS
       TYPE(dbcsr_distribution_obj)                       :: dist_a, dist_b, dist_c
       TYPE(dbcsr_mp_obj)                                 :: mp_env
       TYPE(dbcsr_type), TARGET                           :: matrix_a, matrix_b, matrix_c
+      TYPE(mp_comm_type)                                 :: cart_group
 
 !   ---------------------------------------------------------------------------
 
@@ -311,7 +313,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'test_multiplies_multiproc'
 
-      INTEGER                                            :: cart_group, error_handle, group, &
+      INTEGER                                            :: error_handle, &
                                                             loop_iter, mynode, numnodes, test
       INTEGER(kind=int_8)                                :: flop, flop_sum
       INTEGER, DIMENSION(2)                              :: npdims
@@ -322,6 +324,7 @@ CONTAINS
       TYPE(dbcsr_distribution_obj)                       :: dist_a, dist_b, dist_c
       TYPE(dbcsr_mp_obj)                                 :: mp_env
       TYPE(dbcsr_type)                                   :: m_a, m_b, m_c, m_c_reserve
+      TYPE(mp_comm_type)                                 :: cart_group, group
 
 !   ---------------------------------------------------------------------------
 

--- a/src/ops/dbcsr_transformations.F
+++ b/src/ops/dbcsr_transformations.F
@@ -77,7 +77,7 @@ MODULE dbcsr_transformations
                                   hybrid_alltoall_s1, &
                                   hybrid_alltoall_z1
    USE dbcsr_mpiwrap, ONLY: mp_allgather, &
-                            mp_alltoall
+                            mp_alltoall, mp_comm_type
    USE dbcsr_operations, ONLY: dbcsr_set
    USE dbcsr_ptr_util, ONLY: pointer_view
    USE dbcsr_types, ONLY: &
@@ -318,7 +318,7 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'dbcsr_desymmetrize_deep'
       INTEGER, PARAMETER                                 :: idata = 2, imeta = 1, metalen = 3
 
-      INTEGER :: blk, blk_l, blk_p, blk_ps, blks, col, col_size, dst_p, handle, mp_group, &
+      INTEGER :: blk, blk_l, blk_p, blk_ps, blks, col, col_size, dst_p, handle, &
                  nsymmetries, numproc, nze, pcol, prow, row, row_size, src_p, stored_col, stored_row, &
                  symmetry_i
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: rd_disp, recv_meta, rm_disp, sd_disp, &
@@ -333,6 +333,7 @@ CONTAINS
       TYPE(dbcsr_distribution_obj)                       :: target_dist
       TYPE(dbcsr_iterator)                               :: iter
       TYPE(dbcsr_mp_obj)                                 :: mp_obj
+      TYPE(mp_comm_type)                                 :: mp_group
 
 !   ---------------------------------------------------------------------------
 
@@ -1300,7 +1301,7 @@ CONTAINS
 
       CHARACTER                                          :: rep_type
       INTEGER :: blk, blk_l, blk_p, blk_ps, blks, col, col_size, data_type, dst_p, handle, &
-                 mp_group, mynode, mypcol, myprow, nblks, numnodes, nze, offset, row, row_size, smp, &
+                 mynode, mypcol, myprow, nblks, numnodes, nze, offset, row, row_size, smp, &
                  src_p, stored_blk_p, stored_col, stored_row
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: rd_disp, recv_meta, rm_disp, send_meta
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: recv_count
@@ -1316,6 +1317,7 @@ CONTAINS
       TYPE(dbcsr_iterator)                               :: iter
       TYPE(dbcsr_mp_obj)                                 :: mp_obj
       TYPE(dbcsr_type)                                   :: replicated
+      TYPE(mp_comm_type)                                 :: mp_group
 
 !   ---------------------------------------------------------------------------
 
@@ -1561,7 +1563,7 @@ CONTAINS
 
       INTEGER :: blk, blk_col_new, blk_ps, blk_row_new, blks, cnt_fnd, cnt_new, cnt_skip, col, &
                  col_int, col_offset_new, col_offset_old, col_rle, col_size, col_size_new, data_offset_l, &
-                 data_type, dst_p, handle, i, meta_l, mp_group, numnodes, nze_rle, row, row_int, &
+                 data_type, dst_p, handle, i, meta_l, numnodes, nze_rle, row, row_int, &
                  row_offset_new, row_offset_old, row_rle, row_size, row_size_new, src_p, stored_col_new, &
                  stored_row_new
       INTEGER, ALLOCATABLE, DIMENSION(:) :: col_end_new, col_end_old, col_start_new, &
@@ -1581,6 +1583,7 @@ CONTAINS
       TYPE(dbcsr_distribution_obj)                       :: dist_new
       TYPE(dbcsr_iterator)                               :: iter
       TYPE(dbcsr_mp_obj)                                 :: mp_obj_new
+      TYPE(mp_comm_type)                                 :: mp_group
 
 !   ---------------------------------------------------------------------------
 
@@ -1958,7 +1961,7 @@ CONTAINS
       INTEGER, PARAMETER                                 :: metalen = 2
       LOGICAL, PARAMETER                                 :: dbg = .FALSE.
 
-      INTEGER :: blk, blk_ps, blks, col, col_size, data_type, dst_p, handle, meta_l, mp_group, &
+      INTEGER :: blk, blk_ps, blks, col, col_size, data_type, dst_p, handle, meta_l, &
                  numnodes, nze, row, row_size, src_p, stored_col_new, stored_row_new
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: rd_disp, recv_meta, rm_disp, sd_disp, &
                                                             sdp, send_meta, sm_disp, smp
@@ -1972,6 +1975,7 @@ CONTAINS
       TYPE(dbcsr_distribution_obj)                       :: dist_new
       TYPE(dbcsr_iterator)                               :: iter
       TYPE(dbcsr_mp_obj)                                 :: mp_obj_new
+      TYPE(mp_comm_type)                                 :: mp_group
 
 !   ---------------------------------------------------------------------------
 
@@ -2200,7 +2204,7 @@ CONTAINS
       COMPLEX(kind=dp), DIMENSION(:), POINTER, CONTIGUOUS :: c_dp
       COMPLEX(kind=sp), DIMENSION(:), POINTER, CONTIGUOUS :: c_sp
       INTEGER :: bcol, blk, blk_ps, blk_size, blks, brow, col_size, data_type, &
-                 dst_p, handle, i, ind, job_count, meta_l, mp_group, &
+                 dst_p, handle, i, ind, job_count, meta_l, &
                  nblkrows_total, numnodes, row_size, src_p, stored_col_new, &
                  stored_row_new
       INTEGER(kind=int_8)                      :: actual_blk, blkp, end_ind, &
@@ -2221,6 +2225,7 @@ CONTAINS
                                                   send_data
       TYPE(dbcsr_distribution_obj)             :: dist
       TYPE(dbcsr_mp_obj)                       :: mp_env
+      TYPE(mp_comm_type)                                 :: mp_group
 
       CALL timeset(routineN, handle)
 

--- a/src/tas/dbcsr_tas_base.F
+++ b/src/tas/dbcsr_tas_base.F
@@ -48,7 +48,7 @@ MODULE dbcsr_tas_base
    USE dbcsr_kinds, ONLY: &
       default_string_length, int_8, real_8, real_4
    USE dbcsr_mpiwrap, ONLY: &
-      mp_cart_rank, mp_environ, mp_sum, mp_max, mp_comm_type
+      mp_cart_rank, mp_environ, mp_sum, mp_comm_type
 #include "base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE

--- a/src/tas/dbcsr_tas_base.F
+++ b/src/tas/dbcsr_tas_base.F
@@ -48,7 +48,7 @@ MODULE dbcsr_tas_base
    USE dbcsr_kinds, ONLY: &
       default_string_length, int_8, real_8, real_4
    USE dbcsr_mpiwrap, ONLY: &
-      mp_cart_rank, mp_environ, mp_sum, mp_max
+      mp_cart_rank, mp_environ, mp_sum, mp_max, mp_comm_type
 #include "base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -356,7 +356,7 @@ CONTAINS
       !! arrays.
 
       TYPE(dbcsr_tas_distribution_type), INTENT(OUT)   :: dist
-      INTEGER, INTENT(IN)                              :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                              :: mp_comm
       CLASS(dbcsr_tas_distribution), INTENT(IN)        :: row_dist, col_dist
       TYPE(dbcsr_tas_split_info), INTENT(IN), OPTIONAL :: split_info
          !! Strategy of how to split process grid (optional). If not present a default split heuristic is applied.

--- a/src/tas/dbcsr_tas_io.F
+++ b/src/tas/dbcsr_tas_io.F
@@ -22,7 +22,7 @@ MODULE dbcsr_tas_io
    USE dbcsr_tas_split, ONLY: &
       dbcsr_tas_get_split_info, rowsplit, colsplit
    USE dbcsr_mpiwrap, ONLY: &
-      mp_environ, mp_sum, mp_max
+      mp_environ, mp_sum, mp_max, mp_comm_type
    USE dbcsr_dist_methods, ONLY: &
       dbcsr_distribution_row_dist, dbcsr_distribution_col_dist
 
@@ -109,7 +109,7 @@ CONTAINS
          !! Whether to print subgroup DBCSR distribution
 
       CHARACTER(default_string_length) :: name
-      INTEGER                          :: mp_comm, ngroup, igroup, mp_comm_group, nproc, iproc, &
+      INTEGER                          :: ngroup, igroup, nproc, iproc, &
                                           nblock_p_max, nelement_p_max, &
                                           nblock, nelement
       INTEGER(KIND=int_8), DIMENSION(2) :: tmp_i8
@@ -119,6 +119,7 @@ CONTAINS
       REAL(KIND=real_8)                :: occupation
       INTEGER, DIMENSION(:), POINTER   :: rowdist, coldist
       INTEGER                          :: split_rowcol, icol, irow, unit_nr_prv
+      TYPE(mp_comm_type)               :: mp_comm, mp_comm_group
 
       unit_nr_prv = prep_output_unit(unit_nr)
       IF (unit_nr_prv == 0) RETURN
@@ -190,12 +191,13 @@ CONTAINS
       TYPE(dbcsr_tas_split_info), INTENT(IN)             :: info
       INTEGER, INTENT(IN) :: unit_nr
       CHARACTER(len=*), INTENT(IN), OPTIONAL             :: name
-      INTEGER                                            :: groupsize, igroup, mp_comm, &
-                                                            mp_comm_group, mynode, nsplit, &
+      INTEGER                                            :: groupsize, igroup, &
+                                                            mynode, nsplit, &
                                                             numnodes, split_rowcol, unit_nr_prv
       INTEGER, DIMENSION(2)                              :: coord, dims, groupcoord, groupdims, &
                                                             pgrid_offset
       CHARACTER(len=:), ALLOCATABLE                      :: name_prv
+      TYPE(mp_comm_type)                                 :: mp_comm, mp_comm_group
 
       unit_nr_prv = prep_output_unit(unit_nr)
       IF (unit_nr_prv == 0) RETURN

--- a/src/tas/dbcsr_tas_mm.F
+++ b/src/tas/dbcsr_tas_mm.F
@@ -48,7 +48,7 @@ MODULE dbcsr_tas_mm
    USE dbcsr_kinds, ONLY: &
       int_8, real_8, real_4, default_string_length
    USE dbcsr_mpiwrap, ONLY: &
-      mp_comm_compare, mp_environ, mp_sum, mp_comm_free, mp_cart_create, mp_max, mp_sync, mp_comm_type
+      mp_environ, mp_sum, mp_comm_free, mp_cart_create, mp_max, mp_sync, mp_comm_type
    USE dbcsr_operations, ONLY: &
       dbcsr_scale, dbcsr_get_info, dbcsr_copy, dbcsr_clear, dbcsr_add, dbcsr_zero
    USE dbcsr_tas_io, ONLY: &

--- a/src/tas/dbcsr_tas_mm.F
+++ b/src/tas/dbcsr_tas_mm.F
@@ -48,7 +48,7 @@ MODULE dbcsr_tas_mm
    USE dbcsr_kinds, ONLY: &
       int_8, real_8, real_4, default_string_length
    USE dbcsr_mpiwrap, ONLY: &
-      mp_comm_compare, mp_environ, mp_sum, mp_comm_free, mp_cart_create, mp_max, mp_sync
+      mp_comm_compare, mp_environ, mp_sum, mp_comm_free, mp_cart_create, mp_max, mp_sync, mp_comm_type
    USE dbcsr_operations, ONLY: &
       dbcsr_scale, dbcsr_get_info, dbcsr_copy, dbcsr_clear, dbcsr_add, dbcsr_zero
    USE dbcsr_tas_io, ONLY: &
@@ -112,11 +112,10 @@ CONTAINS
       INTEGER(KIND=int_8), DIMENSION(2)          :: dims_a, dims_b, dims_c
       INTEGER, DIMENSION(2)                      :: pdims, pcoord, pcoord_sub, pdims_sub
       INTEGER(KIND=int_8), DIMENSION(3)          :: dims
-      INTEGER                                    :: max_mm_dim, data_type, mp_comm, comm_tmp, &
-                                                    handle, handle2, handle3, handle4, &
+      INTEGER                                    :: max_mm_dim, data_type, handle, handle2, handle3, handle4, &
                                                     unit_nr_prv, nsplit, nsplit_opt, numproc, numproc_sub, iproc, &
-                                                    mp_comm_group, mp_comm_mm, split_rc, split_a, split_b, split_c, &
-                                                    mp_comm_opt, batched_repl, max_mm_dim_batched, nsplit_batched
+                                                    split_rc, split_a, split_b, split_c, &
+                                                    batched_repl, max_mm_dim_batched, nsplit_batched
       CHARACTER(LEN=1)                           :: tr_case, transa_prv, transb_prv, transc_prv
       TYPE(dbcsr_scalar_type)                    :: zero
       LOGICAL                                    :: new_a, new_b, new_c, simple_split_prv, opt_pgrid, &
@@ -126,6 +125,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER                :: routineN = 'dbcsr_tas_multiply'
       INTEGER(KIND=int_8)                        :: nze_a, nze_b, nze_c, nze_c_sum
       TYPE(dbcsr_type)                           :: matrix_a_mm, matrix_b_mm, matrix_c_mm
+      TYPE(mp_comm_type)                         :: mp_comm, comm_tmp, mp_comm_group, mp_comm_mm, mp_comm_opt
 
       CALL timeset(routineN, handle)
       CALL mp_sync(matrix_a%dist%info%mp_comm)
@@ -809,7 +809,7 @@ CONTAINS
       !! Make sure that smallest matrix involved in a multiplication is not split and bring it to
       !! the same process grid as the other 2 matrices.
 
-      INTEGER, INTENT(IN)               :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)               :: mp_comm
          !! communicator that defines Cartesian topology
       TYPE(dbcsr_tas_type), INTENT(INOUT) :: matrix_in
       TYPE(dbcsr_tas_type), INTENT(OUT)   :: matrix_out
@@ -896,7 +896,7 @@ CONTAINS
       INTEGER, INTENT(INOUT)                     :: split_rc_1, split_rc_2
          !! Whether to split rows or columns for matrix 1
          !! Whether to split rows or columns for matrix 2
-      INTEGER, INTENT(OUT), OPTIONAL             :: comm_new
+      TYPE(mp_comm_type), INTENT(OUT), OPTIONAL             :: comm_new
          !! returns the new communicator only if optimize_dist
       LOGICAL, OPTIONAL, INTENT(IN)              :: nodata1, nodata2
          !! Don't copy matrix data from matrix1_in to matrix1_out
@@ -910,7 +910,7 @@ CONTAINS
       INTEGER(KIND=int_8), DIMENSION(2)          :: dims1, dims2, dims_ref
       INTEGER(KIND=int_8)                        :: d1, d2
       CHARACTER(LEN=*), PARAMETER                :: routineN = 'reshape_mm_compatible'
-      INTEGER                                    :: handle, mp_comm, numnodes, unit_nr_prv, &
+      INTEGER                                    :: handle, numnodes, unit_nr_prv, &
                                                     nsplit_prv, ref, split_rc_ref
       INTEGER, DIMENSION(2)                      :: pcoord, pdims
       LOGICAL                                    :: optimize_dist_prv, trans1_newdist, trans2_newdist
@@ -919,6 +919,7 @@ CONTAINS
       TYPE(dbcsr_tas_split_info)                 :: split_info
       INTEGER(KIND=int_8)                        :: nze1, nze2
       LOGICAL                                    :: nodata1_prv, nodata2_prv
+      TYPE(mp_comm_type)                         :: mp_comm
 
       CALL timeset(routineN, handle)
       new1 = .FALSE.; new2 = .FALSE.
@@ -1130,13 +1131,14 @@ CONTAINS
          !! memory optimization: move data such that matrix_in is empty on return.
 
       INTEGER                                    :: &
-         mp_comm, split_rc, nsplit_old, handle, data_type, nsplit_new, nsplit_prv
+         split_rc, nsplit_old, handle, data_type, nsplit_new, nsplit_prv
       TYPE(dbcsr_tas_split_info)                 :: split_info
       CHARACTER(len=default_string_length)       :: name
       TYPE(dbcsr_tas_distribution_type)          :: dist
       LOGICAL                                    :: nodata_prv
       CLASS(dbcsr_tas_distribution), ALLOCATABLE :: rdist, cdist
       CLASS(dbcsr_tas_rowcol_data), ALLOCATABLE  :: rbsize, cbsize
+      TYPE(mp_comm_type)                         :: mp_comm
       CHARACTER(LEN=*), PARAMETER                :: routineN = 'change_split'
 
       NULLIFY (matrix_out)
@@ -1280,10 +1282,11 @@ CONTAINS
 
       TYPE(dbcsr_tas_distribution_type)          :: dist_new
       TYPE(dbcsr_tas_split_info)                 :: info_template, info_matrix
-      INTEGER                                    :: mp_comm, dim_split_template, dim_split_matrix, &
+      INTEGER                                    :: dim_split_template, dim_split_matrix, &
                                                     numnodes, handle
       INTEGER, DIMENSION(2)                      :: pcoord, pdims
       LOGICAL                                    :: nodata_prv, transposed
+      TYPE(mp_comm_type)                         :: mp_comm
       CHARACTER(LEN=*), PARAMETER :: routineN = 'reshape_mm_template'
 
       CALL timeset(routineN, handle)
@@ -1362,9 +1365,10 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_tas_result_index'
       LOGICAL :: retain_sparsity_prv
-      INTEGER :: bn, row_size, col_size, handle, iblk, mp_comm, nblk
+      INTEGER :: bn, row_size, col_size, handle, iblk, nblk
       INTEGER(int_8) :: row, col
       TYPE(dbcsr_tas_iterator) :: iter
+      TYPE(mp_comm_type) :: mp_comm
 
       CALL timeset(routineN, handle)
 
@@ -1519,7 +1523,7 @@ CONTAINS
    SUBROUTINE convert_to_new_pgrid(mp_comm_cart, matrix_in, matrix_out, move_data, nodata, optimize_pgrid)
       !! Convert a DBCSR matrix to a new process grid
 
-      INTEGER, INTENT(IN)                        :: mp_comm_cart
+      TYPE(mp_comm_type), INTENT(IN)             :: mp_comm_cart
          !! new process grid
       TYPE(dbcsr_type), INTENT(INOUT)            :: matrix_in
       TYPE(dbcsr_type), INTENT(OUT)              :: matrix_out

--- a/src/tas/dbcsr_tas_reshape_ops.F
+++ b/src/tas/dbcsr_tas_reshape_ops.F
@@ -51,7 +51,7 @@ MODULE dbcsr_tas_reshape_ops
    USE dbcsr_kinds, ONLY: &
       int_8, real_8, real_4
    USE dbcsr_mpiwrap, ONLY: &
-      mp_alltoall, mp_environ, mp_isend, mp_irecv, mp_waitall
+      mp_alltoall, mp_environ, mp_isend, mp_irecv, mp_waitall, mp_comm_type
    USE dbcsr_tas_util, ONLY: &
       swap, index_unique
 #include "base/dbcsr_base_uses.f90"
@@ -104,7 +104,7 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_tas_reshape'
 
-      INTEGER                                            :: handle, handle2, iproc, mp_comm, mynode, nblock, &
+      INTEGER                                            :: handle, handle2, iproc, mynode, nblock, &
                                                             ndata, numnodes, bcount, nblk
       INTEGER(KIND=int_8), ALLOCATABLE, DIMENSION(:, :)  :: index_recv, blks_to_allocate
       INTEGER(KIND=int_8), DIMENSION(2)                  :: blk_index
@@ -118,6 +118,7 @@ CONTAINS
       TYPE(dbcsr_data_obj)                               :: block
       TYPE(dbcsr_tas_iterator)                           :: iter
       TYPE(dbcsr_tas_split_info)                         :: info
+      TYPE(mp_comm_type)                                 :: mp_comm
 
       CALL timeset(routineN, handle)
 
@@ -288,7 +289,7 @@ CONTAINS
       TYPE(dbcsr_tas_blk_size_repl), TARGET :: repl_blksize
       TYPE(dbcsr_tas_blk_size_arb), TARGET :: dir_blksize
       TYPE(dbcsr_tas_distribution_type) :: dist
-      INTEGER :: mp_comm, numnodes, mynode
+      INTEGER :: numnodes, mynode
       TYPE(block_buffer_type), ALLOCATABLE, DIMENSION(:) :: buffer_recv, buffer_send
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: num_blocks_recv, num_blocks_send, &
                                                             num_entries_recv, num_entries_send, &
@@ -303,6 +304,7 @@ CONTAINS
       LOGICAL :: tr, nodata_prv, move_prv
       INTEGER(KIND=int_8), ALLOCATABLE, DIMENSION(:, :) :: index_recv
       INTEGER :: ndata
+      TYPE(mp_comm_type) :: mp_comm
 
       TYPE(dbcsr_data_obj) :: block
 
@@ -481,7 +483,7 @@ CONTAINS
          !! memory optimization: move data to matrix_out such that matrix_in is empty on return
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_tas_merge'
-      INTEGER                                            :: data_type, handle, handle2, iproc, mp_comm, &
+      INTEGER                                            :: data_type, handle, handle2, iproc, &
                                                             mynode, nblock, ndata, numnodes, nblk, bcount
       INTEGER(KIND=int_8), ALLOCATABLE, DIMENSION(:, :)  :: index_recv
       INTEGER(KIND=int_8), DIMENSION(2)                  :: blk_index_i8
@@ -495,6 +497,7 @@ CONTAINS
       TYPE(dbcsr_data_obj)                               :: block
       TYPE(dbcsr_iterator)                               :: iter
       TYPE(dbcsr_tas_split_info)                         :: info
+      TYPE(mp_comm_type)                                 :: mp_comm
 
       CALL timeset(routineN, handle)
 
@@ -831,7 +834,7 @@ CONTAINS
 
    SUBROUTINE dbcsr_tas_communicate_buffer(mp_comm, buffer_recv, buffer_send, req_array)
       !! communicate buffer
-      INTEGER, INTENT(IN)                    :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                    :: mp_comm
       TYPE(block_buffer_type), DIMENSION(0:), INTENT(INOUT) :: buffer_recv, buffer_send
       INTEGER, DIMENSION(:, :), INTENT(OUT)               :: req_array
 

--- a/src/tas/dbcsr_tas_reshape_ops.F
+++ b/src/tas/dbcsr_tas_reshape_ops.F
@@ -51,7 +51,7 @@ MODULE dbcsr_tas_reshape_ops
    USE dbcsr_kinds, ONLY: &
       int_8, real_8, real_4
    USE dbcsr_mpiwrap, ONLY: &
-      mp_alltoall, mp_environ, mp_isend, mp_irecv, mp_waitall, mp_comm_type
+      mp_alltoall, mp_environ, mp_isend, mp_irecv, mp_waitall, mp_comm_type, mp_request_type
    USE dbcsr_tas_util, ONLY: &
       swap, index_unique
 #include "base/dbcsr_base_uses.f90"
@@ -111,7 +111,7 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: num_blocks_recv, num_blocks_send, &
                                                             num_entries_recv, num_entries_send, &
                                                             num_rec, num_send
-      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: req_array
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:, :)              :: req_array
       INTEGER, DIMENSION(2)                              :: blk_size
       LOGICAL                                            :: tr, tr_in, move_prv
       TYPE(block_buffer_type), ALLOCATABLE, DIMENSION(:) :: buffer_recv, buffer_send
@@ -294,7 +294,7 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: num_blocks_recv, num_blocks_send, &
                                                             num_entries_recv, num_entries_send, &
                                                             num_rec, num_send
-      INTEGER, ALLOCATABLE, DIMENSION(:, :) :: req_array, blks_to_allocate
+      INTEGER, ALLOCATABLE, DIMENSION(:, :) :: blks_to_allocate
       INTEGER, DIMENSION(2) :: blk_size
       INTEGER, DIMENSION(2) :: blk_index
       INTEGER(KIND=int_8), DIMENSION(2) :: blk_index_i8
@@ -305,6 +305,7 @@ CONTAINS
       INTEGER(KIND=int_8), ALLOCATABLE, DIMENSION(:, :) :: index_recv
       INTEGER :: ndata
       TYPE(mp_comm_type) :: mp_comm
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:, :) :: req_array
 
       TYPE(dbcsr_data_obj) :: block
 
@@ -490,7 +491,7 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: iprocs, num_blocks_recv, &
                                                             num_blocks_send, num_entries_recv, &
                                                             num_entries_send, num_rec, num_send
-      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: req_array, blks_to_allocate, blks_to_allocate_u
+      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: blks_to_allocate, blks_to_allocate_u
       INTEGER, DIMENSION(2)                              :: blk_index, blk_size
       LOGICAL                                            :: tr, move_prv
       TYPE(block_buffer_type), ALLOCATABLE, DIMENSION(:) :: buffer_recv, buffer_send
@@ -498,6 +499,7 @@ CONTAINS
       TYPE(dbcsr_iterator)                               :: iter
       TYPE(dbcsr_tas_split_info)                         :: info
       TYPE(mp_comm_type)                                 :: mp_comm
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:, :) :: req_array
 
       CALL timeset(routineN, handle)
 
@@ -836,7 +838,7 @@ CONTAINS
       !! communicate buffer
       TYPE(mp_comm_type), INTENT(IN)                    :: mp_comm
       TYPE(block_buffer_type), DIMENSION(0:), INTENT(INOUT) :: buffer_recv, buffer_send
-      INTEGER, DIMENSION(:, :), INTENT(OUT)               :: req_array
+      TYPE(mp_request_type), DIMENSION(:, :), INTENT(OUT)               :: req_array
 
       INTEGER                                :: iproc, mynode, numnodes, rec_counter, &
                                                 send_counter

--- a/src/tas/dbcsr_tas_split.F
+++ b/src/tas/dbcsr_tas_split.F
@@ -22,7 +22,7 @@ MODULE dbcsr_tas_split
    USE dbcsr_kinds, ONLY: &
       int_8
    USE dbcsr_mpiwrap, ONLY: &
-      mp_bcast, mp_cart_create, mp_comm_dup, mp_comm_free, mp_comm_split_direct, mp_dims_create, mp_environ
+      mp_bcast, mp_cart_create, mp_comm_dup, mp_comm_free, mp_comm_split_direct, mp_dims_create, mp_environ, mp_comm_type
    USE dbcsr_kinds, ONLY: &
       real_8
 #include "base/dbcsr_base_uses.f90"
@@ -67,7 +67,7 @@ CONTAINS
       !! split mpi grid by rows or columns
 
       TYPE(dbcsr_tas_split_info), INTENT(OUT)            :: split_info
-      INTEGER, INTENT(IN)                                :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                                :: mp_comm
          !! global mpi communicator with a 2d cartesian grid
       INTEGER, INTENT(INOUT)                             :: ngroup
          !! number of groups
@@ -78,10 +78,11 @@ CONTAINS
          !! Whether split_info should own communicator
 
       INTEGER :: &
-         igroup_check, iproc, iproc_group, iproc_group_check, mp_comm_group, numproc, &
+         igroup_check, iproc, iproc_group, iproc_group_check, numproc, &
          numproc_group, numproc_group_check, handle
       INTEGER, DIMENSION(2)                              :: pcoord, pcoord_group, pdims, pdims_group
       LOGICAL                                            :: to_assert, own_comm_prv
+      TYPE(mp_comm_type)                                 :: mp_comm_group
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_tas_create_split_rows_or_cols'
 
       CALL timeset(routineN, handle)
@@ -146,10 +147,10 @@ CONTAINS
       !! of dbcsr_tas_create_split
       !! \return new communicator
 
-      INTEGER, INTENT(IN)                                :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                                :: mp_comm
       INTEGER, INTENT(IN)                                :: split_rowcol
       INTEGER, INTENT(IN)                             :: nsplit
-      INTEGER                                            :: dbcsr_tas_mp_comm
+      TYPE(mp_comm_type)                                 :: dbcsr_tas_mp_comm
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_tas_mp_comm'
 
@@ -281,12 +282,12 @@ CONTAINS
       !! Derive optimal cartesian process grid from matrix sizes. This ensures optimality for
       !! dense matrices only
 
-      INTEGER, INTENT(IN)                                :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                                :: mp_comm
       INTEGER(KIND=int_8), INTENT(IN)                    :: nblkrows, nblkcols
          !! total number of block rows
          !! total number of block columns
       INTEGER                                            :: nsplit, split_rowcol
-      INTEGER                                            :: mp_comm_new
+      TYPE(mp_comm_type)                                 :: mp_comm_new
          !! MPI communicator
 
       IF (nblkrows >= nblkcols) THEN
@@ -305,7 +306,7 @@ CONTAINS
 
       TYPE(dbcsr_tas_split_info), INTENT(OUT)            :: split_info
          !! object storing all data corresponding to split, submatrices and parallelization
-      INTEGER, INTENT(IN)                                :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                                :: mp_comm
          !! MPI communicator with associated cartesian grid
       INTEGER, INTENT(IN)                                :: split_rowcol
          !! split rows or columns
@@ -389,7 +390,8 @@ CONTAINS
       !! Get info on split
 
       TYPE(dbcsr_tas_split_info), INTENT(IN)             :: info
-      INTEGER, INTENT(OUT), OPTIONAL                     :: mp_comm, nsplit, igroup, mp_comm_group, &
+      TYPE(mp_comm_type), INTENT(OUT), OPTIONAL          :: mp_comm, mp_comm_group
+      INTEGER, INTENT(OUT), OPTIONAL                     :: nsplit, igroup, &
                                                             split_rowcol
          !! communicator (global process grid)
          !! split factor

--- a/src/tas/dbcsr_tas_test.F
+++ b/src/tas/dbcsr_tas_test.F
@@ -46,7 +46,7 @@ MODULE dbcsr_tas_test
                                dbcsr_add
    USE dbcsr_transformations, ONLY: dbcsr_complete_redistribute
    USE dbcsr_blas_operations, ONLY: &
-      dbcsr_lapack_larnv, set_larnv_seed
+      set_larnv_seed
 #include "base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE

--- a/src/tas/dbcsr_tas_test.F
+++ b/src/tas/dbcsr_tas_test.F
@@ -37,7 +37,7 @@ MODULE dbcsr_tas_test
                           real_8
    USE dbcsr_mpiwrap, ONLY: mp_environ, &
                             mp_cart_create, &
-                            mp_comm_free
+                            mp_comm_free, mp_comm_type
    USE dbcsr_dist_methods, ONLY: dbcsr_distribution_new
    USE dbcsr_work_operations, ONLY: dbcsr_create, &
                                     dbcsr_finalize
@@ -69,8 +69,8 @@ CONTAINS
                                           dist_splitsize, name, sparsity, reuse_comm)
 
       TYPE(dbcsr_tas_type), INTENT(OUT)                    :: matrix
-      INTEGER, INTENT(OUT)                               :: mp_comm_out
-      INTEGER, INTENT(IN)                                :: mp_comm
+      TYPE(mp_comm_type), INTENT(OUT)                               :: mp_comm_out
+      TYPE(mp_comm_type), INTENT(IN)                                :: mp_comm
       INTEGER(KIND=int_8), INTENT(IN)                    :: nrows, ncols
       INTEGER, DIMENSION(nrows), INTENT(IN)              :: rbsizes
       INTEGER, DIMENSION(ncols), INTENT(IN)              :: cbsizes
@@ -179,7 +179,7 @@ CONTAINS
       INTEGER                                            :: handle1, handle2
       TYPE(dbcsr_type)                                   :: dbcsr_a, dbcsr_b, dbcsr_c, &
                                                             dbcsr_a_mm, dbcsr_b_mm, dbcsr_c_mm
-      INTEGER                                            :: mp_comm, comm_dbcsr
+      TYPE(mp_comm_type)                                 :: mp_comm, comm_dbcsr
       TYPE(dbcsr_distribution_obj)                       :: dist_a, dist_b, dist_c
       INTEGER, DIMENSION(2)                              :: npdims, myploc
       INTEGER, DIMENSION(:), POINTER, CONTIGUOUS         :: cd_a, cd_b, cd_c, &
@@ -290,7 +290,7 @@ CONTAINS
       REAL(KIND=real_8), INTENT(IN), OPTIONAL            :: filter_eps
 
       CHARACTER(LEN=1)                                   :: transa_prv, transb_prv
-      INTEGER                                            :: comm_dbcsr, io_unit, mp_comm, mynode, &
+      INTEGER                                            :: io_unit, mynode, &
                                                             numnodes
       INTEGER, DIMENSION(2)                              :: myploc, npdims
       INTEGER, DIMENSION(:), POINTER, CONTIGUOUS         :: cd_a, cd_b, cd_c, &
@@ -301,6 +301,7 @@ CONTAINS
       TYPE(dbcsr_type)                                   :: dbcsr_a, dbcsr_a_mm, dbcsr_b, &
                                                             dbcsr_b_mm, dbcsr_c, dbcsr_c_mm, &
                                                             dbcsr_c_mm_check
+      TYPE(mp_comm_type)                                 :: comm_dbcsr, mp_comm
       REAL(KIND=real_8), PARAMETER :: test_tol = 1.0E-10_real_8
 
       CALL dbcsr_tas_get_split_info(dbcsr_tas_info(matrix_a), mp_comm=mp_comm)

--- a/src/tas/dbcsr_tas_types.F
+++ b/src/tas/dbcsr_tas_types.F
@@ -17,6 +17,7 @@ MODULE dbcsr_tas_types
       dbcsr_distribution_obj, dbcsr_iterator, dbcsr_type
    USE dbcsr_kinds, ONLY: int_8
    USE dbcsr_data_types, ONLY: dbcsr_scalar_type
+   USE dbcsr_mpiwrap, ONLY: mp_comm_type
 #include "base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -34,14 +35,14 @@ MODULE dbcsr_tas_types
    ! info on MPI Cartesian grid that is split on MPI subgroups.
    ! info on distribution of matrix rows / columns to different subgroups.
    TYPE dbcsr_tas_split_info
-      INTEGER :: mp_comm ! global communicator
+      TYPE(mp_comm_type) :: mp_comm ! global communicator
       INTEGER, DIMENSION(2) :: pdims ! dimensions of process grid
       INTEGER :: igroup ! which subgroup do I belong to
       INTEGER :: ngroup ! how many groups in total
       INTEGER :: split_rowcol ! split row or column?
       INTEGER :: pgrid_split_size ! how many process rows/cols in subgroups
       INTEGER :: group_size ! group size (how many cores) of subgroups
-      INTEGER :: mp_comm_group ! sub communicator
+      TYPE(mp_comm_type) :: mp_comm_group ! sub communicator
       INTEGER, ALLOCATABLE :: ngroup_opt ! optimal number of groups (split factor)
       LOGICAL, DIMENSION(2) :: strict_split = [.FALSE., .FALSE.]
       ! if .true., split factor should not be modified (2 parameters for current and general settings)

--- a/src/tas/dbcsr_tas_util.F
+++ b/src/tas/dbcsr_tas_util.F
@@ -17,7 +17,7 @@ MODULE dbcsr_tas_util
                           dbcsr_no_transpose
    USE dbcsr_kinds, ONLY: int_8
    USE dbcsr_mpiwrap, ONLY: mp_cart_rank, &
-                            mp_environ
+                            mp_environ, mp_comm_type
    USE dbcsr_index_operations, ONLY: dbcsr_sort_indices
 
 #include "base/dbcsr_base_uses.f90"
@@ -53,7 +53,7 @@ MODULE dbcsr_tas_util
 CONTAINS
    FUNCTION dbcsr_mp_environ(mp_comm)
       !! Create a dbcsr mp environment from communicator
-      INTEGER, INTENT(IN)                                :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                                :: mp_comm
       TYPE(dbcsr_mp_obj)                                 :: dbcsr_mp_environ
 
       INTEGER                                            :: mynode, numnodes, pcol, prow

--- a/src/tensors/dbcsr_tensor.F
+++ b/src/tensors/dbcsr_tensor.F
@@ -55,7 +55,7 @@ MODULE dbcsr_tensor
    USE dbcsr_kinds, ONLY: &
       ${uselist(dtype_float_prec)}$, default_string_length, int_8, dp
    USE dbcsr_mpiwrap, ONLY: &
-      mp_environ, mp_max, mp_sum, mp_comm_free, mp_cart_create, mp_sync, mp_comm_type
+      mp_environ, mp_max, mp_comm_free, mp_cart_create, mp_sync, mp_comm_type
    USE dbcsr_toollib, ONLY: &
       sort
    USE dbcsr_tensor_reshape, ONLY: &

--- a/src/tensors/dbcsr_tensor.F
+++ b/src/tensors/dbcsr_tensor.F
@@ -55,7 +55,7 @@ MODULE dbcsr_tensor
    USE dbcsr_kinds, ONLY: &
       ${uselist(dtype_float_prec)}$, default_string_length, int_8, dp
    USE dbcsr_mpiwrap, ONLY: &
-      mp_environ, mp_max, mp_sum, mp_comm_free, mp_cart_create, mp_sync
+      mp_environ, mp_max, mp_sum, mp_comm_free, mp_cart_create, mp_sync, mp_comm_type
    USE dbcsr_toollib, ONLY: &
       sort
    USE dbcsr_tensor_reshape, ONLY: &
@@ -590,8 +590,8 @@ CONTAINS
 
       INTEGER(int_8), DIMENSION(:, :), ALLOCATABLE  :: result_index_2d
       LOGICAL                                        :: assert_stmt, tensors_remapped
-      INTEGER                                        :: data_type, max_mm_dim, max_tensor, mp_comm, &
-                                                        iblk, nblk, unit_nr_prv, ref_tensor, mp_comm_opt, &
+      INTEGER                                        :: data_type, max_mm_dim, max_tensor, &
+                                                        iblk, nblk, unit_nr_prv, ref_tensor, &
                                                         handle
       INTEGER, DIMENSION(SIZE(contract_1))           :: contract_1_mod
       INTEGER, DIMENSION(SIZE(notcontract_1))        :: notcontract_1_mod
@@ -618,6 +618,7 @@ CONTAINS
       INTEGER, DIMENSION(2) :: pdims_2d_opt, pdims_2d, pcoord_2d, pdims_sub, pdims_sub_opt
       LOGICAL, DIMENSION(2) :: periods_2d
       REAL(real_8) :: pdim_ratio, pdim_ratio_opt
+      TYPE(mp_comm_type) :: mp_comm, mp_comm_opt
 
       NULLIFY (tensor_contr_1, tensor_contr_2, tensor_contr_3, tensor_crop_1, tensor_crop_2, &
                tensor_small)
@@ -1217,7 +1218,7 @@ CONTAINS
       INTEGER, INTENT(IN), OPTIONAL               :: unit_nr
          !! output unit
       INTEGER                                     :: compat1, compat1_old, compat2, compat2_old, &
-                                                     comm_2d, unit_nr_prv
+                                                     unit_nr_prv
       TYPE(array_list)                            :: dist_list
       INTEGER, DIMENSION(:), ALLOCATABLE          :: mp_dims
       TYPE(dbcsr_t_distribution_type)             :: dist_in
@@ -1225,6 +1226,7 @@ CONTAINS
       LOGICAL                                     :: optimize_dist_prv
       INTEGER, DIMENSION(ndims_tensor(tensor1)) :: dims1
       INTEGER, DIMENSION(ndims_tensor(tensor2)) :: dims2
+      TYPE(mp_comm_type) :: comm_2d
 
       NULLIFY (tensor1_out, tensor2_out)
 
@@ -1610,7 +1612,7 @@ CONTAINS
       TYPE(dbcsr_t_type), INTENT(OUT)        :: tensor_out
       CHARACTER(len=*), INTENT(IN), OPTIONAL :: name
       LOGICAL, INTENT(IN), OPTIONAL          :: nodata, move_data
-      INTEGER, INTENT(IN), OPTIONAL          :: comm_2d
+      TYPE(mp_comm_type), INTENT(IN), OPTIONAL          :: comm_2d
       TYPE(array_list), INTENT(IN), OPTIONAL :: dist1, dist2
       INTEGER, DIMENSION(SIZE(map1_2d)), OPTIONAL :: mp_dims_1
       INTEGER, DIMENSION(SIZE(map2_2d)), OPTIONAL :: mp_dims_2
@@ -1618,11 +1620,12 @@ CONTAINS
       INTEGER, DIMENSION(:), ALLOCATABLE     :: ${varlist("blk_sizes")}$, &
                                                 ${varlist("nd_dist")}$
       TYPE(dbcsr_t_distribution_type)        :: dist
-      INTEGER                                :: comm_2d_prv, handle, i
+      INTEGER                                :: handle, i
       INTEGER, DIMENSION(ndims_tensor(tensor_in)) :: pdims, myploc
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_remap'
       LOGICAL                               :: nodata_prv
       TYPE(dbcsr_t_pgrid_type)              :: comm_nd
+      TYPE(mp_comm_type) :: comm_2d_prv
 
       CALL timeset(routineN, handle)
 
@@ -2183,7 +2186,7 @@ CONTAINS
    SUBROUTINE dbcsr_t_change_pgrid_2d(tensor, mp_comm, pdims, nodata, nsplit, dimsplit, pgrid_changed, unit_nr)
       !! map tensor to a new 2d process grid for the matrix representation.
       TYPE(dbcsr_t_type), INTENT(INOUT)                  :: tensor
-      INTEGER, INTENT(IN)               :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)               :: mp_comm
       INTEGER, DIMENSION(2), INTENT(IN), OPTIONAL :: pdims
       LOGICAL, INTENT(IN), OPTIONAL                      :: nodata
       INTEGER, INTENT(IN), OPTIONAL :: nsplit, dimsplit

--- a/src/tensors/dbcsr_tensor_api.F
+++ b/src/tensors/dbcsr_tensor_api.F
@@ -19,15 +19,15 @@ MODULE dbcsr_tensor_api
       dbcsr_t_contract, dbcsr_t_get_block, dbcsr_t_get_stored_coordinates, dbcsr_t_put_block, &
       dbcsr_t_reserve_blocks, dbcsr_t_copy_matrix_to_tensor, dbcsr_t_copy, &
       dbcsr_t_copy_tensor_to_matrix, dbcsr_t_batched_contract_init, &
-      dbcsr_t_batched_contract_finalize, &
-      dbcsr_t_contract_index
+      dbcsr_t_batched_contract_finalize, dbcsr_t_contract_index
    USE dbcsr_tensor_block, ONLY: &
       dbcsr_t_iterator_blocks_left, dbcsr_t_iterator_next_block, dbcsr_t_iterator_start, &
       dbcsr_t_iterator_stop, dbcsr_t_iterator_type, dbcsr_t_reserved_block_indices
    USE dbcsr_tensor_types, ONLY: &
       dbcsr_t_create, dbcsr_t_destroy, dbcsr_t_distribution_destroy, dbcsr_t_distribution_new, &
-      dbcsr_t_distribution_type, dbcsr_t_nd_mp_comm, dbcsr_t_nd_mp_free, dbcsr_t_type, &
-      dbcsr_t_pgrid_type, dbcsr_t_pgrid_create, dbcsr_t_pgrid_create_expert, dbcsr_t_pgrid_destroy, &
+      dbcsr_t_distribution_type, dbcsr_t_nd_mp_comm_prv => dbcsr_t_nd_mp_comm, dbcsr_t_nd_mp_free, dbcsr_t_type, &
+      dbcsr_t_pgrid_type, dbcsr_t_pgrid_create_prv => dbcsr_t_pgrid_create, &
+      dbcsr_t_pgrid_create_expert_prv => dbcsr_t_pgrid_create_expert, dbcsr_t_pgrid_destroy, &
       dbcsr_t_set, dbcsr_t_filter, &
       dbcsr_t_mp_environ_pgrid => mp_environ_pgrid, dbcsr_t_blk_sizes, dbcsr_t_get_info, &
       dbcsr_t_finalize, dbcsr_t_scale, dbcsr_t_get_nze, dbcsr_t_get_nze_total, &
@@ -44,6 +44,7 @@ MODULE dbcsr_tensor_api
       dbcsr_t_get_mapping_info
    USE dbcsr_tensor_io, ONLY: &
       dbcsr_t_write_tensor_info, dbcsr_t_write_split_info, dbcsr_t_write_blocks, dbcsr_t_write_tensor_dist
+   USE dbcsr_mpiwrap, ONLY: mp_comm_type
 
    IMPLICIT NONE
 
@@ -108,5 +109,49 @@ MODULE dbcsr_tensor_api
    PUBLIC :: dbcsr_t_blk_size
    PUBLIC :: dbcsr_t_max_nblks_local
    PUBLIC :: dbcsr_t_default_distvec
+
+CONTAINS
+
+   FUNCTION dbcsr_t_nd_mp_comm(comm_2d, map1_2d, map2_2d, dims_nd, dims1_nd, dims2_nd, pdims_2d, tdims, &
+                               nsplit, dimsplit)
+      INTEGER, INTENT(IN)                               :: comm_2d
+      INTEGER, DIMENSION(:), INTENT(IN)                 :: map1_2d, map2_2d
+      INTEGER, DIMENSION(SIZE(map1_2d) + SIZE(map2_2d)), &
+         INTENT(IN), OPTIONAL                           :: dims_nd
+      INTEGER, DIMENSION(SIZE(map1_2d)), INTENT(IN), OPTIONAL :: dims1_nd
+      INTEGER, DIMENSION(SIZE(map2_2d)), INTENT(IN), OPTIONAL :: dims2_nd
+      INTEGER, DIMENSION(2), INTENT(IN), OPTIONAL           :: pdims_2d
+      INTEGER, DIMENSION(SIZE(map1_2d) + SIZE(map2_2d)), &
+         INTENT(IN), OPTIONAL                           :: tdims
+      INTEGER, INTENT(IN), OPTIONAL :: nsplit, dimsplit
+      TYPE(dbcsr_t_pgrid_type)                          :: dbcsr_t_nd_mp_comm
+
+      dbcsr_t_nd_mp_comm = dbcsr_t_nd_mp_comm_prv(mp_comm_type(comm_2d), map1_2d, map2_2d, &
+                                                  dims_nd, dims1_nd, dims2_nd, pdims_2d, tdims, &
+                                                  nsplit, dimsplit)
+
+   END FUNCTION dbcsr_t_nd_mp_comm
+
+   SUBROUTINE dbcsr_t_pgrid_create_expert(mp_comm, dims, pgrid, map1_2d, map2_2d, tensor_dims, nsplit, dimsplit)
+      INTEGER, INTENT(IN) :: mp_comm
+      INTEGER, DIMENSION(:), INTENT(INOUT) :: dims
+      TYPE(dbcsr_t_pgrid_type), INTENT(OUT) :: pgrid
+      INTEGER, DIMENSION(:), INTENT(IN) :: map1_2d, map2_2d
+      INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL :: tensor_dims
+      INTEGER, INTENT(IN), OPTIONAL :: nsplit, dimsplit
+
+      CALL dbcsr_t_pgrid_create_expert_prv(mp_comm_type(mp_comm), dims, pgrid, map1_2d, map2_2d, tensor_dims, nsplit, dimsplit)
+
+   END SUBROUTINE dbcsr_t_pgrid_create_expert
+
+   SUBROUTINE dbcsr_t_pgrid_create(mp_comm, dims, pgrid, tensor_dims)
+      INTEGER, INTENT(IN) :: mp_comm
+      INTEGER, DIMENSION(:), INTENT(INOUT) :: dims
+      TYPE(dbcsr_t_pgrid_type), INTENT(OUT) :: pgrid
+      INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL :: tensor_dims
+
+      CALL dbcsr_t_pgrid_create_prv(mp_comm_type(mp_comm), dims, pgrid, tensor_dims)
+
+   END SUBROUTINE dbcsr_t_pgrid_create
 
 END MODULE dbcsr_tensor_api

--- a/src/tensors/dbcsr_tensor_api.F
+++ b/src/tensors/dbcsr_tensor_api.F
@@ -126,7 +126,11 @@ CONTAINS
       INTEGER, INTENT(IN), OPTIONAL :: nsplit, dimsplit
       TYPE(dbcsr_t_pgrid_type)                          :: dbcsr_t_nd_mp_comm
 
-      dbcsr_t_nd_mp_comm = dbcsr_t_nd_mp_comm_prv(mp_comm_type(comm_2d), map1_2d, map2_2d, &
+      TYPE(mp_comm_type)                                :: my_comm_2d
+
+      CALL my_comm_2d%set_handle(comm_2d)
+
+      dbcsr_t_nd_mp_comm = dbcsr_t_nd_mp_comm_prv(my_comm_2d, map1_2d, map2_2d, &
                                                   dims_nd, dims1_nd, dims2_nd, pdims_2d, tdims, &
                                                   nsplit, dimsplit)
 
@@ -140,7 +144,11 @@ CONTAINS
       INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL :: tensor_dims
       INTEGER, INTENT(IN), OPTIONAL :: nsplit, dimsplit
 
-      CALL dbcsr_t_pgrid_create_expert_prv(mp_comm_type(mp_comm), dims, pgrid, map1_2d, map2_2d, tensor_dims, nsplit, dimsplit)
+      TYPE(mp_comm_type)                                :: my_mp_comm
+
+      CALL my_mp_comm%set_handle(mp_comm)
+
+      CALL dbcsr_t_pgrid_create_expert_prv(my_mp_comm, dims, pgrid, map1_2d, map2_2d, tensor_dims, nsplit, dimsplit)
 
    END SUBROUTINE dbcsr_t_pgrid_create_expert
 
@@ -150,7 +158,11 @@ CONTAINS
       TYPE(dbcsr_t_pgrid_type), INTENT(OUT) :: pgrid
       INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL :: tensor_dims
 
-      CALL dbcsr_t_pgrid_create_prv(mp_comm_type(mp_comm), dims, pgrid, tensor_dims)
+      TYPE(mp_comm_type)                                :: my_mp_comm
+
+      CALL my_mp_comm%set_handle(mp_comm)
+
+      CALL dbcsr_t_pgrid_create_prv(my_mp_comm, dims, pgrid, tensor_dims)
 
    END SUBROUTINE dbcsr_t_pgrid_create
 

--- a/src/tensors/dbcsr_tensor_block.F
+++ b/src/tensors/dbcsr_tensor_block.F
@@ -17,11 +17,10 @@ MODULE dbcsr_tensor_block
    USE dbcsr_allocate_wrap, ONLY: &
       allocate_any
    USE dbcsr_api, ONLY: &
-      ${uselist(dtype_float_param)}$, dbcsr_iterator_type, dbcsr_iterator_blocks_left, &
+      ${uselist(dtype_float_param)}$, dbcsr_iterator_type, &
       dbcsr_iterator_next_block, dbcsr_iterator_start, dbcsr_iterator_stop, dbcsr_type, &
       dbcsr_reserve_blocks, dbcsr_scalar_type, dbcsr_finalize, dbcsr_get_num_blocks, &
-      dbcsr_type_no_symmetry, dbcsr_get_matrix_type, dbcsr_desymmetrize, dbcsr_release, &
-      dbcsr_has_symmetry
+      dbcsr_type_no_symmetry, dbcsr_desymmetrize, dbcsr_release, dbcsr_has_symmetry
    USE dbcsr_tas_types, ONLY: &
       dbcsr_tas_iterator
    USE dbcsr_tas_base, ONLY: &
@@ -30,8 +29,7 @@ MODULE dbcsr_tensor_block
    USE dbcsr_kinds, ONLY: &
       ${uselist(dtype_float_prec)}$, int_8
    USE dbcsr_tensor_index, ONLY: &
-      nd_to_2d_mapping, ndims_mapping, get_nd_indices_tensor, destroy_nd_to_2d_mapping, get_2d_indices_tensor, &
-      create_nd_to_2d_mapping
+      nd_to_2d_mapping, ndims_mapping, get_nd_indices_tensor, destroy_nd_to_2d_mapping, get_2d_indices_tensor
    USE dbcsr_array_list_methods, ONLY: &
       array_list, get_array_elements, destroy_array_list, sizes_of_arrays, create_array_list, &
       get_arrays

--- a/src/tensors/dbcsr_tensor_io.F
+++ b/src/tensors/dbcsr_tensor_io.F
@@ -19,7 +19,7 @@ MODULE dbcsr_tensor_io
       blk_dims_tensor, dbcsr_t_get_stored_coordinates, dbcsr_t_get_nze, dbcsr_t_get_nze_total, &
       dbcsr_t_pgrid_type, dbcsr_t_nblks_total
    USE dbcsr_kinds, ONLY: default_string_length, int_8, real_8
-   USE dbcsr_mpiwrap, ONLY: mp_environ, mp_sum, mp_max, mp_comm_type
+   USE dbcsr_mpiwrap, ONLY: mp_environ, mp_max, mp_comm_type
    USE dbcsr_tensor_block, ONLY: &
       dbcsr_t_iterator_type, dbcsr_t_iterator_next_block, dbcsr_t_iterator_start, &
       dbcsr_t_iterator_blocks_left, dbcsr_t_iterator_stop, dbcsr_t_get_block

--- a/src/tensors/dbcsr_tensor_io.F
+++ b/src/tensors/dbcsr_tensor_io.F
@@ -19,7 +19,7 @@ MODULE dbcsr_tensor_io
       blk_dims_tensor, dbcsr_t_get_stored_coordinates, dbcsr_t_get_nze, dbcsr_t_get_nze_total, &
       dbcsr_t_pgrid_type, dbcsr_t_nblks_total
    USE dbcsr_kinds, ONLY: default_string_length, int_8, real_8
-   USE dbcsr_mpiwrap, ONLY: mp_environ, mp_sum, mp_max
+   USE dbcsr_mpiwrap, ONLY: mp_environ, mp_sum, mp_max, mp_comm_type
    USE dbcsr_tensor_block, ONLY: &
       dbcsr_t_iterator_type, dbcsr_t_iterator_next_block, dbcsr_t_iterator_start, &
       dbcsr_t_iterator_blocks_left, dbcsr_t_iterator_stop, dbcsr_t_get_block
@@ -119,7 +119,7 @@ CONTAINS
       INTEGER                        :: nproc, myproc, nblock_max, nelement_max
       INTEGER(KIND=int_8)            :: nblock_sum, nelement_sum, nblock_tot
       INTEGER                        :: nblock, nelement, unit_nr_prv
-      INTEGER                        :: mp_comm
+      TYPE(mp_comm_type)             :: mp_comm
       INTEGER, DIMENSION(2)          :: tmp
       INTEGER, DIMENSION(ndims_tensor(tensor)) :: bdims
       REAL(KIND=real_8)              :: occupation

--- a/src/tensors/dbcsr_tensor_reshape.F
+++ b/src/tensors/dbcsr_tensor_reshape.F
@@ -34,7 +34,7 @@ MODULE dbcsr_tensor_reshape
                             mp_environ, &
                             mp_irecv, &
                             mp_isend, &
-                            mp_waitall
+                            mp_waitall, mp_comm_type
 
 #include "base/dbcsr_base_uses.f90"
 
@@ -73,7 +73,7 @@ CONTAINS
          !! tensor_in is empty on return
       LOGICAL, INTENT(IN), OPTIONAL                    :: move_data
 
-      INTEGER                                            :: blk, iproc, mp_comm, mynode, ndata, &
+      INTEGER                                            :: blk, iproc, mynode, ndata, &
                                                             numnodes, bcount, nblk
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: num_blocks_recv, num_blocks_send, &
                                                             num_entries_recv, num_entries_send, &
@@ -84,6 +84,7 @@ CONTAINS
       TYPE(block_buffer_type), ALLOCATABLE, DIMENSION(:) :: buffer_recv, buffer_send
       INTEGER, DIMENSION(ndims_tensor(tensor_in))       :: blk_size, ind_nd, index
       LOGICAL :: found, summation_prv, move_prv
+      TYPE(mp_comm_type) :: mp_comm
 
       IF (PRESENT(summation)) THEN
          summation_prv = summation
@@ -285,7 +286,7 @@ CONTAINS
 
    SUBROUTINE dbcsr_t_communicate_buffer(mp_comm, buffer_recv, buffer_send, req_array)
       !! communicate buffer
-      INTEGER, INTENT(IN)                    :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                    :: mp_comm
       TYPE(block_buffer_type), DIMENSION(0:), INTENT(INOUT) :: buffer_recv, buffer_send
       INTEGER, DIMENSION(:, :), INTENT(OUT)               :: req_array
 

--- a/src/tensors/dbcsr_tensor_reshape.F
+++ b/src/tensors/dbcsr_tensor_reshape.F
@@ -34,7 +34,7 @@ MODULE dbcsr_tensor_reshape
                             mp_environ, &
                             mp_irecv, &
                             mp_isend, &
-                            mp_waitall, mp_comm_type
+                            mp_waitall, mp_comm_type, mp_request_type
 
 #include "base/dbcsr_base_uses.f90"
 
@@ -78,13 +78,14 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: num_blocks_recv, num_blocks_send, &
                                                             num_entries_recv, num_entries_send, &
                                                             num_rec, num_send
-      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: req_array, index_recv, blks_to_allocate
+      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: index_recv, blks_to_allocate
       TYPE(dbcsr_t_iterator_type)                        :: iter
       TYPE(block_nd)                                     :: blk_data
       TYPE(block_buffer_type), ALLOCATABLE, DIMENSION(:) :: buffer_recv, buffer_send
       INTEGER, DIMENSION(ndims_tensor(tensor_in))       :: blk_size, ind_nd, index
       LOGICAL :: found, summation_prv, move_prv
       TYPE(mp_comm_type) :: mp_comm
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:, :) :: req_array
 
       IF (PRESENT(summation)) THEN
          summation_prv = summation
@@ -288,7 +289,7 @@ CONTAINS
       !! communicate buffer
       TYPE(mp_comm_type), INTENT(IN)                    :: mp_comm
       TYPE(block_buffer_type), DIMENSION(0:), INTENT(INOUT) :: buffer_recv, buffer_send
-      INTEGER, DIMENSION(:, :), INTENT(OUT)               :: req_array
+      TYPE(mp_request_type), DIMENSION(:, :), INTENT(OUT)               :: req_array
 
       INTEGER                                :: iproc, mynode, numnodes, rec_counter, &
                                                 send_counter

--- a/src/tensors/dbcsr_tensor_test.F
+++ b/src/tensors/dbcsr_tensor_test.F
@@ -37,7 +37,7 @@ MODULE dbcsr_tensor_test
                             mp_comm_free, &
                             mp_comm_free, &
                             mp_sum, &
-                            mp_cart_create
+                            mp_cart_create, mp_comm_type
    USE dbcsr_allocate_wrap, ONLY: allocate_any
    USE dbcsr_tensor_index, ONLY: &
       combine_tensor_index, get_2d_indices_tensor, dbcsr_t_get_mapping_info
@@ -177,7 +177,7 @@ CONTAINS
          !! output unit, needs to be a valid unit number on all mpi ranks
       LOGICAL, INTENT(IN)                         :: verbose
          !! if .TRUE., print all tensor blocks
-      INTEGER, INTENT(IN)                         :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                         :: mp_comm
       TYPE(dbcsr_t_distribution_type)             :: dist1, dist2
       TYPE(dbcsr_t_type)                          :: tensor1, tensor2
       INTEGER                                     :: isep, iblk
@@ -359,7 +359,7 @@ CONTAINS
       !! Allocate and fill test tensor - entries are enumerated by their index s.t. they only depend
       !! on global properties of the tensor but not on distribution, matrix representation, etc.
       TYPE(dbcsr_t_type), INTENT(INOUT)                  :: tensor
-      INTEGER, INTENT(IN)                                :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                                :: mp_comm
          !! communicator
       LOGICAL, INTENT(IN)                                :: enumerate
       INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL        :: ${varlist("blk_ind")}$
@@ -560,11 +560,12 @@ CONTAINS
                OPTIONAL                          :: bounds_3
             LOGICAL, INTENT(IN), OPTIONAL        :: log_verbose
             LOGICAL, INTENT(IN), OPTIONAL        :: write_int
-            INTEGER                              :: io_unit, mynode, numnodes, mp_comm
+            INTEGER                              :: io_unit, mynode, numnodes
             INTEGER, DIMENSION(:), ALLOCATABLE   :: size_1, size_2, size_3, &
                                                     order_t1, order_t2, order_t3
             INTEGER, DIMENSION(2, ndims_tensor(tensor_1)) :: bounds_t1
             INTEGER, DIMENSION(2, ndims_tensor(tensor_2)) :: bounds_t2
+            TYPE(mp_comm_type)                   :: mp_comm
 
             #:for ndim in ndims
                REAL(KIND=real_8), ALLOCATABLE, &

--- a/src/tensors/dbcsr_tensor_test.F
+++ b/src/tensors/dbcsr_tensor_test.F
@@ -15,7 +15,6 @@ MODULE dbcsr_tensor_test
    #:set ndims = range(2,maxdim+1)
 
    USE dbcsr_api, ONLY: ${uselist(dtype_float_param)}$
-   USE dbcsr_tas_base, ONLY: dbcsr_tas_info
    USE dbcsr_tensor, ONLY: &
       dbcsr_t_copy, dbcsr_t_get_block, dbcsr_t_iterator_type, dbcsr_t_iterator_blocks_left, &
       dbcsr_t_iterator_next_block, dbcsr_t_iterator_start, dbcsr_t_iterator_stop, &
@@ -24,7 +23,7 @@ MODULE dbcsr_tensor_test
    USE dbcsr_tensor_block, ONLY: block_nd
    USE dbcsr_tensor_types, ONLY: &
       dbcsr_t_create, dbcsr_t_destroy, dbcsr_t_type, dbcsr_t_distribution_type, dbcsr_t_distribution_destroy, &
-      dims_tensor, ndims_tensor, dbcsr_t_distribution_new, dbcsr_t_nd_mp_comm, dbcsr_t_get_data_type, &
+      dims_tensor, ndims_tensor, dbcsr_t_distribution_new, dbcsr_t_get_data_type, &
       mp_environ_pgrid, dbcsr_t_pgrid_type, dbcsr_t_pgrid_create, dbcsr_t_pgrid_destroy, dbcsr_t_get_info, &
       dbcsr_t_default_distvec
    USE dbcsr_tensor_io, ONLY: &
@@ -33,18 +32,16 @@ MODULE dbcsr_tensor_test
                           default_string_length, &
                           int_8
    USE dbcsr_mpiwrap, ONLY: mp_environ, &
-                            mp_bcast, &
-                            mp_comm_free, &
                             mp_comm_free, &
                             mp_sum, &
-                            mp_cart_create, mp_comm_type
+                            mp_comm_type
    USE dbcsr_allocate_wrap, ONLY: allocate_any
    USE dbcsr_tensor_index, ONLY: &
       combine_tensor_index, get_2d_indices_tensor, dbcsr_t_get_mapping_info
    USE dbcsr_tas_test, ONLY: dbcsr_tas_checksum
    USE dbcsr_data_types, ONLY: dbcsr_scalar_type
    USE dbcsr_blas_operations, ONLY: &
-      dbcsr_lapack_larnv, set_larnv_seed
+      set_larnv_seed
 #include "base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -177,7 +174,7 @@ CONTAINS
          !! output unit, needs to be a valid unit number on all mpi ranks
       LOGICAL, INTENT(IN)                         :: verbose
          !! if .TRUE., print all tensor blocks
-      TYPE(mp_comm_type), INTENT(IN)                         :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)              :: mp_comm
       TYPE(dbcsr_t_distribution_type)             :: dist1, dist2
       TYPE(dbcsr_t_type)                          :: tensor1, tensor2
       INTEGER                                     :: isep, iblk

--- a/src/tensors/dbcsr_tensor_types.F
+++ b/src/tensors/dbcsr_tensor_types.F
@@ -969,7 +969,7 @@ CONTAINS
 
             CHARACTER(len=default_string_length)        :: name_in
             INTEGER, DIMENSION(2)                       :: order_in
-            INTEGER                                     :: data_type
+            INTEGER                                     :: comm_2d_handle, data_type
             TYPE(dbcsr_distribution_type)                :: matrix_dist
             TYPE(dbcsr_t_distribution_type)             :: dist
             INTEGER, DIMENSION(:), POINTER              :: row_blk_size, col_blk_size
@@ -996,8 +996,9 @@ CONTAINS
             END IF
 
             CALL dbcsr_get_info(matrix_in, distribution=matrix_dist)
-            CALL dbcsr_distribution_get(matrix_dist, group=comm_2d%handle, row_dist=row_dist, col_dist=col_dist, &
+            CALL dbcsr_distribution_get(matrix_dist, group=comm_2d_handle, row_dist=row_dist, col_dist=col_dist, &
                                         nprows=pdims_2d(1), npcols=pdims_2d(2))
+            CALL comm_2d%set_handle(comm_2d_handle)
             comm_nd = dbcsr_t_nd_mp_comm(comm_2d, [order_in(1)], [order_in(2)], pdims_2d=pdims_2d)
 
             CALL dbcsr_t_distribution_new_expert( &

--- a/src/tensors/dbcsr_tensor_types.F
+++ b/src/tensors/dbcsr_tensor_types.F
@@ -38,11 +38,11 @@ MODULE dbcsr_tensor_types
       dbcsr_t_get_mapping_info, nd_to_2d_mapping, split_tensor_index, combine_tensor_index, combine_pgrid_index, &
       split_pgrid_index, ndims_mapping, ndims_mapping_row, ndims_mapping_column
    USE dbcsr_tas_split, ONLY: &
-      dbcsr_tas_create_split_rows_or_cols, dbcsr_tas_release_info, dbcsr_tas_info_hold, &
+      dbcsr_tas_release_info, dbcsr_tas_info_hold, &
       dbcsr_tas_create_split, dbcsr_tas_get_split_info, dbcsr_tas_set_strict_split
    USE dbcsr_kinds, ONLY: default_string_length, int_8, dp
    USE dbcsr_mpiwrap, ONLY: &
-      mp_cart_create, mp_cart_rank, mp_environ, mp_dims_create, mp_comm_free, mp_comm_dup, mp_sum, mp_max
+      mp_cart_create, mp_cart_rank, mp_environ, mp_dims_create, mp_comm_free, mp_comm_dup, mp_sum, mp_max, mp_comm_type
    USE dbcsr_tas_global, ONLY: dbcsr_tas_distribution, dbcsr_tas_rowcol_data, dbcsr_tas_default_distvec
    USE dbcsr_allocate_wrap, ONLY: allocate_any
    USE dbcsr_data_types, ONLY: dbcsr_scalar_type
@@ -104,7 +104,7 @@ MODULE dbcsr_tensor_types
 
    TYPE dbcsr_t_pgrid_type
       TYPE(nd_to_2d_mapping)                  :: nd_index_grid
-      INTEGER                                 :: mp_comm_2d
+      TYPE(mp_comm_type)                      :: mp_comm_2d
       TYPE(dbcsr_tas_split_info), ALLOCATABLE :: tas_split_info
       INTEGER                                 :: nproc
    END TYPE
@@ -379,7 +379,7 @@ CONTAINS
       !! This is needed to enable contraction of 2 tensors (must have the same 2d process grid).
       !! \return with nd cartesian grid
 
-            INTEGER, INTENT(IN)                               :: comm_2d
+            TYPE(mp_comm_type), INTENT(IN)                               :: comm_2d
          !! communicator with 2-dimensional topology
             INTEGER, DIMENSION(:), INTENT(IN)                 :: map1_2d, map2_2d
          !! which nd-indices map to first matrix index and in which order
@@ -559,7 +559,7 @@ CONTAINS
 
          SUBROUTINE dbcsr_t_nd_mp_free(mp_comm)
       !! Release the MPI communicator.
-            INTEGER, INTENT(INOUT)                               :: mp_comm
+            TYPE(mp_comm_type), INTENT(INOUT)                               :: mp_comm
 
             CALL mp_comm_free(mp_comm)
          END SUBROUTINE dbcsr_t_nd_mp_free
@@ -593,7 +593,8 @@ CONTAINS
             INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL     :: ${varlist("nd_dist")}$
             LOGICAL, INTENT(IN), OPTIONAL                   :: own_comm
          !! whether distribution should own communicator
-            INTEGER                                         :: ndims, comm_2d
+            INTEGER                                         :: ndims
+            TYPE(mp_comm_type)                              :: comm_2d
             INTEGER, DIMENSION(2)                           :: pdims_2d_check, &
                                                                pdims_2d, task_coor_2d
             INTEGER, DIMENSION(SIZE(map1_2d) + SIZE(map2_2d)) :: dims, nblks_nd, task_coor
@@ -968,7 +969,7 @@ CONTAINS
 
             CHARACTER(len=default_string_length)        :: name_in
             INTEGER, DIMENSION(2)                       :: order_in
-            INTEGER                                     :: comm_2d, data_type
+            INTEGER                                     :: data_type
             TYPE(dbcsr_distribution_type)                :: matrix_dist
             TYPE(dbcsr_t_distribution_type)             :: dist
             INTEGER, DIMENSION(:), POINTER              :: row_blk_size, col_blk_size
@@ -977,6 +978,7 @@ CONTAINS
             CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_t_create_matrix'
             TYPE(dbcsr_t_pgrid_type)                  :: comm_nd
             INTEGER, DIMENSION(2)                     :: pdims_2d
+            TYPE(mp_comm_type)                        :: comm_2d
 
             CALL timeset(routineN, handle)
 
@@ -994,7 +996,7 @@ CONTAINS
             END IF
 
             CALL dbcsr_get_info(matrix_in, distribution=matrix_dist)
-            CALL dbcsr_distribution_get(matrix_dist, group=comm_2d, row_dist=row_dist, col_dist=col_dist, &
+            CALL dbcsr_distribution_get(matrix_dist, group=comm_2d%handle, row_dist=row_dist, col_dist=col_dist, &
                                         nprows=pdims_2d(1), npcols=pdims_2d(2))
             comm_nd = dbcsr_t_nd_mp_comm(comm_2d, [order_in(1)], [order_in(2)], pdims_2d=pdims_2d)
 
@@ -1175,7 +1177,7 @@ CONTAINS
          END SUBROUTINE
 
          SUBROUTINE dbcsr_t_pgrid_create(mp_comm, dims, pgrid, tensor_dims)
-            INTEGER, INTENT(IN) :: mp_comm
+            TYPE(mp_comm_type), INTENT(IN) :: mp_comm
             INTEGER, DIMENSION(:), INTENT(INOUT) :: dims
             TYPE(dbcsr_t_pgrid_type), INTENT(OUT) :: pgrid
             INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL :: tensor_dims
@@ -1206,7 +1208,7 @@ CONTAINS
       !! coordinates to processes depends on the ordering of the indices and is not equivalent to a MPI
       !! cartesian grid.
 
-            INTEGER, INTENT(IN) :: mp_comm
+            TYPE(mp_comm_type), INTENT(IN) :: mp_comm
          !! simple MPI Communicator
             INTEGER, DIMENSION(:), INTENT(INOUT) :: dims
          !! grid dimensions - if entries are 0, dimensions are chosen automatically.

--- a/src/tensors/dbcsr_tensor_types.F
+++ b/src/tensors/dbcsr_tensor_types.F
@@ -42,7 +42,7 @@ MODULE dbcsr_tensor_types
       dbcsr_tas_create_split, dbcsr_tas_get_split_info, dbcsr_tas_set_strict_split
    USE dbcsr_kinds, ONLY: default_string_length, int_8, dp
    USE dbcsr_mpiwrap, ONLY: &
-      mp_cart_create, mp_cart_rank, mp_environ, mp_dims_create, mp_comm_free, mp_comm_dup, mp_sum, mp_max, mp_comm_type
+      mp_cart_create, mp_environ, mp_dims_create, mp_comm_free, mp_comm_type
    USE dbcsr_tas_global, ONLY: dbcsr_tas_distribution, dbcsr_tas_rowcol_data, dbcsr_tas_default_distvec
    USE dbcsr_allocate_wrap, ONLY: allocate_any
    USE dbcsr_data_types, ONLY: dbcsr_scalar_type

--- a/tests/dbcsr_performance_driver.F
+++ b/tests/dbcsr_performance_driver.F
@@ -84,7 +84,7 @@ PROGRAM dbcsr_performance_driver
    IF (mynode .EQ. mp_env%mp%source) io_unit = default_output_unit
 
    ! initialize libdbcsr
-   CALL dbcsr_init_lib(mp_comm%handle, io_unit)
+   CALL dbcsr_init_lib(mp_comm%get_handle(), io_unit)
 
    ! initialize libdbcsr errors
    CALL timeset(routineN, handle)

--- a/tests/dbcsr_performance_driver.F
+++ b/tests/dbcsr_performance_driver.F
@@ -22,7 +22,7 @@ PROGRAM dbcsr_performance_driver
                                dbcsr_mp_release
    USE dbcsr_mpiwrap, ONLY: &
       mp_bcast, mp_cart_create, mp_cart_rank, mp_comm_free, mp_environ, &
-      mp_world_finalize, mp_world_init
+      mp_world_finalize, mp_world_init, mp_comm_type
    USE dbcsr_performance_multiply, ONLY: dbcsr_perf_multiply
    USE dbcsr_toollib, ONLY: atoi, atol
    USE dbcsr_types, ONLY: dbcsr_mp_obj
@@ -32,12 +32,13 @@ PROGRAM dbcsr_performance_driver
 
    IMPLICIT NONE
 
-   INTEGER                                  :: mp_comm, group, numnodes, mynode, &
+   INTEGER                                  :: numnodes, mynode, &
                                                prow, pcol, io_unit, narg, handle
    INTEGER, DIMENSION(2)                    :: npdims, myploc
    INTEGER, DIMENSION(:, :), POINTER        :: pgrid
    TYPE(dbcsr_mp_obj)                       :: mp_env
    CHARACTER(len=default_string_length)     :: args(100)
+   TYPE(mp_comm_type)                       :: mp_comm, group
 
    CHARACTER(len=*), PARAMETER :: routineN = 'dbcsr_performance_driver'
 
@@ -83,7 +84,7 @@ PROGRAM dbcsr_performance_driver
    IF (mynode .EQ. mp_env%mp%source) io_unit = default_output_unit
 
    ! initialize libdbcsr
-   CALL dbcsr_init_lib(mp_comm, io_unit)
+   CALL dbcsr_init_lib(mp_comm%handle, io_unit)
 
    ! initialize libdbcsr errors
    CALL timeset(routineN, handle)

--- a/tests/dbcsr_performance_multiply.F
+++ b/tests/dbcsr_performance_multiply.F
@@ -31,7 +31,7 @@ MODULE dbcsr_performance_multiply
                                dbcsr_mp_nprows
    USE dbcsr_mpiwrap, ONLY: mp_environ, &
                             mp_sum, &
-                            mp_sync
+                            mp_sync, mp_comm_type
    USE dbcsr_multiply_api, ONLY: dbcsr_multiply
    USE dbcsr_operations, ONLY: dbcsr_copy, &
                                dbcsr_scale
@@ -65,7 +65,7 @@ CONTAINS
 
    SUBROUTINE dbcsr_perf_multiply(group, mp_env, npdims, io_unit, narg, args_shift, args)
 
-      INTEGER                                            :: group
+      TYPE(mp_comm_type)                                 :: group
       TYPE(dbcsr_mp_obj), INTENT(IN)                     :: mp_env
       INTEGER, DIMENSION(2), INTENT(in)                  :: npdims
       INTEGER                                            :: io_unit, narg, args_shift
@@ -195,7 +195,7 @@ CONTAINS
       !! Performs a variety of matrix multiplies of same matrices on different
       !! processor grids
 
-      INTEGER, INTENT(IN)                                :: mp_group
+      TYPE(mp_comm_type), INTENT(IN)                                :: mp_group
          !! MPI communicator
       TYPE(dbcsr_mp_obj), INTENT(IN)                     :: mp_env
       INTEGER, DIMENSION(2), INTENT(in)                  :: npdims
@@ -456,7 +456,7 @@ CONTAINS
       !! Performs a variety of matrix multiplies of same matrices on different
       !! processor grids
 
-      INTEGER, INTENT(IN)                                :: mp_group
+      TYPE(mp_comm_type), INTENT(IN)                                :: mp_group
          !! MPI communicator
       TYPE(dbcsr_mp_obj), INTENT(IN)                     :: mp_env
       INTEGER, INTENT(IN)                                :: io_unit

--- a/tests/dbcsr_tas_unittest.F
+++ b/tests/dbcsr_tas_unittest.F
@@ -29,7 +29,7 @@ PROGRAM dbcsr_tas_unittest
    USE dbcsr_mpiwrap, ONLY: mp_comm_free, &
                             mp_environ, &
                             mp_world_finalize, &
-                            mp_world_init
+                            mp_world_init, mp_comm_type
    USE dbcsr_tas_io, ONLY: dbcsr_tas_write_split_info
 #include "base/dbcsr_base_uses.f90"
 
@@ -41,8 +41,8 @@ PROGRAM dbcsr_tas_unittest
    INTEGER, DIMENSION(n)          :: bsize_n
    INTEGER, DIMENSION(k)          :: bsize_k
    REAL(KIND=real_8), PARAMETER   :: sparsity = 0.1
-   INTEGER                        :: mp_comm, numnodes, mynode, io_unit
-   INTEGER                        :: mp_comm_A, mp_comm_At, mp_comm_B, mp_comm_Bt, mp_comm_C, mp_comm_Ct
+   INTEGER                        :: numnodes, mynode, io_unit
+   TYPE(mp_comm_type)             :: mp_comm, mp_comm_A, mp_comm_At, mp_comm_B, mp_comm_Bt, mp_comm_C, mp_comm_Ct
    REAL(KIND=real_8), PARAMETER   :: filter_eps = 1.0E-08
 
    CALL mp_world_init(mp_comm)
@@ -52,7 +52,7 @@ PROGRAM dbcsr_tas_unittest
    io_unit = -1
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
-   CALL dbcsr_init_lib(mp_comm, io_unit)
+   CALL dbcsr_init_lib(mp_comm%handle, io_unit)
 
    CALL dbcsr_tas_reset_randmat_seed()
 

--- a/tests/dbcsr_tas_unittest.F
+++ b/tests/dbcsr_tas_unittest.F
@@ -52,7 +52,7 @@ PROGRAM dbcsr_tas_unittest
    io_unit = -1
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
-   CALL dbcsr_init_lib(mp_comm%handle, io_unit)
+   CALL dbcsr_init_lib(mp_comm%get_handle(), io_unit)
 
    CALL dbcsr_tas_reset_randmat_seed()
 

--- a/tests/dbcsr_tensor_unittest.F
+++ b/tests/dbcsr_tensor_unittest.F
@@ -67,7 +67,7 @@ PROGRAM dbcsr_tensor_unittest
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
    ! initialize libdbcsr
-   CALL dbcsr_init_lib(mp_comm%handle, io_unit)
+   CALL dbcsr_init_lib(mp_comm%get_handle(), io_unit)
 
    CALL dbcsr_t_reset_randmat_seed()
 

--- a/tests/dbcsr_tensor_unittest.F
+++ b/tests/dbcsr_tensor_unittest.F
@@ -18,7 +18,7 @@ PROGRAM dbcsr_tensor_unittest
                             mp_comm_free, &
                             mp_environ, &
                             mp_world_finalize, &
-                            mp_world_init
+                            mp_world_init, mp_comm_type
    USE dbcsr_tensor_test, ONLY: dbcsr_t_contract_test, &
                                 dbcsr_t_setup_test_tensor, &
                                 dbcsr_t_test_formats, &
@@ -33,7 +33,7 @@ PROGRAM dbcsr_tensor_unittest
 
    IMPLICIT NONE
 
-   INTEGER                            :: mp_comm, numnodes, mynode, io_unit
+   INTEGER                            :: numnodes, mynode, io_unit
    INTEGER                            :: ndims, nblks_alloc, nblks_1, nblks_2, nblks_3, nblks_4, nblks_5, &
                                          nblks_alloc_1, nblks_alloc_2, nblks_alloc_3, nblks_alloc_4, nblks_alloc_5
    INTEGER, DIMENSION(:), ALLOCATABLE :: size_1, size_2, size_3, size_4, size_5, dist1_1, dist1_2, dist1_3, &
@@ -57,6 +57,7 @@ PROGRAM dbcsr_tensor_unittest
    TYPE(dbcsr_t_pgrid_type)           :: pgrid_2d, pgrid_3d, pgrid_4d
    INTEGER, DIMENSION(:), ALLOCATABLE :: bounds_t
    INTEGER, DIMENSION(:, :), ALLOCATABLE :: bounds, bounds_1, bounds_2
+   TYPE(mp_comm_type)                 :: mp_comm
 
    CALL mp_world_init(mp_comm)
    CALL mp_environ(numnodes, mynode, mp_comm)
@@ -66,7 +67,7 @@ PROGRAM dbcsr_tensor_unittest
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
    ! initialize libdbcsr
-   CALL dbcsr_init_lib(mp_comm, io_unit)
+   CALL dbcsr_init_lib(mp_comm%handle, io_unit)
 
    CALL dbcsr_t_reset_randmat_seed()
 

--- a/tests/dbcsr_test_add.F
+++ b/tests/dbcsr_test_add.F
@@ -25,7 +25,7 @@ MODULE dbcsr_test_add
       dbcsr_nblkcols_total, dbcsr_nblkrows_total, dbcsr_nfullcols_total, dbcsr_nfullrows_total, &
       dbcsr_release, dbcsr_row_block_sizes
    USE dbcsr_mpiwrap, ONLY: mp_bcast, &
-                            mp_environ
+                            mp_environ, mp_comm_type
    USE dbcsr_operations, ONLY: dbcsr_add, &
                                dbcsr_get_occupation
    USE dbcsr_test_methods, ONLY: compx_to_dbcsr_scalar, &
@@ -63,7 +63,7 @@ CONTAINS
       !! Performs a variety of matrix add
 
       CHARACTER(len=*), INTENT(IN)                       :: test_name
-      INTEGER, INTENT(IN)                                :: mp_group
+      TYPE(mp_comm_type), INTENT(IN)                                :: mp_group
          !! MPI communicator
       TYPE(dbcsr_mp_obj), INTENT(IN)                     :: mp_env
       INTEGER, DIMENSION(2), INTENT(in)                  :: npdims
@@ -233,7 +233,7 @@ CONTAINS
       !! Performs a variety of matrix add
 
       CHARACTER(len=*), INTENT(IN)                       :: test_name
-      INTEGER, INTENT(IN)                                :: mp_group
+      TYPE(mp_comm_type), INTENT(IN)                                :: mp_group
          !! MPI communicator
       TYPE(dbcsr_mp_obj), INTENT(IN)                     :: mp_env
       INTEGER, DIMENSION(2), INTENT(in)                  :: npdims
@@ -364,8 +364,9 @@ CONTAINS
       INTEGER, DIMENSION(4), INTENT(in)                  :: limits
          !! limits for the add
       LOGICAL, INTENT(in)                                :: retain_sparsity
-      INTEGER, INTENT(IN)                                :: io_unit, mp_group
+      INTEGER, INTENT(IN)                                :: io_unit
          !! io unit for printing
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_group
       LOGICAL, INTENT(out)                               :: success
          !! if passed the check success=T
 

--- a/tests/dbcsr_test_csr_conversions.F
+++ b/tests/dbcsr_test_csr_conversions.F
@@ -62,7 +62,7 @@ PROGRAM dbcsr_test_csr_conversions
    io_unit = 0
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
-   CALL dbcsr_init_lib(mp_comm%handle, io_unit)
+   CALL dbcsr_init_lib(mp_comm%get_handle(), io_unit)
 
    npdims(:) = 0
    CALL mp_cart_create(mp_comm, 2, npdims, myploc, group)
@@ -188,7 +188,7 @@ CONTAINS
       REAL(real_8), ALLOCATABLE, DIMENSION(:)            :: values
       TYPE(dbcsr_distribution_type)                      :: dist
 
-      CALL dbcsr_distribution_new(dist, group=group%handle, row_dist=row_dist, col_dist=col_dist, reuse_arrays=.TRUE.)
+      CALL dbcsr_distribution_new(dist, group=group%get_handle(), row_dist=row_dist, col_dist=col_dist, reuse_arrays=.TRUE.)
 
       CALL dbcsr_create(matrix=matrix_a, &
                         name="this is my matrix a", &

--- a/tests/dbcsr_test_csr_conversions.F
+++ b/tests/dbcsr_test_csr_conversions.F
@@ -25,7 +25,7 @@ PROGRAM dbcsr_test_csr_conversions
                             mp_comm_free, &
                             mp_environ, &
                             mp_world_finalize, &
-                            mp_world_init
+                            mp_world_init, mp_comm_type
 #include "base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -38,7 +38,7 @@ PROGRAM dbcsr_test_csr_conversions
 
    INTEGER, DIMENSION(:), POINTER :: col_dist, row_dist
 
-   INTEGER                      :: mp_comm, group, numnodes, mynode, io_unit
+   INTEGER                      :: numnodes, mynode, io_unit
 
    INTEGER, DIMENSION(2)                    :: npdims, myploc
 
@@ -52,6 +52,8 @@ PROGRAM dbcsr_test_csr_conversions
 
    CHARACTER(LEN=10)            :: k_str, mynode_str
 
+   TYPE(mp_comm_type)           :: mp_comm, group
+
    ! Set up everything as in the dbcsr example codes
    CALL mp_world_init(mp_comm)
 
@@ -60,7 +62,7 @@ PROGRAM dbcsr_test_csr_conversions
    io_unit = 0
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
-   CALL dbcsr_init_lib(mp_comm, io_unit)
+   CALL dbcsr_init_lib(mp_comm%handle, io_unit)
 
    npdims(:) = 0
    CALL mp_cart_create(mp_comm, 2, npdims, myploc, group)
@@ -173,7 +175,7 @@ CONTAINS
       !! Create a DBCSR matrix with random values and random blocks
                                        col_blk_sizes, row_blk_sizes, col_dist, row_dist, sparsity)
       TYPE(dbcsr_type), INTENT(OUT)                      :: matrix_a
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                                :: group
       INTEGER, DIMENSION(:), POINTER                     :: col_blk_sizes, row_blk_sizes, col_dist, &
                                                             row_dist
       REAL(real_8), INTENT(IN)                           :: sparsity
@@ -186,7 +188,7 @@ CONTAINS
       REAL(real_8), ALLOCATABLE, DIMENSION(:)            :: values
       TYPE(dbcsr_distribution_type)                      :: dist
 
-      CALL dbcsr_distribution_new(dist, group=group, row_dist=row_dist, col_dist=col_dist, reuse_arrays=.TRUE.)
+      CALL dbcsr_distribution_new(dist, group=group%handle, row_dist=row_dist, col_dist=col_dist, reuse_arrays=.TRUE.)
 
       CALL dbcsr_create(matrix=matrix_a, &
                         name="this is my matrix a", &

--- a/tests/dbcsr_test_multiply.F
+++ b/tests/dbcsr_test_multiply.F
@@ -27,7 +27,7 @@ MODULE dbcsr_test_multiply
       dbcsr_nfullcols_total, dbcsr_nfullrows_total, dbcsr_release, dbcsr_row_block_offsets, &
       dbcsr_row_block_sizes
    USE dbcsr_mpiwrap, ONLY: mp_bcast, &
-                            mp_environ
+                            mp_environ, mp_comm_type
    USE dbcsr_multiply_api, ONLY: dbcsr_multiply
    USE dbcsr_operations, ONLY: dbcsr_copy, &
                                dbcsr_get_occupation, &
@@ -70,7 +70,7 @@ CONTAINS
       !! processor grids
 
       CHARACTER(len=*), INTENT(IN)                       :: test_name
-      INTEGER, INTENT(IN)                                :: mp_group
+      TYPE(mp_comm_type), INTENT(IN)                                :: mp_group
          !! MPI communicator
       TYPE(dbcsr_mp_obj), INTENT(IN)                     :: mp_env
       INTEGER, DIMENSION(2), INTENT(in)                  :: npdims
@@ -353,7 +353,7 @@ CONTAINS
       !! processor grids
 
       CHARACTER(len=*), INTENT(IN)                       :: test_name
-      INTEGER, INTENT(IN)                                :: mp_group
+      TYPE(mp_comm_type), INTENT(IN)                                :: mp_group
          !! MPI communicator
       TYPE(dbcsr_mp_obj), INTENT(IN)                     :: mp_env
       INTEGER, DIMENSION(2), INTENT(in)                  :: npdims
@@ -541,8 +541,9 @@ CONTAINS
       INTEGER, DIMENSION(6), INTENT(in)                  :: limits
          !! limits for the gemm
       LOGICAL, INTENT(in)                                :: retain_sparsity
-      INTEGER, INTENT(IN)                                :: io_unit, mp_group
+      INTEGER, INTENT(IN)                                :: io_unit
          !! io unit for printing
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_group
       LOGICAL, INTENT(out)                               :: success
          !! if passed the check success=T
 

--- a/tests/dbcsr_test_scale_by_vector.F
+++ b/tests/dbcsr_test_scale_by_vector.F
@@ -22,7 +22,7 @@ MODULE dbcsr_test_scale_by_vector
       dbcsr_get_matrix_type, dbcsr_name, dbcsr_nblkcols_total, dbcsr_nblkrows_total, &
       dbcsr_nfullcols_total, dbcsr_nfullrows_total, dbcsr_release
 
-   USE dbcsr_mpiwrap, ONLY: mp_environ
+   USE dbcsr_mpiwrap, ONLY: mp_environ, mp_comm_type
    USE dbcsr_test_methods, ONLY: dbcsr_make_random_block_sizes, &
                                  dbcsr_make_random_matrix, &
                                  dbcsr_random_dist, &
@@ -57,7 +57,7 @@ CONTAINS
       !! processor grids
 
       CHARACTER(len=*), INTENT(IN)                       :: test_name
-      INTEGER, INTENT(IN)                                :: mp_group
+      TYPE(mp_comm_type), INTENT(IN)                                :: mp_group
          !! MPI communicator
       TYPE(dbcsr_mp_obj), INTENT(IN)                     :: mp_env
       INTEGER, DIMENSION(2), INTENT(IN)                  :: npdims

--- a/tests/dbcsr_unittest1.F
+++ b/tests/dbcsr_unittest1.F
@@ -65,7 +65,7 @@ PROGRAM dbcsr_unittest_1
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
    ! initialize libdbcsr
-   CALL dbcsr_init_lib(mp_comm%handle, io_unit)
+   CALL dbcsr_init_lib(mp_comm%get_handle(), io_unit)
 
    ! initialize libdbcsr errors
    CALL timeset(routineN, handle)

--- a/tests/dbcsr_unittest1.F
+++ b/tests/dbcsr_unittest1.F
@@ -23,7 +23,7 @@ PROGRAM dbcsr_unittest_1
                             mp_comm_free, &
                             mp_environ, &
                             mp_world_finalize, &
-                            mp_world_init
+                            mp_world_init, mp_comm_type
    USE dbcsr_test_add, ONLY: dbcsr_test_adds
    USE dbcsr_test_methods, ONLY: dbcsr_reset_randmat_seed
    USE dbcsr_test_multiply, ONLY: dbcsr_test_multiplies
@@ -32,11 +32,12 @@ PROGRAM dbcsr_unittest_1
 
    IMPLICIT NONE
 
-   INTEGER                                  :: mp_comm, group, numnodes, mynode, &
+   INTEGER                                  :: numnodes, mynode, &
                                                prow, pcol, io_unit, handle
    INTEGER, DIMENSION(2)                    :: npdims, myploc
    INTEGER, DIMENSION(:, :), POINTER         :: pgrid
    TYPE(dbcsr_mp_obj)                       :: mp_env
+   TYPE(mp_comm_type)                       :: mp_comm, group
 
    CHARACTER(len=*), PARAMETER :: routineN = 'dbcsr_unittest'
 
@@ -64,7 +65,7 @@ PROGRAM dbcsr_unittest_1
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
    ! initialize libdbcsr
-   CALL dbcsr_init_lib(mp_comm, io_unit)
+   CALL dbcsr_init_lib(mp_comm%handle, io_unit)
 
    ! initialize libdbcsr errors
    CALL timeset(routineN, handle)

--- a/tests/dbcsr_unittest2.F
+++ b/tests/dbcsr_unittest2.F
@@ -24,7 +24,7 @@ PROGRAM dbcsr_unittest_2
                             mp_comm_free, &
                             mp_environ, &
                             mp_world_finalize, &
-                            mp_world_init
+                            mp_world_init, mp_comm_type
    USE dbcsr_test_methods, ONLY: dbcsr_reset_randmat_seed
    USE dbcsr_test_multiply, ONLY: dbcsr_test_multiplies
    USE dbcsr_types, ONLY: dbcsr_mp_obj
@@ -32,11 +32,12 @@ PROGRAM dbcsr_unittest_2
 
    IMPLICIT NONE
 
-   INTEGER                                  :: mp_comm, group, numnodes, mynode, &
+   INTEGER                                  :: numnodes, mynode, &
                                                prow, pcol, io_unit, handle
    INTEGER, DIMENSION(2)                    :: npdims, myploc
    INTEGER, DIMENSION(:, :), POINTER         :: pgrid
    TYPE(dbcsr_mp_obj)                       :: mp_env
+   TYPE(mp_comm_type)                       :: mp_comm, group
 
    CHARACTER(len=*), PARAMETER :: routineN = 'dbcsr_unittest'
 
@@ -64,7 +65,7 @@ PROGRAM dbcsr_unittest_2
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
    ! initialize libdbcsr
-   CALL dbcsr_init_lib(mp_comm, io_unit)
+   CALL dbcsr_init_lib(mp_comm%handle, io_unit)
 
    ! initialize libdbcsr errors
    CALL timeset(routineN, handle)

--- a/tests/dbcsr_unittest2.F
+++ b/tests/dbcsr_unittest2.F
@@ -65,7 +65,7 @@ PROGRAM dbcsr_unittest_2
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
    ! initialize libdbcsr
-   CALL dbcsr_init_lib(mp_comm%handle, io_unit)
+   CALL dbcsr_init_lib(mp_comm%get_handle(), io_unit)
 
    ! initialize libdbcsr errors
    CALL timeset(routineN, handle)

--- a/tests/dbcsr_unittest3.F
+++ b/tests/dbcsr_unittest3.F
@@ -65,7 +65,7 @@ PROGRAM dbcsr_unittest_3
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
    ! initialize libdbcsr
-   CALL dbcsr_init_lib(mp_comm%handle, io_unit)
+   CALL dbcsr_init_lib(mp_comm%get_handle(), io_unit)
 
    ! initialize libdbcsr errors
    CALL timeset(routineN, handle)

--- a/tests/dbcsr_unittest3.F
+++ b/tests/dbcsr_unittest3.F
@@ -24,7 +24,7 @@ PROGRAM dbcsr_unittest_3
                             mp_comm_free, &
                             mp_environ, &
                             mp_world_finalize, &
-                            mp_world_init
+                            mp_world_init, mp_comm_type
    USE dbcsr_test_methods, ONLY: dbcsr_reset_randmat_seed
    USE dbcsr_test_multiply, ONLY: dbcsr_test_multiplies
    USE dbcsr_types, ONLY: dbcsr_mp_obj
@@ -32,11 +32,12 @@ PROGRAM dbcsr_unittest_3
 
    IMPLICIT NONE
 
-   INTEGER                                  :: mp_comm, group, numnodes, mynode, &
+   INTEGER                                  :: numnodes, mynode, &
                                                prow, pcol, io_unit, handle
    INTEGER, DIMENSION(2)                    :: npdims, myploc
    INTEGER, DIMENSION(:, :), POINTER         :: pgrid
    TYPE(dbcsr_mp_obj)                       :: mp_env
+   TYPE(mp_comm_type)                       :: mp_comm, group
 
    CHARACTER(len=*), PARAMETER :: routineN = 'dbcsr_unittest'
 
@@ -64,7 +65,7 @@ PROGRAM dbcsr_unittest_3
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
    ! initialize libdbcsr
-   CALL dbcsr_init_lib(mp_comm, io_unit)
+   CALL dbcsr_init_lib(mp_comm%handle, io_unit)
 
    ! initialize libdbcsr errors
    CALL timeset(routineN, handle)

--- a/tests/dbcsr_unittest4.F
+++ b/tests/dbcsr_unittest4.F
@@ -22,7 +22,7 @@ PROGRAM dbcsr_unittest
                             mp_comm_free, &
                             mp_environ, &
                             mp_world_finalize, &
-                            mp_world_init
+                            mp_world_init, mp_comm_type
    USE dbcsr_test_add, ONLY: dbcsr_test_adds
    USE dbcsr_test_methods, ONLY: dbcsr_reset_randmat_seed
    USE dbcsr_test_scale_by_vector, ONLY: dbcsr_test_scale_by_vectors
@@ -31,12 +31,13 @@ PROGRAM dbcsr_unittest
 
    IMPLICIT NONE
 
-   INTEGER                                  :: mp_comm, group, numnodes, mynode, &
+   INTEGER                                  :: numnodes, mynode, &
                                                prow, pcol, io_unit, handle
    INTEGER, DIMENSION(2)                    :: npdims, myploc
    INTEGER, DIMENSION(:, :), POINTER        :: pgrid
    TYPE(dbcsr_mp_obj)                       :: mp_env
    LOGICAL                                  :: success
+   TYPE(mp_comm_type)                       :: mp_comm, group
 
    CHARACTER(len=*), PARAMETER :: routineN = 'dbcsr_unittest'
 
@@ -62,7 +63,7 @@ PROGRAM dbcsr_unittest
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
    ! initialize DBCSR
-   CALL dbcsr_init_lib(mp_comm, io_unit)
+   CALL dbcsr_init_lib(mp_comm%handle, io_unit)
 
    ! start measuring the complete test
    CALL timeset(routineN, handle)

--- a/tests/dbcsr_unittest4.F
+++ b/tests/dbcsr_unittest4.F
@@ -63,7 +63,7 @@ PROGRAM dbcsr_unittest
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
    ! initialize DBCSR
-   CALL dbcsr_init_lib(mp_comm%handle, io_unit)
+   CALL dbcsr_init_lib(mp_comm%get_handle(), io_unit)
 
    ! start measuring the complete test
    CALL timeset(routineN, handle)


### PR DESCRIPTION
This PR wraps the MPI handles which used to be plain integers into their own derived types. The handle component is kept private to facilitate the transition to the new mpi_f08 bindings introducing their own types and allow to switch between serial/MPI 90 binding/MPI 2008 bindings. I implemented setters and getters and the comparison operators for convenience. Regarding the constants, the wrapper module will distinguish the handles (which are used for the default initializers) and the actual parameters exposed to the rest of the library. This refactoring improves the type safety within the library.

The new types are used only internally and are not meant to be exposed to users of DBCSR which is why some routines accessible via the dbcsr_api.F module need a wrapper routine to wrap the passed integer handles into the new types. Thus, the external APIs did not change.

Similar changes have already been applied to CP2K. I will continue this PR by adding support for the MPI 2008 bindings which should solve some issues with the old MPI 90 bindings.