### PR TITLE
ocl: improved stand-alone reproducers and updated some settings

### DIFF
--- a/.ci/daint.cscs.ch/ocl.build.sh
+++ b/.ci/daint.cscs.ch/ocl.build.sh
@@ -27,7 +27,7 @@ if [ ! -d "${HOME}/libxsmm" ]; then
 fi
 cd "${HOME}/libxsmm"
 git fetch
-git checkout d8b8cbb398948b61da00005d06125da0e482b469
+git checkout 7871d611393dd2354aaba6d5558e718eb6d86d75
 make -j
 cd ..
 

--- a/src/acc/cuda/Makefile
+++ b/src/acc/cuda/Makefile
@@ -30,6 +30,7 @@ UNAME := $(shell uname)
 HEADERONLY ?= 0
 STATIC ?= 1
 INTEL ?= 0
+GNU ?= 0
 DEV ?= 0
 
 # select from set of predefined triplet specifications
@@ -109,6 +110,15 @@ else ifneq (0,$(INTEL))
   CXX := icpx
   CC := icx
   AR := xiar
+else ifneq (0,$(GNU))
+  override CXX := g++
+  override CC := gcc
+  ifneq (Darwin,$(UNAME))
+    override AR := gcc-ar
+  else
+    override AR := ar
+  endif
+  override LD_LIBRARY_DIRS := $(NULL)
 else
   CXX := g++
   CC := gcc
@@ -184,8 +194,9 @@ ifneq (,$(LIBXSMMROOT))
 endif
 
 ifneq (,$(CUDA_PATH))
-  LDFLAGS += -L$(CUDA_PATH)/lib64/stubs -Wl,-rpath=$(CUDA_PATH)/lib64/stubs
-  LDFLAGS += -L$(CUDA_PATH)/lib64 -Wl,-rpath=$(CUDA_PATH)/lib64
+  CUDA_LIBDIR := $(if $(wildcard $(CUDA_PATH)/lib64),lib64,lib)
+  LDFLAGS += -L$(CUDA_PATH)/$(CUDA_LIBDIR)/stubs -Wl,-rpath=$(CUDA_PATH)/$(CUDA_LIBDIR)/stubs
+  LDFLAGS += -L$(CUDA_PATH)/$(CUDA_LIBDIR) -Wl,-rpath=$(CUDA_PATH)/$(CUDA_LIBDIR)
   CUDAINC := $(strip $(lastword $(sort $(wildcard $(CUDA_PATH)/../cuda/*/targets/x86_64-linux/include/cuda.h))))
   ifneq (,$(CUDAINC))
     CFLAGS += -I$(abspath $(dir $(CUDAINC)))
@@ -195,9 +206,9 @@ ifneq (,$(CUDA_PATH))
 endif
 
 # Collect all paths in LD_LIBRARY_PATH and LD_LIBRARY_PATH/stubs, and append to LDFLAGS
-LD_LIBRARY_PATH := $(wildcard $(subst :, ,$(LD_LIBRARY_PATH)))
-LD_LIBSTUB_PATH := $(wildcard $(patsubst %,%/stubs,$(LD_LIBRARY_PATH)))
-LIBPATHS := $(foreach DIR,$(LD_LIBRARY_PATH),$(if $(filter -L$(DIR),$(LDFLAGS)),$(NULL),-L$(DIR)))
+LD_LIBRARY_DIRS := $(wildcard $(subst :, ,$(LD_LIBRARY_PATH)))
+LD_LIBSTUB_PATH := $(wildcard $(patsubst %,%/stubs,$(LD_LIBRARY_DIRS)))
+LIBPATHS := $(foreach DIR,$(LD_LIBRARY_DIRS),$(if $(filter -L$(DIR),$(LDFLAGS)),$(NULL),-L$(DIR)))
 LIBSTUBS := $(foreach DIR,$(LD_LIBSTUB_PATH),$(if $(filter -L$(DIR),$(LDFLAGS)),$(NULL),-L$(DIR)))
 LDFLAGS += $(LIBPATHS) $(LIBSTUBS) -lcudart -lcublas -lnvrtc -lcuda
 CXXFLAGS += -std=c++11 $(CFLAGS)

--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -23,6 +23,7 @@ UNAME := $(shell uname)
 HEADERONLY ?= 0
 STATIC ?= 1
 INTEL ?= 0
+GNU ?= 0
 DEV ?= 0
 
 # select from set of predefined triplet specifications
@@ -80,6 +81,15 @@ else ifneq (0,$(INTEL))
   CXX := icpx
   CC := icx
   AR := xiar
+else ifneq (0,$(GNU))
+  override CXX := g++
+  override CC := gcc
+  ifneq (Darwin,$(UNAME))
+    override AR := gcc-ar
+  else
+    override AR := ar
+  endif
+  override LD_LIBRARY_DIRS := $(NULL)
 else
   CXX := g++
   CC := gcc
@@ -186,6 +196,7 @@ else
     CUDATOOLKIT_HOME := $(if $(NVCC),$(abspath $(dir $(NVCC))/..))
   endif
   ifneq (,$(CUDATOOLKIT_HOME))
+    CUDA_LIBDIR := $(if $(wildcard $(CUDATOOLKIT_HOME)/lib64),lib64,lib)
     ifeq (,$(wildcard $(OPENCL_INC)))
       CLINC := $(strip $(lastword $(sort $(wildcard $(CUDATOOLKIT_HOME)/../cuda/*/targets/x86_64-linux/include/CL/cl.h))))
       ifneq (,$(CLINC))
@@ -195,8 +206,8 @@ else
       endif
     endif
     ifeq (,$(wildcard $(OPENCL_LIB)))
-      LDFLAGS += -L$(CUDATOOLKIT_HOME)/lib64
-      LDFLAGS += -Wl,-rpath=$(CUDATOOLKIT_HOME)/lib64
+      LDFLAGS += -L$(CUDATOOLKIT_HOME)/$(CUDA_LIBDIR)
+      LDFLAGS += -Wl,-rpath=$(CUDATOOLKIT_HOME)/$(CUDA_LIBDIR)
     endif
   endif
   # OPENCL_INC: directory containing CL/cl.h.
@@ -212,9 +223,9 @@ else
 endif
 
 # Collect all paths in LD_LIBRARY_PATH and LD_LIBRARY_PATH/stubs, and append to LDFLAGS
-LD_LIBRARY_PATH := $(wildcard $(subst :, ,$(LD_LIBRARY_PATH)))
-LD_LIBSTUB_PATH := $(wildcard $(patsubst %,%/stubs,$(LD_LIBRARY_PATH)))
-LIBPATHS := $(foreach DIR,$(LD_LIBRARY_PATH),$(if $(filter -L$(DIR),$(LDFLAGS)),$(NULL),-L$(DIR)))
+LD_LIBRARY_DIRS := $(wildcard $(subst :, ,$(LD_LIBRARY_PATH)))
+LD_LIBSTUB_PATH := $(wildcard $(patsubst %,%/stubs,$(LD_LIBRARY_DIRS)))
+LIBPATHS := $(foreach DIR,$(LD_LIBRARY_DIRS),$(if $(filter -L$(DIR),$(LDFLAGS)),$(NULL),-L$(DIR)))
 LIBSTUBS := $(foreach DIR,$(LD_LIBSTUB_PATH),$(if $(filter -L$(DIR),$(LDFLAGS)),$(NULL),-L$(DIR)))
 LDFLAGS += $(LIBPATHS) $(LIBSTUBS)
 

--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -225,7 +225,7 @@ int c_dbcsr_acc_init(void) {
     c_dbcsr_acc_opencl_config.verbosity = (NULL == env_verbose ? 0 : atoi(env_verbose));
     c_dbcsr_acc_opencl_config.priority = (NULL == env_priority ? /*default*/ 3 : atoi(env_priority));
     c_dbcsr_acc_opencl_config.devcopy = (NULL == env_devcopy ? /*default*/ 0 : atoi(env_devcopy));
-    c_dbcsr_acc_opencl_config.xhints = (NULL == env_xhints ? /*default*/ 1 : atoi(env_xhints));
+    c_dbcsr_acc_opencl_config.xhints = (NULL == env_xhints ? /*default*/ 5 : atoi(env_xhints));
     c_dbcsr_acc_opencl_config.share = (NULL == env_share ? /*default*/ 0 : atoi(env_share));
     c_dbcsr_acc_opencl_config.async = (NULL == env_async ? /*default*/ 3 : atoi(env_async));
     c_dbcsr_acc_opencl_config.flush = (NULL == env_flush ? /*default*/ 0 : atoi(env_flush));


### PR DESCRIPTION
* Adjusted XHINTS for revised UMD.
* Makefile: Avoid hard-coded "lib64".
* Makefile: Support GNU=1.
* LIBXSMM upd. (Daint-CI).