### PR TITLE
acc: Always set active device before accessing a GPU

### DIFF
--- a/src/acc/dbcsr_acc_devmem.F
+++ b/src/acc/dbcsr_acc_devmem.F
@@ -24,6 +24,8 @@ MODULE dbcsr_acc_devmem
                                acc_stream_cptr, &
                                acc_stream_synchronize, &
                                acc_stream_type
+   USE dbcsr_acc_device, ONLY: dbcsr_acc_set_active_device
+   USE dbcsr_config, ONLY: get_accdrv_active_device_id
 #include "base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -209,6 +211,8 @@ CONTAINS
       IF (this%size_in_bytes < requested_size_in_bytes) THEN
          !WRITE (*,*) "acc_devmem_ensure_size_bytes: growing dev_mem to: ", data_size
 
+         CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
+
          new_size = requested_size_in_bytes
          old_size = this%size_in_bytes
          old_cptr = this%cptr
@@ -332,6 +336,7 @@ CONTAINS
       INTEGER(KIND=C_INT)                      :: istat
       INTEGER(KIND=C_SIZE_T)                   :: free_c, total_c
 
+      CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
       istat = acc_interface_dev_mem_info(free_c, total_c)
       IF (istat /= 0) &
          DBCSR_ABORT("acc_devmem_info: failed")
@@ -360,6 +365,7 @@ CONTAINS
          DBCSR_ABORT("acc_devmem_alloc: already allocated")
       this%size_in_bytes = size_in_bytes
       IF (size_in_bytes > 0) THEN
+         CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
          istat = acc_interface_dev_mem_alloc(this%cptr, INT(this%size_in_bytes, KIND=C_SIZE_T))
          IF (istat /= 0) &
             DBCSR_ABORT("acc_devmem_allocate: failed")
@@ -381,6 +387,7 @@ CONTAINS
       IF (this%size_in_bytes < 0) &
          DBCSR_ABORT("acc_devmem_deallocate: double free")
       IF (this%size_in_bytes > 0) THEN
+         CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
          istat = acc_interface_dev_mem_dealloc(this%cptr)
          IF (istat /= 0) &
             DBCSR_ABORT("acc_devmem_deallocate: failed")
@@ -426,6 +433,7 @@ CONTAINS
       stream_cptr = acc_stream_cptr(stream)
 
       IF (length > 0) THEN
+         CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
          istat = acc_interface_memzero(this%cptr, offset, length, stream_cptr)
          IF (istat /= 0) &
             DBCSR_ABORT("acc_devmem_setzero: failed")
@@ -451,6 +459,7 @@ CONTAINS
 
       stream_cptr = acc_stream_cptr(stream)
       IF (n_bytes > 0) THEN
+         CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
          istat = acc_interface_memcpy_h2d(hostmem_cptr, this%cptr, &
                                           INT(n_bytes, KIND=C_SIZE_T), stream_cptr)
          IF (istat /= 0) &
@@ -479,6 +488,7 @@ CONTAINS
       stream_cptr = acc_stream_cptr(stream)
 
       IF (n_bytes > 0) THEN
+         CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
          istat = acc_interface_memcpy_d2h(this%cptr, hostmem_cptr, &
                                           INT(n_bytes, KIND=C_SIZE_T), stream_cptr)
          IF (istat /= 0) &

--- a/src/acc/dbcsr_acc_event.F
+++ b/src/acc/dbcsr_acc_event.F
@@ -14,6 +14,8 @@ MODULE dbcsr_acc_event
 #endif
    USE dbcsr_acc_stream, ONLY: acc_stream_cptr, &
                                acc_stream_type
+   USE dbcsr_acc_device, ONLY: dbcsr_acc_set_active_device
+   USE dbcsr_config, ONLY: get_accdrv_active_device_id
 #include "base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -115,6 +117,7 @@ CONTAINS
          DBCSR_ABORT("acc_stream_wait_event: event not allocated")
       IF (.NOT. C_ASSOCIATED(stream_cptr)) &
          DBCSR_ABORT("acc_stream_wait_event: stream not allocated")
+      CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
       istat = acc_interface_stream_wait_event(stream_cptr, event%cptr)
       IF (istat /= 0) &
          DBCSR_ABORT("acc_stream_wait_event failed")
@@ -140,6 +143,7 @@ CONTAINS
          DBCSR_ABORT("acc_event_record: event not allocated")
       IF (.NOT. C_ASSOCIATED(stream_cptr)) &
          DBCSR_ABORT("acc_event_record: stream not allocated")
+      CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
       istat = acc_interface_event_record(this%cptr, stream_cptr)
       IF (istat /= 0) &
          DBCSR_ABORT("acc_event_record failed")
@@ -160,6 +164,7 @@ CONTAINS
 
       IF (C_ASSOCIATED(this%cptr)) &
          DBCSR_ABORT("acc_event_create: already allocated")
+      CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
       istat = acc_interface_event_create(this%cptr)
       IF (istat /= 0 .OR. .NOT. C_ASSOCIATED(this%cptr)) &
          DBCSR_ABORT("acc_event_create: failed")
@@ -179,6 +184,7 @@ CONTAINS
       INTEGER                                  :: istat
       IF (.NOT. C_ASSOCIATED(this%cptr)) &
          DBCSR_ABORT("acc_event_destroy: event not allocated")
+      CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
       istat = acc_interface_event_destroy(this%cptr)
       IF (istat /= 0) &
          DBCSR_ABORT("acc_event_destroy failed")
@@ -201,6 +207,7 @@ CONTAINS
       INTEGER                                  :: istat, has_occurred
       IF (.NOT. C_ASSOCIATED(this%cptr)) &
          DBCSR_ABORT("acc_event_query: event not allocated")
+      CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
       istat = acc_interface_event_query(this%cptr, has_occurred)
       IF (istat /= 0) &
          DBCSR_ABORT("acc_event_query failed")
@@ -220,6 +227,7 @@ CONTAINS
       INTEGER                                  :: istat
       IF (.NOT. C_ASSOCIATED(this%cptr)) &
          DBCSR_ABORT("acc_event_synchronize: event not allocated")
+      CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
       istat = acc_interface_event_synchronize(this%cptr)
       IF (istat < 0) &
          DBCSR_ABORT("acc_event_synchronize failed")

--- a/src/acc/dbcsr_acc_hostmem.F
+++ b/src/acc/dbcsr_acc_hostmem.F
@@ -23,6 +23,8 @@ MODULE dbcsr_acc_hostmem
    USE dbcsr_acc_stream, ONLY: acc_stream_associated, &
                                acc_stream_cptr, &
                                acc_stream_type
+   USE dbcsr_acc_device, ONLY: dbcsr_acc_set_active_device
+   USE dbcsr_config, ONLY: get_accdrv_active_device_id
 #include "base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -98,6 +100,7 @@ CONTAINS
 
       stream_cptr = acc_stream_cptr(stream)
 
+      CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
       istat = acc_interface_host_mem_alloc(host_mem_c_ptr, n_bytes, stream_cptr)
       IF (istat /= 0) &
          DBCSR_ABORT("acc_hostmem_alloc_raw: Could not allocate host pinned memory")
@@ -120,6 +123,7 @@ CONTAINS
 
       stream_cptr = acc_stream_cptr(stream)
 
+      CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
       istat = acc_interface_host_mem_dealloc(host_mem_c_ptr, stream_cptr)
       IF (istat /= 0) &
          DBCSR_ABORT("acc_hostmem_dealloc_raw: Could not deallocate host pinned memory")

--- a/src/acc/dbcsr_acc_stream.F
+++ b/src/acc/dbcsr_acc_stream.F
@@ -12,6 +12,8 @@ MODULE dbcsr_acc_stream
 #if defined (__DBCSR_ACC)
    USE ISO_C_BINDING, ONLY: C_INT, C_CHAR, C_PTR, C_NULL_PTR, C_NULL_CHAR, C_ASSOCIATED
 #endif
+   USE dbcsr_acc_device, ONLY: dbcsr_acc_set_active_device
+   USE dbcsr_config, ONLY: get_accdrv_active_device_id
 #include "base/dbcsr_base_uses.f90"
 
    IMPLICIT NONE
@@ -126,6 +128,7 @@ CONTAINS
       IF (C_ASSOCIATED(this%cptr)) &
          DBCSR_ABORT("acc_stream_create: stream already allocated")
 
+      CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
       istat = acc_interface_stream_create(this%cptr, name//c_null_char, my_priority)
 
       IF (istat /= 0 .OR. .NOT. C_ASSOCIATED(this%cptr)) &
@@ -146,6 +149,7 @@ CONTAINS
       INTEGER                                  :: istat
       IF (.NOT. C_ASSOCIATED(this%cptr)) &
          DBCSR_ABORT("acc_stream_destroy: stream not allocated")
+      CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
       istat = acc_interface_stream_destroy(this%cptr)
       IF (istat /= 0) &
          DBCSR_ABORT("acc_stream_destroy failed")
@@ -166,6 +170,7 @@ CONTAINS
       INTEGER                                  :: istat
       IF (.NOT. C_ASSOCIATED(this%cptr)) &
          DBCSR_ABORT("acc_stream_synchronize: stream not allocated")
+      CALL dbcsr_acc_set_active_device(get_accdrv_active_device_id())
       istat = acc_interface_stream_sync(this%cptr)
       IF (istat /= 0) &
          DBCSR_ABORT("acc_stream_synchronize failed")


### PR DESCRIPTION
I've had for a while the problem that some CP2K regtests would fail with `cudaErrorInvalidResourceHandle` when I ran on two GPUs. I believe this is because the active device gets changed between calls to DBCSR.

Presumably, most users are not affect by this because Slurm et al. set `CUDA_VISIBLE_DEVICES` to pin GPUs to CPU sockets. 