### PR TITLE
[cmake] fix hiprtc dependency

### DIFF
--- a/src/cmake/DBCSRConfig.cmake.in
+++ b/src/cmake/DBCSRConfig.cmake.in
@@ -21,6 +21,7 @@ if ("@USE_ACCEL@" MATCHES "hip")
   enable_language(HIP)
   find_dependency(hip)
   find_dependency(hipblas)
+  find_dependency(hiprtc)
 endif ()
 
 


### PR DESCRIPTION
Small fix providing hiprtc target when `find_package(DBCSR)` is called