### PR TITLE
Expose DBCSR C API procedures explicitly

### DIFF
--- a/src/dbcsr_api_c.F
+++ b/src/dbcsr_api_c.F
@@ -26,6 +26,96 @@ MODULE dbcsr_api_c
 
    #:include 'data/dbcsr.fypp'
 
+   PUBLIC :: c_dbcsr_clear_mempools, &
+             c_dbcsr_init_lib, &
+             c_dbcsr_finalise_lib, &
+             c_dbcsr_mp_grid_setup, &
+             c_dbcsr_print_statistics, &
+             c_dbcsr_distribution_hold, &
+             c_dbcsr_distribution_new, &
+             c_dbcsr_distribution_release, &
+             c_dbcsr_release, &
+             c_dbcsr_create_new, &
+             c_dbcsr_create_template, &
+             c_dbcsr_finalize, &
+             c_dbcsr_complete_redistribute, &
+             c_dbcsr_filter, &
+             c_dbcsr_get_block_diag, &
+             c_dbcsr_transposed, &
+             c_dbcsr_copy, &
+             c_dbcsr_copy_into_existing, &
+             c_dbcsr_desymmetrize, &
+             c_dbcsr_clear, &
+             c_dbcsr_reserve_diag_blocks, &
+             c_dbcsr_reserve_blocks, &
+             c_dbcsr_reserve_all_blocks, &
+             c_dbcsr_iterator_stop, &
+             c_dbcsr_iterator_start, &
+             c_dbcsr_iterator_blocks_left, &
+             c_dbcsr_iterator_next_block_index, &
+             c_dbcsr_replicate_all, &
+             c_dbcsr_distribute, &
+             c_dbcsr_sum_replicated, &
+             c_dbcsr_hadamard_product, &
+             c_dbcsr_print, &
+             c_dbcsr_print_block_sum, &
+             c_dbcsr_checksum, &
+             c_dbcsr_maxabs, &
+             c_dbcsr_gershgorin_norm, &
+             c_dbcsr_frobenius_norm, &
+             c_dbcsr_norm_scalar, &
+             c_dbcsr_triu, &
+             c_dbcsr_init_random, &
+             c_dbcsr_function_of_elements, &
+             c_dbcsr_nblkrows_total, &
+             c_dbcsr_nblkcols_total, &
+             c_dbcsr_nblkrows_local, &
+             c_dbcsr_nblkcols_local, &
+             c_dbcsr_get_info, &
+             c_dbcsr_get_name, &
+             c_dbcsr_get_group, &
+             c_dbcsr_get_distribution, &
+             c_dbcsr_distribution_get, &
+             c_dbcsr_get_stored_coordinates, &
+             c_dbcsr_setname, &
+             c_dbcsr_get_matrix_type, &
+             c_dbcsr_get_occupation, &
+             c_dbcsr_get_num_blocks, &
+             c_dbcsr_get_data_size, &
+             c_dbcsr_has_symmetry, &
+             c_dbcsr_nfullrows_total, &
+             c_dbcsr_nfullcols_total, &
+             c_dbcsr_valid_index, &
+             c_dbcsr_get_data_type, &
+             c_dbcsr_binary_write, &
+             c_dbcsr_binary_read, &
+             c_free_string
+
+   #:for n, nametype, base, prec, kind, type, dkind, normname, ctype in c_inst_params_float
+      PUBLIC :: c_dbcsr_set_${nametype}$, &
+                c_dbcsr_add_${nametype}$, &
+                c_dbcsr_scale_${nametype}$, &
+                c_dbcsr_scale_by_vector_${nametype}$, &
+                c_dbcsr_multiply_${nametype}$, &
+                c_dbcsr_add_on_diag_${nametype}$, &
+                c_dbcsr_set_diag_${nametype}$, &
+                c_dbcsr_get_diag_${nametype}$, &
+                c_dbcsr_trace_${nametype}$, &
+                c_dbcsr_dot_${nametype}$, &
+                c_dbcsr_get_block_p_${nametype}$, &
+                c_dbcsr_get_block_notrans_p_${nametype}$, &
+                c_dbcsr_reserve_block2d_${nametype}$, &
+                c_dbcsr_iterator_next_2d_block_${nametype}$, &
+                c_dbcsr_put_block2d_${nametype}$, &
+                c_dbcsr_get_data_${nametype}$
+   #:endfor
+
+   #:set c_api_infovars = ['local_rows', 'local_cols', 'proc_row_dist', 'proc_col_dist', &
+      'row_blk_size', 'col_blk_size', 'row_blk_offset', 'col_blk_offset']
+   #:for var in c_api_infovars
+      PUBLIC :: c_dbcsr_get_${var}$
+   #:endfor
+
 CONTAINS
 
    SUBROUTINE c_f_string(c_str, str)

--- a/src/tensors/dbcsr_tensor_api_c.F
+++ b/src/tensors/dbcsr_tensor_api_c.F
@@ -36,6 +36,60 @@ MODULE dbcsr_tensor_api_c
    IMPLICIT NONE
    PRIVATE
 
+   PUBLIC :: c_dbcsr_t_finalize, &
+             c_dbcsr_t_pgrid_create_expert, &
+             c_dbcsr_t_pgrid_create, &
+             c_dbcsr_t_pgrid_destroy, &
+             c_dbcsr_t_distribution_new, &
+             c_dbcsr_t_distribution_destroy, &
+             c_dbcsr_t_create_new, &
+             c_dbcsr_t_create_template, &
+             c_dbcsr_t_create_matrix, &
+             c_dbcsr_t_destroy, &
+             c_dbcsr_t_get_stored_coordinates, &
+             c_dbcsr_t_reserve_blocks_index, &
+             c_dbcsr_t_reserve_blocks_template, &
+             c_ndims_iterator, &
+             c_dbcsr_t_iterator_start, &
+             c_dbcsr_t_iterator_stop, &
+             c_dbcsr_t_iterator_next_block, &
+             c_dbcsr_t_iterator_blocks_left, &
+             c_dbcsr_t_split_blocks, &
+             c_dbcsr_t_copy_matrix_to_tensor, &
+             c_dbcsr_t_copy_tensor_to_matrix, &
+             c_dbcsr_t_blk_sizes, &
+             c_dbcsr_t_copy, &
+             c_dbcsr_t_clear, &
+             c_dbcsr_t_get_info, &
+             c_dbcsr_t_get_mapping_info, &
+             c_dbcsr_t_get_num_blocks, &
+             c_dbcsr_t_get_num_blocks_total, &
+             c_dbcsr_t_nblks_local, &
+             c_dbcsr_t_nblks_total, &
+             c_dbcsr_t_dims, &
+             c_dbcsr_t_ndims, &
+             c_dbcsr_t_ndims_matrix_row, &
+             c_dbcsr_t_ndims_matrix_column, &
+             c_dbcsr_t_get_nze, &
+             c_dbcsr_t_get_nze_total, &
+             c_dbcsr_t_max_nblks_local, &
+             c_dbcsr_t_batched_contract_init, &
+             c_dbcsr_t_batched_contract_finalize
+
+   #:for dparam, dtype, dsuffix, dbase, dctype in cf_dtype_float_list
+      PUBLIC :: c_dbcsr_t_contract_${dsuffix}$, &
+                c_dbcsr_t_contract_index_${dsuffix}$, &
+                c_dbcsr_t_filter_${dsuffix}$, &
+                c_dbcsr_t_set_${dsuffix}$, &
+                c_dbcsr_t_scale_${dsuffix}$, &
+                c_dbcsr_t_get_data_${dsuffix}$
+      #:for ndim in ndims
+         PUBLIC :: c_dbcsr_t_get_${ndim}$d_block_${dsuffix}$, &
+                   c_dbcsr_t_put_${ndim}$d_block_${dsuffix}$, &
+                   c_dbcsr_t_get_${ndim}$d_block_p_${dsuffix}$
+      #:endfor
+   #:endfor
+
 CONTAINS
 
    SUBROUTINE c_f_string(c_str, str)


### PR DESCRIPTION
The `dbcsr_api_c` and `dbcsr_tensor_api_c` modules use `PRIVATE` by default, while the `BIND(C)` procedures declared in `dbcsr.h` and `dbcsr_tensor.h` are intended to be exported as the public C API.

With the Fedora Rawhide/GCC 16 RPM build, these symbols are present in `libdbcsr_c.so`, but they are emitted as local symbols and therefore are not available from the dynamic symbol table. As a result, linking the C++ tests against `libdbcsr_c.so` fails with unresolved references to `c_dbcsr_init_lib_internal`, `c_dbcsr_create_new`, `c_dbcsr_t_ndims`, and many other C API entry points.

This PR makes the C API procedures explicitly `PUBLIC`. This documents the intended API boundary and avoids relying on compiler-specific handling of private module procedures with C binding.