### PR TITLE
ocl: minor corrections

### DIFF
--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -641,6 +641,11 @@ int c_dbcsr_acc_init(void) {
             result = c_dbcsr_acc_opencl_set_active_device(NULL /*lock*/, ACC_OPENCL_ACTIVATE);
           }
           else {
+            const char* const env_rank = (NULL != getenv("PMI_RANK") ? getenv("PMI_RANK") : getenv("OMPI_COMM_WORLD_LOCAL_RANK"));
+            const int rank = (NULL != env_rank ? atoi(env_rank) : 0);
+            if (0 < rank && 1 < c_dbcsr_acc_opencl_config.ndevices) {
+              device_id = rank % c_dbcsr_acc_opencl_config.ndevices;
+            }
             result = c_dbcsr_acc_opencl_set_active_device(NULL /*lock*/, device_id);
           }
 #  else
@@ -1002,17 +1007,8 @@ int c_dbcsr_acc_opencl_set_active_device(ACC_OPENCL_LOCKTYPE* lock, int device_i
   int result = EXIT_SUCCESS;
   assert(c_dbcsr_acc_opencl_config.ndevices < ACC_OPENCL_MAXNDEVS);
   if (0 <= device_id && device_id < c_dbcsr_acc_opencl_config.ndevices) {
-    cl_device_id active_id = NULL;
-    static int rank = -1;
-    if (0 > rank) {
-      const char* const env_rank = (NULL != getenv("PMI_RANK") ? getenv("PMI_RANK") : getenv("OMPI_COMM_WORLD_LOCAL_RANK"));
-      rank = (NULL != env_rank ? atoi(env_rank) : 0);
-    }
-    if (0 < rank && 1 < c_dbcsr_acc_opencl_config.ndevices) {
-      device_id = (device_id + rank) % c_dbcsr_acc_opencl_config.ndevices;
-    }
     /* accessing devices is thread-safe (array is fixed after initialization) */
-    active_id = c_dbcsr_acc_opencl_config.devices[device_id];
+    const cl_device_id active_id = c_dbcsr_acc_opencl_config.devices[device_id];
     if (NULL != active_id) {
       cl_device_id context_id = NULL;
       cl_context context = NULL;
@@ -1172,13 +1168,8 @@ int c_dbcsr_acc_opencl_set_active_device(ACC_OPENCL_LOCKTYPE* lock, int device_i
 
 
 int c_dbcsr_acc_set_active_device(int device_id) {
+  /* avoid ACC_OPENCL_PROFILE in this routine */
   int result = EXIT_SUCCESS;
-#  if defined(__DBCSR_ACC) && defined(ACC_OPENCL_PROFILE) && 0
-  int routine_handle;
-  static const char* const routine_name_ptr = LIBXSMM_FUNCNAME;
-  static const int routine_name_len = (int)sizeof(LIBXSMM_FUNCNAME) - 1;
-  c_dbcsr_timeset((const char**)&routine_name_ptr, &routine_name_len, &routine_handle);
-#  endif
   if (0 <= device_id && device_id < c_dbcsr_acc_opencl_config.ndevices) {
 #  if defined(ACC_OPENCL_CACHE_DID)
     if (c_dbcsr_acc_opencl_active_id != (device_id + 1))
@@ -1190,12 +1181,7 @@ int c_dbcsr_acc_set_active_device(int device_id) {
 #  endif
     }
   }
-#  if !defined(NDEBUG)
   else result = EXIT_FAILURE;
-#  endif
-#  if defined(__DBCSR_ACC) && defined(ACC_OPENCL_PROFILE) && 0
-  c_dbcsr_timestop(&routine_handle);
-#  endif
   ACC_OPENCL_RETURN(result);
 }
 


### PR DESCRIPTION
* Apply rank-aware device-id only if ACC_OPENCL_ACTIVATE is defined.
* Forward error code and cleanup (c_dbcsr_acc_set_active_device).
* More sensible output in case of upfront error.
* Made selecting device rank-aware. Cleanup.