### PR TITLE
Fixed #776

### DIFF
--- a/src/acc/cuda_hip/acc_dev.cpp
+++ b/src/acc/cuda_hip/acc_dev.cpp
@@ -45,7 +45,11 @@ extern "C" int c_dbcsr_acc_set_active_device(int device_id) {
   ACC_API_CALL(Free, (0));
 
 #if defined(__CUDA) || defined(__HIP_PLATFORM_NVCC__)
-  ACC_API_CALL(DeviceSetLimit, (ACC(LimitPrintfFifoSize), (size_t)1000000000));
+  static bool once = false;
+  if (!once) {
+    ACC_API_CALL(DeviceSetLimit, (ACC(LimitPrintfFifoSize), (size_t)1000000000));
+    once = true;
+  }
 #endif
 
   return 0;


### PR DESCRIPTION
* Citation: "Setting cudaLimitPrintfFifoSize must not be performed after launching any kernel that uses the printf() device system call - in such case cudaErrorInvalidValue will be returned."
* Since DeviceSetLimit is governed by ACC_API_CALL, the symbol NDEBUG must not be defined for reproducing the issue.