### PR TITLE
ocl: code cleanup

### DIFF
--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -548,9 +548,6 @@ int c_dbcsr_acc_init(void) {
         assert(NULL == c_dbcsr_acc_opencl_config.event_data);
         assert(0 == c_dbcsr_acc_opencl_config.nstreams);
         assert(0 == c_dbcsr_acc_opencl_config.nevents);
-#  if defined(ACC_OPENCL_CACHE_DID)
-        c_dbcsr_acc_opencl_active_id = device_id + 1; /* update c_dbcsr_acc_opencl_active_id */
-#  endif
         /* allocate and initialize memptr registry */
         c_dbcsr_acc_opencl_config.nmemptrs = nhandles;
         c_dbcsr_acc_opencl_config.memptrs = (c_dbcsr_acc_opencl_info_memptr_t**)malloc(

--- a/src/acc/opencl/acc_opencl.h
+++ b/src/acc/opencl/acc_opencl.h
@@ -274,7 +274,7 @@ typedef struct c_dbcsr_acc_opencl_device_t {
   cl_int (*clSetKernelArgMemPointerINTEL)(cl_kernel, cl_uint, const void*);
   cl_int (*clEnqueueMemFillINTEL)(cl_command_queue, void*, const void*, size_t, size_t, cl_uint, const cl_event*, cl_event*);
   cl_int (*clEnqueueMemcpyINTEL)(cl_command_queue, cl_bool, void*, const void*, size_t, cl_uint, const cl_event*, cl_event*);
-  void* (*clDeviceMemAllocINTEL)(cl_context, cl_device_id, const void /*cl_mem_properties_intel*/*, size_t, cl_uint, cl_int*);
+  void* (*clDeviceMemAllocINTEL)(cl_context, cl_device_id, const /*cl_mem_properties_intel*/ void*, size_t, cl_uint, cl_int*);
   cl_int (*clMemFreeINTEL)(cl_context, void*);
 } c_dbcsr_acc_opencl_device_t;
 


### PR DESCRIPTION
- Prepared code for tracking device allocations
- Prepared code for c_dbcsr_acc_dev_mem_info.
- Fixed ACC_OPENCL_CACHE_DID.