### PR TITLE
ocl: adjusted finalization-flow of OpenCL backend

### DIFF
--- a/src/acc/opencl/acc_opencl_stream.c
+++ b/src/acc/opencl/acc_opencl_stream.c
@@ -251,11 +251,7 @@ int c_dbcsr_acc_stream_sync(void* stream) {
   static const int routine_name_len = (int)sizeof(LIBXSMM_FUNCNAME) - 1;
   c_dbcsr_timeset((const char**)&routine_name_ptr, &routine_name_len, &routine_handle);
 #  endif
-#  if defined(ACC_OPENCL_STREAM_NULL)
   str = (NULL != stream ? ACC_OPENCL_STREAM(stream) : c_dbcsr_acc_opencl_stream_default());
-#  else
-  str = ACC_OPENCL_STREAM(stream);
-#  endif
   assert(NULL != str && NULL != str->queue);
   result = clFinish(str->queue);
 #  if defined(__DBCSR_ACC) && defined(ACC_OPENCL_PROFILE)


### PR DESCRIPTION
* Fixed case when ACC_OPENCL_MEM_DEVPTR is turned off at compile-time.
* Ensure termination message appears one time at most (cleanup).
* Introduced ACC_OPENCL_EVENT_CHAIN and ACC_OPENCL_EVENT_WAIT.
* Removed compile-time option for ACC_OPENCL_MEM_CPYSYNC.
* Removed compile-time setting (ACC_OPENCL_STREAM_NULL).
* Introduced WA-levels to distinct certain WAs.
* Ensure final cleanup (atexit).