### PR TITLE
HIP: removed unused hipHostAllocDefault

### DIFF
--- a/src/acc/hip/acc_hip.cpp
+++ b/src/acc/hip/acc_hip.cpp
@@ -15,8 +15,6 @@ hipError_t hipHostAlloc(void** ptr, size_t size, unsigned int flags) { return hi
 hipError_t hipFreeHost(void* ptr) { return hipHostFree(ptr); }
 #endif
 
-unsigned int hipHostAllocDefault = hipHostMallocDefault;
-
 hiprtcResult hiprtcGetLowLevelCode(hiprtcProgram prog, char* code) { return hiprtcGetCode(prog, code); }
 
 hiprtcResult hiprtcGetLowLevelCodeSize(hiprtcProgram prog, size_t* codeSizeRet) { return hiprtcGetCodeSize(prog, codeSizeRet); }

--- a/src/acc/hip/acc_hip.h
+++ b/src/acc/hip/acc_hip.h
@@ -90,8 +90,6 @@
   } while (0)
 
 extern hipError_t hipHostAlloc(void** ptr, size_t size, unsigned int flags);
-extern hipError_t hipHostAlloc(void** ptr, size_t size, unsigned int flags);
-extern unsigned int hipHostAllocDefault;
 extern hipError_t hipFreeHost(void* ptr);
 extern hiprtcResult hiprtcGetLowLevelCode(hiprtcProgram prog, char* code);
 extern hiprtcResult hiprtcGetLowLevelCodeSize(hiprtcProgram prog, size_t* codeSizeRet);


### PR DESCRIPTION
- Apparently, some API elements are "mirrored" (TODO: confirm why necessary).
- In particular, "hipHostAllocDefault" now changed "upstream" hence clash.
- Cleanup: removed duplicated prototype (hipHostAlloc).