### PR TITLE
feat: Fedora packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,4 @@ spack-*
 .DS_Store
 
 BUILD/
+!tools/fedora/dbcsr.spec

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,48 @@
+specfile_path: tools/fedora/dbcsr.spec
+files_to_sync:
+  - src: tools/fedora/
+    dest: ./
+    delete: true
+    filters:
+      - "protect .git*"
+      - "protect sources"
+      - "protect changelog"
+  - .packit.yaml
+upstream_package_name: dbcsr
+downstream_package_name: dbcsr
+upstream_tag_template: v{version}
+
+targets:
+  - fedora-development-x86_64
+  - fedora-development-aarch64
+
+_:
+  # Job templates
+  - &build-in-packit
+    job: copr_build
+  - &build-at-lecris
+    <<: *build-in-packit
+    owner: lecris
+
+jobs:
+  - <<: *build-at-lecris
+    trigger: release
+    project: release
+  - <<: *build-at-lecris
+    trigger: commit
+    branch: master
+    project: nightly
+  - <<: *build-in-packit
+    trigger: pull_request
+  - job: propose_downstream
+    trigger: release
+    dist_git_branches:
+      - fedora-rawhide
+  - job: koji_build
+    trigger: commit
+    dist_git_branches:
+      - fedora-all
+  - job: bodhi_update
+    trigger: commit
+    dist_git_branches:
+      - fedora-branched

--- a/tools/fedora/dbcsr.spec
+++ b/tools/fedora/dbcsr.spec
@@ -1,0 +1,199 @@
+# Currently does not build with opencl/libxsmm
+%bcond_with opencl
+
+# No openmpi on i668 with openmpi 5 in Fedora 40+
+%if 0%{?fedora} >= 40
+%ifarch %{ix86}
+%bcond_with openmpi
+%else
+%bcond_without openmpi
+%endif
+%else
+%bcond_without openmpi
+%endif
+
+Name:          dbcsr
+Version:       0.0.0
+Release:       %autorelease
+Summary:       Distributed Block Compressed Sparse Row matrix library
+License:       GPL-2.0-or-later
+URL:           https://cp2k.github.io/dbcsr/develop/
+Source0:       https://github.com/cp2k/dbcsr/releases/download/v%{version}/dbcsr-%{version}.tar.gz
+
+BuildRequires: cmake
+BuildRequires: gcc-c++
+BuildRequires: gcc-gfortran
+BuildRequires: make
+BuildRequires: flexiblas-devel
+%if %{with opencl}
+BuildRequires: libxsmm-devel
+%endif
+BuildRequires: python3-fypp
+
+%global _description %{expand:
+DBCSR stands for Distributed Blocked Compressed Sparse Row.
+
+DBCSR is a library designed to efficiently perform sparse matrix-matrix
+multiplication, among other operations.  It is MPI and OpenMP parallel and
+can exploit Nvidia and AMD GPUs via CUDA and HIP.}
+
+
+%description
+%{_description}
+
+This package contains the non-MPI single process and multi-threaded versions.
+
+%package devel
+Summary: Development files for %{name}
+Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: gcc-gfortran%{_isa}
+
+%description devel
+The %{name}-devel package contains libraries and header files for
+developing applications that use %{name}.
+
+%global mpi_list mpich
+
+%if %{with openmpi}
+%global mpi_list %{mpi_list} openmpi
+%package openmpi
+Summary: DBCSR - openmpi version
+BuildRequires:  openmpi-devel
+
+%description openmpi
+%{_description}
+
+This package contains the parallel single- and multi-threaded versions
+using OpenMPI.
+
+%package openmpi-devel
+Summary: Development files for %{name}-openmpi
+Requires: %{name}-openmpi%{?_isa} = %{version}-%{release}
+
+%description openmpi-devel
+The %{name}-openmpi-devel package contains libraries and header files for
+developing applications that use %{name}-openmpi.
+%endif
+
+%package mpich
+Summary: DBCSR - mpich version
+BuildRequires:  mpich-devel
+
+%description mpich
+%{_description}
+
+This package contains the parallel single- and multi-threaded versions
+using mpich.
+
+%package mpich-devel
+Summary: Development files for %{name}-mpich
+Requires: %{name}-mpich%{?_isa} = %{version}-%{release}
+
+%description mpich-devel
+The %{name}-mpich-devel package contains libraries and header files for
+developing applications that use %{name}-mpich.
+
+
+%prep
+%autosetup -p1
+# Use cmake's version so it can find flexiblas
+rm cmake/Find{BLAS,LAPACK}.cmake
+# Use system fypp, other tools not needed
+rm -r tools
+
+
+# $mpi will be evaluated in the loops below
+%global _vpath_builddir %{_vendor}-%{_target_os}-build-${mpi:-serial}
+
+%build
+export CFLAGS="%{optflags} -fPIC"
+export CXXFLAGS="%{optflags} -fPIC"
+export FFLAGS="%{optflags} -fPIC"
+%cmake \
+  -DCMAKE_INSTALL_Fortran_MODULES=%{_fmoddir} \
+  -DUSE_MPI=OFF \
+  %{?with_opencl:-DUSE_ACCEL=opencl -DUSE_SMM=libxsmm}
+%cmake_build
+for mpi in %{mpi_list}
+do
+  module load mpi/$mpi-%{_arch}
+  %cmake \
+    -DCMAKE_INSTALL_Fortran_MODULES=$MPI_FORTRAN_MOD_DIR \
+    %{?with_opencl:-DUSE_ACCEL=opencl -DUSE_SMM=libxsmm} \
+    -DCMAKE_INSTALL_PREFIX:PATH=$MPI_HOME \
+    -DCMAKE_INSTALL_LIBDIR:PATH=$MPI_LIB \
+    -DUSE_MPI_F08=ON \
+    -DTEST_MPI_RANKS=2
+  %cmake_build
+  module purge
+done
+
+
+%install
+%cmake_install
+for mpi in %{mpi_list}
+do
+  module load mpi/$mpi-%{_arch}
+  %cmake_install
+  module purge
+done
+
+
+%check
+%ctest
+for mpi in %{mpi_list}
+do
+  module load mpi/$mpi-%{_arch}
+  fail=
+  # mpich tests fail on s390x - reported https://github.com/cp2k/dbcsr/issues/703
+  [ $mpi = mpich -a %{_arch} = s390x ] && fail=no
+  %ctest || test $fail
+  module purge
+done
+
+
+%files
+%license LICENSE
+%doc README.md
+%{_libdir}/libdbcsr.so.*
+
+%files devel
+%{_fmoddir}/dbcsr_api.mod
+%{_fmoddir}/dbcsr_tensor_api.mod
+%{_libdir}/cmake/dbcsr/
+%{_libdir}/libdbcsr.so
+
+%if %{with openmpi}
+%files openmpi
+%license LICENSE
+%doc README.md
+%{_libdir}/openmpi/lib/libdbcsr.so.*
+%{_libdir}/openmpi/lib/libdbcsr_c.so.*
+
+%files openmpi-devel
+%{_libdir}/openmpi/include/dbcsr.h
+%{_libdir}/openmpi/include/dbcsr_tensor.h
+%{_fmoddir}/openmpi/dbcsr_api.mod
+%{_fmoddir}/openmpi/dbcsr_tensor_api.mod
+%{_libdir}/openmpi/lib/cmake/dbcsr/
+%{_libdir}/openmpi/lib/libdbcsr.so
+%{_libdir}/openmpi/lib/libdbcsr_c.so
+%endif
+
+%files mpich
+%license LICENSE
+%doc README.md
+%{_libdir}/mpich/lib/libdbcsr.so.*
+%{_libdir}/mpich/lib/libdbcsr_c.so.*
+
+%files mpich-devel
+%{_libdir}/mpich/include/dbcsr.h
+%{_libdir}/mpich/include/dbcsr_tensor.h
+%{_fmoddir}/mpich/dbcsr_api.mod
+%{_fmoddir}/mpich/dbcsr_tensor_api.mod
+%{_libdir}/mpich/lib/cmake/dbcsr/
+%{_libdir}/mpich/lib/libdbcsr.so
+%{_libdir}/mpich/lib/libdbcsr_c.so
+
+%changelog
+%autochangelog


### PR DESCRIPTION
This adds packaging CI/CD for Fedora:
- When a new release is pushed, a pull-request is created at https://src.fedoraproject.org/rpms/dbcsr
- For each PR/commit to `develop`, the packaging is tested in copr
- (not yet implemented) Tests for packaging imports, e.g. via `find_package`. Needs some refactoring similar to [spglib](https://github.com/spglib/spglib)

To fully work the [packit app](https://packit.dev/docs/guide) needs to be installed on the repo. In the meantime the example run can be seen on my fork: https://github.com/LecrisUT/dbcsr/pull/1

soft-depends-on: #757 