### PR TITLE
Fixed compilation warning and typo

### DIFF
--- a/src/acc/cuda_hip/acc_stream.cpp
+++ b/src/acc/cuda_hip/acc_stream.cpp
@@ -51,7 +51,7 @@ extern "C" int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int 
     cErr = ACC(StreamCreate)(acc_stream);
   }
 
-  if (verbose_print) printf("StreamCreate : %p -> %p \n", *stream_p, *acc_stream);
+  if (verbose_print) printf("StreamCreate : %p -> %p \n", *stream_p, (const void*)*acc_stream);
   if (acc_error_check(cErr)) return -1;
   if (acc_error_check(ACC(GetLastError)())) return -1;
 

--- a/src/core/dbcsr_lib.F
+++ b/src/core/dbcsr_lib.F
@@ -220,7 +220,7 @@ CONTAINS
             ! Use round-robin assignment per rank
             CALL set_accdrv_active_device_id(MOD(mynode, dbcsr_acc_get_ndevices()))
          ELSE
-            DBCSR_ABORT("dbcsr_init_lib: No recongnized GPU devices")
+            DBCSR_ABORT("dbcsr_init_lib: No recognized GPU devices")
          END IF
          CALL acc_init()
       END IF


### PR DESCRIPTION
* Avoid warning about format %p expecting void-pointer.
* Fixed typo (DBCSR_ABORT message).