### PR TITLE
ocl: fixed handling events wrt release/retain

### DIFF
--- a/src/acc/opencl/acc_opencl.c
+++ b/src/acc/opencl/acc_opencl.c
@@ -175,7 +175,7 @@ void c_dbcsr_acc_opencl_configure(void) {
 #  endif
 #  if defined(ACC_OPENCL_ASYNC)
   const char* const env_async = (ACC_OPENCL_ASYNC);
-  const int async_default = 1 + 2;
+  const int async_default = 1 + 2 + 4 + 8;
 #  else
   const char* const env_async = NULL;
   const int async_default = 0;


### PR DESCRIPTION
- Extended ACC_OPENCL_ASYNC flag to remaining memory-ops.
- Avoid creating certain events unnecessarily.
- Increased lock-scope.
- Adjusted debug.
- Code cleanup.