### PR TITLE
ocl: updated Makefile

### DIFF
--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -27,7 +27,7 @@ if [ ! -d "${HOME}/libxsmm" ]; then
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout edc62775a227e23f789b78e7b5ca9d435184fa56
+git checkout 3235b3e09c9f084abf4213748da46844254bfef9
 make -j
 cd ..
 

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -111,8 +111,8 @@ ifneq (0,$(DEV))
     OMP := 0
   endif
   CFLAGS += -pedantic
-else
-  CFLAGS += -std=c99
+#else
+  #CFLAGS += -std=c99
 endif
 
 ifneq (0,$(DBG))


### PR DESCRIPTION
* Avoid specifying C-standard (and rely on compiler's default).
* Updated LIBXSMM (Daint-CI).