### PR TITLE
ocl: fixed leaking event objects

### DIFF
--- a/src/acc/opencl/Makefile
+++ b/src/acc/opencl/Makefile
@@ -24,6 +24,10 @@ HEADERONLY ?= 0
 STATIC ?= 1
 DEV ?= 0
 
+# Kind of Clang/GCC based analysis:
+#   leak, address, undefined, thread
+SANITIZE ?= $(NULL)
+
 # Intel Compiler
 ICX := $(shell which icx 2>/dev/null)
 INTEL ?= $(if $(ICX),$(if $(filter-out 0,$(GNU)),0,2),0)
@@ -113,6 +117,14 @@ ifneq (0,$(DEV))
   #CFLAGS += -std=c99
 endif
 
+ifneq (,$(SANITIZE))
+  CXXFLAGS += -fsanitize=$(SANITIZE)
+  CFLAGS += -fsanitize=$(SANITIZE)
+  FCFLAGS += -fsanitize=$(SANITIZE)
+  LDFLAGS += -fsanitize=$(SANITIZE)
+  SYM = 1
+endif
+
 ifneq (0,$(DBG))
   CPP_OPENCL_FLAGS += -C
   ifeq (,$(DBG))
@@ -125,7 +137,7 @@ ifneq (0,$(DBG))
   endif
 else
   CFLAGS += -O2 -DNDEBUG
-  SYM := 0
+  SYM ?= 0
 endif
 ifneq (0,$(SYM))
   CFLAGS += -g

--- a/src/acc/opencl/acc_opencl_event.c
+++ b/src/acc/opencl/acc_opencl_event.c
@@ -83,8 +83,7 @@ int c_dbcsr_acc_stream_wait_event(void* stream, void* event) { /* wait for an ev
   clevent = *ACC_OPENCL_EVENT(event);
   if (NULL != clevent) {
 #  if defined(CL_VERSION_1_2)
-    cl_event clevent_result = NULL;
-    result = clEnqueueBarrierWithWaitList(str->queue, 1, &clevent, &clevent_result);
+    result = clEnqueueBarrierWithWaitList(str->queue, 1, &clevent, NULL);
 #  else
     result = clEnqueueWaitForEvents(str->queue, 1, &clevent);
 #  endif

--- a/src/acc/opencl/smm/opencl_libsmm.c
+++ b/src/acc/opencl/smm/opencl_libsmm.c
@@ -326,7 +326,7 @@ int opencl_libsmm_read_smm_params(char* parambuf, opencl_libsmm_smmkey_t* key, o
   if (max_consumed == consumed) {
     switch (key->type) {
       case dbcsr_type_real_8:
-        if (NULL != perfest) {
+        if (NULL != perfest && 0 < gflops) {
           const double ratio = gflops / OPENCL_LIBSMM_AI(key->m, key->n, key->k, sizeof(double));
 #  if LIBXSMM_VERSION4(1, 17, 0, 0) < LIBXSMM_VERSION_NUMBER
           libxsmm_kahan_sum(log(ratio), &perfest->gf_ai_dratio_sumlog, &perfest->gf_ai_dratio_kahan);
@@ -338,7 +338,7 @@ int opencl_libsmm_read_smm_params(char* parambuf, opencl_libsmm_smmkey_t* key, o
         }
         break;
       case dbcsr_type_real_4:
-        if (NULL != perfest) {
+        if (NULL != perfest && 0 < gflops) {
           const double ratio = gflops / OPENCL_LIBSMM_AI(key->m, key->n, key->k, sizeof(float));
 #  if LIBXSMM_VERSION4(1, 17, 0, 0) < LIBXSMM_VERSION_NUMBER
           libxsmm_kahan_sum(log(ratio), &perfest->gf_ai_sratio_sumlog, &perfest->gf_ai_sratio_kahan);


### PR DESCRIPTION
- Makefile (acc_bench): introduced SANITIZE.
- Test condition prior to calling function.
- Check runtime state during setup.
- Ensure valid data; avoid log(0).
- Improved handling errors.