### PR TITLE
test: restore bounded GPU correctness tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -211,6 +211,42 @@ endif ()
 
 # =================================== GPU BACKEND TESTS (CUDA/HIP)
 
+set(DBCSR_LIBSMM_ACC_TEST_SAMPLES
+    64
+    CACHE STRING "Number of predicted libsmm_acc kernels in GPU smoke tests")
+set(DBCSR_LIBSMM_ACC_TEST_MAX_AUTOTUNED
+    64
+    CACHE
+      STRING
+      "Maximum number of autotuned libsmm_acc kernels in GPU smoke tests; zero means all"
+)
+set(DBCSR_LIBSMM_ACC_TEST_MAX_TRANSPOSE_PAIRS
+    64
+    CACHE
+      STRING
+      "Maximum number of libsmm_acc transpose pairs in GPU smoke tests; zero means all"
+)
+set(DBCSR_LIBSMM_ACC_TEST_MPI_RANKS
+    1
+    CACHE STRING "Number of MPI ranks for libsmm_acc GPU smoke tests")
+set(DBCSR_LIBSMM_ACC_TEST_TIMEOUT
+    300
+    CACHE STRING "Timeout in seconds for each libsmm_acc GPU correctness test")
+
+if (DBCSR_LIBSMM_ACC_TEST_MPI_RANKS LESS 1)
+  message(FATAL_ERROR "DBCSR_LIBSMM_ACC_TEST_MPI_RANKS must be at least 1")
+endif ()
+if (DBCSR_LIBSMM_ACC_TEST_TIMEOUT LESS 1)
+  message(FATAL_ERROR "DBCSR_LIBSMM_ACC_TEST_TIMEOUT must be at least 1")
+endif ()
+foreach (libsmm_acc_test_limit
+         DBCSR_LIBSMM_ACC_TEST_SAMPLES DBCSR_LIBSMM_ACC_TEST_MAX_AUTOTUNED
+         DBCSR_LIBSMM_ACC_TEST_MAX_TRANSPOSE_PAIRS)
+  if (${libsmm_acc_test_limit} LESS 0)
+    message(FATAL_ERROR "${libsmm_acc_test_limit} must be non-negative")
+  endif ()
+endforeach ()
+
 # Add custom commands for the test files that need to be generated from a
 # template
 file(RELATIVE_PATH CURRENT_BINARY_DIR_RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/..
@@ -224,6 +260,8 @@ add_custom_target(
     ${CMAKE_CURRENT_SOURCE_DIR}/generate_libsmm_acc_unittest_multiply.py
     --base_dir ${CMAKE_CURRENT_SOURCE_DIR}/.. --out_dir
     ${CURRENT_BINARY_DIR_RELATIVE} --gpu_version=${WITH_GPU_PARAMS}
+    --nsamples=${DBCSR_LIBSMM_ACC_TEST_SAMPLES}
+    --max-autotuned=${DBCSR_LIBSMM_ACC_TEST_MAX_AUTOTUNED}
   DEPENDS libsmm_acc_unittest_multiply.cpp.template
           generate_libsmm_acc_unittest_multiply.py
   BYPRODUCTS libsmm_acc_unittest_multiply.cpp
@@ -243,6 +281,9 @@ add_custom_target(
   COMMENT "Generate tests/generate_libsmm_acc_timer_multiply.cpp")
 
 if (USE_ACCEL STREQUAL "cuda" OR USE_ACCEL STREQUAL "hip")
+
+  set(LIBSMM_ACC_CORRECTNESS_TESTS libsmm_acc_unittest_multiply
+                                   libsmm_acc_unittest_transpose)
 
   # All libsmm_acc tests
   set(LIBSMM_ACC_TESTS_SRCS
@@ -267,16 +308,41 @@ if (USE_ACCEL STREQUAL "cuda" OR USE_ACCEL STREQUAL "hip")
     if (OpenMP_FOUND)
       target_link_libraries(${libsmm_acc_test_name} OpenMP::OpenMP_CXX)
     endif ()
+    if (libsmm_acc_test_name IN_LIST LIBSMM_ACC_CORRECTNESS_TESTS)
+      target_include_directories(${libsmm_acc_test_name}
+                                 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+      if (USE_MPI)
+        target_compile_definitions(${libsmm_acc_test_name}
+                                   PRIVATE DBCSR_LIBSMM_ACC_TEST_USE_MPI)
+        target_link_libraries(${libsmm_acc_test_name} MPI::MPI_CXX)
+      endif ()
+    endif ()
   endforeach ()
 
-  # Comment for the moment, they are not parallelized, very slow... Check issue
-  # https://github.com/cp2k/dbcsr/issues/427 add_test(NAME
-  # libsmm_acc_unittest_multiply COMMAND libsmm_acc_unittest_multiply)
-  # add_test(NAME libsmm_acc_unittest_transpose COMMAND
-  # libsmm_acc_unittest_transpose) add_test(NAME
-  # libsmm_acc_timer_multiply-autotuned COMMAND libsmm_acc_timer_multiply
-  # autotuned) add_test(NAME libsmm_acc_timer_multiply-predicted COMMAND
-  # libsmm_acc_timer_multiply predicted)
+  target_compile_definitions(
+    libsmm_acc_unittest_transpose
+    PRIVATE
+      LIBSMM_ACC_TEST_MAX_TRANSPOSE_PAIRS=${DBCSR_LIBSMM_ACC_TEST_MAX_TRANSPOSE_PAIRS}
+  )
+
+  foreach (libsmm_acc_correctness_test ${LIBSMM_ACC_CORRECTNESS_TESTS})
+    if (USE_MPI)
+      separate_arguments(MPIEXEC_PREFLAGS)
+      add_test(
+        NAME ${libsmm_acc_correctness_test}
+        COMMAND
+          ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG}
+          ${DBCSR_LIBSMM_ACC_TEST_MPI_RANKS} ${MPIEXEC_PREFLAGS}
+          $<TARGET_FILE:${libsmm_acc_correctness_test}> ${MPIEXEC_POSTFLAGS})
+    else ()
+      add_test(NAME ${libsmm_acc_correctness_test}
+               COMMAND $<TARGET_FILE:${libsmm_acc_correctness_test}>)
+    endif ()
+    set_tests_properties(
+      ${libsmm_acc_correctness_test}
+      PROPERTIES LABELS "gpu;libsmm_acc" RUN_SERIAL TRUE TIMEOUT
+                 ${DBCSR_LIBSMM_ACC_TEST_TIMEOUT})
+  endforeach ()
 
 endif ()
 

--- a/tests/generate_libsmm_acc_unittest_multiply.py
+++ b/tests/generate_libsmm_acc_unittest_multiply.py
@@ -26,6 +26,15 @@ def format_to_cpp(kernels):
     return out
 
 
+def sample_kernels(kernels, nsamples, rng):
+    """Select a reproducible subset, treating zero as unlimited."""
+    if nsamples < 0:
+        raise ValueError("Kernel sample limits must be non-negative")
+    if nsamples == 0 or nsamples >= len(kernels):
+        return kernels
+    return rng.sample(kernels, nsamples)
+
+
 # ===============================================================================
 def main(
     dbcsr_base_dir,
@@ -34,6 +43,7 @@ def main(
     test_output_dir,
     gpu_version,
     nsamples,
+    max_autotuned,
 ):
     """
     Generate a performance test of libsmm_acc in the form of a CUDA or HIP file, using libsmm_acc_unittest_multiply.cpp.template
@@ -49,21 +59,19 @@ def main(
     with open(param_fn, "r") as f:
         all_kernels = json.load(f)
 
+    rng = random.Random(0)
+
     # Get the autotuned kernels to test
     autotuned_kernels = [k for k in all_kernels if k["source"] == "autotuned"]
     print("Found {:,} autotuned kernels".format(len(autotuned_kernels)))
+    kernels_to_test_autotuned = sample_kernels(autotuned_kernels, max_autotuned, rng)
 
     # Get the non-autotuned kernels to test
     predicted_kernels = [k for k in all_kernels if k["source"] != "autotuned"]
     print("Found {:,} predicted kernels".format(len(predicted_kernels)))
-    num_predicted_kernels = len(predicted_kernels)
-    if num_predicted_kernels > 0:
-        if nsamples >= num_predicted_kernels:
-            nsamples = num_predicted_kernels
-        kernels_to_test_predicted = random.sample(predicted_kernels, nsamples)
-    else:
-        kernels_to_test_predicted = list()
-    kernels_to_print = format_to_cpp(autotuned_kernels + kernels_to_test_predicted)
+    kernels_to_test_predicted = sample_kernels(predicted_kernels, nsamples, rng)
+    kernels_to_test = kernels_to_test_autotuned + kernels_to_test_predicted
+    kernels_to_print = format_to_cpp(kernels_to_test)
 
     # Print to test file
     file_template = os.path.join(
@@ -75,7 +83,7 @@ def main(
     test = test.replace("[[UNITTEST_KERNELS_HERE]]", kernels_to_print.lstrip())
     with open(file_generate, "w") as f:
         f.write(test)
-    print("Wrote {:,} test kernels to {}".format(len(kernels_to_print), file_generate))
+    print("Wrote {:,} test kernels to {}".format(len(kernels_to_test), file_generate))
 
 
 # ===============================================================================
@@ -107,11 +115,18 @@ if __name__ == "__main__":
     parser.add_argument(
         "-n",
         "--nsamples",
+        type=int,
         default=1000,
         help=(
             "Number of samples from the matrix sizes space 4 <= m,n,k <= 45 (except autotuned kernels)"
-            " to sample for performance testing"
+            " to sample for performance testing; zero means all"
         ),
+    )
+    parser.add_argument(
+        "--max-autotuned",
+        type=int,
+        default=0,
+        help="Maximum number of autotuned kernels to test; zero means all",
     )
 
     args = parser.parse_args()
@@ -128,4 +143,5 @@ if __name__ == "__main__":
         test_output_dir,
         args.gpu_version,
         args.nsamples,
+        args.max_autotuned,
     )

--- a/tests/libsmm_acc_test_runtime.h
+++ b/tests/libsmm_acc_test_runtime.h
@@ -1,0 +1,92 @@
+/*------------------------------------------------------------------------------------------------*/
+/* Copyright (C) by the DBCSR developers group - All rights reserved                              */
+/* This file is part of the DBCSR library.                                                        */
+/*                                                                                                */
+/* For information on the license, see the LICENSE file.                                          */
+/* For further information please visit https://dbcsr.cp2k.org                                    */
+/* SPDX-License-Identifier: GPL-2.0+                                                              */
+/*------------------------------------------------------------------------------------------------*/
+
+#ifndef LIBSMM_ACC_TEST_RUNTIME_H
+#define LIBSMM_ACC_TEST_RUNTIME_H
+
+#include <stdio.h>
+
+#include "acc/acc.h"
+
+#if defined(DBCSR_LIBSMM_ACC_TEST_USE_MPI)
+#  include <mpi.h>
+#endif
+
+struct libsmm_acc_test_runtime {
+  int rank;
+  int nranks;
+};
+
+inline int libsmm_acc_test_runtime_init(int* argc, char*** argv, libsmm_acc_test_runtime* runtime) {
+  runtime->rank = 0;
+  runtime->nranks = 1;
+  int local_rank = 0;
+
+#if defined(DBCSR_LIBSMM_ACC_TEST_USE_MPI)
+  if (MPI_Init(argc, argv) != MPI_SUCCESS) return 1;
+  if (MPI_Comm_rank(MPI_COMM_WORLD, &runtime->rank) != MPI_SUCCESS ||
+      MPI_Comm_size(MPI_COMM_WORLD, &runtime->nranks) != MPI_SUCCESS)
+  {
+    MPI_Abort(MPI_COMM_WORLD, 1);
+    return 1;
+  }
+
+  MPI_Comm local_comm = MPI_COMM_NULL;
+  if (MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, runtime->rank, MPI_INFO_NULL, &local_comm) != MPI_SUCCESS ||
+      MPI_Comm_rank(local_comm, &local_rank) != MPI_SUCCESS || MPI_Comm_free(&local_comm) != MPI_SUCCESS)
+  {
+    MPI_Abort(MPI_COMM_WORLD, 1);
+    return 1;
+  }
+#else
+  DBCSR_MARK_USED(argc);
+  DBCSR_MARK_USED(argv);
+#endif
+
+  int ndevices = 0;
+  int status = 0;
+  if (c_dbcsr_acc_get_ndevices(&ndevices) != 0 || ndevices < 1) {
+    fprintf(stderr, "ERROR: No accelerator device found.\n");
+    status = 1;
+  }
+
+  int device = -1;
+  if (status == 0) {
+    device = local_rank % ndevices;
+    if (c_dbcsr_acc_set_active_device(device) != 0 || c_dbcsr_acc_init() != 0) {
+      fprintf(stderr, "ERROR: Rank %d failed to initialize accelerator device %d.\n", runtime->rank, device);
+      status = 1;
+    }
+  }
+
+  if (status != 0) {
+#if defined(DBCSR_LIBSMM_ACC_TEST_USE_MPI)
+    MPI_Abort(MPI_COMM_WORLD, status);
+#endif
+    return 1;
+  }
+
+  printf("# Rank %d/%d activated device %d/%d.\n", runtime->rank, runtime->nranks, device, ndevices);
+  return 0;
+}
+
+inline int libsmm_acc_test_runtime_finalize(int errors) {
+  if (c_dbcsr_acc_finalize() != 0) errors += 1;
+
+#if defined(DBCSR_LIBSMM_ACC_TEST_USE_MPI)
+  int total_errors = 0;
+  if (MPI_Allreduce(&errors, &total_errors, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD) != MPI_SUCCESS) total_errors += 1;
+  if (MPI_Finalize() != MPI_SUCCESS) total_errors += 1;
+#else
+  const int total_errors = errors;
+#endif
+  return total_errors;
+}
+
+#endif /* LIBSMM_ACC_TEST_RUNTIME_H */

--- a/tests/libsmm_acc_unittest_multiply.cpp.template
+++ b/tests/libsmm_acc_unittest_multiply.cpp.template
@@ -13,6 +13,7 @@
 #include <array>
 #include "libsmm_acc_benchmark.h"
 #include "libsmm_acc.h"
+#include "libsmm_acc_test_runtime.h"
 
 
 /****************************************************************************\
@@ -21,8 +22,8 @@
 
 int main(int argc, char** argv) {
 
-    DBCSR_MARK_USED(argc);
-    DBCSR_MARK_USED(argv);
+    libsmm_acc_test_runtime runtime;
+    if (libsmm_acc_test_runtime_init(&argc, &argv, &runtime) != 0) return 1;
 
     KernelLauncher launcher_mm = libsmm_acc_process_d;
 
@@ -34,7 +35,7 @@ int main(int argc, char** argv) {
             [[UNITTEST_KERNELS_HERE]]
     };
     int n_triplets = libsmm_acc_triplets.size();
-    printf("# libsmm_acc has %d blocksizes for multiplication\n", n_triplets);
+    if (runtime.rank == 0) printf("# libsmm_acc has %d blocksizes for multiplication\n", n_triplets);
 
     int max_m=0, max_n=0, max_k=0;
     for (int i=0; i<n_triplets; i++) {
@@ -42,12 +43,11 @@ int main(int argc, char** argv) {
         max_n = std::max(max_m, libsmm_acc_triplets[i][1]);
         max_k = std::max(max_k, libsmm_acc_triplets[i][2]);
     }
-
     libsmm_acc_benchmark_t* handle;
     libsmm_acc_benchmark_init(&handle, test, max_m, max_n, max_k);
 
     int errors = 0;
-    for (int i=0; i<n_triplets; i++) {
+    for (int i=runtime.rank; i<n_triplets; i += runtime.nranks) {
         int m = libsmm_acc_triplets[i][0];
         int n = libsmm_acc_triplets[i][1];
         int k = libsmm_acc_triplets[i][2];
@@ -56,6 +56,8 @@ int main(int argc, char** argv) {
     }
     libsmm_acc_benchmark_finalize(handle);
 
-    printf("# Done, found %d matrix-matrix multiplication errors.\n", errors);
-    return errors;
+    errors = libsmm_acc_test_runtime_finalize(errors);
+
+    if (runtime.rank == 0) printf("# Done, found %d matrix-matrix multiplication errors.\n", errors);
+    return errors == 0 ? 0 : 1;
 }

--- a/tests/libsmm_acc_unittest_transpose.cpp
+++ b/tests/libsmm_acc_unittest_transpose.cpp
@@ -15,6 +15,11 @@
 #include <utility>
 #include "libsmm_acc_benchmark.h"
 #include "libsmm_acc.h"
+#include "libsmm_acc_test_runtime.h"
+
+#if !defined(LIBSMM_ACC_TEST_MAX_TRANSPOSE_PAIRS)
+#  define LIBSMM_ACC_TEST_MAX_TRANSPOSE_PAIRS 0
+#endif
 
 
 /****************************************************************************\
@@ -22,8 +27,8 @@
 \****************************************************************************/
 
 int main(int argc, char** argv) {
-  DBCSR_MARK_USED(argc);
-  DBCSR_MARK_USED(argv);
+  libsmm_acc_test_runtime runtime;
+  if (libsmm_acc_test_runtime_init(&argc, &argv, &runtime) != 0) return 1;
 
   TransposeLauncher launcher_tr = libsmm_acc_transpose_d;
 
@@ -60,8 +65,23 @@ int main(int argc, char** argv) {
   });
   auto last = std::unique(libsmm_acc_transpose_pairs.begin(), libsmm_acc_transpose_pairs.end());
   libsmm_acc_transpose_pairs.erase(last, libsmm_acc_transpose_pairs.end());
+
+  const int max_pairs = LIBSMM_ACC_TEST_MAX_TRANSPOSE_PAIRS;
+  if (0 < max_pairs && max_pairs < static_cast<int>(libsmm_acc_transpose_pairs.size())) {
+    const std::vector<std::pair<int, int>> all_pairs = libsmm_acc_transpose_pairs;
+    libsmm_acc_transpose_pairs.clear();
+    if (max_pairs == 1) {
+      libsmm_acc_transpose_pairs.push_back(all_pairs[all_pairs.size() / 2]);
+    }
+    else {
+      for (int i = 0; i < max_pairs; ++i) {
+        const size_t index = i * (all_pairs.size() - 1) / (max_pairs - 1);
+        libsmm_acc_transpose_pairs.push_back(all_pairs[index]);
+      }
+    }
+  }
   int n_pairs = libsmm_acc_transpose_pairs.size();
-  printf("# libsmm_acc has %d blocksizes for transposition\n", n_pairs);
+  if (runtime.rank == 0) printf("# libsmm_acc has %d blocksizes for transposition\n", n_pairs);
 
   // Sort (m,n) pairs in growing order
   std::sort(
@@ -75,7 +95,7 @@ int main(int argc, char** argv) {
     });
 
   int errors = 0;
-  for (int i = 0; i < n_pairs; i++) {
+  for (int i = runtime.rank; i < n_pairs; i += runtime.nranks) {
     int m = libsmm_acc_transpose_pairs[i].first;
     int n = libsmm_acc_transpose_pairs[i].second;
     sprintf(buffer, "%d x %d", m, n);
@@ -83,6 +103,8 @@ int main(int argc, char** argv) {
   }
   libsmm_acc_benchmark_finalize(handle);
 
-  printf("# Done, found %d transpose errors.\n", errors);
-  return errors;
+  errors = libsmm_acc_test_runtime_finalize(errors);
+
+  if (runtime.rank == 0) printf("# Done, found %d transpose errors.\n", errors);
+  return errors == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Motivation

The `libsmm_acc_unittest_multiply` and `libsmm_acc_unittest_transpose` executables are built for CUDA and HIP, but their CTest registrations have been disabled because the original tests were not parallelized and were too slow (see cp2k/dbcsr#427). As a result, accelerator builds currently compile the tests without running their correctness checks.

Fixes cp2k/dbcsr#427.

## Changes

- Register the two libsmm_acc correctness tests for CUDA and HIP builds while leaving the timer/performance tests disabled.
- Bound the default smoke coverage to 64 autotuned multiplication kernels, 64 predicted kernels, and 64 transpose pairs.
- Make sampling deterministic and expose zero-valued limits as an explicit full-coverage mode.
- Initialize MPI and the accelerator in the correctness executables, select a device using the node-local MPI rank, and shard cases cyclically across global ranks.
- Aggregate correctness failures across ranks and normalize the process exit status to avoid truncating large error counts.
- Label the tests `gpu;libsmm_acc`, run them serially to avoid GPU contention, and provide configurable rank and timeout settings.

Non-MPI builds continue to execute the same tests directly with one process.
No production DBCSR kernel or accelerator code is changed.

## GitHub Actions red/green validation

I ran the same temporary self-hosted workflow against the code before and after this patch. The workflow itself is kept only on validation branches in my fork and is not part of this PR.

- **Before:** [run 29677536620](https://github.com/Stardust0831/dbcsr/actions/runs/29677536620)
  - source: upstream `develop` plus only the temporary workflow
  - configure: passed
  - build: passed
  - CTest: failed as expected with `Total Tests: 0` and `test_rc=8`
  - Slurm logs were uploaded as the `dbcsr-v100-gha-gpu-before-29677536620`
    artifact
- **After:** [run 29677660083](https://github.com/Stardust0831/dbcsr/actions/runs/29677660083)
  - source files are byte-identical to this PR patch
  - 4 NVIDIA V100 GPUs, CUDA 12.4.1, GCC 14.3, OpenMPI 5.0.10
  - configure: passed
  - build: passed
  - `libsmm_acc_unittest_multiply`: passed in 50.27 s
  - `libsmm_acc_unittest_transpose`: passed in 3.47 s
  - 2/2 tests passed; logs were uploaded as the `dbcsr-v100-gha-gpu-after-29677660083` artifact

## Additional validation

- Full V100 parameter coverage on 32 GPUs across two nodes:
  - 1,235 autotuned and 72,857 predicted multiplication kernels
  - 1,769 transpose pairs
  - zero correctness errors
- Round-robin multi-node placement on 8 GPUs across two nodes verified that node-local ranks select devices 0-3 independently on each node; both tests passed with zero errors.
- Non-MPI CUDA smoke tests passed on one V100.
- The relevant pre-commit hooks pass, including ruff, Black, Python AST, cmake-format, header checks, and clang-format-fypp.

As a separate validation of the MPI/device-sharding approach, I also ran `libsmm_acc_timer_multiply` with a benchmark-only patch on 1, 2, 4, 8, and 16 V100 GPUs. A fixed 1,024-kernel workload reached 1.98x, 3.44x, 4.82x, and 7.59x speedup, respectively, and all CPU checksum validations passed. The timer changes are not included in this PR.

CUDA runtime behavior was validated on V100 GPUs. HIP/ROCm remains covered by the existing compile CI, but I did not have an AMD GPU runner for a HIP runtime test. These are DBCSR backend correctness tests rather than CP2K application
regression inputs. The upstream GitHub Actions accelerator jobs currently compile these executables without access to a physical GPU; this PR makes the tests runnable by GPU-enabled CTest environments but does not add a permanent GPU runner.
