### PR TITLE
ocl: always print number of devices found

### DIFF
--- a/src/acc/acc_bench_smm.c
+++ b/src/acc/acc_bench_smm.c
@@ -227,9 +227,7 @@ int main(int argc, char* argv[]) {
     int ndevices = 0;
     result = c_dbcsr_acc_get_ndevices(&ndevices);
     if (0 < ndevices && (0 == device || EXIT_SUCCESS == c_dbcsr_acc_set_active_device(device))) {
-#if defined(_DEBUG)
-      fprintf(stderr, "Activated device %i of %i (device%i).\n", device + 1, ndevices, device);
-#endif
+      PRINTF("Activated device%i (ndevices=%i)\n", device, ndevices);
     }
     else {
       if (0 >= ndevices) {

--- a/src/acc/acc_bench_trans.c
+++ b/src/acc/acc_bench_trans.c
@@ -123,9 +123,7 @@ int main(int argc, char* argv[]) {
   if (EXIT_SUCCESS == result) {
     result = c_dbcsr_acc_get_ndevices(&ndevices);
     if (0 < ndevices && (0 == device || EXIT_SUCCESS == c_dbcsr_acc_set_active_device(device))) {
-#if defined(_DEBUG)
-      fprintf(stderr, "Activated device %i of %i (device%i).\n", device + 1, ndevices, device);
-#endif
+      printf("Activated device%i (ndevices=%i)\n", device, ndevices);
     }
     else {
       if (0 >= ndevices) {


### PR DESCRIPTION
* Using the CUDA backend, ACC_OPENCL_VERBOSE is not available.
* Prints the activated device and number of found devices.
* Helps, e.g., CI to capture basic information.