### PR TITLE
Specify version of Clang-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,4 +65,5 @@ repos:
     language: python
     files: \.(c|cc|cxx|cpp|cl|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|mm|proto|textproto|vert)$
     args: ['-i', '-fallback-style=none', '--style=file']
-    additional_dependencies: ['clang-format']
+    # specify version since clang-format is not stable version-to-version
+    additional_dependencies: ['clang-format~=19.1.0']

--- a/src/acc/libsmm_acc/kernels/smm_acc_dnt_medium.h
+++ b/src/acc/libsmm_acc/kernels/smm_acc_dnt_medium.h
@@ -422,7 +422,7 @@ __global__ void __launch_bounds__(threads, minblocks) smm_acc_dnt_medium(const i
         }
         if (need_sync) syncthreads();
 
-          /* Add results from shared memory buffer to global C block. */
+        /* Add results from shared memory buffer to global C block. */
 #pragma unroll
         for (int i = tidx; i < mn; i += threads) {
           atomicAdd(&c_data[srcC + i], buff[i]);

--- a/src/acc/libsmm_acc/kernels/smm_acc_dnt_small.h
+++ b/src/acc/libsmm_acc/kernels/smm_acc_dnt_small.h
@@ -114,7 +114,7 @@ __global__ void __launch_bounds__(threads, minblocks) smm_acc_dnt_small(const in
   nrun = grouping;
   if (((bidx + 1) * grouping) > stack_size) nrun = stack_size % grouping;
 
-    /* Set the partial sum (tile T) to zero */
+  /* Set the partial sum (tile T) to zero */
 #pragma unroll
   for (int i = 0; i < M * N; i++) myc[i] = 0.0;
 
@@ -203,7 +203,7 @@ __global__ void __launch_bounds__(threads, minblocks) smm_acc_dnt_small(const in
 
         if (need_sync) syncthreads();
 
-          /* Add results from shared memory buffer to global C block. */
+        /* Add results from shared memory buffer to global C block. */
 #pragma unroll
         for (int i = tidx; i < mn; i += threads) atomicAdd(&c_data[srcC + i], buff[i]);
       }

--- a/src/acc/opencl/smm/opencl_libsmm.c
+++ b/src/acc/opencl/smm/opencl_libsmm.c
@@ -189,7 +189,7 @@ int opencl_libsmm_read_smm_params(char* parambuf, opencl_libsmm_smmkey_t* key, o
   LIBXSMM_MEMZERO127(key); /* potentially heterogeneous key-data (alignment gaps) */
   memset(value, 0, sizeof(opencl_libsmm_smm_t));
   for (; NULL != s;
-       ++i, s = (c != consumed ? ((s + 1) < end ? strtok((s + 1) + strlen(s), ACC_OPENCL_DELIMS) : NULL) : s), c = consumed)
+    ++i, s = (c != consumed ? ((s + 1) < end ? strtok((s + 1) + strlen(s), ACC_OPENCL_DELIMS) : NULL) : s), c = consumed)
   {
     switch (i) {
       case 0:


### PR DESCRIPTION
- clang-format is not stable version-to-version
- Hook is reformatting code already committed,  
  it may be better to only change touched code