### PR TITLE
ocl: removed unused code

### DIFF
--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -82,7 +82,7 @@
 #  define ACC_OPENCL_MAXSTRLEN 48
 #endif
 #if !defined(ACC_OPENCL_DEVICES_MAXCOUNT)
-#  define ACC_OPENCL_DEVICES_MAXCOUNT 256
+#  define ACC_OPENCL_DEVICES_MAXCOUNT 64
 #endif
 /** Counted on a per-thread basis! */
 #if !defined(ACC_OPENCL_HANDLES_MAXCOUNT)
@@ -112,6 +112,7 @@
 #    define ACC_OPENCL_STREAM_PRIORITIES
 #  endif
 #endif
+/** Use DBCSR's profile for detailed timings */
 #if !defined(ACC_OPENCL_PROFILE) && 0
 #  define ACC_OPENCL_PROFILE
 #endif
@@ -262,12 +263,8 @@ typedef struct c_dbcsr_acc_opencl_config_t {
   cl_int devcopy;
   /** Execution-hints (command stream). */
   cl_int xhints;
-  /** Share streams across threads. */
-  cl_int share;
   /** Asynchronous memory ops. */
   cl_int async;
-  /** Flush level. */
-  cl_int flush;
   /** Dump level. */
   cl_int dump;
 } c_dbcsr_acc_opencl_config_t;

--- a/src/acc/opencl/acc_opencl_event.c
+++ b/src/acc/opencl/acc_opencl_event.c
@@ -192,12 +192,7 @@ int c_dbcsr_acc_event_query(void* event, c_dbcsr_acc_bool_t* has_occurred) {
 #  endif
   assert(NULL != event && NULL != has_occurred);
   result = clGetEventInfo(*ACC_OPENCL_EVENT(event), CL_EVENT_COMMAND_EXECUTION_STATUS, sizeof(cl_int), &status, NULL);
-  if (CL_SUCCESS == result && 0 <= status) {
-    *has_occurred = (CL_COMPLETE == status ? 1 : 0);
-    if (0 == *has_occurred && 0 != (8 & c_dbcsr_acc_opencl_config.flush)) {
-      result = c_dbcsr_acc_opencl_device_synchronize(ACC_OPENCL_OMP_TID());
-    }
-  }
+  if (CL_SUCCESS == result && 0 <= status) *has_occurred = (CL_COMPLETE == status ? 1 : 0);
   else { /* error state */
 #  if defined(ACC_OPENCL_EVENT_CREATE)
     if (CL_SUCCESS == result) result = EXIT_FAILURE;

--- a/src/acc/opencl/smm/opencl_libsmm.c
+++ b/src/acc/opencl/smm/opencl_libsmm.c
@@ -1672,7 +1672,7 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
             &blob, precision, m_max, n_max, k_max, m_max, k_max, m_max, LIBXSMM_GEMM_FLAG_NONE, LIBXSMM_PREFETCH_NONE);
           const size_t scratch_size = psize + asize + bsize + csize + csize + k_max * n_max * typesize +
                                       5 * (LIBXSMM_ALIGNMENT - 1) /*alignments*/;
-          scratch = libxsmm_aligned_malloc(scratch_size, LIBXSMM_ALIGNMENT);
+          scratch = libxsmm_aligned_scratch(scratch_size, LIBXSMM_ALIGNMENT);
           if (NULL != desc && NULL != scratch) {
             pinp = (int*)scratch;
             ainp = (char*)LIBXSMM_UP2((uintptr_t)pinp + psize, LIBXSMM_ALIGNMENT);
@@ -1783,10 +1783,16 @@ int libsmm_acc_process(const int* host_param_stack, const int* dev_param_stack, 
           /* some result may be validated multiple times in case of duplicated c-indexes */
           for (i = 0; i < ((size_t)stack_size * nparams); i += nparams) {
             const size_t ic = (size_t)(params[i + 2] - 1) * typesize;
+            double epsilon = 0;
             libxsmm_matdiff_info diff;
             libxsmm_matdiff(
               &diff, (libxsmm_datatype)precision, m_max, n_max, gold + ic, test + ic, &m_max /*ldref*/, &m_max /*ldtst*/);
-            if (tolerance < diff.normf_rel) {
+#      if LIBXSMM_VERSION4(1, 17, 0, 0) < LIBXSMM_VERSION_NUMBER
+            epsilon = libxsmm_matdiff_epsilon(&diff);
+#      else
+            epsilon = diff.normf_rel;
+#      endif
+            if (tolerance < epsilon) {
               if (0 == c_dbcsr_acc_opencl_config.verbosity) {
                 fprintf(stderr, "libsmm_acc_process(size=%i, type=%s, m=%i, n=%i, k=%i, max=%i, stream=%p)", stack_size,
                   dbcsr_type_real_8 == datatype ? "f64" : (dbcsr_type_real_4 == datatype ? "f32" : "unknown"), m_max, n_max, k_max,


### PR DESCRIPTION
* Removed support for sharing streams among threads, removed support for flush-bits.
* OPENCL_LIBSMM_VALIDATE_SMM: rely on libxsmm_matdiff_epsilon.
* Revised console output (acc_bench_smm).
* Code cleanup.