### PR TITLE
ocl: several minor fixes

### DIFF
--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -164,7 +164,7 @@ LIBXSMM_ATTRIBUTE_DTOR void c_dbcsr_acc_opencl_finalize(void) {
     for (i = 0; i < ACC_OPENCL_MAXNDEVS; ++i) {
       const cl_device_id device_id = c_dbcsr_acc_opencl_config.devices[i];
       if (NULL != device_id) {
-#  if defined(CL_VERSION_1_2)
+#  if defined(CL_VERSION_1_2) && 0 /* avoid potential segfault */
         ACC_OPENCL_EXPECT(EXIT_SUCCESS == clReleaseDevice(device_id));
 #  endif
         /* c_dbcsr_acc_opencl_create_context scans for non-NULL devices */
@@ -229,7 +229,7 @@ int c_dbcsr_acc_init(void) {
     const int nccs = (NULL == env_nccs ? ACC_OPENCL_NCCS : atoi(env_nccs));
 #  endif
     const char *const env_neo = getenv("NEOReadDebugKeys"), *const env_wa = getenv("ACC_OPENCL_WA");
-    const int neo = (NULL == env_neo ? 1 : atoi(env_neo)), wa = neo * (NULL == env_wa ? 3 : atoi(env_wa));
+    const int neo = (NULL == env_neo ? 1 : atoi(env_neo)), wa = neo * (NULL == env_wa ? 7 : atoi(env_wa));
 #  if defined(ACC_OPENCL_ASYNC)
     const char* const env_async = (ACC_OPENCL_ASYNC);
     const int async_default = 3;
@@ -290,12 +290,12 @@ int c_dbcsr_acc_init(void) {
       ACC_OPENCL_EXPECT(0 == LIBXSMM_PUTENV(ze_flat)); /* soft-error */
     }
 #  if defined(ACC_OPENCL_NCCS)
-    if (NULL == getenv("ZEX_NUMBER_OF_CCS") && 0 != nccs) {
+    if (NULL == getenv("ZEX_NUMBER_OF_CCS") && 0 != nccs && 0 == (1 & wa)) {
       static char zex_nccs[ACC_OPENCL_MAXNDEVS * 8 + 32] = "ZEX_NUMBER_OF_CCS=";
       int j = strlen(zex_nccs);
       for (i = 0; i < ACC_OPENCL_MAXNDEVS; ++i) {
         const char* const istr = (0 < i ? ",%u:%i" : "%u:%i");
-        const int n = LIBXSMM_SNPRINTF(zex_nccs + j, sizeof(zex_nccs) - j, istr, i, LIBXSMM_CLMP(nccs, 1, 0 != wa ? 2 : 4));
+        const int n = LIBXSMM_SNPRINTF(zex_nccs + j, sizeof(zex_nccs) - j, istr, i, LIBXSMM_CLMP(nccs, 1, 4));
         if (0 < n) j += n;
         else {
           j = 0;
@@ -306,14 +306,14 @@ int c_dbcsr_acc_init(void) {
       if (0 < j) ACC_OPENCL_EXPECT(0 == LIBXSMM_PUTENV(zex_nccs)); /* soft-error */
     }
 #  endif
-    if (0 != wa) { /* environment is populated before touching the compute runtime */
+    if (~1 & wa) { /* environment is populated before touching the compute runtime */
       static char* key_value[] = {
         "NEOReadDebugKeys=1", "EnableRecoverablePageFaults=0", "DirectSubmissionOverrideBlitterSupport=0"};
       if (NULL == env_neo) ACC_OPENCL_EXPECT(0 == LIBXSMM_PUTENV(key_value[0]));
-      if (0 != (1 & wa) && NULL == getenv("EnableRecoverablePageFaults")) {
+      if ((2 & wa) && NULL == getenv("EnableRecoverablePageFaults")) {
         ACC_OPENCL_EXPECT(0 == LIBXSMM_PUTENV(key_value[1]));
       }
-      if (0 != (2 & wa) && NULL == getenv("DirectSubmissionOverrideBlitterSupport")) {
+      if ((4 & wa) && NULL == getenv("DirectSubmissionOverrideBlitterSupport")) {
         ACC_OPENCL_EXPECT(0 == LIBXSMM_PUTENV(key_value[2]));
       }
     }
@@ -628,6 +628,8 @@ int c_dbcsr_acc_init(void) {
           else {
             result = c_dbcsr_acc_opencl_set_active_device(NULL /*lock*/, device_id);
           }
+#  else
+          c_dbcsr_acc_opencl_config.device.uid = (cl_uint)device_id; /* hack */
 #  endif
           if (2 <= c_dbcsr_acc_opencl_config.verbosity || 0 > c_dbcsr_acc_opencl_config.verbosity) {
             char platform_name[ACC_OPENCL_BUFFERSIZE];

--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -278,7 +278,7 @@ typedef struct c_dbcsr_acc_opencl_device_t {
   cl_device_id id;
   /** Whether host memory is unified. */
   cl_int unified;
-  /** Device-ID. */
+  /** Device-UID. */
   cl_uint uid;
   /** Main vendor? */
   cl_int intel, amd, nv;

--- a/src/acc/opencl/acc_opencl_mem.c
+++ b/src/acc/opencl/acc_opencl_mem.c
@@ -182,7 +182,8 @@ int c_dbcsr_acc_host_mem_allocate(void** host_mem, size_t nbytes, void* stream) 
   assert(NULL != host_mem);
 #  if !defined(ACC_OPENCL_ACTIVATE)
   if (NULL == c_dbcsr_acc_opencl_config.device.context) {
-    ACC_OPENCL_EXPECT(EXIT_SUCCESS == c_dbcsr_acc_opencl_set_active_device(NULL /*lock*/, 0 /*device_id*/));
+    ACC_OPENCL_EXPECT(
+      EXIT_SUCCESS == c_dbcsr_acc_opencl_set_active_device(NULL /*lock*/, (int)c_dbcsr_acc_opencl_config.device.uid));
   }
 #  endif
   memory = clCreateBuffer(c_dbcsr_acc_opencl_config.device.context, CL_MEM_ALLOC_HOST_PTR, nbytes, NULL /*host_ptr*/, &result);
@@ -307,7 +308,8 @@ int c_dbcsr_acc_dev_mem_allocate(void** dev_mem, size_t nbytes) {
 #  endif
 #  if !defined(ACC_OPENCL_ACTIVATE)
   if (NULL == context) {
-    ACC_OPENCL_EXPECT(EXIT_SUCCESS == c_dbcsr_acc_opencl_set_active_device(NULL /*lock*/, 0 /*device_id*/));
+    ACC_OPENCL_EXPECT(
+      EXIT_SUCCESS == c_dbcsr_acc_opencl_set_active_device(NULL /*lock*/, (int)c_dbcsr_acc_opencl_config.device.uid));
     context = c_dbcsr_acc_opencl_config.device.context;
   }
 #  endif

--- a/src/acc/opencl/acc_opencl_stream.c
+++ b/src/acc/opencl/acc_opencl_stream.c
@@ -112,7 +112,7 @@ int c_dbcsr_acc_stream_create(void** stream_p, const char* name, int priority) {
   else
 #  else
   {
-    result = c_dbcsr_acc_opencl_set_active_device(NULL /*lock*/, 0 /*device*/);
+    result = c_dbcsr_acc_opencl_set_active_device(NULL /*lock*/, (int)c_dbcsr_acc_opencl_config.device.uid);
   }
   if (NULL != c_dbcsr_acc_opencl_config.device.context)
 #  endif

--- a/src/acc/opencl/smm/kernels/multiply.cl
+++ b/src/acc/opencl/smm/kernels/multiply.cl
@@ -144,8 +144,7 @@ FN(global T* restrict cdata, GLOBAL const T* restrict adata, GLOBAL const T* res
 #  if defined(SLM_C)
   local T cnm[SN][SM + SLM_C - 1]; /* tile in SLM */
   for (SINT n = (SINT)idx; n < SN; n += SWG) {
-    UNROLL_FORCE(SM)
-    for (SINT m = 0; m < SM; ++m) cnm[n][m] = ZERO;
+    UNROLL_FORCE(SM) for (SINT m = 0; m < SM; ++m) cnm[n][m] = ZERO;
   }
 #  elif (BM < SM || 1 != BN)
 #    if (1 != BN)
@@ -153,16 +152,13 @@ FN(global T* restrict cdata, GLOBAL const T* restrict adata, GLOBAL const T* res
   for (SINT bn = 0; bn < BN; ++bn)
 #    endif
   {
-    UNROLL_FORCE(BM)
-    for (SINT bm = 0; bm < BM; ++bm) CNM(bn, bm) = ZERO;
+    UNROLL_FORCE(BM) for (SINT bm = 0; bm < BM; ++bm) CNM(bn, bm) = ZERO;
   }
 #  else
-  UNROLL_FORCE(SM)
-  for (SINT m = 0; m < SM; ++m) cnm[m] = ZERO;
+  UNROLL_FORCE(SM) for (SINT m = 0; m < SM; ++m) cnm[m] = ZERO;
 #  endif
 #  if defined(SLM_P)
-  UNROLL_FORCE(3 * BS)
-  for (int i = idx; i < (3 * batchsize); i += SWG) params[i] = pbase[i] - 1;
+  UNROLL_FORCE(3 * BS) for (int i = idx; i < (3 * batchsize); i += SWG) params[i] = pbase[i] - 1;
 #  endif
 #  if defined(BARRIER) && (MAX(1, SGS) < SWG) && (defined(SLM_C) || defined(SLM_P))
   BARRIER(CLK_LOCAL_MEM_FENCE);
@@ -200,8 +196,7 @@ FN(global T* restrict cdata, GLOBAL const T* restrict adata, GLOBAL const T* res
       for (; m < SM; m += WRK)
 #  endif
       {
-        UNROLL_FORCE(SK)
-        for (SINT k = 0; k < SK; ++k) amk[m][k] = ADX(m, k);
+        UNROLL_FORCE(SK) for (SINT k = 0; k < SK; ++k) amk[m][k] = ADX(m, k);
       }
     }
 #endif
@@ -213,8 +208,7 @@ FN(global T* restrict cdata, GLOBAL const T* restrict adata, GLOBAL const T* res
       for (; n < SN; n += WRK)
 #  endif
       {
-        UNROLL(SK)
-        for (SINT k = 0; k < SK; ++k) bnk[n][k] = BDX(k, n);
+        UNROLL(SK) for (SINT k = 0; k < SK; ++k) bnk[n][k] = BDX(k, n);
       }
     }
 #elif defined(REG_B)
@@ -224,8 +218,7 @@ FN(global T* restrict cdata, GLOBAL const T* restrict adata, GLOBAL const T* res
 #  else
     { /* copy or transpose B-matrix into registers */
 #  endif
-      UNROLL(SK)
-      for (SINT k = 0; k < SK; ++k) {
+      UNROLL(SK) for (SINT k = 0; k < SK; ++k) {
 #  if (BM < SM || 1 != BN)
         SINT bn = 0;
 #    if (1 != BN)
@@ -256,7 +249,8 @@ FN(global T* restrict cdata, GLOBAL const T* restrict adata, GLOBAL const T* res
     { /* calculate result-tile using general tiles */
 #  if defined(REG_A) && !defined(SLM_A) && (1 != BK)
 #    if (1 == BS)
-      T cnm[BN] = {ZERO}; /* row */
+      T cnm[BN]; /* row */
+      UNROLL_FORCE(BN) for (SINT n = 0; n < BN; ++n) cnm[n] = ZERO;
 #    endif
       UNROLL(BM)
 #    if (SM % BM)
@@ -266,8 +260,7 @@ FN(global T* restrict cdata, GLOBAL const T* restrict adata, GLOBAL const T* res
 #    endif
       { /* general BK, A in registers */
         SINT bn = 0;
-        UNROLL_FORCE(SK)
-        for (SINT k = 0; k < SK; ++k) amk[k] = ADX(m, k);
+        UNROLL_FORCE(SK) for (SINT k = 0; k < SK; ++k) amk[k] = ADX(m, k);
 #    if (1 != BN)
         UNROLL(BN)
         for (; bn < BN; ++bn)
@@ -287,8 +280,7 @@ FN(global T* restrict cdata, GLOBAL const T* restrict adata, GLOBAL const T* res
 #    else
             const int mc = bn, nc = idx;
 #    endif
-            UNROLL_FORCE(SK)
-            for (SINT k = 0; k < SK; ++k) {
+            UNROLL_FORCE(SK) for (SINT k = 0; k < SK; ++k) {
               CNM(nc, mc) = MAD(AMK(m, k),
 #    if defined(REG_B)
                 BNK(bn, k),
@@ -318,16 +310,15 @@ FN(global T* restrict cdata, GLOBAL const T* restrict adata, GLOBAL const T* res
       }
 #  elif (1 == BK)
 #    if (1 == BS)
-      T cnm[BM] = {ZERO}; /* column-block */
+      T cnm[BM]; /* column-block */
+      UNROLL_FORCE(BM) for (SINT m = 0; m < BM; ++m) cnm[m] = ZERO;
 #    endif
-      UNROLL(SK)
-      for (SINT k = 0; k < SK; ++k) {
+      UNROLL(SK) for (SINT k = 0; k < SK; ++k) {
 #    if (SN % BN) || !defined(REG_B) || (defined(SLM_C) && (1 < BS)) || (1 == BS) || (1 != BN)
         SINT bn = 0;
 #    endif
 #    if defined(REG_A) && !defined(SLM_A)
-        UNROLL_FORCE(BM)
-        for (SINT bm = 0; bm < BM; ++bm) amk[bm] = ADX(bm + m0, k);
+        UNROLL_FORCE(BM) for (SINT bm = 0; bm < BM; ++bm) amk[bm] = ADX(bm + m0, k);
 #    endif
 #    if (1 != BN)
         UNROLL(BN)
@@ -365,8 +356,7 @@ FN(global T* restrict cdata, GLOBAL const T* restrict adata, GLOBAL const T* res
 #    endif
             }
 #    if (1 == BS)
-            UNROLL(BM)
-            for (SINT bm = 0; bm < BM; ++bm) {
+            UNROLL(BM) for (SINT bm = 0; bm < BM; ++bm) {
 #      if defined(ATOMIC_INC_NZ)
               if (ZERO != CNM(idx, bm))
 #      endif
@@ -394,7 +384,8 @@ FN(global T* restrict cdata, GLOBAL const T* restrict adata, GLOBAL const T* res
 #    endif
       { /* general BK */
 #    if (1 == BS)
-        T cnm[BM] = {ZERO}; /* column-block */
+        T cnm[BM]; /* column-block */
+        UNROLL_FORCE(BM) for (SINT m = 0; m < BM; ++m) cnm[m] = ZERO;
 #    endif
         UNROLL(BM)
 #    if (SM % BM)
@@ -421,12 +412,10 @@ FN(global T* restrict cdata, GLOBAL const T* restrict adata, GLOBAL const T* res
 #    else
           const int nb = n;
 #    endif
-          UNROLL_FORCE(SK)
-          for (SINT k = 0; k < SK; ++k) CNM(nc, mc) = MAD(AMK(m, k), BNK(nb, k), CNM(nc, mc));
+          UNROLL_FORCE(SK) for (SINT k = 0; k < SK; ++k) CNM(nc, mc) = MAD(AMK(m, k), BNK(nb, k), CNM(nc, mc));
         }
 #    if (1 == BS)
-        UNROLL(BM)
-        for (SINT bm = 0; bm < BM; ++bm) {
+        UNROLL(BM) for (SINT bm = 0; bm < BM; ++bm) {
 #      if defined(ATOMIC_INC_NZ)
           if (ZERO != CNM(idx, bm))
 #      endif
@@ -443,11 +432,11 @@ FN(global T* restrict cdata, GLOBAL const T* restrict adata, GLOBAL const T* res
 #else /* BM == SM && 1 == BN */
     { /* calculate result-tile using columns */
 #  if (1 == BS)
-      T cnm[UM] = {ZERO}; /* column-block */
+      T cnm[UM]; /* column-block */
+      UNROLL_FORCE(UM) for (SINT m = 0; m < UM; ++m) cnm[m] = ZERO;
 #  endif
 #  if (1 == BK)
-      UNROLL_OUTER(SK)
-      for (SINT k = 0; k < SK; ++k) {
+      UNROLL_OUTER(SK) for (SINT k = 0; k < SK; ++k) {
         const T b = BNK(idx, k);
 #    if defined(SLM_A)
 #      if (WRK != SM)
@@ -456,8 +445,7 @@ FN(global T* restrict cdata, GLOBAL const T* restrict adata, GLOBAL const T* res
         amk[idx] = ADX(idx, k);
 #      endif
 #    elif defined(REG_A)
-        UNROLL_FORCE(SM)
-        for (SINT m = 0; m < SM; ++m) amk[m] = ADX(m, k);
+        UNROLL_FORCE(SM) for (SINT m = 0; m < SM; ++m) amk[m] = ADX(m, k);
 #    endif
 #    if defined(BARRIER) && (MAX(1, SGS) < SWG) && defined(SLM_A)
         BARRIER(CLK_LOCAL_MEM_FENCE);
@@ -465,8 +453,7 @@ FN(global T* restrict cdata, GLOBAL const T* restrict adata, GLOBAL const T* res
 #    if defined(ACC_OPENCL_VERSION) && (200 /*2.0*/ <= ACC_OPENCL_VERSION) && (!defined(GPU) || (0 != GPU)) && !defined(SLM_A) && \
       !defined(REG_A) && (WRK == SM) && (SM <= SGS || SM <= SWG) /* use ACC_OPENCL_VERSION rather than ACC_OPENCL_C_VERSION */
         const T a = AMK(idx, k);
-        UNROLL_FORCE(SM)
-        for (SINT m = 0; m < SM; ++m) {
+        UNROLL_FORCE(SM) for (SINT m = 0; m < SM; ++m) {
 #      if (SM <= SGS)
           CNM(idx, m) = MAD(sub_group_broadcast(a, m), b, CNM(idx, m)); /* size of subgroup is sufficient */
 #      else
@@ -474,16 +461,14 @@ FN(global T* restrict cdata, GLOBAL const T* restrict adata, GLOBAL const T* res
 #      endif
         }
 #    else
-        UNROLL_FORCE(SM)
-        for (SINT m = 0; m < SM; ++m) CNM(idx, m) = MAD(AMK(m, k), b, CNM(idx, m)); /* fallback */
+        UNROLL_FORCE(SM) for (SINT m = 0; m < SM; ++m) CNM(idx, m) = MAD(AMK(m, k), b, CNM(idx, m)); /* fallback */
 #    endif
 #    if defined(BARRIER) && (MAX(1, SGS) < SWG) && defined(SLM_A)
         BARRIER(CLK_LOCAL_MEM_FENCE);
 #    endif
       }
 #    if (1 == BS)
-      UNROLL(SM)
-      for (SINT m = 0; m < SM; ++m) {
+      UNROLL(SM) for (SINT m = 0; m < SM; ++m) {
 #      if defined(ATOMIC_INC_NZ)
         if (ZERO != CNM(idx, m))
 #      endif
@@ -512,13 +497,9 @@ FN(global T* restrict cdata, GLOBAL const T* restrict adata, GLOBAL const T* res
           const int vm = u;
 #    endif
 #    if defined(REG_A) && !defined(SLM_A)
-          UNROLL_FORCE(SK)
-          for (SINT k = 0; k < SK; ++k) amk[k] = ADX(um, k);
+          UNROLL_FORCE(SK) for (SINT k = 0; k < SK; ++k) amk[k] = ADX(um, k);
 #    endif
-          UNROLL_FORCE(SK)
-          for (SINT k = 0; k < SK; ++k) {
-            CNM(idx, vm) = MAD(AMK(um, k), BNK(idx, k), CNM(idx, vm));
-          }
+          UNROLL_FORCE(SK) for (SINT k = 0; k < SK; ++k) { CNM(idx, vm) = MAD(AMK(um, k), BNK(idx, k), CNM(idx, vm)); }
         }
 #    if (1 == BS)
         u = 0;
@@ -550,13 +531,9 @@ FN(global T* restrict cdata, GLOBAL const T* restrict adata, GLOBAL const T* res
         const int vm = u;
 #      endif
 #      if defined(REG_A) && !defined(SLM_A)
-        UNROLL_FORCE(SK)
-        for (SINT k = 0; k < SK; ++k) amk[k] = ADX(um, k);
+        UNROLL_FORCE(SK) for (SINT k = 0; k < SK; ++k) amk[k] = ADX(um, k);
 #      endif
-        UNROLL_FORCE(SK)
-        for (SINT k = 0; k < SK; ++k) {
-          CNM(idx, vm) = MAD(AMK(um, k), BNK(idx, k), CNM(idx, vm));
-        }
+        UNROLL_FORCE(SK) for (SINT k = 0; k < SK; ++k) { CNM(idx, vm) = MAD(AMK(um, k), BNK(idx, k), CNM(idx, vm)); }
       }
 #      if (1 == BS)
       u = 0;


### PR DESCRIPTION
* Avoid potential segfault during finalization (ACC_OPENCL_DEVICE != 0).
* Avoid initializing private memory (aka registers) using curly braces.
* Lock ACC_OPENCL_NCCS behind first WA-bit (ZEX_NUMBER_OF_CCS).
* Improved error output (tune_multiply.py).
* Fixed ACC_OPENCL_ACTIVATE.
* Fixed comment.