### PR TITLE
HIP: fixed compilation error

### DIFF
--- a/src/acc/hip/acc_hip.h
+++ b/src/acc/hip/acc_hip.h
@@ -18,6 +18,7 @@
 #  include <hipblas.h>
 #endif
 #include <hip/hiprtc.h>
+#include <stdio.h>
 
 #define ACC(x) hip##x
 #define ACC_DRV(x) ACC(x)


### PR DESCRIPTION
- Error: `printf` was not declared in this scope.
- Appeared when compiling cuda_hip/acc_utils.cpp.