### PR TITLE
CMake: allow USE_SMM=auto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,10 +89,10 @@ set(TEST_OMP_THREADS
     CACHE STRING "Number of OpenMP threads for testing")
 
 set(USE_SMM
-    "blas"
+    "auto"
     CACHE STRING
-          "Small Matrix Multiplication implementation to use (default: blas)")
-set_property(CACHE USE_SMM PROPERTY STRINGS blas libxsmm)
+          "Small Matrix Multiplication implementation to use (default: auto)")
+set_property(CACHE USE_SMM PROPERTY STRINGS auto blas libxsmm)
 
 set(USE_ACCEL
     ""
@@ -138,36 +138,38 @@ if (USE_OPENMP)
   find_package(OpenMP REQUIRED)
 endif ()
 
-if ((USE_ACCEL MATCHES "opencl") AND (NOT USE_SMM MATCHES "libxsmm"))
-  message(FATAL_ERROR "OpenCL requires USE_SMM=libxsmm")
-endif ()
-
-# =================================== SMM (Small Matrix-Matrix multiplication)
-if (USE_SMM MATCHES "blas")
-  message(STATUS "Using BLAS for Small Matrix Multiplication")
-elseif (USE_SMM MATCHES "libxsmm")
-  message(STATUS "Using libxsmm for Small Matrix Multiplication")
-else ()
-  message(FATAL_ERROR "Unknown SMM library specified")
-endif ()
-
 # =================================== LIBXSMM (rely on pkg-config)
-if (USE_SMM MATCHES "libxsmm")
-  find_package(PkgConfig REQUIRED)
+if (USE_SMM MATCHES "libxsmm" OR USE_SMM MATCHES "auto")
+  if (USE_SMM MATCHES "libxsmm")
+    set(LIBXSMM_REQUIRED "REQUIRED")
+  endif ()
+  find_package(PkgConfig ${LIBXSMM_REQUIRED})
   if (USE_OPENMP)
     if (NOT USE_SMM MATCHES "libxsmm-shared")
       pkg_check_modules(LIBXSMMEXT IMPORTED_TARGET GLOBAL libxsmmext-static)
     endif ()
     if (NOT LIBXSMMEXT_FOUND)
-      pkg_check_modules(LIBXSMMEXT REQUIRED IMPORTED_TARGET GLOBAL libxsmmext)
+      pkg_check_modules(LIBXSMMEXT ${LIBXSMM_REQUIRED} IMPORTED_TARGET GLOBAL libxsmmext)
     endif ()
   endif ()
   if (NOT USE_SMM MATCHES "libxsmm-shared")
     pkg_check_modules(LIBXSMM IMPORTED_TARGET GLOBAL libxsmmf-static)
   endif ()
   if (NOT LIBXSMM_FOUND)
-    pkg_check_modules(LIBXSMM REQUIRED IMPORTED_TARGET GLOBAL libxsmmf)
+    pkg_check_modules(LIBXSMM ${LIBXSMM_REQUIRED} IMPORTED_TARGET GLOBAL libxsmmf)
   endif ()
+endif ()
+
+# =================================== SMM (Small Matrix-Matrix multiplication)
+if (USE_SMM MATCHES "blas" OR (USE_SMM MATCHES "auto" AND NOT LIBXSMM_FOUND))
+  if (USE_ACCEL MATCHES "opencl")
+    message(FATAL_ERROR "OpenCL requires USE_SMM=libxsmm")
+  endif ()
+  message(STATUS "Using BLAS for Small Matrix Multiplication")
+elseif (USE_SMM MATCHES "libxsmm" OR USE_SMM MATCHES "auto")
+  message(STATUS "Using libxsmm for Small Matrix Multiplication")
+else ()
+  message(FATAL_ERROR "Unknown SMM library specified")
 endif ()
 
 # =================================== BLAS & LAPACK, PkgConfig

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,14 +149,16 @@ if (USE_SMM MATCHES "libxsmm" OR USE_SMM MATCHES "auto")
       pkg_check_modules(LIBXSMMEXT IMPORTED_TARGET GLOBAL libxsmmext-static)
     endif ()
     if (NOT LIBXSMMEXT_FOUND)
-      pkg_check_modules(LIBXSMMEXT ${LIBXSMM_REQUIRED} IMPORTED_TARGET GLOBAL libxsmmext)
+      pkg_check_modules(LIBXSMMEXT ${LIBXSMM_REQUIRED} IMPORTED_TARGET GLOBAL
+                        libxsmmext)
     endif ()
   endif ()
   if (NOT USE_SMM MATCHES "libxsmm-shared")
     pkg_check_modules(LIBXSMM IMPORTED_TARGET GLOBAL libxsmmf-static)
   endif ()
   if (NOT LIBXSMM_FOUND)
-    pkg_check_modules(LIBXSMM ${LIBXSMM_REQUIRED} IMPORTED_TARGET GLOBAL libxsmmf)
+    pkg_check_modules(LIBXSMM ${LIBXSMM_REQUIRED} IMPORTED_TARGET GLOBAL
+                      libxsmmf)
   endif ()
 endif ()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -185,7 +185,7 @@ elseif (USE_ACCEL MATCHES "cuda")
                                          "${ACC_ARCH_NUMBER}")
 endif ()
 
-if (USE_SMM MATCHES "libxsmm")
+if (USE_SMM MATCHES "libxsmm" OR (USE_SMM MATCHES "auto" AND LIBXSMM_FOUND))
   target_compile_definitions(dbcsr PRIVATE __LIBXSMM)
   target_link_directories(dbcsr PUBLIC ${LIBXSMM_LIBRARY_DIRS})
   if (USE_OPENMP)


### PR DESCRIPTION
- Requesting LIBXSMM uses PkgConfig, which tests and resolves it.
- Hence: run this test prior instead of concluding with BLAS.
- BLAS is needed always and "auto" is no significant burden.