### PR TITLE
#857: Remove PARALLEL WORKSHARE

### DIFF
--- a/src/acc/dbcsr_acc_device.F
+++ b/src/acc/dbcsr_acc_device.F
@@ -13,6 +13,8 @@ MODULE dbcsr_acc_device
 #endif
 #include "base/dbcsr_base_uses.f90"
 
+!$ USE OMP_LIB, ONLY: omp_get_level
+
    IMPLICIT NONE
 
    PUBLIC :: dbcsr_acc_get_ndevices, dbcsr_acc_set_active_device, dbcsr_acc_clear_errors
@@ -83,11 +85,16 @@ CONTAINS
 #if defined (__DBCSR_ACC)
       INTEGER :: istat
 
-!$OMP PARALLEL DEFAULT(NONE) PRIVATE(istat) SHARED(device_id)
-      istat = acc_set_active_device_cu(device_id)
+!$    IF (0 == omp_get_level()) THEN
+         istat = 0
+!$OMP    PARALLEL DEFAULT(NONE) SHARED(device_id) REDUCTION(MAX:istat)
+         istat = acc_set_active_device_cu(device_id)
+!$OMP    END PARALLEL
+!$    ELSE
+         istat = acc_set_active_device_cu(device_id)
+!$    END IF
       IF (istat /= 0) &
          DBCSR_ABORT("dbcsr_acc_set_active_device: failed")
-!$OMP END PARALLEL
 
 #else
       MARK_USED(device_id)

--- a/src/data/dbcsr_ptr_util.F
+++ b/src/data/dbcsr_ptr_util.F
@@ -28,8 +28,6 @@ MODULE dbcsr_ptr_util
                             mp_deallocate
 #include "base/dbcsr_base_uses.f90"
 
-!$ USE OMP_LIB, ONLY: omp_get_max_threads, omp_get_thread_num, omp_get_num_threads
-
    IMPLICIT NONE
 
    PRIVATE
@@ -294,15 +292,9 @@ CONTAINS
         !! length of copy
          ${type1}$, DIMENSION(1:n), INTENT(OUT) :: dst
         !! destination memory
-         ${type1}$, DIMENSION(1:n), INTENT(IN) :: src
+         ${type1}$, DIMENSION(1:n), INTENT(IN)  :: src
         !! source memory
-#if !defined(__DBCSR_DISABLE_WORKSHARE)
-!$OMP     PARALLEL WORKSHARE DEFAULT(none) SHARED(dst,src)
-#endif
          dst(:) = src(:)
-#if !defined(__DBCSR_DISABLE_WORKSHARE)
-!$OMP     END PARALLEL WORKSHARE
-#endif
       END SUBROUTINE mem_copy_${nametype1}$
 
       SUBROUTINE mem_zero_${nametype1}$ (dst, n)
@@ -312,13 +304,7 @@ CONTAINS
         !! length of elements to zero
          ${type1}$, DIMENSION(1:n), INTENT(OUT) :: dst
         !! destination memory
-#if !defined(__DBCSR_DISABLE_WORKSHARE)
-!$OMP     PARALLEL WORKSHARE DEFAULT(none) SHARED(dst)
-#endif
          dst(:) = ${zero1}$
-#if !defined(__DBCSR_DISABLE_WORKSHARE)
-!$OMP     END PARALLEL WORKSHARE
-#endif
       END SUBROUTINE mem_zero_${nametype1}$
 
       SUBROUTINE mem_alloc_${nametype1}$ (mem, n, mem_type)

--- a/src/mpi/dbcsr_mpiwrap.F
+++ b/src/mpi/dbcsr_mpiwrap.F
@@ -5182,13 +5182,7 @@ CONTAINS
             MARK_USED(myproc)
 #endif
             IF (do_local_copy) THEN
-#if !defined(__DBCSR_DISABLE_WORKSHARE)
-!$OMP           PARALLEL WORKSHARE DEFAULT(none) SHARED(base,win_data,disp_aint,len)
-#endif
                base(:) = win_data(disp_aint + 1:disp_aint + len)
-#if !defined(__DBCSR_DISABLE_WORKSHARE)
-!$OMP           END PARALLEL WORKSHARE
-#endif
                request = mp_request_null
                ierr = 0
             ELSE

--- a/src/ops/dbcsr_operations.F
+++ b/src/ops/dbcsr_operations.F
@@ -94,7 +94,7 @@ MODULE dbcsr_operations
                             mp_sum
 #include "base/dbcsr_base_uses.f90"
 
-!$ USE OMP_LIB, ONLY: omp_get_max_threads, omp_get_thread_num, omp_get_num_threads
+!$ USE OMP_LIB, ONLY: omp_get_thread_num, omp_get_num_threads
 
    IMPLICIT NONE
 
@@ -316,7 +316,6 @@ CONTAINS
 
       CALL timeset(routineN, handle)
       SELECT CASE (dbcsr_get_data_type(matrix_a))
-#if defined(__DBCSR_DISABLE_WORKSHARE)
       CASE (dbcsr_type_complex_4)
          matrix_a%data_area%d%c_sp = (0.0, 0.0)
       CASE (dbcsr_type_complex_8)
@@ -325,24 +324,6 @@ CONTAINS
          matrix_a%data_area%d%r_sp = 0.0
       CASE (dbcsr_type_real_8)
          matrix_a%data_area%d%r_dp = 0.0_dp
-#else
-      CASE (dbcsr_type_complex_4)
-!$OMP       PARALLEL WORKSHARE DEFAULT(NONE), SHARED(matrix_a)
-         matrix_a%data_area%d%c_sp = (0.0, 0.0)
-!$OMP       END PARALLEL WORKSHARE
-      CASE (dbcsr_type_complex_8)
-!$OMP       PARALLEL WORKSHARE DEFAULT(NONE), SHARED(matrix_a)
-         matrix_a%data_area%d%c_dp = (0.0_dp, 0.0_dp)
-!$OMP       END PARALLEL WORKSHARE
-      CASE (dbcsr_type_real_4)
-!$OMP       PARALLEL WORKSHARE DEFAULT(NONE), SHARED(matrix_a)
-         matrix_a%data_area%d%r_sp = 0.0
-!$OMP       END PARALLEL WORKSHARE
-      CASE (dbcsr_type_real_8)
-!$OMP       PARALLEL WORKSHARE DEFAULT(NONE), SHARED(matrix_a)
-         matrix_a%data_area%d%r_dp = 0.0_dp
-!$OMP       END PARALLEL WORKSHARE
-#endif
       END SELECT
       CALL timestop(handle)
    END SUBROUTINE dbcsr_zero


### PR DESCRIPTION
- Avoid nested parallelism (dbcsr_acc_set_active_device).
- Rely on omp_get_level (instead of omp_in_parallel),
  omp_in_parallel only accounts for active regions.
- Avoid IF-condition as part of the WORKSHARE-directive.
- Removed WORKSHARE construct from dbcsr_ptr_util,
- otherwise keep WORKSHARE if not in parallel region.
- There is potentially invalid nesting (parallel+X),
  e.g., nested in master or sections constructs.